### PR TITLE
feat: default max_items to unlimited for event import handlers

### DIFF
--- a/inc/Steps/EventImport/Handlers/EventImportHandler.php
+++ b/inc/Steps/EventImport/Handlers/EventImportHandler.php
@@ -50,6 +50,21 @@ abstract class EventImportHandler extends FetchHandler {
 		parent::__construct( $handler_type );
 	}
 
+	/**
+	 * Event import handlers default to unlimited items per run.
+	 *
+	 * Structured event scrapers produce clean, deduped data that is
+	 * cheap to process. The base FetchHandler default of 1 is too
+	 * conservative for event import — it causes most fetched events
+	 * to be discarded after dedup. Individual flows can still set
+	 * max_items in their handler config to override.
+	 *
+	 * @return int 0 = unlimited.
+	 */
+	protected function getDefaultMaxItems(): int {
+		return 0;
+	}
+
 	protected function sanitizeText( string $text ): string {
 		return sanitize_text_field( trim( $text ) );
 	}


### PR DESCRIPTION
## Summary
- Overrides `getDefaultMaxItems()` in `EventImportHandler` to return `0` (unlimited)
- All event scrapers (universal_web_scraper, ticketmaster, dice_fm) now process every new event per run instead of just 1

## Why
The inherited default of 1 item per run was silently discarding most fetched events. With the dedup fix in data-machine v0.45.0, uncapped items no longer get burned — but they still get throttled to 1 per cycle. This removes the throttle for event import specifically.

## Requires
data-machine PR adding `getDefaultMaxItems()` override point.