### PR TITLE
fix: MusicItemExtractor::resolveUrl() visibility must match parent

### DIFF
--- a/inc/Steps/EventImport/Handlers/WebScraper/Extractors/MusicItemExtractor.php
+++ b/inc/Steps/EventImport/Handlers/WebScraper/Extractors/MusicItemExtractor.php
@@ -208,7 +208,7 @@ class MusicItemExtractor extends BaseExtractor {
 	/**
 	 * Resolve relative URL to absolute.
 	 */
-	private function resolveUrl( string $url, string $source_url ): string {
+	protected function resolveUrl( string $url, string $source_url ): string {
 		if ( strpos( $url, 'http' ) === 0 ) {
 			return esc_url_raw( $url );
 		}


### PR DESCRIPTION
One-line fix — parent has `protected`, child had `private`. PHP fatal on load.