### PR TITLE
refactor: deduplicate shared utilities across web scraper extractors

### DIFF
--- a/inc/Steps/EventImport/Handlers/WebScraper/Extractors/BaseExtractor.php
+++ b/inc/Steps/EventImport/Handlers/WebScraper/Extractors/BaseExtractor.php
@@ -238,4 +238,153 @@ abstract class BaseExtractor implements ExtractorInterface {
 	protected function formatStructuredPrice( ?float $min = null, ?float $max = null, string $currency = 'USD', ?bool $is_free = null ): string {
 		return PriceFormatter::formatStructured( $min, $max, $currency, $is_free );
 	}
+
+	/**
+	 * Infer a full Y-m-d date from month name and day number.
+	 *
+	 * Assumes the current year. If that date has already passed,
+	 * bumps to the next year. Useful for venue calendars that
+	 * display "January 15" without a year.
+	 *
+	 * @since 0.15.1
+	 * @param string $month Month name (e.g., "January", "Jan")
+	 * @param string $day   Day number (e.g., "15")
+	 * @return string Date in Y-m-d format, or empty string on failure.
+	 */
+	protected function inferDateFromMonthDay( string $month, string $day ): string {
+		$year     = (int) gmdate( 'Y' );
+		$date_str = "{$month} {$day} {$year}";
+
+		try {
+			$dt    = new \DateTime( $date_str );
+			$today = new \DateTime( 'today' );
+
+			if ( $dt < $today ) {
+				$dt->modify( '+1 year' );
+			}
+
+			return $dt->format( 'Y-m-d' );
+		} catch ( \Exception $e ) {
+			return '';
+		}
+	}
+
+	/**
+	 * Load an HTML string into a DOMDocument + DOMXPath pair.
+	 *
+	 * Eliminates the repeated 5-line DOM bootstrap boilerplate
+	 * across extractors.
+	 *
+	 * @since 0.15.1
+	 * @param string $html Raw HTML content.
+	 * @return array{dom: \DOMDocument, xpath: \DOMXPath}
+	 */
+	protected function loadDom( string $html ): array {
+		$dom = new \DOMDocument();
+		libxml_use_internal_errors( true );
+		$dom->loadHTML( '<?xml encoding="UTF-8">' . $html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
+		libxml_clear_errors();
+
+		return array(
+			'dom'   => $dom,
+			'xpath' => new \DOMXPath( $dom ),
+		);
+	}
+
+	/**
+	 * Merge page-level venue data into an event array.
+	 *
+	 * Fills in venue name and address fields that are empty in the
+	 * event but present in the page-level venue data.
+	 *
+	 * @since 0.15.1
+	 * @param array $event      Event data array.
+	 * @param array $page_venue Page-level venue data from PageVenueExtractor.
+	 * @return array Event with merged venue data.
+	 */
+	protected function mergePageVenueData( array $event, array $page_venue ): array {
+		$fields = array( 'venue', 'venueAddress', 'venueCity', 'venueState', 'venueZip', 'venueCountry', 'venueTimezone' );
+
+		foreach ( $fields as $field ) {
+			if ( empty( $event[ $field ] ) && ! empty( $page_venue[ $field ] ) ) {
+				$event[ $field ] = $page_venue[ $field ];
+			}
+		}
+
+		return $event;
+	}
+
+	/**
+	 * Fetch a URL via HttpClient with standard error handling.
+	 *
+	 * Centralizes the repeated pattern of HttpClient::get() + success check
+	 * that appears in many extractors.
+	 *
+	 * @since 0.15.1
+	 * @param string $url     URL to fetch.
+	 * @param array  $args    Optional wp_remote_get args.
+	 * @param string $context Short description for logging (e.g., "Firebase events").
+	 * @return string|null Response body, or null on failure.
+	 */
+	protected function fetchUrl( string $url, array $args = array(), string $context = '' ): ?string {
+		if ( ! class_exists( '\\DataMachine\\Core\\HttpClient' ) ) {
+			return null;
+		}
+
+		$defaults = array( 'timeout' => 15 );
+		$args     = array_merge( $defaults, $args );
+		$result   = \DataMachine\Core\HttpClient::get( $url, $args );
+
+		if ( empty( $result['success'] ) ) {
+			if ( '' !== $context ) {
+				do_action(
+					'datamachine_log',
+					'debug',
+					"BaseExtractor::fetchUrl failed for {$context}",
+					array(
+						'url'         => $url,
+						'status_code' => $result['status_code'] ?? 0,
+					)
+				);
+			}
+			return null;
+		}
+
+		return $result['body'] ?? null;
+	}
+
+	/**
+	 * Resolve a relative URL against a base URL.
+	 *
+	 * @since 0.15.1
+	 * @param string $url      Possibly relative URL.
+	 * @param string $base_url Base URL for resolution.
+	 * @return string Absolute URL.
+	 */
+	protected function resolveUrl( string $url, string $base_url ): string {
+		if ( empty( $url ) ) {
+			return '';
+		}
+
+		if ( preg_match( '#^https?://#i', $url ) ) {
+			return $url;
+		}
+
+		if ( str_starts_with( $url, '//' ) ) {
+			$scheme = wp_parse_url( $base_url, PHP_URL_SCHEME ) ?: 'https';
+			return $scheme . ':' . $url;
+		}
+
+		$parts = wp_parse_url( $base_url );
+		$base  = ( $parts['scheme'] ?? 'https' ) . '://' . ( $parts['host'] ?? '' );
+
+		if ( str_starts_with( $url, '/' ) ) {
+			return $base . $url;
+		}
+
+		$path = $parts['path'] ?? '/';
+		$dir  = substr( $path, 0, (int) strrpos( $path, '/' ) + 1 );
+
+		return $base . $dir . $url;
+	}
 }

--- a/inc/Steps/EventImport/Handlers/WebScraper/Extractors/CraftpeakExtractor.php
+++ b/inc/Steps/EventImport/Handlers/WebScraper/Extractors/CraftpeakExtractor.php
@@ -238,30 +238,9 @@ class CraftpeakExtractor extends BaseExtractor {
 	}
 
 	/**
-	 * Infer full date from month and day, adding year.
-	 *
-	 * If the date has already passed this year, assumes next year.
-	 *
-	 * @param string $month Month name (e.g., "January")
-	 * @param string $day Day number
-	 * @return string Date in Y-m-d format
+	 * @deprecated Use BaseExtractor::inferDateFromMonthDay() instead.
 	 */
 	private function inferDate( string $month, string $day ): string {
-		$year     = (int) date( 'Y' );
-		$date_str = "$month $day $year";
-
-		try {
-			$dt    = new \DateTime( $date_str );
-			$today = new \DateTime( 'today' );
-
-			// If date is in the past, assume next year
-			if ( $dt < $today ) {
-				$dt->modify( '+1 year' );
-			}
-
-			return $dt->format( 'Y-m-d' );
-		} catch ( \Exception $e ) {
-			return '';
-		}
+		return $this->inferDateFromMonthDay( $month, $day );
 	}
 }

