### PR TITLE
Add distance indicators on event cards (#27)

### DIFF
--- a/inc/blocks/calendar/src/modules/lazy-render.js
+++ b/inc/blocks/calendar/src/modules/lazy-render.js
@@ -86,6 +86,8 @@ function hydratePlaceholder(placeholder) {
     const isoStartDate = displayVars.iso_start_date || '';
     const ticketUrl = displayVars.ticket_url || '';
     const showTicketLink = displayVars.show_ticket_link !== false;
+    const venueDistance = displayVars.venue_distance;
+    const distanceUnit = displayVars.distance_unit || 'mi';
 
     const itemClasses = ['datamachine-event-item'];
     if (displayVars.is_continuation) {
@@ -106,6 +108,15 @@ function hydratePlaceholder(placeholder) {
         timeHtml += '</div>';
     }
 
+    let distanceHtml = '';
+    if (venueDistance != null) {
+        var unitLabel = distanceUnit === 'km' ? 'km' : 'mi';
+        distanceHtml = '<div class="datamachine-event-distance">' +
+            '<span class="dashicons dashicons-location"></span>' +
+            escapeHtml(venueDistance + ' ' + unitLabel) +
+            '</div>';
+    }
+
     let performerHtml = '';
     if (showPerformer && performerName) {
         performerHtml = '<div class="datamachine-event-performer">' +
@@ -123,6 +134,7 @@ function hydratePlaceholder(placeholder) {
         '</h4>' +
         '<div class="datamachine-event-meta">' +
             timeHtml +
+            distanceHtml +
             performerHtml +
             '<a href="' + escapeAttr(data.permalink) + '" class="' + escapeAttr(data.button_classes || 'datamachine-more-info-button') + '">More Info</a>' +
         '</div>' +

--- a/inc/blocks/calendar/style.css
+++ b/inc/blocks/calendar/style.css
@@ -527,6 +527,7 @@
 /* Event Meta Information */
 .datamachine-event-date,
 .datamachine-event-time,
+.datamachine-event-distance,
 .datamachine-event-artist,
 .datamachine-event-address {
     display: flex;
@@ -535,6 +536,18 @@
     font-size: 0.9rem;
     color: var(--datamachine-text-secondary);
     line-height: 1.4;
+}
+
+.datamachine-event-distance {
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: var(--datamachine-text-muted);
+}
+
+.datamachine-event-distance .dashicons {
+    font-size: 14px;
+    width: 14px;
+    height: 14px;
 }
 
 .datamachine-event-date-icon,
@@ -744,7 +757,7 @@
 
 /* 480px breakpoint reserved for future mobile refinements */
 
-/* ========== Taxonomy Filter Modal Styles ========== */
+/* ========== Taxonomy Filter Styles ========== */
 
 /* Filter Button */
 .datamachine-events-taxonomy-filter {
@@ -795,123 +808,6 @@
     width: 16px;
     height: 16px;
     font-size: 16px;
-}
-
-/* Custom Modal Structure */
-.datamachine-taxonomy-modal {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 999999999999999999999999;
-    display: none;
-    align-items: center;
-    justify-content: center;
-}
-
-.datamachine-taxonomy-modal.datamachine-modal-active {
-    display: flex;
-}
-
-.datamachine-taxonomy-modal-overlay {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(0, 0, 0, 0.5);
-    cursor: pointer;
-}
-
-.datamachine-taxonomy-modal-container {
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    background: var(--datamachine-background-primary);
-    border-radius: var(--datamachine-border-radius);
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
-    max-width: 600px;
-    width: 90%;
-    max-height: 80vh;
-    overflow: hidden;
-    z-index: 1;
-}
-
-.datamachine-taxonomy-modal-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 1.5rem;
-    border-bottom: 1px solid var(--datamachine-border-light);
-    background: var(--datamachine-background-secondary);
-    flex-shrink: 0;
-}
-
-.datamachine-taxonomy-modal-title {
-    margin: 0;
-    font-size: 1.25rem;
-    font-weight: 600;
-    color: var(--datamachine-text-primary);
-}
-
-.datamachine-taxonomy-modal-close {
-    background: none;
-    border: none;
-    font-size: 1.5rem;
-    cursor: pointer;
-    padding: 0.25rem;
-    color: var(--datamachine-text-secondary);
-    transition: color 0.2s ease;
-    width: 32px;
-    height: 32px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-.datamachine-taxonomy-modal-close:hover {
-    color: var(--datamachine-text-primary);
-}
-
-.datamachine-taxonomy-modal-body {
-    flex: 1 1 auto;
-    overflow-y: auto;
-    min-height: 0;
-    max-height: calc(80vh - 160px);
-}
-
-.datamachine-taxonomy-modal-footer {
-    flex-shrink: 0;
-    background: var(--datamachine-background-secondary);
-    border-top: 1px solid var(--datamachine-border-light);
-}
-
-.datamachine-taxonomy-filter-content {
-    padding: 1.5rem;
-}
-
-/* Filter Loading State */
-.datamachine-filter-loading {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.75rem;
-    padding: 3rem 1.5rem;
-    color: var(--datamachine-text-secondary);
-}
-
-.datamachine-filter-loading .datamachine-filter-spinner {
-    width: 20px;
-    height: 20px;
-    border: 2px solid var(--datamachine-border-light);
-    border-top-color: var(--datamachine-accent);
-    border-radius: 50%;
-    animation: datamachine-spin 0.8s linear infinite;
-}
-
-@keyframes datamachine-spin {
-    to { transform: rotate(360deg); }
 }
 
 .datamachine-filter-error {
@@ -1019,62 +915,11 @@
     border-top: 1px solid var(--datamachine-border-light);
 }
 
-/* Modal Actions */
-.datamachine-modal-actions {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 1.5rem;
-    background: var(--datamachine-background-secondary);
-}
-
-.datamachine-modal-actions-left,
-.datamachine-modal-actions-right {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-}
-
-/* Modal Button Sizing */
-.datamachine-modal-actions .datamachine-button {
-    padding: 0.625rem 1.25rem;
-    font-size: 0.9rem;
-    min-height: 2.5rem;
-    cursor: pointer;
-}
-
-/* No Taxonomies State */
-.datamachine-no-taxonomies {
-    padding: 2rem;
-    text-align: center;
-}
-
-.datamachine-no-taxonomies p {
-    margin: 0;
-    color: var(--datamachine-text-secondary);
-    font-size: 0.95rem;
-}
-
 /* Responsive Styles */
 @media (max-width: 768px) {
     .datamachine-events-filter-row {
         grid-template-columns: 1fr;
         gap: 1rem;
-    }
-    
-    .datamachine-taxonomy-filter-content {
-        padding: 1rem;
-    }
-    
-    .datamachine-modal-actions {
-        flex-direction: column;
-        gap: 1rem;
-        align-items: stretch;
-    }
-    
-    .datamachine-modal-actions-left,
-    .datamachine-modal-actions-right {
-        justify-content: center;
     }
 }
 

--- a/inc/blocks/calendar/templates/event-item.php
+++ b/inc/blocks/calendar/templates/event-item.php
@@ -23,9 +23,11 @@ $show_performer   = $display_vars['show_performer'] ?? true;
 $show_price       = $display_vars['show_price'] ?? true;
 $show_ticket_link = $display_vars['show_ticket_link'] ?? true;
 
-$multi_day_label = $display_vars['multi_day_label'] ?? '';
-$is_continuation = $display_vars['is_continuation'] ?? false;
-$is_multi_day    = $display_vars['is_multi_day'] ?? false;
+$multi_day_label  = $display_vars['multi_day_label'] ?? '';
+$is_continuation  = $display_vars['is_continuation'] ?? false;
+$is_multi_day     = $display_vars['is_multi_day'] ?? false;
+$venue_distance   = $display_vars['venue_distance'] ?? null;
+$distance_unit    = $display_vars['distance_unit'] ?? 'mi';
 
 $item_classes = array( 'datamachine-event-item' );
 if ( $is_continuation ) {
@@ -62,6 +64,16 @@ if ( $is_multi_day ) {
 					<?php if ( ! empty( $multi_day_label ) ) : ?>
 						<span class="datamachine-event-multi-day-label"><?php echo esc_html( $multi_day_label ); ?></span>
 					<?php endif; ?>
+				</div>
+			<?php endif; ?>
+
+			<?php if ( null !== $venue_distance ) : ?>
+				<div class="datamachine-event-distance">
+					<span class="dashicons dashicons-location"></span>
+					<?php
+					$unit_label = 'km' === $distance_unit ? 'km' : 'mi';
+					echo esc_html( $venue_distance . ' ' . $unit_label );
+					?>
 				</div>
 			<?php endif; ?>
 


### PR DESCRIPTION
## Summary

- Displays venue distance badge (📍 X mi/km) on event cards when the geo location filter is active
- Threads `distance_unit` alongside `venue_distance_map` through the full render pipeline: `CalendarAbilities` → `render_date_groups()` → `build_display_vars()` → template
- Distance badge renders in both server-side PHP (`event-item.php`) and client-side lazy-load hydration (`lazy-render.js`)
- Removes 168 lines of dead modal CSS left over from the inline collapsible refactor (#32)
- Fixes missing `Geo_Query` use statement in `CalendarAbilities.php`

## Changes

### `CalendarAbilities.php`
- Add `use Geo_Query` import (was missing, would have caused fatal when geo filter active)
- Build `venue_distance_map` via `Geo_Query::get_venue_distance_map()` when geo params present
- Pass `$venue_distance_map` and `$distance_unit` through `renderHtml()` to `render_date_groups()`

### `Calendar_Query.php`
- Add `venue_term_id` to event data during `hydrate_venue_from_taxonomy()`
- Add `$venue_distance_map` and `$distance_unit` params to `render_date_groups()` and `build_display_vars()`
- Return `venue_distance` and `distance_unit` in display vars

### `event-item.php`
- Render distance badge between time and performer meta when `venue_distance` is set

### `lazy-render.js`
- Read `venue_distance` and `distance_unit` from placeholder JSON
- Render distance badge in hydrated HTML

### `style.css`
- Add `.datamachine-event-distance` styles (consistent with existing meta item styling)
- Remove 168 lines of dead modal CSS (closes #32)

## Testing

- Without geo filter: no distance badge appears (distance is `null`)
- With geo filter (`?lat=X&lng=Y&radius=Z`): each event card shows distance from search point
- Lazy-loaded cards (beyond threshold 5) also show distance after hydration

Closes #27, closes #32