### PR TITLE
fix: calendar query and taxonomy counts use start_datetime as primary

### DIFF
--- a/inc/Blocks/Calendar/Query/EventQueryBuilder.php
+++ b/inc/Blocks/Calendar/Query/EventQueryBuilder.php
@@ -82,19 +82,45 @@ class EventQueryBuilder {
 		$current_datetime = current_time( 'mysql' );
 		$has_date_range   = ! empty( $params['date_start'] ) || ! empty( $params['date_end'] );
 
+		// Use start_datetime as primary with end_datetime OR fallback.
+		// Most events don't have end_datetime meta (no real end time provided).
+		// An event is "upcoming" if start >= now OR end >= now (still ongoing).
+		// An event is "past" if start < now AND (end < now OR no end meta).
 		if ( $params['show_past'] && ! $params['user_date_range'] ) {
 			$meta_query[] = array(
-				'key'     => EVENT_END_DATETIME_META_KEY,
+				'key'     => EVENT_DATETIME_META_KEY,
 				'value'   => $current_datetime,
 				'compare' => '<',
 				'type'    => 'DATETIME',
 			);
+			$meta_query[] = array(
+				'relation' => 'OR',
+				array(
+					'key'     => EVENT_END_DATETIME_META_KEY,
+					'value'   => $current_datetime,
+					'compare' => '<',
+					'type'    => 'DATETIME',
+				),
+				array(
+					'key'     => EVENT_END_DATETIME_META_KEY,
+					'compare' => 'NOT EXISTS',
+				),
+			);
 		} elseif ( ! $params['show_past'] && ! $params['user_date_range'] ) {
 			$meta_query[] = array(
-				'key'     => EVENT_END_DATETIME_META_KEY,
-				'value'   => $current_datetime,
-				'compare' => '>=',
-				'type'    => 'DATETIME',
+				'relation' => 'OR',
+				array(
+					'key'     => EVENT_DATETIME_META_KEY,
+					'value'   => $current_datetime,
+					'compare' => '>=',
+					'type'    => 'DATETIME',
+				),
+				array(
+					'key'     => EVENT_END_DATETIME_META_KEY,
+					'value'   => $current_datetime,
+					'compare' => '>=',
+					'type'    => 'DATETIME',
+				),
 			);
 		}
 
@@ -228,6 +254,7 @@ class EventQueryBuilder {
 	private static function compute_event_counts(): array {
 		$current_datetime = current_time( 'mysql' );
 
+		// Upcoming: start >= now OR end >= now (still ongoing).
 		$future_query = new WP_Query(
 			array(
 				'post_type'      => Event_Post_Type::POST_TYPE,
@@ -235,6 +262,13 @@ class EventQueryBuilder {
 				'fields'         => 'ids',
 				'posts_per_page' => 1,
 				'meta_query'     => array(
+					'relation' => 'OR',
+					array(
+						'key'     => EVENT_DATETIME_META_KEY,
+						'value'   => $current_datetime,
+						'compare' => '>=',
+						'type'    => 'DATETIME',
+					),
 					array(
 						'key'     => EVENT_END_DATETIME_META_KEY,
 						'value'   => $current_datetime,
@@ -245,6 +279,7 @@ class EventQueryBuilder {
 			)
 		);
 
+		// Past: start < now AND (end < now OR no end meta).
 		$past_query = new WP_Query(
 			array(
 				'post_type'      => Event_Post_Type::POST_TYPE,
@@ -252,11 +287,25 @@ class EventQueryBuilder {
 				'fields'         => 'ids',
 				'posts_per_page' => 1,
 				'meta_query'     => array(
+					'relation' => 'AND',
 					array(
-						'key'     => EVENT_END_DATETIME_META_KEY,
+						'key'     => EVENT_DATETIME_META_KEY,
 						'value'   => $current_datetime,
 						'compare' => '<',
 						'type'    => 'DATETIME',
+					),
+					array(
+						'relation' => 'OR',
+						array(
+							'key'     => EVENT_END_DATETIME_META_KEY,
+							'value'   => $current_datetime,
+							'compare' => '<',
+							'type'    => 'DATETIME',
+						),
+						array(
+							'key'     => EVENT_END_DATETIME_META_KEY,
+							'compare' => 'NOT EXISTS',
+						),
 					),
 				),
 			)

--- a/inc/Blocks/Calendar/Taxonomy_Helper.php
+++ b/inc/Blocks/Calendar/Taxonomy_Helper.php
@@ -8,6 +8,7 @@
 namespace DataMachineEvents\Blocks\Calendar;
 
 use DataMachineEvents\Core\Event_Post_Type;
+use const DataMachineEvents\Core\EVENT_DATETIME_META_KEY;
 use const DataMachineEvents\Core\EVENT_END_DATETIME_META_KEY;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -140,11 +141,11 @@ class Taxonomy_Helper {
 		$where_clauses = '';
 		$params        = array( $taxonomy_slug, $post_type );
 
-		// Date context filtering - uses EVENT_END_DATETIME to match EventQueryBuilder behavior
+		// Date context filtering — uses start_datetime as primary with end_datetime
+		// OR fallback. Most events don't have end_datetime meta (no real end time).
 		if ( ! empty( $date_context ) ) {
-			$joins         .= " INNER JOIN {$wpdb->postmeta} pm_date ON p.ID = pm_date.post_id";
-			$where_clauses .= ' AND pm_date.meta_key = %s';
-			$params[]       = EVENT_END_DATETIME_META_KEY;
+			$joins .= " INNER JOIN {$wpdb->postmeta} pm_start_date ON p.ID = pm_start_date.post_id AND pm_start_date.meta_key = '" . esc_sql( EVENT_DATETIME_META_KEY ) . "'";
+			$joins .= " LEFT JOIN {$wpdb->postmeta} pm_end_date ON p.ID = pm_end_date.post_id AND pm_end_date.meta_key = '" . esc_sql( EVENT_END_DATETIME_META_KEY ) . "'";
 
 			$date_start       = $date_context['date_start'] ?? '';
 			$date_end         = $date_context['date_end'] ?? '';
@@ -152,17 +153,19 @@ class Taxonomy_Helper {
 			$current_datetime = current_time( 'mysql' );
 
 			if ( ! empty( $date_start ) && ! empty( $date_end ) ) {
-				// Explicit date range from date picker
-				$where_clauses .= ' AND pm_date.meta_value >= %s AND pm_date.meta_value <= %s';
+				// Explicit date range from date picker.
+				$where_clauses .= ' AND pm_start_date.meta_value >= %s AND pm_start_date.meta_value <= %s';
 				$params[]       = $date_start . ' 00:00:00';
 				$params[]       = $date_end . ' 23:59:59';
 			} elseif ( $show_past ) {
-				// Past events only (end time before current datetime)
-				$where_clauses .= ' AND pm_date.meta_value < %s';
+				// Past: start < now AND (end < now OR no end meta).
+				$where_clauses .= ' AND pm_start_date.meta_value < %s AND (pm_end_date.meta_value < %s OR pm_end_date.meta_value IS NULL)';
+				$params[]       = $current_datetime;
 				$params[]       = $current_datetime;
 			} else {
-				// Default: future events only (end time >= current datetime)
-				$where_clauses .= ' AND pm_date.meta_value >= %s';
+				// Upcoming: start >= now OR end >= now (still ongoing).
+				$where_clauses .= ' AND (pm_start_date.meta_value >= %s OR pm_end_date.meta_value >= %s)';
+				$params[]       = $current_datetime;
 				$params[]       = $current_datetime;
 			}
 		}


### PR DESCRIPTION
## Summary

Follow-up to #136 — the calendar query layer was still filtering exclusively by `_datamachine_event_end_datetime`, making 21k+ events without end meta invisible.

- **EventQueryBuilder**: Upcoming/past filter and past/future counts now use `_datamachine_event_datetime` as primary with `_datamachine_event_end_datetime` OR fallback
- **Taxonomy_Helper**: Filter bar term counts use same start-primary/end-fallback pattern
- **PageBoundary**: Already used LEFT JOIN on end_datetime — no change needed

Pattern everywhere: `upcoming = start >= now OR end >= now`, `past = start < now AND (end < now OR no end meta)`