### PR TITLE
Remove PostTrackingTrait from EventUpsert

### DIFF
--- a/inc/Steps/Upsert/Events/EventUpsert.php
+++ b/inc/Steps/Upsert/Events/EventUpsert.php
@@ -30,12 +30,10 @@ use DataMachine\Core\Steps\Update\Handlers\UpdateHandler;
 use DataMachine\Core\WordPress\TaxonomyHandler;
 use DataMachine\Core\WordPress\WordPressSettingsResolver;
 use DataMachine\Core\WordPress\WordPressPublishHelper;
-use DataMachine\Core\WordPress\PostTrackingTrait;
 
 defined( 'ABSPATH' ) || exit;
 
 class EventUpsert extends UpdateHandler {
-	use PostTrackingTrait;
 
 	protected $taxonomy_handler;
 
@@ -726,8 +724,6 @@ class EventUpsert extends UpdateHandler {
 			return $post_id;
 		}
 
-		$this->storePostTrackingMeta( $post_id, $handler_config );
-
 		$this->processEventFeaturedImage( $post_id, $handler_config, $engine );
 		$this->processVenue( $post_id, $parameters, $engine );
 		$this->processPromoter( $post_id, $parameters, $engine, $handler_config );
@@ -776,8 +772,6 @@ class EventUpsert extends UpdateHandler {
 				'post_content' => $this->generate_event_block_content( $event_data, $parameters ),
 			)
 		);
-
-		$this->storePostTrackingMeta( $post_id, $handler_config );
 
 		$this->processEventFeaturedImage( $post_id, $handler_config, $engine );
 		$this->processVenue( $post_id, $parameters, $engine );


### PR DESCRIPTION
## Summary

Companion to data-machine PR #464. Removes the manual PostTrackingTrait usage from EventUpsert.

Post tracking is now automatic in the base `UpdateHandler.handle_tool_call()` — after `executeUpdate()` returns a successful result with a `post_id`, the base class writes origin metadata via `PostTracking::store()`. Individual handlers no longer need to import the trait or call `storePostTrackingMeta()`.

## Changes

- Remove `use DataMachine\Core\WordPress\PostTrackingTrait` import
- Remove `use PostTrackingTrait` declaration
- Remove two manual `$this->storePostTrackingMeta()` calls from `createEventPost()` and `updateEventPost()`

**6 lines deleted, 0 added.** Pure cleanup.

## Dependency

Requires **data-machine PR #464** to be deployed first — that PR refactors the trait into a static class and adds automatic tracking in the base handler.