### PR TITLE
feat: migrate to homeboy-action v2 convention-driven CI

### DIFF
--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -5,16 +5,16 @@ on:
     branches: [main]
   push:
     branches: [main]
+    tags: ['v*']
 
 permissions:
-  contents: read
-  issues: write
+  contents: write
   pull-requests: write
+  issues: write
 
 jobs:
-  pull-request:
-    if: github.event_name == 'pull_request'
-    name: Homeboy PR (Scoped)
+  homeboy:
+    name: Homeboy
     runs-on: ubuntu-latest
     services:
       mysql:
@@ -35,71 +35,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        continue-on-error: true
         with:
-          php-version: '8.3'
-          extensions: mbstring, intl, pdo_sqlite, mysqli
-          tools: composer:v2
-          coverage: none
+          app-id: ${{ secrets.HOMEBOY_APP_ID }}
+          private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
-      - name: Install project dependencies
-        run: composer install --no-interaction --prefer-dist
-
-      - uses: Extra-Chill/homeboy-action@v1
+      - uses: Extra-Chill/homeboy-action@v2
         with:
-          version: 'latest'
-          extension: wordpress
-          commands: lint,test,audit
-          lint-changed-only: 'true'
-          test-scope: 'changed'
-          component: data-machine-events
-          settings: '{"database_type": "mysql"}'
-          php-version: '8.3'
-          node-version: '20'
-
-  main:
-    if: github.event_name != 'pull_request'
-    name: Homeboy Main (Full)
-    runs-on: ubuntu-latest
-    services:
-      mysql:
-        image: mysql:8.0
-        env:
-          MYSQL_ROOT_PASSWORD: ''
-          MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-          MYSQL_DATABASE: homeboy_wptests
-        ports:
-          - 3306:3306
-        options: >-
-          --health-cmd="mysqladmin ping"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=3
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.3'
-          extensions: mbstring, intl, pdo_sqlite, mysqli
-          tools: composer:v2
-          coverage: none
-
-      - name: Install project dependencies
-        run: composer install --no-interaction --prefer-dist
-
-      - uses: Extra-Chill/homeboy-action@v1
-        with:
-          version: 'latest'
-          extension: wordpress
-          commands: lint,test,audit
-          test-scope: 'full'
-          auto-issue: 'true'
-          component: data-machine-events
-          settings: '{"database_type": "mysql"}'
-          php-version: '8.3'
-          node-version: '20'
+          app-token: ${{ steps.app-token.outputs.token || '' }}

--- a/homeboy.json
+++ b/homeboy.json
@@ -2,7 +2,11 @@
   "auto_cleanup": false,
   "changelog_target": "docs/CHANGELOG.md",
   "extensions": {
-    "wordpress": {}
+    "wordpress": {
+      "php": "8.3",
+      "node": "20",
+      "database_type": "mysql"
+    }
   },
   "id": "data-machine-events",
   "version_targets": [


### PR DESCRIPTION
## Summary

Migrate from homeboy-action v1 (deprecated inputs, 2 conditional jobs, 105 lines) to v2 convention-driven CI (1 job, 45 lines).

## Changes
- **Replaced** 105-line workflow with 45-line v2 template
- **Removed** deprecated inputs: `lint-changed-only`, `test-scope`, `settings`
- **Removed** manual PHP setup and composer install (v2 auto-handles)
- **Removed** conditional PR/push job split (v2 detects context automatically)
- **Added** `php: "8.3"`, `node: "20"`, `database_type: "mysql"` to `homeboy.json`
- **Added** app-token with `continue-on-error: true` for fork-safe autofix

## Depends on
- Extra-Chill/homeboy-action `feat/v2-convention-driven` (must be merged and tagged as v2 first)