### PR TITLE
ci: drop cron schedule — push to main covers release

### DIFF
--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -6,8 +6,6 @@ on:
   push:
     branches: [main]
     tags: ['v*']
-  schedule:
-    - cron: '*/15 * * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- Remove `schedule: '*/15 * * * *'` cron trigger
- Push to main already triggers the release pipeline via homeboy-action
- Eliminates **96 unnecessary CI runs per day**

Same change as Extra-Chill/data-machine#927.