### PR TITLE
Fix mobile map scroll trap and border-radius

### DIFF
--- a/inc/Blocks/EventsMap/src/frontend.css
+++ b/inc/Blocks/EventsMap/src/frontend.css
@@ -134,6 +134,34 @@ a.venue-popup-name:hover {
 	box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.4), 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 
+/* Map container — relative anchor for gesture overlay */
+.data-machine-events-map-container {
+	position: relative;
+}
+
+/* Gesture overlay — shown on touch devices on single-finger drag */
+.data-machine-events-map-gesture-overlay {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: rgba(0, 0, 0, 0.5);
+	color: #fff;
+	font-size: 0.875rem;
+	font-weight: 600;
+	pointer-events: none;
+	opacity: 0;
+	transition: opacity 0.3s ease;
+	z-index: 1000;
+	border-radius: inherit;
+}
+
+/* Touch devices: let browser own single-finger scroll */
+.data-machine-events-map.leaflet-touch-drag {
+	touch-action: pan-y !important;
+}
+
 /* Summary below map */
 .data-machine-events-map-summary {
 	margin: 0.5rem 0 0;
@@ -211,15 +239,11 @@ a.venue-popup-name:hover {
 	color: #dc2626;
 }
 
-/* Responsive */
+/* Responsive — map keeps rounded corners at all breakpoints.
+   The parent theme handles edge-to-edge padding; the map itself
+   should always retain its border-radius for visual consistency. */
 @media (max-width: 768px) {
 	.data-machine-events-map {
 		border-radius: var(--data-machine-border-radius, 8px);
-	}
-}
-
-@media (max-width: 480px) {
-	.data-machine-events-map {
-		border-radius: 0;
 	}
 }

--- a/inc/Blocks/EventsMap/src/frontend.tsx
+++ b/inc/Blocks/EventsMap/src/frontend.tsx
@@ -34,6 +34,11 @@ import './frontend.css';
 
 /* ---------- helpers ---------- */
 
+/** Detect touch-primary devices (phones/tablets). */
+function isTouchDevice(): boolean {
+	return 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+}
+
 function escapeHtml( text: string ): string {
 	const div = document.createElement( 'div' );
 	div.textContent = text;
@@ -262,6 +267,10 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 	const markersRef = useRef<L.Marker[]>( [] );
 	const userMarkerRef = useRef<L.Marker | null>( null );
 	const containerRef = useRef<HTMLDivElement | null>( null );
+	const gestureOverlayRef = useRef<HTMLDivElement | null>( null );
+	const gestureTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+		null,
+	);
 
 	const [ venues, setVenues ] = useState<Venue[]>( initialVenues );
 	const [ loading, setLoading ] = useState( false );
@@ -319,23 +328,60 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 			? venues[ 0 ].lon
 			: -97.7431;
 
+		const isTouch = isTouchDevice();
+
 		const map = L.map( el, {
 			scrollWheelZoom: false,
 			boxZoom: true,
+			// On touch devices: disable dragging so single-finger
+			// scrolls the page. Users pinch-zoom or use two fingers.
+			dragging: ! isTouch,
+			tap: ! isTouch,
 		} ).setView( [ initialLat, initialLon ], zoom );
 
-		// Ctrl/Cmd + scroll to zoom.
-		el.addEventListener(
-			'wheel',
-			( e: WheelEvent ) => {
-				if ( e.ctrlKey || e.metaKey ) {
-					e.preventDefault();
-					map.scrollWheelZoom.enable();
+		if ( isTouch ) {
+			// Show gesture hint when user tries single-finger drag.
+			const showGestureHint = () => {
+				const overlay = gestureOverlayRef.current;
+				if ( ! overlay ) return;
+
+				overlay.style.opacity = '1';
+
+				if ( gestureTimeoutRef.current ) {
+					clearTimeout( gestureTimeoutRef.current );
 				}
-			},
-			{ passive: false },
-		);
-		map.on( 'mouseout', () => map.scrollWheelZoom.disable() );
+				gestureTimeoutRef.current = setTimeout( () => {
+					overlay.style.opacity = '0';
+				}, 1500 );
+			};
+
+			el.addEventListener( 'touchstart', ( e: TouchEvent ) => {
+				if ( e.touches.length === 1 ) {
+					showGestureHint();
+				} else if ( e.touches.length >= 2 ) {
+					// Two-finger gesture — enable dragging temporarily.
+					map.dragging.enable();
+				}
+			}, { passive: true } );
+
+			el.addEventListener( 'touchend', () => {
+				// Re-disable dragging after gesture ends.
+				map.dragging.disable();
+			}, { passive: true } );
+		} else {
+			// Desktop: Ctrl/Cmd + scroll to zoom.
+			el.addEventListener(
+				'wheel',
+				( e: WheelEvent ) => {
+					if ( e.ctrlKey || e.metaKey ) {
+						e.preventDefault();
+						map.scrollWheelZoom.enable();
+					}
+				},
+				{ passive: false },
+			);
+			map.on( 'mouseout', () => map.scrollWheelZoom.disable() );
+		}
 
 		// Tile layer.
 		const tileUrl = TILE_URLS[ mapType ] || TILE_URLS[ 'osm-standard' ];
@@ -489,14 +535,23 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 
 	return (
 		<>
-			<div
-				id={ containerId }
-				ref={ containerRef }
-				className="data-machine-events-map"
-				style={ { height: `${ height }px` } }
-				aria-label="Events map"
-				role="application"
-			/>
+			<div className="data-machine-events-map-container">
+				<div
+					id={ containerId }
+					ref={ containerRef }
+					className="data-machine-events-map"
+					style={ { height: `${ height }px` } }
+					aria-label="Events map"
+					role="application"
+				/>
+				<div
+					ref={ gestureOverlayRef }
+					className="data-machine-events-map-gesture-overlay"
+					aria-hidden="true"
+				>
+					Use two fingers to move the map
+				</div>
+			</div>
 			{ showLocationSearch && geocodeUrl && (
 				<LocationSearch
 					geocodeUrl={ geocodeUrl }


### PR DESCRIPTION
## Summary

- **Scroll trap fix**: On touch devices, Leaflet's `dragging` is now disabled by default. Single-finger touch scrolls the page normally instead of panning the map. Two-finger gesture temporarily enables dragging for intentional map interaction.
- **Gesture hint overlay**: Shows "Use two fingers to move the map" message when user single-finger touches the map (fades after 1.5s). Same pattern as Google Maps embedded.
- **Border-radius fix**: Removed the `border-radius: 0` rule at 480px breakpoint — the map now keeps rounded corners at all screen sizes, matching the rest of the design system.
- **touch-action override**: CSS overrides Leaflet's `touch-action: none` with `pan-y` so the browser regains ownership of vertical scroll.

Fixes mobile UX issue where users couldn't scroll past the map on phones.