### PR TITLE
Fix multi-day events showing past days on calendar

### DIFF
--- a/inc/Blocks/Calendar/Calendar_Query.php
+++ b/inc/Blocks/Calendar/Calendar_Query.php
@@ -546,8 +546,10 @@ class Calendar_Query {
 				$event_dates = array( $start_date );
 			}
 
-			// Filter out past occurrence dates when show_past is false.
-			if ( ! $show_past && $has_occurrence_dates ) {
+			// Filter out past dates when show_past is false.
+			// Applies to both explicit occurrence dates and multi-day date range expansions
+			// so that yesterday's entry for an ongoing multi-day event doesn't appear.
+			if ( ! $show_past && ( $has_occurrence_dates || $is_multi_day ) ) {
 				$current_date = current_time( 'Y-m-d' );
 				$event_dates  = array_filter(
 					$event_dates,
@@ -1000,9 +1002,11 @@ class Calendar_Query {
 					$event_dates = array( $start_date );
 				}
 
-				// Filter out past occurrence dates when show_past is false.
+				// Filter out past dates when show_past is false.
+				// Applies to both explicit occurrence dates and multi-day date range expansions.
 				$show_past_param = $params['show_past'] ?? false;
-				if ( ! $show_past_param && ! empty( $occurrence_dates ) && is_array( $occurrence_dates ) ) {
+				$is_expanded     = ( ! empty( $occurrence_dates ) && is_array( $occurrence_dates ) ) || ( $start_date !== $end_date );
+				if ( ! $show_past_param && $is_expanded ) {
 					$current_date = current_time( 'Y-m-d' );
 					$event_dates  = array_filter(
 						$event_dates,


### PR DESCRIPTION
## Summary
- Filters past dates from multi-day event date range expansions, not just explicit occurrence dates
- Fixes ongoing multi-day events (e.g. festivals) displaying yesterday's entry on the calendar

## Root Cause
`group_events_by_date()` and `compute_unique_event_dates()` had a past-date filter that only triggered for events with explicit `occurrenceDates` block attributes. Multi-day events using start/end date ranges were expanded to all days (including past ones) with no filtering.

Example: "Surf By Surf East 2026" spans Feb 27 – Mar 1. On Feb 28, the calendar still showed the Feb 27 date group with this event because the range expansion included all days.

## Changes
- `group_events_by_date()`: past-date filter now triggers for `$has_occurrence_dates || $is_multi_day`
- `compute_unique_event_dates()`: past-date filter now triggers for occurrence dates OR multi-day ranges (`$start_date !== $end_date`)

## Related
- Filed #49 for Calendar_Query decomposition — this god class needs to be broken into focused modules