### PR TITLE
Fix taxonomy archive pagination 404 on shared taxonomies

### DIFF
--- a/inc/Core/Event_Post_Type.php
+++ b/inc/Core/Event_Post_Type.php
@@ -109,17 +109,19 @@ class Event_Post_Type {
 		add_filter( 'manage_edit-' . self::POST_TYPE . '_sortable_columns', array( __CLASS__, 'sortable_event_date_column' ) );
 		add_action( 'pre_get_posts', array( __CLASS__, 'sort_by_event_date' ) );
 		add_action( 'pre_get_posts', array( __CLASS__, 'prevent_taxonomy_archive_404' ) );
+		add_action( 'wp', array( __CLASS__, 'fix_taxonomy_archive_404' ) );
 	}
 
 	/**
 	 * Prevent WordPress from returning 404 on paginated taxonomy archives.
 	 *
-	 * The calendar block uses its own date-based pagination (?paged=N), but
-	 * WordPress's main query for /artist/name/page/2/ runs with the default
-	 * posts_per_page. If fewer posts exist than needed for page 2, WP returns
-	 * 404 before the calendar block renders. Setting posts_per_page to 1
-	 * ensures WP finds at least one post (preventing 404) while the calendar
-	 * block handles the real pagination independently.
+	 * Shared taxonomies (e.g. artist, registered on both 'post' and
+	 * 'data_machine_events') cause WordPress's main query to default to the
+	 * 'post' post type. With 0 blog posts matching that artist, WP finds no
+	 * results on page 2+ and returns 404 before the calendar block renders.
+	 *
+	 * Fix: force the post type to events and set posts_per_page high so
+	 * the main query finds results and doesn't prematurely 404.
 	 *
 	 * @param \WP_Query $query The main query.
 	 */
@@ -128,23 +130,58 @@ class Event_Post_Type {
 			return;
 		}
 
-		if ( ! $query->is_tax() ) {
-			return;
-		}
-
-		$queried_object = $query->get_queried_object();
-		if ( ! $queried_object || ! isset( $queried_object->taxonomy ) ) {
-			return;
-		}
-
+		// Check query vars directly — conditional tags like is_tax() aren't
+		// reliable inside pre_get_posts because the query hasn't executed yet.
 		$event_taxonomies = get_object_taxonomies( self::POST_TYPE );
-		if ( ! in_array( $queried_object->taxonomy, $event_taxonomies, true ) ) {
+		foreach ( $event_taxonomies as $taxonomy ) {
+			if ( $query->get( $taxonomy ) ) {
+				// Force post type to events so shared taxonomies query the
+				// correct post type instead of defaulting to 'post'.
+				$query->set( 'post_type', self::POST_TYPE );
+
+				// High posts_per_page prevents WordPress from 404-ing paginated
+				// requests. The calendar block does its own query independently.
+				$query->set( 'posts_per_page', 100 );
+				return;
+			}
+		}
+	}
+
+	/**
+	 * Override false 404s on event taxonomy archive pagination.
+	 *
+	 * Even after pre_get_posts sets post_type and posts_per_page, WordPress
+	 * may still flag the page as 404 (e.g., when handle_404 runs its own
+	 * checks). This hook fires after the main query and corrects the status.
+	 *
+	 * @param \WP $wp The WordPress environment object.
+	 */
+	public static function fix_taxonomy_archive_404( $wp ) {
+		if ( is_admin() ) {
 			return;
 		}
 
-		// Set high posts_per_page so WordPress never 404s paginated requests.
-		// The calendar block does its own query with posts_per_page=-1.
-		$query->set( 'posts_per_page', 100 );
+		global $wp_query;
+
+		if ( ! $wp_query->is_404() ) {
+			return;
+		}
+
+		// Only fix 404s for event taxonomy archives.
+		$event_taxonomies = get_object_taxonomies( self::POST_TYPE );
+		foreach ( $event_taxonomies as $taxonomy ) {
+			if ( ! empty( $wp_query->query[ $taxonomy ] ) ) {
+				// Verify the term actually exists.
+				$term = get_term_by( 'slug', $wp_query->query[ $taxonomy ], $taxonomy );
+				if ( $term && ! is_wp_error( $term ) ) {
+					$wp_query->is_404  = false;
+					$wp_query->is_tax  = true;
+					$wp_query->is_archive = true;
+					status_header( 200 );
+				}
+				return;
+			}
+		}
 	}
 
 	public static function add_event_date_column( $columns ) {


### PR DESCRIPTION
## Summary

- Fixes pagination 404 on artist and other shared taxonomy archives (e.g., `/artist/radiohead/page/2/`)
- Root cause: shared taxonomies (registered on both `post` and `data_machine_events`) cause WP's main query to default to `post` type — with 0 blog posts matching, WP 404s page 2+

## Changes

**`Event_Post_Type.php`** — Two-layer fix:
- `pre_get_posts`: forces `post_type` to `data_machine_events` and sets `posts_per_page=100` for event taxonomy archives (checked via query vars, not conditional tags which aren't reliable pre-query)
- `wp` hook: catches false 404s after the main query runs — verifies the term slug exists and resets `is_404`/`is_tax`/`is_archive` flags + `status_header(200)`

## Notes

- Completely taxonomy-agnostic — checks `get_object_taxonomies()` dynamically, no hardcoded taxonomy names
- Fake/nonexistent terms still properly 404 (verified)
- The earlier PageBoundary fix (taxonomy-aware date pagination) was committed directly to main in `34b0e45`

Closes #129
Related: #128 (PageBoundary taxonomy filtering — already on main)