### PR TITLE
fix: set producesBatchItems on event_import step type

### DIFF
--- a/inc/Steps/EventImport/EventImportStep.php
+++ b/inc/Steps/EventImport/EventImportStep.php
@@ -32,7 +32,8 @@ class EventImportStep extends Step {
 			class: self::class,
 			position: 25,
 			usesHandler: true,
-			hasPipelineConfig: false
+			hasPipelineConfig: false,
+			producesBatchItems: true
 		);
 	}
 


### PR DESCRIPTION
## Summary

Companion to Extra-Chill/data-machine#610.

- Sets `producesBatchItems: true` on the `event_import` step registration
- Required so the new batch gate in `ExecuteStepAbility` continues to fan out event imports into child jobs (one per event)
- Without this flag, event imports would advance inline instead of creating per-event child jobs

## Deploy Note

Must be deployed alongside or after data-machine#610. The `producesBatchItems` parameter is harmless if deployed before (it's just an unrecognized named argument that PHP ignores until the trait is updated).