### PR TITLE
fix: harden cross-source dedup + clean-duplicates CLI

### DIFF
--- a/data-machine-events.php
+++ b/data-machine-events.php
@@ -83,6 +83,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	\WP_CLI::add_command( 'data-machine-events check meta-sync', \DataMachineEvents\Cli\Check\CheckMetaSyncCommand::class );
 	\WP_CLI::add_command( 'data-machine-events check duration', \DataMachineEvents\Cli\Check\CheckDurationCommand::class );
 	\WP_CLI::add_command( 'data-machine-events check duplicates', \DataMachineEvents\Cli\Check\CheckDuplicatesCommand::class );
+	\WP_CLI::add_command( 'data-machine-events check clean-duplicates', \DataMachineEvents\Cli\Check\CleanDuplicatesCommand::class );
 	\WP_CLI::add_command( 'data-machine-events check quality', \DataMachineEvents\Cli\Check\CheckQualityCommand::class );
 	\WP_CLI::add_command( 'data-machine-events check all', \DataMachineEvents\Cli\Check\CheckAllCommand::class );
 }

--- a/inc/Cli/Check/CleanDuplicatesCommand.php
+++ b/inc/Cli/Check/CleanDuplicatesCommand.php
@@ -1,0 +1,245 @@
+<?php
+/**
+ * Clean duplicate events by trashing the newer copy.
+ *
+ * Uses the same detection logic as CheckDuplicatesCommand, then for each
+ * duplicate pair keeps the older post and trashes the newer one. Optionally
+ * merges ticket URL from the trashed post into the kept post.
+ *
+ * @package DataMachineEvents\Cli\Check
+ * @since   0.16.2
+ */
+
+namespace DataMachineEvents\Cli\Check;
+
+use DataMachineEvents\Core\Event_Post_Type;
+use DataMachineEvents\Utilities\EventIdentifierGenerator;
+use const DataMachineEvents\Core\EVENT_TICKET_URL_META_KEY;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class CleanDuplicatesCommand {
+
+	use EventQueryTrait;
+
+	/**
+	 * Clean duplicate events by trashing the newer copy.
+	 *
+	 * Scans for duplicate events using fuzzy title + venue matching, keeps
+	 * the older post (more link equity), and trashes the newer one. If the
+	 * trashed post has a ticket URL that the kept post lacks, it is copied over.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--scope=<scope>]
+	 * : Which events to scan.
+	 * ---
+	 * default: all
+	 * options:
+	 *   - upcoming
+	 *   - past
+	 *   - all
+	 * ---
+	 *
+	 * [--days-ahead=<days>]
+	 * : Days to look ahead for upcoming scope.
+	 * ---
+	 * default: 90
+	 * ---
+	 *
+	 * [--dry-run]
+	 * : Show what would be cleaned without actually trashing.
+	 *
+	 * [--yes]
+	 * : Skip confirmation prompt.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp data-machine-events check clean-duplicates --dry-run
+	 *     wp data-machine-events check clean-duplicates --scope=upcoming --yes
+	 *     wp data-machine-events check clean-duplicates --scope=all --yes
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Named arguments.
+	 */
+	public function __invoke( array $args, array $assoc_args ): void {
+		$scope      = $assoc_args['scope'] ?? 'all';
+		$days_ahead = (int) ( $assoc_args['days-ahead'] ?? 90 );
+		$dry_run    = isset( $assoc_args['dry-run'] );
+		$skip_confirm = isset( $assoc_args['yes'] );
+
+		$events = $this->query_events( $scope, $days_ahead );
+
+		if ( empty( $events ) ) {
+			\WP_CLI::success( "No events found ({$scope} scope)." );
+			return;
+		}
+
+		\WP_CLI::log( sprintf( 'Scanning %d events for duplicates (%s scope)...', count( $events ), $scope ) );
+
+		$duplicate_groups = $this->find_duplicates( $events );
+
+		if ( empty( $duplicate_groups ) ) {
+			\WP_CLI::success( sprintf( 'No duplicates found across %d events.', count( $events ) ) );
+			return;
+		}
+
+		\WP_CLI::log( sprintf( 'Found %d duplicate pair(s).', count( $duplicate_groups ) ) );
+		\WP_CLI::log( '' );
+
+		// For each pair: keep older, trash newer.
+		$to_trash       = array();
+		$ticket_merges  = 0;
+
+		foreach ( $duplicate_groups as $group ) {
+			$a_id   = $group['event_a']['id'];
+			$b_id   = $group['event_b']['id'];
+			$a_date = get_post( $a_id )->post_date;
+			$b_date = get_post( $b_id )->post_date;
+
+			// Keep the older one.
+			if ( strtotime( $a_date ) <= strtotime( $b_date ) ) {
+				$keep_id  = $a_id;
+				$trash_id = $b_id;
+			} else {
+				$keep_id  = $b_id;
+				$trash_id = $a_id;
+			}
+
+			// Check if we should merge ticket URL.
+			$keep_ticket  = get_post_meta( $keep_id, EVENT_TICKET_URL_META_KEY, true );
+			$trash_ticket = get_post_meta( $trash_id, EVENT_TICKET_URL_META_KEY, true );
+			$should_merge_ticket = ! empty( $trash_ticket ) && empty( $keep_ticket );
+
+			if ( $should_merge_ticket ) {
+				++$ticket_merges;
+			}
+
+			$keep_title  = get_the_title( $keep_id );
+			$trash_title = get_the_title( $trash_id );
+
+			$to_trash[] = array(
+				'keep_id'            => $keep_id,
+				'keep_title'         => mb_substr( $keep_title, 0, 40 ),
+				'trash_id'           => $trash_id,
+				'trash_title'        => mb_substr( $trash_title, 0, 40 ),
+				'venue'              => $group['event_a']['venue'] ?: $group['event_b']['venue'],
+				'date'               => $group['date'],
+				'merge_ticket'       => $should_merge_ticket ? 'yes' : 'no',
+			);
+		}
+
+		\WP_CLI\Utils\format_items( 'table', $to_trash, array( 'keep_id', 'keep_title', 'trash_id', 'trash_title', 'venue', 'date', 'merge_ticket' ) );
+
+		\WP_CLI::log( '' );
+		\WP_CLI::log( sprintf( 'Will trash %d posts, merge %d ticket URLs.', count( $to_trash ), $ticket_merges ) );
+
+		if ( $dry_run ) {
+			\WP_CLI::log( 'DRY RUN — no changes made.' );
+			return;
+		}
+
+		if ( ! $skip_confirm ) {
+			\WP_CLI::confirm( sprintf( 'Trash %d duplicate events?', count( $to_trash ) ) );
+		}
+
+		$trashed = 0;
+		$merged  = 0;
+
+		foreach ( $to_trash as $action ) {
+			// Merge ticket URL if needed.
+			if ( 'yes' === $action['merge_ticket'] ) {
+				$trash_ticket = get_post_meta( $action['trash_id'], EVENT_TICKET_URL_META_KEY, true );
+				update_post_meta( $action['keep_id'], EVENT_TICKET_URL_META_KEY, $trash_ticket );
+				++$merged;
+			}
+
+			// Trash the duplicate.
+			$result = wp_trash_post( $action['trash_id'] );
+			if ( $result ) {
+				++$trashed;
+			} else {
+				\WP_CLI::warning( sprintf( 'Failed to trash post %d.', $action['trash_id'] ) );
+			}
+		}
+
+		\WP_CLI::success( sprintf( 'Trashed %d duplicate events, merged %d ticket URLs.', $trashed, $merged ) );
+	}
+
+	/**
+	 * Find duplicate event pairs using fuzzy title + venue matching.
+	 *
+	 * @param array $events Array of WP_Post objects.
+	 * @return array Duplicate groups.
+	 */
+	private function find_duplicates( array $events ): array {
+		$by_date = array();
+		foreach ( $events as $event ) {
+			$start_meta = get_post_meta( $event->ID, '_datamachine_event_datetime', true );
+			$date       = $start_meta ? substr( $start_meta, 0, 10 ) : '';
+
+			if ( empty( $date ) ) {
+				continue;
+			}
+
+			$by_date[ $date ][] = $event;
+		}
+
+		$duplicate_groups = array();
+
+		foreach ( $by_date as $date => $date_events ) {
+			if ( count( $date_events ) < 2 ) {
+				continue;
+			}
+
+			$venue_cache = array();
+			foreach ( $date_events as $event ) {
+				$venue_cache[ $event->ID ] = $this->get_venue_name( $event->ID );
+			}
+
+			$matched_ids = array();
+
+			for ( $i = 0, $count = count( $date_events ); $i < $count; $i++ ) {
+				for ( $j = $i + 1; $j < $count; $j++ ) {
+					$event_a = $date_events[ $i ];
+					$event_b = $date_events[ $j ];
+
+					if ( isset( $matched_ids[ $event_b->ID ] ) ) {
+						continue;
+					}
+
+					if ( ! EventIdentifierGenerator::titlesMatch( $event_a->post_title, $event_b->post_title ) ) {
+						continue;
+					}
+
+					$venue_a = $venue_cache[ $event_a->ID ];
+					$venue_b = $venue_cache[ $event_b->ID ];
+
+					if ( ! EventIdentifierGenerator::venuesMatch( $venue_a, $venue_b ) ) {
+						continue;
+					}
+
+					$duplicate_groups[] = array(
+						'date'    => $date,
+						'event_a' => array(
+							'id'    => $event_a->ID,
+							'title' => $event_a->post_title,
+							'venue' => $venue_a,
+						),
+						'event_b' => array(
+							'id'    => $event_b->ID,
+							'title' => $event_b->post_title,
+							'venue' => $venue_b,
+						),
+					);
+
+					$matched_ids[ $event_b->ID ] = true;
+				}
+			}
+		}
+
+		return $duplicate_groups;
+	}
+}

