### PR TITLE
ci: add split Homeboy build and audit workflow

### DIFF
--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           extensions: mbstring, intl, pdo_sqlite, mysqli
           tools: composer:v2
           coverage: none
@@ -53,7 +53,7 @@ jobs:
           auto-issue: ${{ github.event_name != 'pull_request' }}
           component: data-machine-events
           settings: '{"database_type": "mysql"}'
-          php-version: '8.2'
+          php-version: '8.3'
           node-version: '20'
 
   audit:
@@ -67,7 +67,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           extensions: mbstring, intl, pdo_sqlite, mysqli
           tools: composer:v2
           coverage: none
@@ -82,5 +82,5 @@ jobs:
           commands: audit
           auto-issue: ${{ github.event_name != 'pull_request' }}
           component: data-machine-events
-          php-version: '8.2'
+          php-version: '8.3'
           node-version: '20'


### PR DESCRIPTION
## Summary
- add a new Homeboy CI workflow for `data-machine-events`
- split checks into two independent jobs:
  - **build**: `lint,test`
  - **audit**: `audit`
- run on both PRs and pushes to `main`
- enable `auto-issue` on non-PR runs (`push`), disabled on PRs

## Why
This mirrors the emerging Homeboy CI pattern: fast code-quality/build signal separate from architecture drift audit signal, while still enabling full-suite monitoring and issue filing on main branch runs.

## Notes
- test scope is currently `full` for stability while Homeboy test changed-since support is tracked upstream: https://github.com/Extra-Chill/homeboy/issues/483