### PR TITLE
refactor: remove static map mode — always dynamic

### DIFF
--- a/inc/Blocks/EventsMap/block.json
+++ b/inc/Blocks/EventsMap/block.json
@@ -6,7 +6,7 @@
     "title": "Events Map",
     "category": "datamachine-events",
     "icon": "location-alt",
-    "description": "Display an interactive map of event venues. Supports static and dynamic (REST API) loading modes.",
+    "description": "Display an interactive map of event venues. Fetches venues dynamically via REST API.",
     "keywords": ["events", "map", "venues", "leaflet", "location"],
     "textdomain": "datamachine-events",
     "attributes": {
@@ -21,10 +21,6 @@
         "mapType": {
             "type": "string",
             "default": "osm-standard"
-        },
-        "dynamic": {
-            "type": "boolean",
-            "default": false
         }
     },
     "supports": {

--- a/inc/Blocks/EventsMap/render.php
+++ b/inc/Blocks/EventsMap/render.php
@@ -5,11 +5,9 @@
  * Outputs a minimal React root container div. All map logic, venue fetching,
  * and Leaflet rendering happens client-side in the bundled frontend.tsx.
  *
- * In static mode (default), venues are embedded as JSON in data-venues for
- * instant render. In dynamic mode, venues are fetched via REST API on pan/zoom.
- *
- * Plugins can still filter the initial venue set for static mode via
- * `datamachine_events_map_venues`.
+ * The map always operates in dynamic mode: venues are fetched from the REST
+ * API on mount and on every pan/zoom. Plugins can influence the initial
+ * center, user location marker, and summary text via filters.
  *
  * @var array    $attributes Block attributes.
  * @var string   $content    Block inner content.
@@ -31,7 +29,6 @@ if ( wp_is_json_request() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
 $height   = absint( $attributes['height'] ?? 400 );
 $zoom     = absint( $attributes['zoom'] ?? 12 );
 $map_type = sanitize_text_field( $attributes['mapType'] ?? 'osm-standard' );
-$dynamic  = ! empty( $attributes['dynamic'] );
 
 // Override map type from plugin settings if available.
 if ( 'osm-standard' === $map_type && class_exists( 'DataMachineEvents\\Admin\\Settings_Page' ) ) {
@@ -67,90 +64,17 @@ $center = apply_filters( 'datamachine_events_map_center', $center, $context );
 // User location (optional — plugins can set via filter).
 $user_location = apply_filters( 'datamachine_events_map_user_location', null, $context );
 
-// Static mode: embed venue data for instant render (no REST round-trip).
-$venue_json = '[]';
-if ( ! $dynamic ) {
-	$venue_taxonomy = 'venue';
-	if ( ! taxonomy_exists( $venue_taxonomy ) ) {
-		return '';
-	}
-
-	$all_venues = get_terms( array(
-		'taxonomy'   => $venue_taxonomy,
-		'hide_empty' => false,
-		'number'     => 0,
-	) );
-
-	if ( ! is_wp_error( $all_venues ) && ! empty( $all_venues ) ) {
-		$venues = array();
-		foreach ( $all_venues as $venue ) {
-			$coordinates = get_term_meta( $venue->term_id, '_venue_coordinates', true );
-			if ( empty( $coordinates ) || strpos( $coordinates, ',' ) === false ) {
-				continue;
-			}
-
-			$parts = explode( ',', $coordinates );
-			$lat   = floatval( trim( $parts[0] ) );
-			$lon   = floatval( trim( $parts[1] ) );
-
-			if ( 0.0 === $lat && 0.0 === $lon ) {
-				continue;
-			}
-
-			$address = '';
-			if ( class_exists( 'DataMachineEvents\\Core\\Venue_Taxonomy' ) ) {
-				$address = \DataMachineEvents\Core\Venue_Taxonomy::get_formatted_address( $venue->term_id );
-			}
-
-			$venues[] = array(
-				'term_id'     => $venue->term_id,
-				'name'        => $venue->name,
-				'slug'        => $venue->slug,
-				'lat'         => $lat,
-				'lon'         => $lon,
-				'address'     => $address,
-				'url'         => get_term_link( $venue ),
-				'event_count' => $venue->count,
-			);
-		}
-
-		/** @see datamachine_events_map_venues */
-		$venues = apply_filters( 'datamachine_events_map_venues', $venues, $context );
-
-		if ( empty( $venues ) ) {
-			return '';
-		}
-
-		// Clean URLs for JSON.
-		$venue_data = array();
-		foreach ( $venues as $venue ) {
-			$venue_data[] = array(
-				'term_id'     => $venue['term_id'],
-				'name'        => $venue['name'],
-				'slug'        => $venue['slug'],
-				'lat'         => $venue['lat'],
-				'lon'         => $venue['lon'],
-				'address'     => $venue['address'],
-				'url'         => is_string( $venue['url'] ) ? $venue['url'] : '',
-				'event_count' => $venue['event_count'] ?? 0,
-			);
-		}
-
-		$venue_json = wp_json_encode( $venue_data );
-	}
-}
-
 $map_id  = wp_unique_id( 'dm-events-map-' );
 $wrapper = get_block_wrapper_attributes( array(
 	'class' => 'datamachine-events-map-block',
 ) );
 
-// REST URL for dynamic mode.
+// REST URL for venue fetching.
 $rest_url = rest_url( 'datamachine/v1/events/venues' );
 $nonce    = wp_create_nonce( 'wp_rest' );
 
-// Summary (kept for backward compat — plugins can filter).
-$summary = apply_filters( 'datamachine_events_map_summary', '', $venues ?? array(), $context );
+// Summary (plugins can filter to show venue/event counts).
+$summary = apply_filters( 'datamachine_events_map_summary', '', array(), $context );
 
 ?>
 <div <?php echo $wrapper; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
@@ -160,14 +84,12 @@ $summary = apply_filters( 'datamachine_events_map_summary', '', $venues ?? array
 		data-height="<?php echo esc_attr( $height ); ?>"
 		data-zoom="<?php echo esc_attr( $zoom ); ?>"
 		data-map-type="<?php echo esc_attr( $map_type ); ?>"
-		data-dynamic="<?php echo $dynamic ? '1' : '0'; ?>"
 		data-center-lat="<?php echo esc_attr( $center['lat'] ?? '' ); ?>"
 		data-center-lon="<?php echo esc_attr( $center['lon'] ?? '' ); ?>"
 		<?php if ( $user_location ) : ?>
 		data-user-lat="<?php echo esc_attr( $user_location['lat'] ); ?>"
 		data-user-lon="<?php echo esc_attr( $user_location['lon'] ); ?>"
 		<?php endif; ?>
-		data-venues="<?php echo esc_attr( $venue_json ); ?>"
 		data-taxonomy="<?php echo esc_attr( $context['taxonomy'] ); ?>"
 		data-term-id="<?php echo esc_attr( $context['term_id'] ); ?>"
 		data-rest-url="<?php echo esc_attr( $rest_url ); ?>"
@@ -180,9 +102,8 @@ $summary = apply_filters( 'datamachine_events_map_summary', '', $venues ?? array
 	/**
 	 * Fires after the map summary, inside the block wrapper.
 	 *
-	 * @param array $venues  Venue data array.
-	 * @param array $context Map context.
+	 * @param array $context Map context with taxonomy/term info.
 	 */
-	do_action( 'datamachine_events_map_after_summary', $venues ?? array(), $context );
+	do_action( 'datamachine_events_map_after_summary', array(), $context );
 	?>
 </div>

--- a/inc/Blocks/EventsMap/src/index.tsx
+++ b/inc/Blocks/EventsMap/src/index.tsx
@@ -18,7 +18,6 @@ import {
 	PanelBody,
 	RangeControl,
 	SelectControl,
-	ToggleControl,
 } from '@wordpress/components';
 
 import type { MapAttributes, MapType } from './types';
@@ -38,7 +37,7 @@ const MAP_STYLE_OPTIONS: { label: string; value: MapType }[] = [
 
 registerBlockType<MapAttributes>( 'datamachine-events/events-map', {
 	edit: function Edit( { attributes, setAttributes }: EditProps ) {
-		const { height, zoom, mapType, dynamic } = attributes;
+		const { height, zoom, mapType } = attributes;
 		const blockProps = useBlockProps( {
 			className: 'datamachine-events-map-block',
 		} );
@@ -69,25 +68,14 @@ registerBlockType<MapAttributes>( 'datamachine-events/events-map', {
 							min={ 4 }
 							max={ 18 }
 						/>
-						<SelectControl
-							label={ __( 'Map Style', 'datamachine-events' ) }
-							value={ mapType }
-							options={ MAP_STYLE_OPTIONS }
-							onChange={ ( value ) =>
-								setAttributes( { mapType: value as MapType } )
-							}
-						/>
-						<ToggleControl
-							label={ __( 'Dynamic Loading', 'datamachine-events' ) }
-							help={ __(
-								'Fetch venues via REST API as the user pans/zooms instead of loading all at once.',
-								'datamachine-events',
-							) }
-							checked={ dynamic }
-							onChange={ ( value ) =>
-								setAttributes( { dynamic: value } )
-							}
-						/>
+					<SelectControl
+						label={ __( 'Map Style', 'datamachine-events' ) }
+						value={ mapType }
+						options={ MAP_STYLE_OPTIONS }
+						onChange={ ( value ) =>
+							setAttributes( { mapType: value as MapType } )
+						}
+					/>
 					</PanelBody>
 				</InspectorControls>
 

--- a/inc/Blocks/EventsMap/src/types.ts
+++ b/inc/Blocks/EventsMap/src/types.ts
@@ -49,7 +49,6 @@ export interface MapAttributes {
 	height: number;
 	zoom: number;
 	mapType: MapType;
-	dynamic: boolean;
 }
 
 /**
@@ -60,7 +59,6 @@ export interface MapProps {
 	height: number;
 	zoom: number;
 	mapType: MapType;
-	dynamic: boolean;
 	centerLat: number | null;
 	centerLon: number | null;
 	userLat: number | null;


### PR DESCRIPTION
## Summary

- Removes the static/dynamic mode distinction from the events-map block
- The map always fetches venues via REST API — no more embedded venue JSON
- Removes the "Dynamic Loading" toggle from the block editor
- Removes the `datamachine_events_map_venues` PHP filter (no static venues to filter)

## Why

With geo-sync (PR #60) the calendar syncs to the map viewport. But that only works when the map dispatches `datamachine-map-bounds-changed` on move/zoom AND re-fetches venues. In static mode the map dispatched events but didn't re-fetch — creating a mismatch where the calendar updates but the markers don't.

Having two modes added complexity:
- Plugins had to implement both PHP venue filters (static) AND REST endpoint support (dynamic)
- The near-me page needed a `render_block_data` hack to force dynamic mode
- The editor had a toggle that most users shouldn't need to think about

## What was removed

```
render.php:
- 70 lines of static venue loading (get_terms, coordinates parsing, JSON encoding)
- datamachine_events_map_venues filter (no longer has static venues to filter)
- data-dynamic attribute
- data-venues attribute

frontend.tsx:
- dynamic prop
- if(dynamic)/else branching in map init
- Venue JSON parsing from data attributes

types.ts:
- dynamic field from MapAttributes and MapProps

block.json:
- dynamic attribute definition

index.tsx:
- ToggleControl for "Dynamic Loading"
```

## What was kept

- Map center filter (`datamachine_events_map_center`) — still useful for setting initial view
- User location filter (`datamachine_events_map_user_location`) — blue dot marker
- Summary filter (`datamachine_events_map_summary`) — text below map
- After-summary action (`datamachine_events_map_after_summary`) — hook for controls
- Taxonomy/term context in data attributes — REST endpoint filters by these

## Breaking changes for extrachill-events

The `datamachine_events_map_venues` filter no longer fires. Need a companion PR:
- `location-map.php`: Remove `extrachill_events_filter_map_venues()` — the REST venue endpoint already supports taxonomy filtering via data attributes
- `near-me.php`: Remove `render_block_data` hack that forced dynamic mode

## Testing

1. Visit any page with an events-map block → map should fetch venues from REST
2. Location archive pages (`/austin/`) → map renders with taxonomy context, REST filters by venue taxonomy
3. Near-me page → works as before (was already dynamic)
4. Editor → no "Dynamic Loading" toggle, map preview unchanged
5. Pan/zoom → venues update, calendar syncs