### PR TITLE
Fix multi-day event display and sort order

### DIFF
--- a/inc/Blocks/Calendar/Display/DisplayVars.php
+++ b/inc/Blocks/Calendar/Display/DisplayVars.php
@@ -47,14 +47,15 @@ class DisplayVars {
 			$is_multi_day    = ! empty( $display_context['is_multi_day'] );
 			$is_continuation = ! empty( $display_context['is_continuation'] );
 
+			$has_real_start_time = ! self::is_sentinel_start_time( $start_time );
+
 			if ( $is_multi_day && ! empty( $end_date ) ) {
 				$end_datetime_obj = new DateTime( $end_date, $event_tz );
 
 				if ( $is_continuation ) {
 					$formatted_time_display = sprintf(
-						/* translators: 1: start date, 2: end date. Example: "Feb 27 – Mar 1" */
-						__( '%1$s – %2$s', 'data-machine-events' ),
-						$start_datetime_obj->format( 'M j' ),
+						/* translators: %s: end date. Example: "Ongoing · ends Mar 22" */
+						__( 'Ongoing · ends %s', 'data-machine-events' ),
 						$end_datetime_obj->format( 'M j' )
 					);
 				} else {
@@ -62,9 +63,11 @@ class DisplayVars {
 						__( 'through %s', 'data-machine-events' ),
 						$end_datetime_obj->format( 'M j' )
 					);
-					$formatted_time_display = self::format_time_range( $start_datetime_obj, $end_date, $end_time, $event_tz );
+					if ( $has_real_start_time ) {
+						$formatted_time_display = self::format_time_range( $start_datetime_obj, $end_date, $end_time, $event_tz );
+					}
 				}
-			} else {
+			} elseif ( $has_real_start_time ) {
 				$formatted_time_display = self::format_time_range( $start_datetime_obj, $end_date, $end_time, $event_tz );
 			}
 		}
@@ -134,6 +137,23 @@ class DisplayVars {
 	public static function is_sentinel_end_time( string $time ): bool {
 		$normalized = substr( $time, 0, 5 );
 		return '23:59' === $normalized;
+	}
+
+	/**
+	 * Check if start time is the sentinel value indicating no real time was provided.
+	 *
+	 * When events have no startTime, meta-storage.php stores 00:00:00 as the default.
+	 * This should not display as "12:00 AM" to users.
+	 *
+	 * @param string $time Time string in HH:MM or HH:MM:SS format.
+	 * @return bool True if time is the 00:00 sentinel value or empty.
+	 */
+	public static function is_sentinel_start_time( string $time ): bool {
+		if ( empty( $time ) ) {
+			return true;
+		}
+		$normalized = substr( $time, 0, 5 );
+		return '00:00' === $normalized;
 	}
 
 	/**

--- a/inc/Blocks/Calendar/Grouping/DateGrouper.php
+++ b/inc/Blocks/Calendar/Grouping/DateGrouper.php
@@ -154,6 +154,34 @@ class DateGrouper {
 			}
 		}
 
+		// Default sort: continuation events (multi-day events on non-start days)
+		// sort after non-continuation events within each day group. This ensures
+		// events actually starting today appear before ongoing multi-day events.
+		foreach ( $date_groups as $date_key => &$date_group ) {
+			usort(
+				$date_group['events'],
+				function ( $a, $b ) {
+					$a_continuation = ! empty( $a['display_context']['is_continuation'] );
+					$b_continuation = ! empty( $b['display_context']['is_continuation'] );
+
+					if ( $a_continuation !== $b_continuation ) {
+						return $a_continuation ? 1 : -1;
+					}
+
+					// Within the same tier, maintain datetime order.
+					$a_time = $a['datetime'] ?? null;
+					$b_time = $b['datetime'] ?? null;
+
+					if ( $a_time && $b_time ) {
+						return $a_time <=> $b_time;
+					}
+
+					return 0;
+				}
+			);
+		}
+		unset( $date_group );
+
 		// Allow reordering events within each day group.
 		foreach ( $date_groups as $date_key => &$date_group ) {
 			$date_group['events'] = apply_filters(


### PR DESCRIPTION
## Summary
- Continuation events (multi-day events on non-start days) now sort to the **bottom** of each day group instead of the top — events happening today appear first in the carousel
- Continuation display changed from stale date range "Mar 12 – Mar 22" to **"Ongoing · ends Mar 22"** — clearer on later days
- Added sentinel start time detection (`00:00:00`) to suppress displaying "12:00 AM" for events with no real start time

## Problem
Multi-day events like "Spring Break Boogie 15" (Mar 12-22) were:
1. Sorting to the top of every day's carousel because their original start datetime was earliest
2. Showing "Mar 12 – Mar 22" as a date range on continuation days, which is confusing when browsing March 18th
3. Events with no real time showed "12:00 AM"

## Changes
- `DisplayVars.php` — continuation display now shows "Ongoing · ends {date}", sentinel start time check suppresses fake times
- `DateGrouper.php` — default sort pushes continuation events after non-continuation events within each day group

## Companion PR
- Extra-Chill/extrachill-events — priority venue sort updated to respect continuation ordering

## Live
Already deployed and verified on events.extrachill.com