--- a/inc/Steps/Upsert/Events/EventUpsert.php
+++ b/inc/Steps/Upsert/Events/EventUpsert.php
@@ -296,8 +296,10 @@ class EventUpsert extends UpdateHandler {
 			return null;
 		}
 
-		// Query events at this venue on this date
-		$args = array(
+		// Query events at this venue on this date.
+		// Use date-only for LIKE query; time comparison is done separately.
+		$date_only = self::extractDateForQuery( $startDate );
+		$args      = array(
 			'post_type'      => Event_Post_Type::POST_TYPE,
 			'posts_per_page' => 10,
 			'post_status'    => array( 'publish', 'draft', 'pending' ),
@@ -311,7 +313,7 @@ class EventUpsert extends UpdateHandler {
 			'meta_query'     => array(
 				array(
 					'key'     => EVENT_DATETIME_META_KEY,
-					'value'   => $startDate,
+					'value'   => $date_only,
 					'compare' => 'LIKE',
 				),
 			),
@@ -384,9 +386,13 @@ class EventUpsert extends UpdateHandler {
 			return true;
 		}
 
-		// Check if both have time components (look for T or space followed by time)
-		$has_time1 = preg_match( '/[T\s]\d{2}:\d{2}/', $datetime1 );
-		$has_time2 = preg_match( '/[T\s]\d{2}:\d{2}/', $datetime2 );
+		// Normalize T separator to space for consistent parsing.
+		$datetime1 = self::normalizeDatetime( $datetime1 );
+		$datetime2 = self::normalizeDatetime( $datetime2 );
+
+		// Check if both have time components (space followed by time)
+		$has_time1 = preg_match( '/\s\d{2}:\d{2}/', $datetime1 );
+		$has_time2 = preg_match( '/\s\d{2}:\d{2}/', $datetime2 );
 
 		// If either lacks time, allow match (can't compare)
 		if ( ! $has_time1 || ! $has_time2 ) {
@@ -405,6 +411,38 @@ class EventUpsert extends UpdateHandler {
 		$diff_hours = abs( $time1 - $time2 ) / 3600;
 
 		return $diff_hours <= $windowHours;
+	}
+
+	/**
+	 * Normalize a datetime string for consistent comparison.
+	 *
+	 * Replaces ISO 8601 'T' separator with space so that LIKE queries
+	 * and string comparisons work against DB-stored values which use
+	 * space separators (e.g. '2026-03-20 21:00:00').
+	 *
+	 * @param string $datetime Datetime string in any common format.
+	 * @return string Normalized datetime with space separator.
+	 */
+	private static function normalizeDatetime( string $datetime ): string {
+		// Replace T separator with space: 2026-03-20T21:00:00 → 2026-03-20 21:00:00
+		return preg_replace( '/(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2})/', '$1 $2', $datetime );
+	}
+
+	/**
+	 * Extract just the date portion (YYYY-MM-DD) from a datetime string.
+	 *
+	 * Used for LIKE queries against the event datetime meta field.
+	 * The time comparison is done separately in isWithinTimeWindow().
+	 *
+	 * @param string $datetime Datetime or date string.
+	 * @return string Date portion only (YYYY-MM-DD).
+	 */
+	private static function extractDateForQuery( string $datetime ): string {
+		// Handle both "2026-03-20" and "2026-03-20 21:00:00" and "2026-03-20T21:00:00"
+		if ( preg_match( '/^(\d{4}-\d{2}-\d{2})/', $datetime, $matches ) ) {
+			return $matches[1];
+		}
+		return $datetime;
 	}
 
 	/**
@@ -435,7 +473,7 @@ class EventUpsert extends UpdateHandler {
 			$args['meta_query'] = array(
 				array(
 					'key'     => EVENT_DATETIME_META_KEY,
-					'value'   => $startDate,
+					'value'   => self::extractDateForQuery( $startDate ),
 					'compare' => 'LIKE',
 				),
 			);
@@ -525,7 +563,7 @@ class EventUpsert extends UpdateHandler {
 				),
 				array(
 					'key'     => EVENT_DATETIME_META_KEY,
-					'value'   => $startDate,
+					'value'   => self::extractDateForQuery( $startDate ),
 					'compare' => 'LIKE',
 				),
 			),
@@ -570,7 +608,7 @@ class EventUpsert extends UpdateHandler {
 				),
 				array(
 					'key'     => EVENT_DATETIME_META_KEY,
-					'value'   => $startDate,
+					'value'   => self::extractDateForQuery( $startDate ),
 					'compare' => 'LIKE',
 				),
 			),
@@ -627,14 +665,15 @@ class EventUpsert extends UpdateHandler {
 			return null;
 		}
 
-		$args = array(
+		$date_only = self::extractDateForQuery( $startDate );
+		$args      = array(
 			'post_type'      => Event_Post_Type::POST_TYPE,
 			'posts_per_page' => 20,
 			'post_status'    => array( 'publish', 'draft', 'pending' ),
 			'meta_query'     => array(
 				array(
 					'key'     => EVENT_DATETIME_META_KEY,
-					'value'   => $startDate,
+					'value'   => $date_only,
 					'compare' => 'LIKE',
 				),
 			),


### PR DESCRIPTION
## Summary
- Fix ISO 8601 `T` separator breaking dedup LIKE queries (all date queries now use date-only extraction)
- Add `wp data-machine-events check clean-duplicates` CLI for batch dedup cleanup

## The Bug
LIKE queries against `_datamachine_event_datetime` meta used the raw `$startDate` value. If it contained a `T` separator (e.g. `2026-03-20T21:00:00`), the LIKE `%2026-03-20T21:00%` would NOT match the stored `2026-03-20 21:00:00` because `T` ≠ space.

## Fix
- `extractDateForQuery()` strips time component for LIKE queries (date comparison only)
- `normalizeDatetime()` replaces T→space for time window checks
- Applied to all 4 dedup query paths: ticket URL, venue+fuzzy, exact title, date+fuzzy

## New CLI
```bash
wp data-machine-events check clean-duplicates --dry-run     # preview
wp data-machine-events check clean-duplicates --scope=all --yes  # run
```

Keeps older post, trashes newer, merges ticket URL if the kept post lacks one.

## Context
249 total duplicate pairs found: 210 pre-dedup legacy, 18 spanning deploy, 21 post-deploy. Closes #105.