### PR TITLE
fix: improve multi-day event continuation display

### DIFF
--- a/inc/Blocks/Calendar/Calendar_Query.php
+++ b/inc/Blocks/Calendar/Calendar_Query.php
@@ -669,14 +669,19 @@ class Calendar_Query {
 
 			if ( $is_multi_day && ! empty( $end_date ) ) {
 				$end_datetime_obj = new DateTime( $end_date, $event_tz );
-				$multi_day_label  = sprintf(
-					__( 'through %s', 'datamachine-events' ),
-					$end_datetime_obj->format( 'M j' )
-				);
 
 				if ( $is_continuation ) {
-					$formatted_time_display = __( 'All Day', 'datamachine-events' );
+					$formatted_time_display = sprintf(
+						/* translators: 1: start date, 2: end date. Example: "Feb 27 – Mar 1" */
+						__( '%1$s – %2$s', 'datamachine-events' ),
+						$start_datetime_obj->format( 'M j' ),
+						$end_datetime_obj->format( 'M j' )
+					);
 				} else {
+					$multi_day_label = sprintf(
+						__( 'through %s', 'datamachine-events' ),
+						$end_datetime_obj->format( 'M j' )
+					);
 					$formatted_time_display = self::format_time_range( $start_datetime_obj, $end_date, $end_time, $event_tz );
 				}
 			} else {

--- a/inc/Blocks/Calendar/style.css
+++ b/inc/Blocks/Calendar/style.css
@@ -1395,12 +1395,6 @@
     opacity: 0.85;
 }
 
-.datamachine-event-continuation .datamachine-event-title::before {
-    content: '\21B3 ';
-    color: var(--datamachine-text-muted);
-    font-weight: normal;
-}
-
 .datamachine-event-multi-day:not(.datamachine-event-continuation) .datamachine-event-multi-day-label {
     background: var(--datamachine-background-hover);
     padding: 0.15rem 0.4rem;


### PR DESCRIPTION
## Summary

- Replace misleading **"All Day through Mar 1"** on continuation days with a clear date range like **"Feb 27 – Mar 1"**
- Remove the **↳ arrow** (`\21B3`) pseudo-element from continuation event titles — it looks like a rendering artifact

## Before / After

**Before:** On Feb 28, Surf By Surf East shows:
> ↳ Surf By Surf East 2026
> 🕐 All Day through Mar 1

**After:**
> Surf By Surf East 2026
> 🕐 Feb 27 – Mar 1

## Why

- "All Day" is wrong — the event has specific hours (6PM start). On continuation days the start time is irrelevant, so showing the date range communicates "this event is ongoing" without lying about the schedule.
- The `multi_day_label` ("through Mar 1") is now only shown on the **start day**, where the actual start time is displayed alongside it (e.g., "6:00 PM through Mar 1"). On continuation days, the date range replaces both.
- The arrow was confusing to users with no context about what "continuation" means.

## Files changed

- `inc/Blocks/Calendar/Calendar_Query.php` — continuation display logic
- `inc/Blocks/Calendar/style.css` — remove `::before` arrow