### PR TITLE
fix: align named argument class → class_name for PHP 8 compatibility

### DIFF
--- a/inc/Steps/EventImport/EventImportStep.php
+++ b/inc/Steps/EventImport/EventImportStep.php
@@ -29,7 +29,7 @@ class EventImportStep extends Step {
 			slug: 'event_import',
 			label: 'Event Import',
 			description: 'Import events from venues and ticketing platforms',
-			class: self::class,
+			class_name: self::class,
 			position: 25,
 			usesHandler: true,
 			hasPipelineConfig: false


### PR DESCRIPTION
## Summary

The `StepTypeRegistrationTrait::registerStepType()` parameter was renamed from `$class` to `$class_name` in data-machine commit `fe240d7f`, but this caller still used `class:` as a named argument — which is a reserved word in PHP 8.

This caused a fatal error on the events site after the latest data-machine deploy:

```
Fatal error: Uncaught Error: Unknown named parameter $class in EventImportStep.php:32
```

One-character fix: `class:` → `class_name:`.