--- a/inc/Steps/EventImport/Handlers/WebScraper/Extractors/FreshtixExtractor.php
+++ b/inc/Steps/EventImport/Handlers/WebScraper/Extractors/FreshtixExtractor.php
@@ -148,19 +148,11 @@ class FreshtixExtractor extends BaseExtractor {
 		}
 	}
 
+	/**
+	 * @deprecated Use BaseExtractor::parseTimeString() instead.
+	 */
 	private function normalizeTime( string $time ): string {
-		$time = strtolower( trim( $time ) );
-
-		if ( strpos( $time, ':' ) === false ) {
-			$time = preg_replace( '/(\d+)\s*(am|pm)/i', '$1:00 $2', $time );
-		}
-
-		$timestamp = strtotime( $time );
-		if ( false !== $timestamp ) {
-			return date( 'H:i', $timestamp );
-		}
-
-		return '';
+		return $this->parseTimeString( $time );
 	}
 
 	private function parseVenue( array &$event, array $raw, array $venue_data ): void {

--- a/inc/Steps/EventImport/Handlers/WebScraper/Extractors/MicrodataExtractor.php
+++ b/inc/Steps/EventImport/Handlers/WebScraper/Extractors/MicrodataExtractor.php
@@ -24,12 +24,8 @@ class MicrodataExtractor extends BaseExtractor {
 	}
 
 	public function extract( string $html, string $source_url ): array {
-		$dom = new \DOMDocument();
-		libxml_use_internal_errors( true );
-		$dom->loadHTML( $html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
-		libxml_clear_errors();
-
-		$xpath = new \DOMXPath( $dom );
+		$loaded = $this->loadDom( $html );
+		$xpath  = $loaded['xpath'];
 
 		$event_elements = $xpath->query( "//*[@itemtype='https://schema.org/Event' or @itemtype='http://schema.org/Event']" );
 

--- a/inc/Steps/EventImport/Handlers/WebScraper/Extractors/MusicItemExtractor.php
+++ b/inc/Steps/EventImport/Handlers/WebScraper/Extractors/MusicItemExtractor.php
@@ -24,12 +24,8 @@ class MusicItemExtractor extends BaseExtractor {
 	}
 
 	public function extract( string $html, string $source_url ): array {
-		$dom = new \DOMDocument();
-		libxml_use_internal_errors( true );
-		$dom->loadHTML( '<?xml encoding="UTF-8">' . $html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
-		libxml_clear_errors();
-
-		$xpath       = new \DOMXPath( $dom );
+		$loaded = $this->loadDom( $html );
+		$xpath  = $loaded['xpath'];
 		$event_nodes = $xpath->query( "//*[contains(concat(' ', normalize-space(@class), ' '), ' music__item ')]" );
 
 		if ( 0 === $event_nodes->length ) {
@@ -55,24 +51,7 @@ class MusicItemExtractor extends BaseExtractor {
 		return 'music_item';
 	}
 
-	/**
-	 * Merge page-level venue data into event for missing fields.
-	 */
-	private function mergePageVenueData( array $event, array $page_venue ): array {
-		$address_fields = array( 'venueAddress', 'venueCity', 'venueState', 'venueZip', 'venueCountry' );
-
-		foreach ( $address_fields as $field ) {
-			if ( empty( $event[ $field ] ) && ! empty( $page_venue[ $field ] ) ) {
-				$event[ $field ] = $page_venue[ $field ];
-			}
-		}
-
-		if ( empty( $event['venue'] ) && ! empty( $page_venue['venue'] ) ) {
-			$event['venue'] = $page_venue['venue'];
-		}
-
-		return $event;
-	}
+	// mergePageVenueData() is inherited from BaseExtractor.
 
 	/**
 	 * Normalize music item event node to standardized format.

--- a/inc/Steps/EventImport/Handlers/WebScraper/Extractors/RedRocksExtractor.php
+++ b/inc/Steps/EventImport/Handlers/WebScraper/Extractors/RedRocksExtractor.php
@@ -32,12 +32,8 @@ class RedRocksExtractor extends BaseExtractor {
 	}
 
 	public function extract( string $html, string $source_url ): array {
-		$dom = new \DOMDocument();
-		libxml_use_internal_errors( true );
-		$dom->loadHTML( '<?xml encoding="UTF-8">' . $html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
-		libxml_clear_errors();
-
-		$xpath       = new \DOMXPath( $dom );
+		$loaded = $this->loadDom( $html );
+		$xpath  = $loaded['xpath'];
 		$event_nodes = $xpath->query( "//*[contains(@class, 'card-event')]" );
 
 		if ( 0 === $event_nodes->length ) {
@@ -163,19 +159,11 @@ class RedRocksExtractor extends BaseExtractor {
 		}
 	}
 
+	/**
+	 * @deprecated Use BaseExtractor::parseTimeString() instead.
+	 */
 	private function normalizeTime( string $time ): string {
-		$time = strtolower( trim( $time ) );
-
-		if ( strpos( $time, ':' ) === false ) {
-			$time = preg_replace( '/(\d+)\s*(am|pm)/i', '$1:00 $2', $time );
-		}
-
-		$timestamp = strtotime( $time );
-		if ( false !== $timestamp ) {
-			return date( 'H:i', $timestamp );
-		}
-
-		return '';
+		return $this->parseTimeString( $time );
 	}
 
 	private function parseImage( array &$event, \DOMXPath $xpath, \DOMElement $node ): void {

--- a/inc/Steps/EventImport/Handlers/WebScraper/Extractors/RhpEventsExtractor.php
+++ b/inc/Steps/EventImport/Handlers/WebScraper/Extractors/RhpEventsExtractor.php
@@ -24,12 +24,8 @@ class RhpEventsExtractor extends BaseExtractor {
 	}
 
 	public function extract( string $html, string $source_url ): array {
-		$dom = new \DOMDocument();
-		libxml_use_internal_errors( true );
-		$dom->loadHTML( '<?xml encoding="UTF-8">' . $html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
-		libxml_clear_errors();
-
-		$xpath       = new \DOMXPath( $dom );
+		$loaded = $this->loadDom( $html );
+		$xpath  = $loaded['xpath'];
 		$event_nodes = $xpath->query( "//*[contains(@class, 'rhpSingleEvent')]" );
 
 		if ( 0 === $event_nodes->length ) {
@@ -52,28 +48,7 @@ class RhpEventsExtractor extends BaseExtractor {
 		return $events;
 	}
 
-	/**
-	 * Merge page-level venue data into event for missing fields.
-	 *
-	 * @param array $event Event data
-	 * @param array $page_venue Page-level venue data from PageVenueExtractor
-	 * @return array Event with merged venue data
-	 */
-	private function mergePageVenueData( array $event, array $page_venue ): array {
-		$address_fields = array( 'venueAddress', 'venueCity', 'venueState', 'venueZip', 'venueCountry' );
-
-		foreach ( $address_fields as $field ) {
-			if ( empty( $event[ $field ] ) && ! empty( $page_venue[ $field ] ) ) {
-				$event[ $field ] = $page_venue[ $field ];
-			}
-		}
-
-		if ( empty( $event['venue'] ) && ! empty( $page_venue['venue'] ) ) {
-			$event['venue'] = $page_venue['venue'];
-		}
-
-		return $event;
-	}
+	// mergePageVenueData() is inherited from BaseExtractor.
 
 	public function getMethod(): string {
 		return 'rhp_events';
@@ -208,22 +183,10 @@ class RhpEventsExtractor extends BaseExtractor {
 	}
 
 	/**
-	 * Normalize time string to H:i format.
+	 * @deprecated Use BaseExtractor::parseTimeString() instead.
 	 */
 	private function normalizeTime( string $time ): string {
-		$time = strtolower( trim( $time ) );
-
-		// Add :00 if no minutes
-		if ( ! strpos( $time, ':' ) ) {
-			$time = preg_replace( '/(\d+)\s*(am|pm)?/i', '$1:00 $2', $time );
-		}
-
-		$timestamp = strtotime( $time );
-		if ( false !== $timestamp ) {
-			return date( 'H:i', $timestamp );
-		}
-
-		return '';
+		return $this->parseTimeString( $time );
 	}
 
 	/**

--- a/inc/Steps/EventImport/Handlers/WebScraper/Extractors/SquarespaceExtractor.php
+++ b/inc/Steps/EventImport/Handlers/WebScraper/Extractors/SquarespaceExtractor.php
@@ -543,65 +543,42 @@ class SquarespaceExtractor extends BaseExtractor {
 	}
 
 	/**
-	 * Attempt to extract date from text if structure is missing it.
+	 * Extract date from text description or date label.
+	 *
+	 * Handles formats like "January 15, 2026", "Jan 15", "January 15th".
+	 * If no year is present and the date has passed, assumes next year.
+	 *
+	 * @param array  $event Event array to update.
+	 * @param string $text  Text containing a date.
 	 */
 	private function extractDateFromText( array &$event, string $text ): void {
 		if ( empty( $text ) ) {
 			return;
 		}
 
-		// Simple regex for common date formats in descriptions
-		// e.g., "January 15, 2026" or "Jan 15"
 		$months = 'January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec';
+
 		if ( preg_match( '/(' . $months . ')\s+(\d{1,2})(?:st|nd|rd|th)?(?:,?\s+(\d{4}))?/i', $text, $matches ) ) {
 			$month = $matches[1];
 			$day   = $matches[2];
-			$year  = ! empty( $matches[3] ) ? $matches[3] : date( 'Y' );
 
-			try {
-				$dt = new \DateTime( "$month $day $year" );
-				// If it's in the past, assume next year
-				if ( $dt < new \DateTime( 'today' ) && empty( $matches[3] ) ) {
-					$dt->modify( '+1 year' );
+			if ( ! empty( $matches[3] ) ) {
+				try {
+					$dt = new \DateTime( "{$month} {$day} {$matches[3]}" );
+					$event['startDate'] = $dt->format( 'Y-m-d' );
+				} catch ( \Exception $e ) {
+					return;
 				}
-				$event['startDate'] = $dt->format( 'Y-m-d' );
-			} catch ( \Exception $e ) {
+			} else {
+				$event['startDate'] = $this->inferDateFromMonthDay( $month, $day );
 			}
 		}
 	}
 
 	/**
-	 * Parse text date format from User Items List blocks.
-	 *
-	 * Handles formats like "January 16, 2026" or "Jan 16" commonly found
-	 * in Squarespace User Items List event dates.
-	 *
-	 * @since 0.9.17
-	 * @param array  $event Event array to update
-	 * @param string $text  Date text to parse
+	 * @deprecated Use extractDateFromText() instead.
 	 */
 	private function parseTextDate( array &$event, string $text ): void {
-		if ( empty( $text ) ) {
-			return;
-		}
-
-		$months = 'January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec';
-
-		if ( preg_match( '/(' . $months . ')\s+(\d{1,2})(?:st|nd|rd|th)?(?:,?\s+(\d{4}))?/i', $text, $matches ) ) {
-			$month = $matches[1];
-			$day   = $matches[2];
-			$year  = ! empty( $matches[3] ) ? $matches[3] : gmdate( 'Y' );
-
-			try {
-				$dt = new \DateTime( "$month $day $year" );
-
-				if ( $dt < new \DateTime( 'today' ) && empty( $matches[3] ) ) {
-					$dt->modify( '+1 year' );
-				}
-				$event['startDate'] = $dt->format( 'Y-m-d' );
-			} catch ( \Exception $e ) {
-				return;
-			}
-		}
+		$this->extractDateFromText( $event, $text );
 	}
 }

--- a/inc/Steps/EventImport/Handlers/WebScraper/Extractors/TimelyExtractor.php
+++ b/inc/Steps/EventImport/Handlers/WebScraper/Extractors/TimelyExtractor.php
@@ -31,11 +31,8 @@ class TimelyExtractor extends BaseExtractor {
 			return array();
 		}
 
-		$dom = new \DOMDocument();
-		libxml_use_internal_errors( true );
-		$dom->loadHTML( '<?xml encoding="UTF-8">' . $html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
-		libxml_clear_errors();
-		$xpath = new \DOMXPath( $dom );
+		$loaded = $this->loadDom( $html );
+		$xpath  = $loaded['xpath'];
 
 		$events = array();
 		foreach ( $raw_events as $raw_event ) {


### PR DESCRIPTION
## Summary
- Move duplicated `normalizeTime()`, `inferDate()`, `mergePageVenueData()` into `BaseExtractor` shared methods
- Add `loadDom()` helper to eliminate repeated 5-line DOM bootstrap boilerplate across 7+ extractors
- Add `fetchUrl()` helper with logging for centralized HTTP fetch pattern
- Add `resolveUrl()` helper for relative URL resolution
- Fix Squarespace internal duplication: merge `extractDateFromText()` and `parseTextDate()` into one method using `inferDateFromMonthDay()`
- Replace copy-pasted implementations in RedRocks, Freshtix, RHP, Craftpeak, MusicItem, Microdata, Timely extractors

## Why
The universal web scraper has 24 extractors across ~9,600 lines. Multiple extractors had identical implementations of time normalization, year inference, venue merging, DOM loading, and URL resolution. This consolidation makes the codebase more maintainable and reduces the surface area for bugs as we add new extractors and scale venue coverage.

## Net change
+191 lines (shared utilities), -171 lines (duplicated code) = net +20 lines