### PR TITLE
Fix check-all flag passthrough for duration and meta-sync

### DIFF
--- a/inc/Cli/Check/CheckAllCommand.php
+++ b/inc/Cli/Check/CheckAllCommand.php
@@ -88,9 +88,14 @@ class CheckAllCommand {
 				'limit'      => $limit,
 			);
 
-			// meta-sync doesn't use scope/days-ahead
+			// meta-sync only uses --limit
 			if ( 'meta-sync' === $subcommand ) {
 				$run_args = array( 'limit' => $limit );
+			}
+
+			// duration uses --max-days and --scope, not --days-ahead or --limit
+			if ( 'duration' === $subcommand ) {
+				$run_args = array( 'scope' => $scope );
 			}
 
 			try {

--- a/inc/Cli/Check/CheckMetaSyncCommand.php
+++ b/inc/Cli/Check/CheckMetaSyncCommand.php
@@ -65,21 +65,11 @@ class CheckMetaSyncCommand {
 		$fix    = isset( $assoc_args['fix'] );
 		$format = $assoc_args['format'] ?? 'table';
 
-		// Delegate to existing ability if available
-		$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'datamachine-events/find-missing-meta-sync' ) : null;
-
-		if ( $ability ) {
-			$result = $ability->execute( array( 'limit' => $limit ) );
-
-			if ( is_wp_error( $result ) ) {
-				\WP_CLI::error( 'Meta sync check failed: ' . $result->get_error_message() );
-			}
-
-			$missing = $result['events'] ?? array();
-		} else {
-			// Fallback: manual scan
-			$missing = $this->find_missing_meta_sync( $limit );
-		}
+		// Direct scan — the Abilities API has a permission_callback that
+		// requires manage_options, which isn't loaded in WP-CLI context.
+		// This CLI command already IS the admin interface, so skip the
+		// ability layer and query directly.
+		$missing = $this->find_missing_meta_sync( $limit );
 
 		if ( 'json' === $format ) {
 			\WP_CLI::log( wp_json_encode(


### PR DESCRIPTION
## Summary

Fixes two bugs in the `check all` aggregator command introduced in PR #56:

1. **`check duration` got invalid flags** — `check all` was passing `--days-ahead` and `--limit` which `check duration` doesn't accept (it uses `--max-days` and `--scope`). Now duration gets its own arg set with just `--scope`.

2. **`check meta-sync` permission error** — Was routing through the Abilities API which has a `permission_callback` requiring `manage_options`. WP-CLI doesn't load a user context, so this always failed. Removed the ability indirection — the CLI command queries directly, same as the ability would.

## Testing

```bash
wp --allow-root --url=events.extrachill.com datamachine-events check all
```

Both `duration` and `meta-sync` sections should now run without errors.