### PR TITLE
fix: update registerTool() calls for Data Machine 0.39.0 compatibility

### DIFF
--- a/inc/Api/Chat/Tools/EventHealthCheck.php
+++ b/inc/Api/Chat/Tools/EventHealthCheck.php
@@ -21,7 +21,7 @@ use DataMachineEvents\Abilities\EventHealthAbilities;
 class EventHealthCheck extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'event_health_check', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'event_health_check', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Api/Chat/Tools/FindBrokenTimezoneEvents.php
+++ b/inc/Api/Chat/Tools/FindBrokenTimezoneEvents.php
@@ -20,7 +20,7 @@ use DataMachineEvents\Abilities\TimezoneAbilities;
 class FindBrokenTimezoneEvents extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'find_broken_timezone_events', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'find_broken_timezone_events', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Api/Chat/Tools/FixEventTimezone.php
+++ b/inc/Api/Chat/Tools/FixEventTimezone.php
@@ -20,7 +20,7 @@ use DataMachineEvents\Abilities\TimezoneAbilities;
 class FixEventTimezone extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'fix_event_timezone', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'fix_event_timezone', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Api/Chat/Tools/GetVenueEvents.php
+++ b/inc/Api/Chat/Tools/GetVenueEvents.php
@@ -20,7 +20,7 @@ use DataMachineEvents\Abilities\EventQueryAbilities;
 class GetVenueEvents extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'get_venue_events', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'get_venue_events', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Api/Chat/Tools/TestEventScraper.php
+++ b/inc/Api/Chat/Tools/TestEventScraper.php
@@ -20,7 +20,7 @@ use DataMachineEvents\Abilities\EventScraperTest;
 class TestEventScraper extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'test_event_scraper', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'test_event_scraper', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Api/Chat/Tools/UpdateEvent.php
+++ b/inc/Api/Chat/Tools/UpdateEvent.php
@@ -21,7 +21,7 @@ use DataMachineEvents\Abilities\EventUpdateAbilities;
 class UpdateEvent extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'update_event', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'update_event', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Api/Chat/Tools/UpdateVenue.php
+++ b/inc/Api/Chat/Tools/UpdateVenue.php
@@ -20,7 +20,7 @@ use DataMachineEvents\Abilities\VenueAbilities;
 class UpdateVenue extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'update_venue', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'update_venue', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Api/Chat/Tools/VenueHealthCheck.php
+++ b/inc/Api/Chat/Tools/VenueHealthCheck.php
@@ -21,7 +21,7 @@ use DataMachineEvents\Abilities\VenueAbilities;
 class VenueHealthCheck extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'chat', 'venue_health_check', array( $this, 'getToolDefinition' ) );
+		$this->registerTool( 'venue_health_check', array( $this, 'getToolDefinition' ), array( 'chat' ) );
 	}
 
 	public function getToolDefinition(): array {


### PR DESCRIPTION
## Summary

- **Updates all 8 chat tools** in `inc/Api/Chat/Tools/` to use the new `BaseTool::registerTool()` signature from Data Machine 0.39.0
- Old: `registerTool(string $context, string $toolName, callable $toolDefinition)`
- New: `registerTool(string $toolName, callable|array $toolDefinition, array $contexts = [])`

## Files Changed

| Tool | Status |
|------|--------|
| EventHealthCheck | ✅ |
| FindBrokenTimezoneEvents | ✅ |
| FixEventTimezone | ✅ |
| GetVenueEvents | ✅ |
| TestEventScraper | ✅ |
| UpdateEvent | ✅ |
| UpdateVenue | ✅ |
| VenueHealthCheck | ✅ |

All 8 files pass `php -l` syntax check. Mirrors the same fix applied to `data-machine-socials` in PR #54.