### PR TITLE
Fix user location blue dot race condition on Near Me page

### DIFF
--- a/inc/Blocks/EventsMap/src/frontend.tsx
+++ b/inc/Blocks/EventsMap/src/frontend.tsx
@@ -442,6 +442,46 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 		};
 	}, [] );
 
+	/* --- listen for external user-location updates (e.g. geolocation) --- */
+	useEffect( () => {
+		const handler = ( e: Event ) => {
+			const map = mapRef.current;
+			if ( ! map ) return;
+
+			const detail = ( e as CustomEvent< {
+				lat: number;
+				lng: number;
+			} > ).detail;
+
+			if ( ! detail?.lat || ! detail?.lng ) return;
+
+			// Remove old user marker if present.
+			if ( userMarkerRef.current ) {
+				map.removeLayer( userMarkerRef.current );
+			}
+
+			const icon = createUserLocationIcon();
+			const marker = L.marker( [ detail.lat, detail.lng ], { icon } )
+				.addTo( map )
+				.bindPopup(
+					'<div class="venue-popup"><span class="venue-popup-name">You are here</span></div>',
+				);
+
+			userMarkerRef.current = marker;
+		};
+
+		document.addEventListener(
+			'data-machine-map-set-user-location',
+			handler,
+		);
+		return () => {
+			document.removeEventListener(
+				'data-machine-map-set-user-location',
+				handler,
+			);
+		};
+	}, [] );
+
 	/* --- update markers when venues change --- */
 	useEffect( () => {
 		const map = mapRef.current;


### PR DESCRIPTION
## Summary

- Adds a `data-machine-map-set-user-location` custom event listener to the EventsMap React component
- When geolocation resolves after mount, near-me.js updates DOM `data-*` attributes — but React already read those as `null` during `parseMapProps()` and never re-reads them
- The new event allows external code to add/update the blue dot marker after the map has initialized, mirroring the existing `data-machine-map-recenter` pattern

## The Race Condition

```
1. Server renders HTML → data-user-lat="" (empty, no geo params)
2. React mounts → parseMapProps() reads null → hasUserLocation=false
3. Blue dot useEffect skips (null coords)
4. Map marked initialized="1"
5. Geolocation resolves → near-me.js sets data-user-lat on DOM
6. React never re-reads DOM attributes → blue dot never appears
```

The recenter event (step 5) moves the map correctly, but there was no equivalent event to add the blue dot. This PR adds one.

## Companion PR

- Extra-Chill/extrachill-events — dispatches the new event from near-me.js