### PR TITLE
Replace postmeta LIKE scans with PostIdentityIndex for event dedup

### DIFF
--- a/data-machine-events.php
+++ b/data-machine-events.php
@@ -217,6 +217,13 @@ class DATAMACHINE_Events {
 			new \DataMachineEvents\Steps\Upsert\Events\EventUpsert();
 		}
 
+		// Register event dedup strategy with DM core's duplicate detection system
+		// and identity writer to keep the PostIdentityIndex in sync.
+		if ( class_exists( 'DataMachine\\Core\\Database\\PostIdentityIndex\\PostIdentityIndex' ) ) {
+			\DataMachineEvents\Core\DuplicateDetection\EventDuplicateStrategy::register();
+			\DataMachineEvents\Core\DuplicateDetection\EventIdentityWriter::register();
+		}
+
 		// Load chat tools - self-register via ToolRegistrationTrait
 		new \DataMachineEvents\Api\Chat\Tools\VenueHealthCheck();
 		new \DataMachineEvents\Api\Chat\Tools\UpdateVenue();

--- a/inc/Abilities/DuplicateDetectionAbilities.php
+++ b/inc/Abilities/DuplicateDetectionAbilities.php
@@ -53,12 +53,85 @@ class DuplicateDetectionAbilities {
 	/**
 	 * Register event duplicate strategy on the unified filter.
 	 *
-	 * When core's `datamachine/check-duplicate` ability runs for the
-	 * `event` post type, this strategy fires first (priority 10) and
-	 * uses venue + date + fuzzy title matching.
+	 * When the PostIdentityIndex is available, the strategy is registered
+	 * by EventDuplicateStrategy (priority 5) instead. This legacy strategy
+	 * only registers as a fallback when the identity index doesn't exist yet.
 	 */
 	private function registerStrategy(): void {
+		// Only register the legacy postmeta-based strategy if the new identity
+		// index strategy is NOT available. EventDuplicateStrategy::register()
+		// adds itself at priority 5, so if both are present, the new one wins.
+		if ( class_exists( 'DataMachine\\Core\\Database\\PostIdentityIndex\\PostIdentityIndex' ) ) {
+			return; // EventDuplicateStrategy handles this now.
+		}
 		add_filter( 'datamachine_duplicate_strategies', array( $this, 'addEventStrategy' ) );
+	}
+
+	/**
+	 * Add legacy event duplicate strategy to the strategy registry.
+	 *
+	 * @deprecated 0.18.0 Replaced by EventDuplicateStrategy using PostIdentityIndex.
+	 *
+	 * @param array $strategies Existing strategies.
+	 * @return array Strategies with event strategy appended.
+	 */
+	public function addEventStrategy( array $strategies ): array {
+		$strategies[] = array(
+			'id'        => 'event_venue_date_title',
+			'post_type' => Event_Post_Type::POST_TYPE,
+			'callback'  => array( $this, 'executeEventStrategy' ),
+			'priority'  => 10,
+		);
+		return $strategies;
+	}
+
+	/**
+	 * Legacy event duplicate strategy callback.
+	 *
+	 * @deprecated 0.18.0 Replaced by EventDuplicateStrategy using PostIdentityIndex.
+	 *
+	 * @param array $input { title: string, context: { venue?: string, startDate?: string } }
+	 * @return array Result with verdict key.
+	 */
+	public function executeEventStrategy( array $input ): array {
+		$title     = $input['title'] ?? '';
+		$context   = $input['context'] ?? array();
+		$venue     = $context['venue'] ?? '';
+		$startDate = $context['startDate'] ?? '';
+
+		if ( empty( $title ) || empty( $startDate ) ) {
+			return array( 'verdict' => 'clear' );
+		}
+
+		$result = $this->executeFindDuplicateEvent(
+			array(
+				'title'     => $title,
+				'venue'     => $venue,
+				'startDate' => $startDate,
+			)
+		);
+
+		if ( ! empty( $result['found'] ) ) {
+			return array(
+				'verdict'  => 'duplicate',
+				'source'   => 'event_' . ( $result['match_strategy'] ?? 'fuzzy' ),
+				'match'    => array(
+					'post_id' => $result['post_id'] ?? 0,
+					'title'   => $result['matched_title'] ?? '',
+					'venue'   => $result['matched_venue'] ?? '',
+				),
+				'reason'   => sprintf(
+					'Rejected: "%s" matches existing event "%s" (ID %d) via %s.',
+					$title,
+					$result['matched_title'] ?? '',
+					$result['post_id'] ?? 0,
+					$result['match_strategy'] ?? 'fuzzy'
+				),
+				'strategy' => 'event_venue_date_title',
+			);
+		}
+
+		return array( 'verdict' => 'clear' );
 	}
 
 	/**
@@ -231,7 +304,8 @@ class DuplicateDetectionAbilities {
 	/**
 	 * Find an existing event matching the given identity fields.
 	 *
-	 * Uses fuzzy title + venue matching to find duplicates across sources.
+	 * When the PostIdentityIndex is available, delegates to EventDuplicateStrategy
+	 * for fast indexed lookups. Otherwise falls back to legacy postmeta queries.
 	 *
 	 * @param array $input { title: string, venue?: string, startDate: string }
 	 * @return array { found: bool, post_id?: int, matched_title?: string, matched_venue?: string, match_strategy?: string }
@@ -245,6 +319,49 @@ class DuplicateDetectionAbilities {
 			return array( 'found' => false );
 		}
 
+		// Fast path: use the identity index when available.
+		if ( class_exists( 'DataMachineEvents\\Core\\DuplicateDetection\\EventDuplicateStrategy' )
+			&& class_exists( 'DataMachine\\Core\\Database\\PostIdentityIndex\\PostIdentityIndex' ) ) {
+
+			$result = \DataMachineEvents\Core\DuplicateDetection\EventDuplicateStrategy::check(
+				array(
+					'title'   => $title,
+					'context' => array(
+						'venue'     => $venue,
+						'startDate' => $startDate,
+					),
+				)
+			);
+
+			if ( is_array( $result ) && 'duplicate' === ( $result['verdict'] ?? '' ) ) {
+				$match = $result['match'] ?? array();
+				return array(
+					'found'          => true,
+					'post_id'        => $match['post_id'] ?? 0,
+					'matched_title'  => $match['title'] ?? '',
+					'matched_venue'  => '',
+					'match_strategy' => $result['strategy'] ?? 'identity_index',
+				);
+			}
+
+			return array( 'found' => false );
+		}
+
+		// Legacy fallback: postmeta LIKE queries.
+		return $this->executeFindDuplicateEventLegacy( $title, $venue, $startDate );
+	}
+
+	/**
+	 * Legacy duplicate event search using postmeta LIKE queries.
+	 *
+	 * @deprecated 0.18.0 Replaced by EventDuplicateStrategy using PostIdentityIndex.
+	 *
+	 * @param string $title     Event title.
+	 * @param string $venue     Venue name.
+	 * @param string $startDate Start date.
+	 * @return array Result array.
+	 */
+	private function executeFindDuplicateEventLegacy( string $title, string $venue, string $startDate ): array {
 		// Strategy 1: venue-scoped fuzzy title match.
 		if ( ! empty( $venue ) ) {
 			$venue_term = get_term_by( 'name', $venue, 'venue' );
@@ -265,6 +382,7 @@ class DuplicateDetectionAbilities {
 								'terms'    => $venue_term->term_id,
 							),
 						),
+						// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Legacy fallback, replaced by PostIdentityIndex.
 						'meta_query'     => array(
 							array(
 								'key'     => EVENT_DATETIME_META_KEY,
@@ -295,6 +413,7 @@ class DuplicateDetectionAbilities {
 				'post_type'      => Event_Post_Type::POST_TYPE,
 				'posts_per_page' => 20,
 				'post_status'    => array( 'publish', 'draft', 'pending' ),
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Legacy fallback, replaced by PostIdentityIndex.
 				'meta_query'     => array(
 					array(
 						'key'     => EVENT_DATETIME_META_KEY,
@@ -310,7 +429,6 @@ class DuplicateDetectionAbilities {
 				continue;
 			}
 
-			// Confirm venue if both sides have one.
 			if ( ! empty( $venue ) ) {
 				$candidate_venues = wp_get_post_terms( $candidate->ID, 'venue', array( 'fields' => 'names' ) );
 				$candidate_venue  = ( ! is_wp_error( $candidate_venues ) && ! empty( $candidate_venues ) ) ? $candidate_venues[0] : '';

--- a/inc/Core/DuplicateDetection/EventDuplicateStrategy.php
+++ b/inc/Core/DuplicateDetection/EventDuplicateStrategy.php
@@ -1,0 +1,447 @@
+<?php
+/**
+ * Event Duplicate Detection Strategy
+ *
+ * Registered via the `datamachine_duplicate_strategies` filter in DM core.
+ * Replaces the 4-method cascade in EventUpsert with indexed lookups against
+ * the PostIdentityIndex table.
+ *
+ * Strategy cascade (same order as the old EventUpsert::findExistingEvent):
+ * 1. Ticket URL + date (most reliable — stable platform identifier)
+ * 2. Venue + date + fuzzy title (venue-scoped matching)
+ * 3. Exact title + date (with venue confirmation)
+ * 4. Date + fuzzy title fallback (venue-agnostic last resort)
+ *
+ * All query logic uses PostIdentityIndex (indexed columns) instead of
+ * wp_postmeta LIKE scans.
+ *
+ * @package DataMachineEvents\Core\DuplicateDetection
+ * @since   0.18.0
+ */
+
+namespace DataMachineEvents\Core\DuplicateDetection;
+
+use DataMachine\Core\Database\PostIdentityIndex\PostIdentityIndex;
+use DataMachineEvents\Utilities\EventIdentifierGenerator;
+use DataMachineEvents\Core\Event_Post_Type;
+use const DataMachineEvents\Core\EVENT_DATETIME_META_KEY;
+use const DataMachineEvents\Core\EVENT_TICKET_URL_META_KEY;
+use function DataMachineEvents\Core\datamachine_normalize_ticket_url;
+use function DataMachineEvents\Core\datamachine_extract_ticket_identity;
+
+defined( 'ABSPATH' ) || exit;
+
+class EventDuplicateStrategy {
+
+	/**
+	 * Register this strategy with DM core's duplicate detection system.
+	 */
+	public static function register(): void {
+		add_filter( 'datamachine_duplicate_strategies', array( static::class, 'addStrategy' ) );
+	}
+
+	/**
+	 * Add event dedup strategy to the registry.
+	 *
+	 * @param array $strategies Existing strategies.
+	 * @return array Strategies with event strategy added.
+	 */
+	public static function addStrategy( array $strategies ): array {
+		$strategies[] = array(
+			'id'        => 'event_identity_index',
+			'post_type' => Event_Post_Type::POST_TYPE,
+			'callback'  => array( static::class, 'check' ),
+			'priority'  => 5, // Run before core strategies.
+		);
+		return $strategies;
+	}
+
+	/**
+	 * Execute the event duplicate check against the identity index.
+	 *
+	 * Called by DuplicateCheckAbility when the post_type matches.
+	 *
+	 * @param array $input {
+	 *     @type string $title      Event title.
+	 *     @type string $post_type  Post type (data_machine_events).
+	 *     @type array  $context    { venue, startDate, ticketUrl }
+	 * }
+	 * @return array|null Duplicate result or null if clear.
+	 */
+	public static function check( array $input ): ?array {
+		$title     = $input['title'] ?? '';
+		$context   = $input['context'] ?? array();
+		$venue     = $context['venue'] ?? '';
+		$startDate = $context['startDate'] ?? '';
+		$ticketUrl = $context['ticketUrl'] ?? '';
+
+		if ( empty( $title ) || empty( $startDate ) ) {
+			return null;
+		}
+
+		$date_only           = self::extractDateOnly( $startDate );
+		$identity_confidence = EventIdentifierGenerator::getIdentityConfidence( $title, $startDate, $venue );
+
+		// Strategy 1: Ticket URL + date (most reliable).
+		if ( ! empty( $ticketUrl ) ) {
+			$match = self::findByTicketUrl( $ticketUrl, $date_only );
+			if ( $match ) {
+				return $match;
+			}
+		}
+
+		// Strategy 2: Venue + date + fuzzy title.
+		if ( ! empty( $venue ) ) {
+			$match = self::findByVenueDateAndFuzzyTitle( $title, $venue, $date_only, $startDate );
+			if ( $match ) {
+				return $match;
+			}
+		}
+
+		// Strategy 3: Exact title + date (with venue confirmation).
+		$match = self::findByExactTitle( $title, $venue, $date_only, $identity_confidence );
+		if ( $match ) {
+			return $match;
+		}
+
+		// Strategy 4: Date + fuzzy title fallback (venue-agnostic).
+		if ( 'low' !== $identity_confidence ) {
+			$match = self::findByDateAndFuzzyTitle( $title, $date_only, $startDate, $venue );
+			if ( $match ) {
+				return $match;
+			}
+		}
+
+		return null;
+	}
+
+	// -----------------------------------------------------------------------
+	// Strategy 1: Ticket URL matching
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Find event by ticket URL on the same date.
+	 *
+	 * Strategy A: exact normalized URL match.
+	 * Strategy B: canonical ticket identity comparison (unwraps affiliate links).
+	 *
+	 * @param string $ticketUrl Ticket URL.
+	 * @param string $date_only Date in YYYY-MM-DD.
+	 * @return array|null Duplicate result or null.
+	 */
+	private static function findByTicketUrl( string $ticketUrl, string $date_only ): ?array {
+		$normalized_url = datamachine_normalize_ticket_url( $ticketUrl );
+		if ( empty( $normalized_url ) ) {
+			return null;
+		}
+
+		$index = new PostIdentityIndex();
+
+		// Strategy A: exact normalized URL match in the index.
+		$match = $index->find_by_ticket_url_and_date( $normalized_url, $date_only );
+		if ( $match ) {
+			$post_id = (int) $match['post_id'];
+			if ( self::isValidPost( $post_id ) ) {
+				return self::duplicateResult( $post_id, 'ticket_url_exact' );
+			}
+		}
+
+		// Strategy B: canonical identity comparison (unwrap affiliate wrappers).
+		$canonical_identity = datamachine_extract_ticket_identity( $ticketUrl );
+		if ( empty( $canonical_identity ) || $canonical_identity === $normalized_url ) {
+			return null;
+		}
+
+		$candidates = $index->find_with_ticket_url_on_date( $date_only );
+		foreach ( $candidates as $candidate ) {
+			$candidate_identity = datamachine_extract_ticket_identity( $candidate['ticket_url'] );
+			if ( $canonical_identity === $candidate_identity ) {
+				$post_id = (int) $candidate['post_id'];
+				if ( self::isValidPost( $post_id ) ) {
+					return self::duplicateResult( $post_id, 'ticket_url_canonical' );
+				}
+			}
+		}
+
+		return null;
+	}
+
+	// -----------------------------------------------------------------------
+	// Strategy 2: Venue + date + fuzzy title
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Find event by venue, date, and fuzzy title match.
+	 *
+	 * Queries the identity index for events at the same venue on the same date,
+	 * then compares titles using the SimilarityEngine and checks time windows.
+	 *
+	 * @param string $title     Event title.
+	 * @param string $venue     Venue name.
+	 * @param string $date_only Date in YYYY-MM-DD.
+	 * @param string $startDate Full datetime for time window comparison.
+	 * @return array|null Duplicate result or null.
+	 */
+	private static function findByVenueDateAndFuzzyTitle( string $title, string $venue, string $date_only, string $startDate ): ?array {
+		if ( EventIdentifierGenerator::isLowConfidenceTitle( $title ) ) {
+			return null;
+		}
+
+		// Resolve venue to term ID.
+		$venue_term = get_term_by( 'name', $venue, 'venue' );
+		if ( ! $venue_term ) {
+			$venue_slug = sanitize_title( $venue );
+			$venue_term = get_term_by( 'slug', $venue_slug, 'venue' );
+		}
+		if ( ! $venue_term ) {
+			return null;
+		}
+
+		$index      = new PostIdentityIndex();
+		$candidates = $index->find_by_date_and_venue( $date_only, (int) $venue_term->term_id, 10 );
+
+		foreach ( $candidates as $candidate ) {
+			$post_id = (int) $candidate['post_id'];
+			$post    = get_post( $post_id );
+			if ( ! $post ) {
+				continue;
+			}
+
+			if ( ! EventIdentifierGenerator::titlesMatch( $title, $post->post_title ) ) {
+				continue;
+			}
+
+			// Check time window.
+			$existing_datetime = get_post_meta( $post_id, EVENT_DATETIME_META_KEY, true );
+			if ( ! self::isWithinTimeWindow( $startDate, $existing_datetime ) ) {
+				continue;
+			}
+
+			return self::duplicateResult( $post_id, 'venue_date_fuzzy_title' );
+		}
+
+		return null;
+	}
+
+	// -----------------------------------------------------------------------
+	// Strategy 3: Exact title + date with venue confirmation
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Find event by exact title and date, with optional venue confirmation.
+	 *
+	 * Uses the title_hash index for fast exact-title lookup.
+	 *
+	 * @param string $title               Event title.
+	 * @param string $venue               Venue name.
+	 * @param string $date_only           Date in YYYY-MM-DD.
+	 * @param string $identity_confidence Identity confidence level.
+	 * @return array|null Duplicate result or null.
+	 */
+	private static function findByExactTitle( string $title, string $venue, string $date_only, string $identity_confidence ): ?array {
+		if ( empty( $date_only ) ) {
+			return null;
+		}
+
+		$title_hash = self::computeTitleHash( $title );
+		$index      = new PostIdentityIndex();
+		$match      = $index->find_by_date_and_title_hash( $date_only, $title_hash );
+
+		if ( ! $match ) {
+			return null;
+		}
+
+		$post_id = (int) $match['post_id'];
+		if ( ! self::isValidPost( $post_id ) ) {
+			return null;
+		}
+
+		// Venue confirmation logic (same as old EventUpsert::findEventByExactTitle).
+		if ( empty( $venue ) ) {
+			if ( 'low' === $identity_confidence ) {
+				return null;
+			}
+			return self::duplicateResult( $post_id, 'exact_title_no_venue' );
+		}
+
+		$venue_terms = wp_get_post_terms( $post_id, 'venue', array( 'fields' => 'names' ) );
+		if ( empty( $venue_terms ) || is_wp_error( $venue_terms ) ) {
+			if ( 'low' === $identity_confidence ) {
+				return null;
+			}
+			return self::duplicateResult( $post_id, 'exact_title_no_existing_venue' );
+		}
+
+		foreach ( $venue_terms as $existing_venue ) {
+			if ( $venue === $existing_venue || EventIdentifierGenerator::venuesMatch( $venue, $existing_venue ) ) {
+				return self::duplicateResult( $post_id, 'exact_title_venue_confirmed' );
+			}
+		}
+
+		return null;
+	}
+
+	// -----------------------------------------------------------------------
+	// Strategy 4: Date + fuzzy title fallback
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Last-resort venue-agnostic fuzzy search.
+	 *
+	 * Queries all events on the date and compares titles.
+	 * When both sides have venue data, venue match is required.
+	 *
+	 * @param string $title     Event title.
+	 * @param string $date_only Date in YYYY-MM-DD.
+	 * @param string $startDate Full datetime for time window.
+	 * @param string $venue     Incoming venue for confirmation.
+	 * @return array|null Duplicate result or null.
+	 */
+	private static function findByDateAndFuzzyTitle( string $title, string $date_only, string $startDate, string $venue = '' ): ?array {
+		if ( EventIdentifierGenerator::isLowConfidenceTitle( $title ) ) {
+			return null;
+		}
+
+		$index      = new PostIdentityIndex();
+		$candidates = $index->find_by_date( $date_only, 20 );
+
+		foreach ( $candidates as $candidate ) {
+			$post_id = (int) $candidate['post_id'];
+			$post    = get_post( $post_id );
+			if ( ! $post ) {
+				continue;
+			}
+
+			if ( ! EventIdentifierGenerator::titlesMatch( $title, $post->post_title ) ) {
+				continue;
+			}
+
+			$existing_datetime = get_post_meta( $post_id, EVENT_DATETIME_META_KEY, true );
+			if ( ! self::isWithinTimeWindow( $startDate, $existing_datetime ) ) {
+				continue;
+			}
+
+			// When both sides have venue data, require venue match to avoid
+			// false positives on generic titles at different venues.
+			if ( ! empty( $venue ) ) {
+				$candidate_venues = wp_get_post_terms( $post_id, 'venue', array( 'fields' => 'names' ) );
+				$candidate_venue  = ( ! is_wp_error( $candidate_venues ) && ! empty( $candidate_venues ) ) ? $candidate_venues[0] : '';
+
+				if ( ! empty( $candidate_venue ) && ! EventIdentifierGenerator::venuesMatch( $venue, $candidate_venue ) ) {
+					continue;
+				}
+			}
+
+			return self::duplicateResult( $post_id, 'date_fuzzy_title' );
+		}
+
+		return null;
+	}
+
+	// -----------------------------------------------------------------------
+	// Helpers
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Extract date-only portion from a datetime string.
+	 *
+	 * @param string $datetime Datetime string.
+	 * @return string Date in YYYY-MM-DD format.
+	 */
+	private static function extractDateOnly( string $datetime ): string {
+		if ( preg_match( '/^(\d{4}-\d{2}-\d{2})/', $datetime, $matches ) ) {
+			return $matches[1];
+		}
+		return $datetime;
+	}
+
+	/**
+	 * Compute a title hash for exact-match lookups.
+	 *
+	 * Uses normalizeBasic (lowercase, trim, remove articles) to create
+	 * a stable hash. The same normalization must be used when writing
+	 * identity rows.
+	 *
+	 * @param string $title Event title.
+	 * @return string MD5 hash of normalized title.
+	 */
+	public static function computeTitleHash( string $title ): string {
+		$normalized = \DataMachine\Core\Similarity\SimilarityEngine::normalizeBasic( $title );
+		return md5( $normalized );
+	}
+
+	/**
+	 * Check if two datetimes are within a 2-hour window.
+	 *
+	 * Preserves the same logic as EventUpsert::isWithinTimeWindow().
+	 *
+	 * @param string $datetime1 First datetime.
+	 * @param string $datetime2 Second datetime.
+	 * @return bool True if within 2 hours or if either lacks time component.
+	 */
+	private static function isWithinTimeWindow( string $datetime1, string $datetime2 ): bool {
+		// If either lacks a time component, allow the match.
+		if ( ! preg_match( '/\d{2}:\d{2}/', $datetime1 ) || ! preg_match( '/\d{2}:\d{2}/', $datetime2 ) ) {
+			return true;
+		}
+
+		$time1 = strtotime( $datetime1 );
+		$time2 = strtotime( $datetime2 );
+
+		if ( false === $time1 || false === $time2 ) {
+			return true;
+		}
+
+		return abs( $time1 - $time2 ) <= 7200; // 2 hours
+	}
+
+	/**
+	 * Check if a post exists and has a valid status.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return bool True if valid.
+	 */
+	private static function isValidPost( int $post_id ): bool {
+		$status = get_post_status( $post_id );
+		return $status && in_array( $status, array( 'publish', 'draft', 'pending' ), true );
+	}
+
+	/**
+	 * Build a standard duplicate result array.
+	 *
+	 * @param int    $post_id  Matched post ID.
+	 * @param string $strategy Strategy that matched.
+	 * @return array Duplicate result.
+	 */
+	private static function duplicateResult( int $post_id, string $strategy ): array {
+		$title = get_the_title( $post_id );
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'EventDuplicateStrategy: matched existing event',
+			array(
+				'post_id'  => $post_id,
+				'title'    => $title,
+				'strategy' => $strategy,
+			)
+		);
+
+		return array(
+			'verdict'  => 'duplicate',
+			'source'   => 'identity_index',
+			'match'    => array(
+				'post_id' => $post_id,
+				'title'   => $title,
+				'url'     => get_permalink( $post_id ),
+			),
+			'reason'   => sprintf(
+				'Matched existing event "%s" (ID %d) via %s.',
+				$title,
+				$post_id,
+				$strategy
+			),
+			'strategy' => 'event_identity_index',
+		);
+	}
+}

--- a/inc/Core/DuplicateDetection/EventIdentityWriter.php
+++ b/inc/Core/DuplicateDetection/EventIdentityWriter.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Event Identity Writer
+ *
+ * Writes identity rows to the PostIdentityIndex table whenever an event
+ * post is created or updated. Called from EventUpsert after successful
+ * create/update, and from a save_post hook for manual edits.
+ *
+ * @package DataMachineEvents\Core\DuplicateDetection
+ * @since   0.18.0
+ */
+
+namespace DataMachineEvents\Core\DuplicateDetection;
+
+use DataMachine\Core\Database\PostIdentityIndex\PostIdentityIndex;
+use DataMachineEvents\Core\Event_Post_Type;
+use const DataMachineEvents\Core\EVENT_DATETIME_META_KEY;
+use const DataMachineEvents\Core\EVENT_TICKET_URL_META_KEY;
+
+defined( 'ABSPATH' ) || exit;
+
+class EventIdentityWriter {
+
+	/**
+	 * Register hooks to keep identity rows in sync with event posts.
+	 */
+	public static function register(): void {
+		// Update identity row when event meta is saved (covers both create and update).
+		add_action( 'updated_post_meta', array( static::class, 'onMetaChange' ), 10, 4 );
+		add_action( 'added_post_meta', array( static::class, 'onMetaChange' ), 10, 4 );
+	}
+
+	/**
+	 * React to postmeta changes and sync the identity index.
+	 *
+	 * Triggered when _datamachine_event_datetime or _datamachine_ticket_url
+	 * is written/updated. Rebuilds the full identity row from current state.
+	 *
+	 * @param int    $meta_id    Meta row ID.
+	 * @param int    $post_id    Post ID.
+	 * @param string $meta_key   Meta key.
+	 * @param mixed  $meta_value Meta value.
+	 */
+	public static function onMetaChange( $meta_id, $post_id, $meta_key, $meta_value ): void {
+		// Only react to event identity meta keys.
+		if ( EVENT_DATETIME_META_KEY !== $meta_key && EVENT_TICKET_URL_META_KEY !== $meta_key ) {
+			return;
+		}
+
+		// Only for event posts.
+		$post_type = get_post_type( $post_id );
+		if ( Event_Post_Type::POST_TYPE !== $post_type ) {
+			return;
+		}
+
+		self::syncIdentityRow( (int) $post_id );
+	}
+
+	/**
+	 * Write or update the identity row for an event post.
+	 *
+	 * Reads current postmeta + taxonomy state and builds the identity fields.
+	 * Can be called directly from EventUpsert for immediate sync, or
+	 * from the meta change hook for passive sync.
+	 *
+	 * @param int         $post_id    Event post ID.
+	 * @param string|null $title      Title override (avoids extra get_the_title call).
+	 * @param string|null $ticket_url Ticket URL override (avoids extra meta read).
+	 */
+	public static function syncIdentityRow( int $post_id, ?string $title = null, ?string $ticket_url = null ): void {
+		if ( ! class_exists( PostIdentityIndex::class ) ) {
+			return;
+		}
+
+		$datetime = get_post_meta( $post_id, EVENT_DATETIME_META_KEY, true );
+		if ( empty( $datetime ) ) {
+			return;
+		}
+
+		// Extract date-only.
+		$event_date = '';
+		if ( preg_match( '/^(\d{4}-\d{2}-\d{2})/', $datetime, $matches ) ) {
+			$event_date = $matches[1];
+		}
+
+		if ( empty( $event_date ) ) {
+			return;
+		}
+
+		// Resolve title.
+		if ( null === $title ) {
+			$title = get_the_title( $post_id );
+		}
+
+		// Resolve venue term ID.
+		$venue_term_id = 0;
+		$venue_terms   = wp_get_post_terms( $post_id, 'venue', array( 'fields' => 'ids' ) );
+		if ( ! is_wp_error( $venue_terms ) && ! empty( $venue_terms ) ) {
+			$venue_term_id = (int) $venue_terms[0];
+		}
+
+		// Resolve ticket URL.
+		if ( null === $ticket_url ) {
+			$ticket_url = get_post_meta( $post_id, EVENT_TICKET_URL_META_KEY, true );
+		}
+
+		// Compute title hash.
+		$title_hash = EventDuplicateStrategy::computeTitleHash( $title );
+
+		$index = new PostIdentityIndex();
+		$index->upsert(
+			$post_id,
+			array(
+				'post_type'     => Event_Post_Type::POST_TYPE,
+				'event_date'    => $event_date,
+				'venue_term_id' => $venue_term_id,
+				'ticket_url'    => $ticket_url ?: null,
+				'title_hash'    => $title_hash,
+			)
+		);
+	}
+
+	/**
+	 * Backfill identity rows for existing events.
+	 *
+	 * Called during migration or via CLI. Processes events in batches.
+	 *
+	 * @param int      $batch_size Number of events per batch.
+	 * @param callable $progress   Optional progress callback (receives count).
+	 * @return int Total events processed.
+	 */
+	public static function backfill( int $batch_size = 500, ?callable $progress = null ): int {
+		$index     = new PostIdentityIndex();
+		$total     = 0;
+		$offset    = 0;
+
+		while ( true ) {
+			$missing = $index->find_missing_post_ids( Event_Post_Type::POST_TYPE, $batch_size, $offset );
+
+			if ( empty( $missing ) ) {
+				break;
+			}
+
+			foreach ( $missing as $post_id ) {
+				self::syncIdentityRow( $post_id );
+				++$total;
+			}
+
+			if ( $progress ) {
+				$progress( $total );
+			}
+
+			// Don't increment offset — find_missing_post_ids returns new results
+			// as we fill in identity rows, effectively shrinking the gap.
+			// But safety valve: if we got a full batch, there might be more.
+			if ( count( $missing ) < $batch_size ) {
+				break;
+			}
+		}
+
+		return $total;
+	}
+}

--- a/inc/Steps/Upsert/Events/EventUpsert.php
+++ b/inc/Steps/Upsert/Events/EventUpsert.php
@@ -32,6 +32,7 @@ use DataMachine\Core\Steps\Update\Handlers\UpdateHandler;
 use DataMachine\Core\WordPress\TaxonomyHandler;
 use DataMachine\Core\WordPress\WordPressSettingsResolver;
 use DataMachine\Core\WordPress\WordPressPublishHelper;
+use DataMachineEvents\Core\DuplicateDetection\EventIdentityWriter;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -144,8 +145,11 @@ class EventUpsert extends UpdateHandler {
 		array $handler_config,
 		EngineData $engine
 	): array {
-		// Search for existing event (now serialized per event identity)
-		$existing_post_id = $this->findExistingEvent( $title, $venue, $startDate, $ticketUrl );
+		// Search for existing event via the core duplicate detection system.
+		// This uses the PostIdentityIndex (indexed lookups) instead of
+		// postmeta LIKE scans. Falls back to the old findExistingEvent()
+		// method if the identity index table doesn't exist yet.
+		$existing_post_id = $this->findExistingEventViaAbility( $title, $venue, $startDate, $ticketUrl );
 
 		if ( $existing_post_id ) {
 			// Event exists - check if data changed
@@ -154,6 +158,9 @@ class EventUpsert extends UpdateHandler {
 			if ( $this->hasDataChanged( $existing_data, $parameters ) ) {
 				// UPDATE existing event
 				$this->updateEventPost( $existing_post_id, $parameters, $handler_config, $engine );
+
+				// Sync identity index after update.
+				EventIdentityWriter::syncIdentityRow( $existing_post_id, $title, datamachine_normalize_ticket_url( $ticketUrl ) ?: null );
 
 				do_action(
 					'datamachine_log',
@@ -205,6 +212,9 @@ class EventUpsert extends UpdateHandler {
 				);
 			}
 
+			// Write identity index row for new event.
+			EventIdentityWriter::syncIdentityRow( $post_id, $title, datamachine_normalize_ticket_url( $ticketUrl ) ?: null );
+
 			do_action(
 				'datamachine_log',
 				'info',
@@ -223,6 +233,57 @@ class EventUpsert extends UpdateHandler {
 				)
 			);
 		}
+	}
+
+	/**
+	 * Find existing event using DM core's duplicate detection system.
+	 *
+	 * Calls the `datamachine/check-duplicate` ability which delegates to
+	 * the registered EventDuplicateStrategy, querying the PostIdentityIndex
+	 * with indexed lookups instead of postmeta LIKE scans.
+	 *
+	 * Falls back to the legacy findExistingEvent() if the ability or
+	 * identity index table is not available.
+	 *
+	 * @param string $title     Event title.
+	 * @param string $venue     Venue name.
+	 * @param string $startDate Start date.
+	 * @param string $ticketUrl Ticket URL.
+	 * @return int|null Post ID if found, null otherwise.
+	 */
+	private function findExistingEventViaAbility( string $title, string $venue, string $startDate, string $ticketUrl ): ?int {
+		// Check if the identity index table class exists (requires DM core >= 0.50.0).
+		if ( ! class_exists( 'DataMachine\\Core\\Database\\PostIdentityIndex\\PostIdentityIndex' ) ) {
+			return $this->findExistingEvent( $title, $venue, $startDate, $ticketUrl );
+		}
+
+		$duplicate_check = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'datamachine/check-duplicate' ) : null;
+
+		if ( ! $duplicate_check ) {
+			return $this->findExistingEvent( $title, $venue, $startDate, $ticketUrl );
+		}
+
+		$result = $duplicate_check->execute(
+			array(
+				'title'     => $title,
+				'post_type' => Event_Post_Type::POST_TYPE,
+				'scope'     => 'published',
+				'context'   => array(
+					'venue'     => $venue,
+					'startDate' => $startDate,
+					'ticketUrl' => $ticketUrl,
+				),
+			)
+		);
+
+		if ( is_array( $result ) && 'duplicate' === ( $result['verdict'] ?? '' ) ) {
+			$post_id = (int) ( $result['match']['post_id'] ?? 0 );
+			if ( $post_id > 0 ) {
+				return $post_id;
+			}
+		}
+
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Replaces all 4 event dedup strategies' postmeta LIKE scans with indexed lookups against the new `PostIdentityIndex` table from DM core
- Registers `EventDuplicateStrategy` via `datamachine_duplicate_strategies` filter — events now go through the core dedup system instead of a private bypass
- `EventIdentityWriter` keeps identity rows in sync via meta change hooks + explicit calls from EventUpsert

## The Problem

Event upsert dedup was doing `LIKE '%2026-04-07%'` on `_datamachine_event_datetime` in postmeta (162K rows, full table scan). With 282 flows and ~29K events, this pegged MariaDB at 100% CPU and caused 2-10s TTFB spikes across all sites during pipeline runs.

## Architecture Change

| Before | After |
|--------|-------|
| `EventUpsert.findExistingEvent()` — private 4-method cascade | `datamachine/check-duplicate` ability via `EventDuplicateStrategy` |
| `wp_postmeta` LIKE scans (full table scan) | `PostIdentityIndex` indexed columns (index hit) |
| Events bypasses core dedup system | Events registers a strategy with core |

All 4 strategies preserved with identical matching logic:
1. Ticket URL + date (exact + canonical identity)
2. Venue + date + fuzzy title
3. Exact title + date + venue confirmation
4. Date + fuzzy title fallback

## Backward Compatibility

Falls back to legacy `findExistingEvent()` postmeta queries when `PostIdentityIndex` class doesn't exist (DM core < 0.50.0).

## Depends On

- [data-machine #906](https://github.com/Extra-Chill/data-machine/pull/906) — PostIdentityIndex table in DM core

## Backfill

`EventIdentityWriter::backfill()` processes existing events in batches of 500. After deploying both PRs, run on events site to populate the index for existing ~29K events. New events are automatically indexed on create/update.