### PR TITLE
feat: replace event datetime postmeta with dedicated event_dates table

### DIFF
--- a/data-machine-events.php
+++ b/data-machine-events.php
@@ -53,6 +53,7 @@ if ( ! function_exists( 'data_machine_events_sanitize_query_params' ) ) {
 
 // Load core meta storage (monitors Event Details block saves)
 require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Core/meta-storage.php';
+require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Core/EventDatesTable.php';
 
 // Load performance optimizations (transient-cached last-modified queries).
 require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Core/performance.php';
@@ -90,6 +91,24 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	\WP_CLI::add_command( 'data-machine-events check clean-duplicates', \DataMachineEvents\Cli\Check\CleanDuplicatesCommand::class );
 	\WP_CLI::add_command( 'data-machine-events check quality', \DataMachineEvents\Cli\Check\CheckQualityCommand::class );
 	\WP_CLI::add_command( 'data-machine-events check all', \DataMachineEvents\Cli\Check\CheckAllCommand::class );
+}
+
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	\WP_CLI::add_command( 'datamachine-events backfill-event-dates', function( $args, $assoc_args ) {
+		\DataMachineEvents\Core\EventDatesTable::create_table();
+		\WP_CLI::log( 'Table ensured. Starting backfill...' );
+
+		$total = \DataMachineEvents\Core\EventDatesTable::backfill(
+			500,
+			function( $count ) {
+				if ( $count % 500 === 0 ) {
+					\WP_CLI::log( "Backfilled {$count} events..." );
+				}
+			}
+		);
+
+		\WP_CLI::success( "Backfilled {$total} events into datamachine_event_dates table." );
+	});
 }
 
 if ( defined( 'WP_CLI' ) && WP_CLI && file_exists( DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Cli/UpdateEventCommand.php' ) ) {
@@ -449,6 +468,7 @@ class DATAMACHINE_Events {
 	}
 
 	public function activate() {
+		\DataMachineEvents\Core\EventDatesTable::create_table();
 		$this->register_post_types();
 		$this->register_taxonomies();
 		flush_rewrite_rules();

--- a/inc/Abilities/CalendarAbilities.php
+++ b/inc/Abilities/CalendarAbilities.php
@@ -268,8 +268,9 @@ class CalendarAbilities {
 			}
 		}
 
-		$query_args   = EventQueryBuilder::build_query_args( $query_params );
-		$events_query = new WP_Query( $query_args );
+		$built         = EventQueryBuilder::build_query_args( $query_params );
+		$events_query  = new WP_Query( $built['args'] );
+		$built['cleanup']();
 
 		$event_counts = EventQueryBuilder::get_event_counts();
 

--- a/inc/Abilities/DuplicateDetectionAbilities.php
+++ b/inc/Abilities/DuplicateDetectionAbilities.php
@@ -304,6 +304,17 @@ class DuplicateDetectionAbilities {
 			}
 
 			if ( $venue_term ) {
+				$dedup_date_filter_1 = function ( $clauses ) use ( $startDate ) {
+					global $wpdb;
+					$table = \DataMachineEvents\Core\EventDatesTable::table_name();
+					if ( strpos( $clauses['join'], $table ) === false ) {
+						$clauses['join'] .= " INNER JOIN {$table} AS ed ON {$wpdb->posts}.ID = ed.post_id";
+					}
+					$clauses['where'] .= $wpdb->prepare( ' AND DATE(ed.start_datetime) = %s', $startDate );
+					return $clauses;
+				};
+				add_filter( 'posts_clauses', $dedup_date_filter_1 );
+
 				$candidates = get_posts(
 					array(
 						'post_type'      => Event_Post_Type::POST_TYPE,
@@ -316,16 +327,10 @@ class DuplicateDetectionAbilities {
 								'terms'    => $venue_term->term_id,
 							),
 						),
-						// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Legacy fallback, replaced by PostIdentityIndex.
-						'meta_query'     => array(
-							array(
-								'key'     => EVENT_DATETIME_META_KEY,
-								'value'   => $startDate,
-								'compare' => 'LIKE',
-							),
-						),
 					)
 				);
+
+				remove_filter( 'posts_clauses', $dedup_date_filter_1 );
 
 				foreach ( $candidates as $candidate ) {
 					if ( EventIdentifierGenerator::titlesMatch( $title, $candidate->post_title ) ) {
@@ -342,21 +347,26 @@ class DuplicateDetectionAbilities {
 		}
 
 		// Strategy 2: date-scoped fuzzy title + venue confirmation.
+		$dedup_date_filter_2 = function ( $clauses ) use ( $startDate ) {
+			global $wpdb;
+			$table = \DataMachineEvents\Core\EventDatesTable::table_name();
+			if ( strpos( $clauses['join'], $table ) === false ) {
+				$clauses['join'] .= " INNER JOIN {$table} AS ed ON {$wpdb->posts}.ID = ed.post_id";
+			}
+			$clauses['where'] .= $wpdb->prepare( ' AND DATE(ed.start_datetime) = %s', $startDate );
+			return $clauses;
+		};
+		add_filter( 'posts_clauses', $dedup_date_filter_2 );
+
 		$candidates = get_posts(
 			array(
 				'post_type'      => Event_Post_Type::POST_TYPE,
 				'posts_per_page' => 20,
 				'post_status'    => array( 'publish', 'draft', 'pending' ),
-				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Legacy fallback, replaced by PostIdentityIndex.
-				'meta_query'     => array(
-					array(
-						'key'     => EVENT_DATETIME_META_KEY,
-						'value'   => $startDate,
-						'compare' => 'LIKE',
-					),
-				),
 			)
 		);
+
+		remove_filter( 'posts_clauses', $dedup_date_filter_2 );
 
 		foreach ( $candidates as $candidate ) {
 			if ( ! EventIdentifierGenerator::titlesMatch( $title, $candidate->post_title ) ) {

--- a/inc/Abilities/EncodingFixAbilities.php
+++ b/inc/Abilities/EncodingFixAbilities.php
@@ -219,39 +219,40 @@ class EncodingFixAbilities {
 	 * @return array|\WP_Error Array of WP_Post objects or WP_Error
 	 */
 	private function queryEvents( string $scope ): array|\WP_Error {
+		$order = 'ASC';
+		if ( 'past' === $scope ) {
+			$order = 'DESC';
+		}
+
 		$args = array(
 			'post_type'      => Event_Post_Type::POST_TYPE,
 			'post_status'    => 'publish',
 			'posts_per_page' => -1,
-			'orderby'        => 'meta_value',
-			'meta_key'       => Event_Post_Type::EVENT_DATE_META_KEY,
-			'order'          => 'ASC',
+			'orderby'        => 'none',
+			'order'          => $order,
 		);
 
 		$now = current_time( 'Y-m-d H:i:s' );
 
-		if ( 'upcoming' === $scope ) {
-			$args['meta_query'] = array(
-				array(
-					'key'     => Event_Post_Type::EVENT_DATE_META_KEY,
-					'value'   => $now,
-					'compare' => '>=',
-					'type'    => 'DATETIME',
-				),
-			);
-		} elseif ( 'past' === $scope ) {
-			$args['meta_query'] = array(
-				array(
-					'key'     => Event_Post_Type::EVENT_DATE_META_KEY,
-					'value'   => $now,
-					'compare' => '<',
-					'type'    => 'DATETIME',
-				),
-			);
-			$args['order']      = 'DESC';
-		}
+		$event_date_filter = function ( $clauses ) use ( $scope, $now, $order ) {
+			global $wpdb;
+			$table = \DataMachineEvents\Core\EventDatesTable::table_name();
+			if ( strpos( $clauses['join'], $table ) === false ) {
+				$clauses['join'] .= " INNER JOIN {$table} AS ed ON {$wpdb->posts}.ID = ed.post_id";
+			}
+			if ( 'upcoming' === $scope ) {
+				$clauses['where'] .= $wpdb->prepare( ' AND ed.start_datetime >= %s', $now );
+			} elseif ( 'past' === $scope ) {
+				$clauses['where'] .= $wpdb->prepare( ' AND ed.start_datetime < %s', $now );
+			}
+			$clauses['orderby'] = 'ed.start_datetime ' . $order;
+			return $clauses;
+		};
+		add_filter( 'posts_clauses', $event_date_filter );
 
 		$query = new \WP_Query( $args );
+
+		remove_filter( 'posts_clauses', $event_date_filter );
 
 		return $query->posts;
 	}

--- a/inc/Abilities/EventHealthAbilities.php
+++ b/inc/Abilities/EventHealthAbilities.php
@@ -358,40 +358,41 @@ class EventHealthAbilities {
 	 * @return array|\WP_Error Array of WP_Post objects or WP_Error
 	 */
 	private function queryEvents( string $scope, int $days_ahead ): array|\WP_Error {
+		$order = 'ASC';
+		if ( 'past' === $scope ) {
+			$order = 'DESC';
+		}
+
 		$args = array(
 			'post_type'      => Event_Post_Type::POST_TYPE,
 			'post_status'    => 'publish',
 			'posts_per_page' => -1,
-			'orderby'        => 'meta_value',
-			'meta_key'       => Event_Post_Type::EVENT_DATE_META_KEY,
-			'order'          => 'ASC',
+			'orderby'        => 'none',
+			'order'          => $order,
 		);
 
 		$now = current_time( 'Y-m-d H:i:s' );
 
-		if ( 'upcoming' === $scope ) {
-			$end_date           = gmdate( 'Y-m-d H:i:s', strtotime( "+{$days_ahead} days" ) );
-			$args['meta_query'] = array(
-				array(
-					'key'     => Event_Post_Type::EVENT_DATE_META_KEY,
-					'value'   => array( $now, $end_date ),
-					'compare' => 'BETWEEN',
-					'type'    => 'DATETIME',
-				),
-			);
-		} elseif ( 'past' === $scope ) {
-			$args['meta_query'] = array(
-				array(
-					'key'     => Event_Post_Type::EVENT_DATE_META_KEY,
-					'value'   => $now,
-					'compare' => '<',
-					'type'    => 'DATETIME',
-				),
-			);
-			$args['order']      = 'DESC';
-		}
+		$event_date_filter = function ( $clauses ) use ( $scope, $now, $days_ahead, $order ) {
+			global $wpdb;
+			$table = \DataMachineEvents\Core\EventDatesTable::table_name();
+			if ( strpos( $clauses['join'], $table ) === false ) {
+				$clauses['join'] .= " INNER JOIN {$table} AS ed ON {$wpdb->posts}.ID = ed.post_id";
+			}
+			if ( 'upcoming' === $scope ) {
+				$end_date = gmdate( 'Y-m-d H:i:s', strtotime( "+{$days_ahead} days" ) );
+				$clauses['where'] .= $wpdb->prepare( ' AND ed.start_datetime BETWEEN %s AND %s', $now, $end_date );
+			} elseif ( 'past' === $scope ) {
+				$clauses['where'] .= $wpdb->prepare( ' AND ed.start_datetime < %s', $now );
+			}
+			$clauses['orderby'] = 'ed.start_datetime ' . $order;
+			return $clauses;
+		};
+		add_filter( 'posts_clauses', $event_date_filter );
 
 		$query = new \WP_Query( $args );
+
+		remove_filter( 'posts_clauses', $event_date_filter );
 
 		return $query->posts;
 	}

--- a/inc/Abilities/EventQualityAuditAbilities.php
+++ b/inc/Abilities/EventQualityAuditAbilities.php
@@ -253,34 +253,36 @@ class EventQualityAuditAbilities {
 			'post_type'      => Event_Post_Type::POST_TYPE,
 			'post_status'    => 'publish',
 			'posts_per_page' => -1,
-			'orderby'        => 'event_start',
+			'orderby'        => 'none',
 			'order'          => 'ASC',
 		);
 
 		$today = current_time( 'Y-m-d' );
-		if ( 'upcoming' === $scope ) {
-			$args['meta_query'] = array(
-				'event_start' => array(
-					'key'     => '_datamachine_event_datetime',
-					'value'   => array( $today . ' 00:00:00', gmdate( 'Y-m-d 23:59:59', strtotime( '+' . $days_ahead . ' days', strtotime( $today ) ) ) ),
-					'compare' => 'BETWEEN',
-				),
-			);
-		} elseif ( 'past' === $scope ) {
-			$args['meta_query'] = array(
-				'event_start' => array(
-					'key'     => '_datamachine_event_datetime',
-					'value'   => $today . ' 00:00:00',
-					'compare' => '<',
-				),
-			);
-		}
+
+		$date_filter = function ( $clauses ) use ( $scope, $today, $days_ahead ) {
+			global $wpdb;
+			$table = \DataMachineEvents\Core\EventDatesTable::table_name();
+			if ( strpos( $clauses['join'], $table ) === false ) {
+				$clauses['join'] .= " INNER JOIN {$table} AS ed ON {$wpdb->posts}.ID = ed.post_id";
+			}
+			if ( 'upcoming' === $scope ) {
+				$end_date = gmdate( 'Y-m-d 23:59:59', strtotime( '+' . $days_ahead . ' days', strtotime( $today ) ) );
+				$clauses['where'] .= $wpdb->prepare( ' AND ed.start_datetime BETWEEN %s AND %s', $today . ' 00:00:00', $end_date );
+			} elseif ( 'past' === $scope ) {
+				$clauses['where'] .= $wpdb->prepare( ' AND ed.start_datetime < %s', $today . ' 00:00:00' );
+			}
+			$clauses['orderby'] = 'ed.start_datetime ASC';
+			return $clauses;
+		};
+		add_filter( 'posts_clauses', $date_filter );
 
 		if ( $flow_id > 0 ) {
-			$args['meta_query'][] = array(
-				'key'     => '_datamachine_post_flow_id',
-				'value'   => (string) $flow_id,
-				'compare' => '=',
+			$args['meta_query'] = array(
+				array(
+					'key'     => '_datamachine_post_flow_id',
+					'value'   => (string) $flow_id,
+					'compare' => '=',
+				),
 			);
 		}
 
@@ -295,6 +297,9 @@ class EventQualityAuditAbilities {
 		}
 
 		$posts = get_posts( $args );
+
+		remove_filter( 'posts_clauses', $date_filter );
+
 		return is_array( $posts ) ? $posts : array();
 	}
 

--- a/inc/Abilities/EventQueryAbilities.php
+++ b/inc/Abilities/EventQueryAbilities.php
@@ -162,14 +162,8 @@ class EventQueryAbilities {
 			'post_type'      => Event_Post_Type::POST_TYPE,
 			'post_status'    => $status,
 			'posts_per_page' => $limit,
-			'orderby'        => 'event_start',
+			'orderby'        => 'none',
 			'order'          => 'DESC',
-			'meta_query'     => array(
-				'event_start' => array(
-					'key'     => '_datamachine_event_datetime',
-					'compare' => 'EXISTS',
-				),
-			),
 			'tax_query'      => array(
 				array(
 					'taxonomy' => 'venue',
@@ -183,13 +177,28 @@ class EventQueryAbilities {
 			$query_args['date_query'] = $date_query;
 		}
 
+		$venue_event_filter = function ( $clauses ) {
+			global $wpdb;
+			$table = \DataMachineEvents\Core\EventDatesTable::table_name();
+			if ( strpos( $clauses['join'], $table ) === false ) {
+				$clauses['join'] .= " INNER JOIN {$table} AS ed ON {$wpdb->posts}.ID = ed.post_id";
+			}
+			$clauses['orderby'] = 'ed.start_datetime DESC';
+			return $clauses;
+		};
+		add_filter( 'posts_clauses', $venue_event_filter );
+
 		$query               = new \WP_Query( $query_args );
+
+		remove_filter( 'posts_clauses', $venue_event_filter );
+
 		$events              = array();
 		$include_description = ! empty( $input['include_description'] );
 
 		foreach ( $query->posts as $post ) {
-			$start_date = get_post_meta( $post->ID, '_datamachine_event_datetime', true );
-			$end_date   = get_post_meta( $post->ID, '_datamachine_event_end_datetime', true );
+			$dates      = \DataMachineEvents\Core\EventDatesTable::get( $post->ID );
+			$start_date = $dates ? $dates->start_datetime : null;
+			$end_date   = $dates ? $dates->end_datetime : null;
 
 			$event_data = array(
 				'post_id'    => $post->ID,

--- a/inc/Abilities/MetaSyncAbilities.php
+++ b/inc/Abilities/MetaSyncAbilities.php
@@ -269,13 +269,14 @@ class MetaSyncAbilities {
 				continue;
 			}
 
-			$before_datetime   = get_post_meta( $event_id, Event_Post_Type::EVENT_DATE_META_KEY, true );
-			$before_end        = get_post_meta( $event_id, '_datamachine_event_end_datetime', true );
+			$before_dates      = \DataMachineEvents\Core\EventDatesTable::get( $event_id );
+			$before_datetime   = $before_dates ? $before_dates->start_datetime : '';
+			$before_end        = $before_dates ? $before_dates->end_datetime : '';
 			$before_ticket_url = get_post_meta( $event_id, '_datamachine_ticket_url', true );
 
 			$before = array(
-				'_datamachine_event_datetime'     => $before_datetime ? $before_datetime : null,
-				'_datamachine_event_end_datetime' => $before_end ? $before_end : null,
+				'_datamachine_event_datetime'     => ! empty( $before_datetime ) ? $before_datetime : null,
+				'_datamachine_event_end_datetime' => ! empty( $before_end ) ? $before_end : null,
 				'_datamachine_ticket_url'         => $before_ticket_url ? $before_ticket_url : null,
 			);
 
@@ -283,8 +284,9 @@ class MetaSyncAbilities {
 				\DataMachineEvents\Core\data_machine_events_sync_datetime_meta( $event_id, $post, true );
 			}
 
-			$after_datetime   = $dry_run ? $this->calculateExpectedDatetime( $block_attrs ) : get_post_meta( $event_id, Event_Post_Type::EVENT_DATE_META_KEY, true );
-			$after_end        = $dry_run ? $this->calculateExpectedEndDatetime( $block_attrs ) : get_post_meta( $event_id, '_datamachine_event_end_datetime', true );
+			$after_dates      = $dry_run ? null : \DataMachineEvents\Core\EventDatesTable::get( $event_id );
+			$after_datetime   = $dry_run ? $this->calculateExpectedDatetime( $block_attrs ) : ( $after_dates ? $after_dates->start_datetime : '' );
+			$after_end        = $dry_run ? $this->calculateExpectedEndDatetime( $block_attrs ) : ( $after_dates ? $after_dates->end_datetime : '' );
 			$after_ticket_url = $dry_run ? ( $block_attrs['ticketUrl'] ?? null ) : get_post_meta( $event_id, '_datamachine_ticket_url', true );
 
 			$after = array(

--- a/inc/Abilities/TicketUrlResyncAbilities.php
+++ b/inc/Abilities/TicketUrlResyncAbilities.php
@@ -123,16 +123,24 @@ class TicketUrlResyncAbilities {
 		);
 
 		if ( $future_only ) {
-			$args['meta_query'] = array(
-				array(
-					'key'     => '_datamachine_event_datetime',
-					'value'   => current_time( 'Y-m-d' ),
-					'compare' => '>=',
-				),
-			);
+			$future_date        = current_time( 'Y-m-d' );
+			$future_date_filter = function ( $clauses ) use ( $future_date ) {
+				global $wpdb;
+				$table = \DataMachineEvents\Core\EventDatesTable::table_name();
+				if ( strpos( $clauses['join'], $table ) === false ) {
+					$clauses['join'] .= " INNER JOIN {$table} AS ed ON {$wpdb->posts}.ID = ed.post_id";
+				}
+				$clauses['where'] .= $wpdb->prepare( ' AND ed.start_datetime >= %s', $future_date );
+				return $clauses;
+			};
+			add_filter( 'posts_clauses', $future_date_filter );
 		}
 
 		$events  = get_posts( $args );
+
+		if ( $future_only ) {
+			remove_filter( 'posts_clauses', $future_date_filter );
+		}
 		$updated = 0;
 		$skipped = 0;
 		$changes = array();

--- a/inc/Abilities/TimezoneAbilities.php
+++ b/inc/Abilities/TimezoneAbilities.php
@@ -220,40 +220,42 @@ class TimezoneAbilities {
 	}
 
 	private function queryEvents( string $scope, int $days_ahead ): array {
+		$order = 'ASC';
+		if ( 'past' === $scope ) {
+			$order = 'DESC';
+		}
+
 		$args = array(
 			'post_type'      => Event_Post_Type::POST_TYPE,
 			'post_status'    => 'publish',
 			'posts_per_page' => -1,
-			'orderby'        => 'meta_value',
-			'meta_key'       => Event_Post_Type::EVENT_DATE_META_KEY,
-			'order'          => 'ASC',
+			'orderby'        => 'none',
+			'order'          => $order,
 		);
 
 		$now = current_time( 'Y-m-d H:i:s' );
 
-		if ( 'upcoming' === $scope ) {
-			$end_date           = gmdate( 'Y-m-d H:i:s', strtotime( "+{$days_ahead} days" ) );
-			$args['meta_query'] = array(
-				array(
-					'key'     => Event_Post_Type::EVENT_DATE_META_KEY,
-					'value'   => array( $now, $end_date ),
-					'compare' => 'BETWEEN',
-					'type'    => 'DATETIME',
-				),
-			);
-		} elseif ( 'past' === $scope ) {
-			$args['meta_query'] = array(
-				array(
-					'key'     => Event_Post_Type::EVENT_DATE_META_KEY,
-					'value'   => $now,
-					'compare' => '<',
-					'type'    => 'DATETIME',
-				),
-			);
-			$args['order']      = 'DESC';
-		}
+		$event_date_filter = function ( $clauses ) use ( $scope, $now, $days_ahead, $order ) {
+			global $wpdb;
+			$table = \DataMachineEvents\Core\EventDatesTable::table_name();
+			if ( strpos( $clauses['join'], $table ) === false ) {
+				$clauses['join'] .= " INNER JOIN {$table} AS ed ON {$wpdb->posts}.ID = ed.post_id";
+			}
+			if ( 'upcoming' === $scope ) {
+				$end_date = gmdate( 'Y-m-d H:i:s', strtotime( "+{$days_ahead} days" ) );
+				$clauses['where'] .= $wpdb->prepare( ' AND ed.start_datetime BETWEEN %s AND %s', $now, $end_date );
+			} elseif ( 'past' === $scope ) {
+				$clauses['where'] .= $wpdb->prepare( ' AND ed.start_datetime < %s', $now );
+			}
+			$clauses['orderby'] = 'ed.start_datetime ' . $order;
+			return $clauses;
+		};
+		add_filter( 'posts_clauses', $event_date_filter );
 
 		$query = new \WP_Query( $args );
+
+		remove_filter( 'posts_clauses', $event_date_filter );
+
 		return $query->posts;
 	}
 

--- a/inc/Abilities/UpcomingCountAbilities.php
+++ b/inc/Abilities/UpcomingCountAbilities.php
@@ -117,11 +117,12 @@ class UpcomingCountAbilities {
 
 		global $wpdb;
 
-		$today = gmdate( 'Y-m-d 00:00:00' );
+		$today    = gmdate( 'Y-m-d 00:00:00' );
+		$ed_table = \DataMachineEvents\Core\EventDatesTable::table_name();
 
 		$parent_clause = $exclude_roots ? 'AND tt.parent != 0' : '';
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$rows = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT t.term_id, t.name, t.slug, COUNT(DISTINCT p.ID) AS event_count
@@ -129,12 +130,11 @@ class UpcomingCountAbilities {
 				INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
 				INNER JOIN {$wpdb->terms} t ON tt.term_id = t.term_id
 				INNER JOIN {$wpdb->posts} p ON tr.object_id = p.ID
-				INNER JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id
+				INNER JOIN {$ed_table} ed ON p.ID = ed.post_id
 				WHERE tt.taxonomy = %s
 				AND p.post_type = 'data_machine_events'
 				AND p.post_status = 'publish'
-				AND pm.meta_key = '_datamachine_event_datetime'
-				AND pm.meta_value >= %s
+				AND ed.start_datetime >= %s
 				{$parent_clause}
 				GROUP BY t.term_id
 				ORDER BY event_count DESC",

--- a/inc/Blocks/Calendar/Data/EventHydrator.php
+++ b/inc/Blocks/Calendar/Data/EventHydrator.php
@@ -13,8 +13,6 @@ namespace DataMachineEvents\Blocks\Calendar\Data;
 
 use DataMachineEvents\Core\Venue_Taxonomy;
 use DataMachineEvents\Core\Promoter_Taxonomy;
-use const DataMachineEvents\Core\EVENT_DATETIME_META_KEY;
-use const DataMachineEvents\Core\EVENT_END_DATETIME_META_KEY;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -59,7 +57,8 @@ class EventHydrator {
 	 * @param array $event_data Event data array (modified by reference).
 	 */
 	private static function hydrate_datetime_from_meta( int $post_id, array &$event_data ): void {
-		$start_datetime = get_post_meta( $post_id, EVENT_DATETIME_META_KEY, true );
+		$dates          = \DataMachineEvents\Core\EventDatesTable::get( $post_id );
+		$start_datetime = $dates ? $dates->start_datetime : '';
 		if ( $start_datetime ) {
 			$date_obj = date_create( $start_datetime );
 			if ( $date_obj ) {
@@ -68,7 +67,7 @@ class EventHydrator {
 			}
 		}
 
-		$end_datetime = get_post_meta( $post_id, EVENT_END_DATETIME_META_KEY, true );
+		$end_datetime = $dates ? $dates->end_datetime : '';
 		if ( $end_datetime ) {
 			$end_obj = date_create( $end_datetime );
 			if ( $end_obj ) {

--- a/inc/Blocks/Calendar/Pagination/PageBoundary.php
+++ b/inc/Blocks/Calendar/Pagination/PageBoundary.php
@@ -13,8 +13,6 @@
 namespace DataMachineEvents\Blocks\Calendar\Pagination;
 
 use DataMachineEvents\Blocks\Calendar\Cache\CalendarCache;
-use const DataMachineEvents\Core\EVENT_DATETIME_META_KEY;
-use const DataMachineEvents\Core\EVENT_END_DATETIME_META_KEY;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -69,18 +67,18 @@ class PageBoundary {
 
 		$show_past_param = $params['show_past'] ?? false;
 		$current_date    = current_time( 'Y-m-d' );
+		$ed_table        = \DataMachineEvents\Core\EventDatesTable::table_name();
 
 		// Build WHERE clauses from params for taxonomy/location filtering.
 		$where_clauses = array(
 			"p.post_type = 'data_machine_events'",
 			"p.post_status = 'publish'",
-			"pm_start.meta_key = '" . esc_sql( EVENT_DATETIME_META_KEY ) . "'",
 		);
 		$join_clauses  = array();
 		$query_values  = array();
 
 		if ( ! $show_past_param ) {
-			$where_clauses[] = 'pm_start.meta_value >= %s';
+			$where_clauses[] = 'ed.start_datetime >= %s';
 			$query_values[]  = $current_date . ' 00:00:00';
 		}
 
@@ -129,21 +127,19 @@ class PageBoundary {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$rows = $wpdb->get_results(
 			empty( $query_values )
-				? "SELECT DATE(pm_start.meta_value) AS start_date, DATE(pm_end.meta_value) AS end_date
+				? "SELECT DATE(ed.start_datetime) AS start_date, DATE(ed.end_datetime) AS end_date
 				   FROM {$wpdb->posts} p
-				   INNER JOIN {$wpdb->postmeta} pm_start ON p.ID = pm_start.post_id
-				   LEFT JOIN {$wpdb->postmeta} pm_end ON p.ID = pm_end.post_id AND pm_end.meta_key = '" . esc_sql( EVENT_END_DATETIME_META_KEY ) . "'
+				   INNER JOIN {$ed_table} ed ON p.ID = ed.post_id
 				   {$joins}
 				   WHERE {$where}
-				   ORDER BY pm_start.meta_value ASC"
+				   ORDER BY ed.start_datetime ASC"
 				: $wpdb->prepare(
-					"SELECT DATE(pm_start.meta_value) AS start_date, DATE(pm_end.meta_value) AS end_date
+					"SELECT DATE(ed.start_datetime) AS start_date, DATE(ed.end_datetime) AS end_date
 					FROM {$wpdb->posts} p
-					INNER JOIN {$wpdb->postmeta} pm_start ON p.ID = pm_start.post_id
-					LEFT JOIN {$wpdb->postmeta} pm_end ON p.ID = pm_end.post_id AND pm_end.meta_key = '" . esc_sql( EVENT_END_DATETIME_META_KEY ) . "'
+					INNER JOIN {$ed_table} ed ON p.ID = ed.post_id
 					{$joins}
 					WHERE {$where}
-					ORDER BY pm_start.meta_value ASC",
+					ORDER BY ed.start_datetime ASC",
 					...$query_values
 				)
 		);

--- a/inc/Blocks/Calendar/Query/DateFilter.php
+++ b/inc/Blocks/Calendar/Query/DateFilter.php
@@ -19,8 +19,7 @@
 
 namespace DataMachineEvents\Blocks\Calendar\Query;
 
-use const DataMachineEvents\Core\EVENT_DATETIME_META_KEY;
-use const DataMachineEvents\Core\EVENT_END_DATETIME_META_KEY;
+use DataMachineEvents\Core\EventDatesTable;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -29,76 +28,105 @@ if ( ! defined( 'ABSPATH' ) ) {
 class DateFilter {
 
 	/**
-	 * WP_Query meta_query for upcoming events.
+	 * Apply "upcoming" date filter via posts_clauses.
+	 *
+	 * Adds a JOIN on the event_dates table and a WHERE clause that selects
+	 * events whose start_datetime >= $datetime OR end_datetime >= $datetime.
 	 *
 	 * @param string $datetime MySQL datetime to compare against.
-	 * @return array meta_query clause.
+	 * @return callable Filter callback (must be removed after WP_Query runs).
 	 */
-	public static function upcoming_meta_query( string $datetime ): array {
-		return array(
-			'relation'    => 'OR',
-			'event_start' => array(
-				'key'     => EVENT_DATETIME_META_KEY,
-				'value'   => $datetime,
-				'compare' => '>=',
-			),
-			'event_end'   => array(
-				'key'     => EVENT_END_DATETIME_META_KEY,
-				'value'   => $datetime,
-				'compare' => '>=',
-			),
-		);
+	public static function apply_upcoming_filter( string $datetime ): callable {
+		$filter = function ( $clauses ) use ( $datetime ) {
+			global $wpdb;
+			$table = EventDatesTable::table_name();
+
+			if ( strpos( $clauses['join'], $table ) === false ) {
+				$clauses['join'] .= " INNER JOIN {$table} AS ed ON {$wpdb->posts}.ID = ed.post_id";
+			}
+
+			$date_where = $wpdb->prepare(
+				'(ed.start_datetime >= %s OR ed.end_datetime >= %s)',
+				$datetime,
+				$datetime
+			);
+			$clauses['where'] .= " AND {$date_where}";
+
+			return $clauses;
+		};
+
+		add_filter( 'posts_clauses', $filter, 10, 1 );
+		return $filter;
 	}
 
 	/**
-	 * WP_Query meta_query for past events.
+	 * Apply "past" date filter via posts_clauses.
 	 *
 	 * @param string $datetime MySQL datetime to compare against.
-	 * @return array meta_query clauses (two entries for AND nesting).
+	 * @return callable Filter callback.
 	 */
-	public static function past_meta_query( string $datetime ): array {
-		return array(
-			'relation'    => 'AND',
-			'event_start' => array(
-				'key'     => EVENT_DATETIME_META_KEY,
-				'value'   => $datetime,
-				'compare' => '<',
-			),
-			array(
-				'relation'  => 'OR',
-				'event_end' => array(
-					'key'     => EVENT_END_DATETIME_META_KEY,
-					'value'   => $datetime,
-					'compare' => '<',
-				),
-				array(
-					'key'     => EVENT_END_DATETIME_META_KEY,
-					'compare' => 'NOT EXISTS',
-				),
-			),
-		);
+	public static function apply_past_filter( string $datetime ): callable {
+		$filter = function ( $clauses ) use ( $datetime ) {
+			global $wpdb;
+			$table = EventDatesTable::table_name();
+
+			if ( strpos( $clauses['join'], $table ) === false ) {
+				$clauses['join'] .= " INNER JOIN {$table} AS ed ON {$wpdb->posts}.ID = ed.post_id";
+			}
+
+			$date_where = $wpdb->prepare(
+				'(ed.start_datetime < %s AND (ed.end_datetime < %s OR ed.end_datetime IS NULL))',
+				$datetime,
+				$datetime
+			);
+			$clauses['where'] .= " AND {$date_where}";
+
+			return $clauses;
+		};
+
+		add_filter( 'posts_clauses', $filter, 10, 1 );
+		return $filter;
+	}
+
+	/**
+	 * Apply event date ordering via posts_clauses.
+	 *
+	 * Ensures the ed JOIN exists and overrides ORDER BY to use ed.start_datetime.
+	 *
+	 * @param string $direction 'ASC' or 'DESC'.
+	 * @return callable Filter callback.
+	 */
+	public static function apply_date_orderby( string $direction = 'ASC' ): callable {
+		$direction = strtoupper( $direction ) === 'DESC' ? 'DESC' : 'ASC';
+
+		$filter = function ( $clauses ) use ( $direction ) {
+			global $wpdb;
+			$table = EventDatesTable::table_name();
+
+			if ( strpos( $clauses['join'], $table ) === false ) {
+				$clauses['join'] .= " INNER JOIN {$table} AS ed ON {$wpdb->posts}.ID = ed.post_id";
+			}
+
+			$clauses['orderby'] = "ed.start_datetime {$direction}";
+
+			return $clauses;
+		};
+
+		add_filter( 'posts_clauses', $filter, 10, 1 );
+		return $filter;
 	}
 
 	/**
 	 * Raw SQL fragments for upcoming events.
 	 *
-	 * Returns JOIN and WHERE clauses. The caller must supply `$wpdb`
-	 * table references and call `$wpdb->prepare()` on the WHERE.
-	 *
-	 * The returned WHERE uses `%s` placeholders — pass `$datetime` twice
-	 * as the corresponding prepare() values.
-	 *
-	 * @param string $postmeta_table Full postmeta table name (e.g. $wpdb->postmeta).
 	 * @return array{joins: string, where: string, param_count: int}
 	 */
-	public static function upcoming_sql( string $postmeta_table ): array {
-		$start_key = esc_sql( EVENT_DATETIME_META_KEY );
-		$end_key   = esc_sql( EVENT_END_DATETIME_META_KEY );
+	public static function upcoming_sql(): array {
+		$table = EventDatesTable::table_name();
 
 		return array(
-			'joins'       => "INNER JOIN {$postmeta_table} pm_start ON p.ID = pm_start.post_id AND pm_start.meta_key = '{$start_key}'"
-				. " LEFT JOIN {$postmeta_table} pm_end ON p.ID = pm_end.post_id AND pm_end.meta_key = '{$end_key}'",
-			'where'       => '(pm_start.meta_value >= %s OR pm_end.meta_value >= %s)',
+			'joins'       => "INNER JOIN {$table} ed ON p.ID = ed.post_id",
+			'where'       => '(ed.start_datetime >= %s OR ed.end_datetime >= %s)',
 			'param_count' => 2,
 		);
 	}
@@ -106,17 +134,14 @@ class DateFilter {
 	/**
 	 * Raw SQL fragments for past events.
 	 *
-	 * @param string $postmeta_table Full postmeta table name.
 	 * @return array{joins: string, where: string, param_count: int}
 	 */
-	public static function past_sql( string $postmeta_table ): array {
-		$start_key = esc_sql( EVENT_DATETIME_META_KEY );
-		$end_key   = esc_sql( EVENT_END_DATETIME_META_KEY );
+	public static function past_sql(): array {
+		$table = EventDatesTable::table_name();
 
 		return array(
-			'joins'       => "INNER JOIN {$postmeta_table} pm_start ON p.ID = pm_start.post_id AND pm_start.meta_key = '{$start_key}'"
-				. " LEFT JOIN {$postmeta_table} pm_end ON p.ID = pm_end.post_id AND pm_end.meta_key = '{$end_key}'",
-			'where'       => '(pm_start.meta_value < %s AND (pm_end.meta_value < %s OR pm_end.meta_value IS NULL))',
+			'joins'       => "INNER JOIN {$table} ed ON p.ID = ed.post_id",
+			'where'       => '(ed.start_datetime < %s AND (ed.end_datetime < %s OR ed.end_datetime IS NULL))',
 			'param_count' => 2,
 		);
 	}
@@ -124,20 +149,14 @@ class DateFilter {
 	/**
 	 * Raw SQL fragments for a date range filter.
 	 *
-	 * Filters events whose start_datetime falls within the range.
-	 * Also includes the standard start/end JOIN for consistency.
-	 *
-	 * @param string $postmeta_table Full postmeta table name.
 	 * @return array{joins: string, where: string, param_count: int}
 	 */
-	public static function date_range_sql( string $postmeta_table ): array {
-		$start_key = esc_sql( EVENT_DATETIME_META_KEY );
-		$end_key   = esc_sql( EVENT_END_DATETIME_META_KEY );
+	public static function date_range_sql(): array {
+		$table = EventDatesTable::table_name();
 
 		return array(
-			'joins'       => "INNER JOIN {$postmeta_table} pm_start ON p.ID = pm_start.post_id AND pm_start.meta_key = '{$start_key}'"
-				. " LEFT JOIN {$postmeta_table} pm_end ON p.ID = pm_end.post_id AND pm_end.meta_key = '{$end_key}'",
-			'where'       => '(pm_start.meta_value >= %s AND pm_start.meta_value <= %s)',
+			'joins'       => "INNER JOIN {$table} ed ON p.ID = ed.post_id",
+			'where'       => '(ed.start_datetime >= %s AND ed.start_datetime <= %s)',
 			'param_count' => 2,
 		);
 	}

--- a/inc/Blocks/Calendar/Query/EventQueryBuilder.php
+++ b/inc/Blocks/Calendar/Query/EventQueryBuilder.php
@@ -15,8 +15,7 @@ namespace DataMachineEvents\Blocks\Calendar\Query;
 use WP_Query;
 use DataMachineEvents\Core\Event_Post_Type;
 use DataMachineEvents\Blocks\Calendar\Geo_Query;
-use const DataMachineEvents\Core\EVENT_DATETIME_META_KEY;
-use const DataMachineEvents\Core\EVENT_END_DATETIME_META_KEY;
+use DataMachineEvents\Core\EventDatesTable;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -27,8 +26,13 @@ class EventQueryBuilder {
 	/**
 	 * Build WP_Query arguments for calendar events.
 	 *
+	 * Date filtering and ordering use posts_clauses filters on the
+	 * event_dates table instead of meta_query. Returns both the query
+	 * args and a cleanup callable that MUST be invoked after the
+	 * WP_Query runs to remove the posts_clauses filters.
+	 *
 	 * @param array $params Query parameters.
-	 * @return array WP_Query arguments.
+	 * @return array{ args: array, cleanup: callable } WP_Query arguments and cleanup function.
 	 */
 	public static function build_query_args( array $params ): array {
 		$defaults = array(
@@ -54,10 +58,6 @@ class EventQueryBuilder {
 
 		/**
 		 * Filter the base query constraint for calendar events.
-		 *
-		 * @param array|null $tax_query_override The base tax_query constraint (null if none).
-		 * @param array      $context Request context.
-		 * @return array|null Modified tax_query constraint or null to remove constraint.
 		 */
 		$params['tax_query_override'] = apply_filters(
 			'data_machine_events_calendar_base_query',
@@ -73,70 +73,71 @@ class EventQueryBuilder {
 			'post_type'      => Event_Post_Type::POST_TYPE,
 			'post_status'    => 'publish',
 			'posts_per_page' => -1,
-			'orderby'        => 'event_start',
-			'order'          => $params['show_past'] ? 'DESC' : 'ASC',
+			// Ordering handled by posts_clauses filter below.
+			'orderby'        => 'none',
 		);
 
-		$meta_query       = array( 'relation' => 'AND' );
+		// Collect all posts_clauses filter callbacks for cleanup.
+		$filters = array();
+
 		$current_datetime = current_time( 'mysql' );
-		$has_date_range   = ! empty( $params['date_start'] ) || ! empty( $params['date_end'] );
 
-		// Track whether DateFilter adds the 'event_start' named clause for ordering.
-		$has_event_start_clause = false;
-
+		// Apply date filter + ordering via posts_clauses.
 		if ( $params['show_past'] && ! $params['user_date_range'] ) {
-			$meta_query[]           = DateFilter::past_meta_query( $current_datetime );
-			$has_event_start_clause = true;
+			$filters[] = DateFilter::apply_past_filter( $current_datetime );
+			$filters[] = DateFilter::apply_date_orderby( 'DESC' );
 		} elseif ( ! $params['show_past'] && ! $params['user_date_range'] ) {
-			$meta_query[]           = DateFilter::upcoming_meta_query( $current_datetime );
-			$has_event_start_clause = true;
+			$filters[] = DateFilter::apply_upcoming_filter( $current_datetime );
+			$filters[] = DateFilter::apply_date_orderby( 'ASC' );
+		} else {
+			// user_date_range mode — just apply ordering.
+			$filters[] = DateFilter::apply_date_orderby( $params['show_past'] ? 'DESC' : 'ASC' );
 		}
 
-		if ( ! empty( $params['date_start'] ) ) {
-			$start_datetime = ! empty( $params['time_start'] )
-				? $params['date_start'] . ' ' . $params['time_start']
-				: $params['date_start'] . ' 00:00:00';
+		// Date range boundaries via posts_clauses.
+		if ( ! empty( $params['date_start'] ) || ! empty( $params['date_end'] ) ) {
+			$date_start = $params['date_start'];
+			$date_end   = $params['date_end'];
+			$time_start = $params['time_start'];
+			$time_end   = $params['time_end'];
 
-			// Include events that START on/after the boundary OR that END on/after it.
-			// This ensures multi-day events that started before the page boundary
-			// but span into it are still returned.
-			$meta_query[] = array(
-				'relation' => 'OR',
-				array(
-					'key'     => EVENT_DATETIME_META_KEY,
-					'value'   => $start_datetime,
-					'compare' => '>=',
-				),
-				array(
-					'key'     => EVENT_END_DATETIME_META_KEY,
-					'value'   => $start_datetime,
-					'compare' => '>=',
-				),
-			);
+			$date_range_filter = function ( $clauses ) use ( $date_start, $date_end, $time_start, $time_end ) {
+				global $wpdb;
+				$table = EventDatesTable::table_name();
+
+				if ( strpos( $clauses['join'], $table ) === false ) {
+					$clauses['join'] .= " INNER JOIN {$table} AS ed ON {$wpdb->posts}.ID = ed.post_id";
+				}
+
+				if ( ! empty( $date_start ) ) {
+					$start_datetime = ! empty( $time_start )
+						? $date_start . ' ' . $time_start
+						: $date_start . ' 00:00:00';
+
+					$clauses['where'] .= $wpdb->prepare(
+						' AND (ed.start_datetime >= %s OR ed.end_datetime >= %s)',
+						$start_datetime,
+						$start_datetime
+					);
+				}
+
+				if ( ! empty( $date_end ) ) {
+					$end_datetime = ! empty( $time_end )
+						? $date_end . ' ' . $time_end
+						: $date_end . ' 23:59:59';
+
+					$clauses['where'] .= $wpdb->prepare(
+						' AND ed.start_datetime <= %s',
+						$end_datetime
+					);
+				}
+
+				return $clauses;
+			};
+
+			add_filter( 'posts_clauses', $date_range_filter );
+			$filters[] = $date_range_filter;
 		}
-
-		if ( ! empty( $params['date_end'] ) ) {
-			$end_datetime = ! empty( $params['time_end'] )
-				? $params['date_end'] . ' ' . $params['time_end']
-				: $params['date_end'] . ' 23:59:59';
-
-			$meta_query[] = array(
-				'key'     => EVENT_DATETIME_META_KEY,
-				'value'   => $end_datetime,
-				'compare' => '<=',
-			);
-		}
-
-		// When DateFilter wasn't applied (user_date_range mode), add a standalone
-		// named clause so 'orderby' => 'event_start' resolves without a redundant JOIN.
-		if ( ! $has_event_start_clause ) {
-			$meta_query['event_start'] = array(
-				'key'     => EVENT_DATETIME_META_KEY,
-				'compare' => 'EXISTS',
-			);
-		}
-
-		$query_args['meta_query'] = $meta_query;
 
 		if ( $params['tax_query_override'] ) {
 			$query_args['tax_query'] = $params['tax_query_override'];
@@ -163,7 +164,6 @@ class EventQueryBuilder {
 						'operator' => 'IN',
 					);
 				} else {
-					// No venues within radius — force empty result set.
 					$tax_query[] = array(
 						'taxonomy' => 'venue',
 						'field'    => 'term_id',
@@ -197,7 +197,19 @@ class EventQueryBuilder {
 			$query_args['s'] = $params['search_query'];
 		}
 
-		return apply_filters( 'data_machine_events_calendar_query_args', $query_args, $params );
+		$query_args = apply_filters( 'data_machine_events_calendar_query_args', $query_args, $params );
+
+		// Return args + cleanup callable that removes all posts_clauses filters.
+		$cleanup = function () use ( $filters ) {
+			foreach ( $filters as $filter ) {
+				remove_filter( 'posts_clauses', $filter );
+			}
+		};
+
+		return array(
+			'args'    => $query_args,
+			'cleanup' => $cleanup,
+		);
 	}
 
 	/**
@@ -228,25 +240,27 @@ class EventQueryBuilder {
 	private static function compute_event_counts(): array {
 		$current_datetime = current_time( 'mysql' );
 
-		$future_query = new WP_Query(
+		$upcoming_filter = DateFilter::apply_upcoming_filter( $current_datetime );
+		$future_query    = new WP_Query(
 			array(
 				'post_type'      => Event_Post_Type::POST_TYPE,
 				'post_status'    => 'publish',
 				'fields'         => 'ids',
 				'posts_per_page' => 1,
-				'meta_query'     => DateFilter::upcoming_meta_query( $current_datetime ),
 			)
 		);
+		remove_filter( 'posts_clauses', $upcoming_filter );
 
-		$past_query = new WP_Query(
+		$past_filter = DateFilter::apply_past_filter( $current_datetime );
+		$past_query  = new WP_Query(
 			array(
 				'post_type'      => Event_Post_Type::POST_TYPE,
 				'post_status'    => 'publish',
 				'fields'         => 'ids',
 				'posts_per_page' => 1,
-				'meta_query'     => DateFilter::past_meta_query( $current_datetime ),
 			)
 		);
+		remove_filter( 'posts_clauses', $past_filter );
 
 		return array(
 			'past'   => $past_query->found_posts,

--- a/inc/Blocks/Calendar/Taxonomy_Helper.php
+++ b/inc/Blocks/Calendar/Taxonomy_Helper.php
@@ -147,19 +147,19 @@ class Taxonomy_Helper {
 			$current_datetime = current_time( 'mysql' );
 
 			if ( ! empty( $date_start ) && ! empty( $date_end ) ) {
-				$filter = DateFilter::date_range_sql( $wpdb->postmeta );
+				$filter = DateFilter::date_range_sql();
 				$joins         .= ' ' . $filter['joins'];
 				$where_clauses .= ' AND ' . $filter['where'];
 				$params[]       = $date_start . ' 00:00:00';
 				$params[]       = $date_end . ' 23:59:59';
 			} elseif ( $show_past ) {
-				$filter = DateFilter::past_sql( $wpdb->postmeta );
+				$filter = DateFilter::past_sql();
 				$joins         .= ' ' . $filter['joins'];
 				$where_clauses .= ' AND ' . $filter['where'];
 				$params[]       = $current_datetime;
 				$params[]       = $current_datetime;
 			} else {
-				$filter = DateFilter::upcoming_sql( $wpdb->postmeta );
+				$filter = DateFilter::upcoming_sql();
 				$joins         .= ' ' . $filter['joins'];
 				$where_clauses .= ' AND ' . $filter['where'];
 				$params[]       = $current_datetime;

--- a/inc/Cli/Check/CheckDuplicatesCommand.php
+++ b/inc/Cli/Check/CheckDuplicatesCommand.php
@@ -94,7 +94,8 @@ class CheckDuplicatesCommand {
 		// Group events by date (YYYY-MM-DD)
 		$by_date = array();
 		foreach ( $events as $event ) {
-			$start_meta = get_post_meta( $event->ID, '_datamachine_event_datetime', true );
+			$dates      = \DataMachineEvents\Core\EventDatesTable::get( $event->ID );
+			$start_meta = $dates ? $dates->start_datetime : '';
 			$date       = $start_meta ? substr( $start_meta, 0, 10 ) : '';
 
 			if ( empty( $date ) ) {

--- a/inc/Cli/Check/CheckDurationCommand.php
+++ b/inc/Cli/Check/CheckDurationCommand.php
@@ -171,33 +171,33 @@ class CheckDurationCommand {
 	private function find_long_span_events( int $max_days, string $scope ): array {
 		global $wpdb;
 
-		$now = current_time( 'Y-m-d H:i:s' );
+		$now      = current_time( 'Y-m-d H:i:s' );
+		$ed_table = \DataMachineEvents\Core\EventDatesTable::table_name();
 
 		$where_scope = '';
 		if ( 'upcoming' === $scope ) {
-			$where_scope = $wpdb->prepare( ' AND end_meta.meta_value >= %s', $now );
+			$where_scope = $wpdb->prepare( ' AND ed.end_datetime >= %s', $now );
 		} elseif ( 'past' === $scope ) {
-			$where_scope = $wpdb->prepare( ' AND end_meta.meta_value < %s', $now );
+			$where_scope = $wpdb->prepare( ' AND ed.end_datetime < %s', $now );
 		}
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$results = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT p.ID, p.post_title, p.post_content,
-					start_meta.meta_value AS start_dt,
-					end_meta.meta_value AS end_dt,
-					DATEDIFF(end_meta.meta_value, start_meta.meta_value) AS span_days,
+					ed.start_datetime AS start_dt,
+					ed.end_datetime AS end_dt,
+					DATEDIFF(ed.end_datetime, ed.start_datetime) AS span_days,
 					handler_meta.meta_value AS pipeline_id
 				FROM {$wpdb->posts} p
-				INNER JOIN {$wpdb->postmeta} start_meta
-					ON p.ID = start_meta.post_id AND start_meta.meta_key = '_datamachine_event_datetime'
-				INNER JOIN {$wpdb->postmeta} end_meta
-					ON p.ID = end_meta.post_id AND end_meta.meta_key = '_datamachine_event_end_datetime'
+				INNER JOIN {$ed_table} ed
+					ON p.ID = ed.post_id
 				LEFT JOIN {$wpdb->postmeta} handler_meta
 					ON p.ID = handler_meta.post_id AND handler_meta.meta_key = '_datamachine_post_pipeline_id'
 				WHERE p.post_type = %s
 					AND p.post_status = 'publish'
-					AND DATEDIFF(end_meta.meta_value, start_meta.meta_value) > %d
+					AND ed.end_datetime IS NOT NULL
+					AND DATEDIFF(ed.end_datetime, ed.start_datetime) > %d
 					{$where_scope}
 				ORDER BY span_days DESC",
 				Event_Post_Type::POST_TYPE,

--- a/inc/Cli/Check/CheckMetaSyncCommand.php
+++ b/inc/Cli/Check/CheckMetaSyncCommand.php
@@ -130,7 +130,8 @@ class CheckMetaSyncCommand {
 				continue;
 			}
 
-			$meta_start = get_post_meta( $event->ID, '_datamachine_event_datetime', true );
+			$dates = \DataMachineEvents\Core\EventDatesTable::get( $event->ID );
+			$meta_start = $dates ? $dates->start_datetime : '';
 
 			if ( empty( $meta_start ) ) {
 				$result[] = array(
@@ -170,21 +171,17 @@ class CheckMetaSyncCommand {
 				$start_datetime .= ' ' . $attrs['startTime'];
 			}
 
-			update_post_meta( (int) $post_id, '_datamachine_event_datetime', $start_datetime );
-
 			if ( ! empty( $attrs['endDate'] ) ) {
 				$end_datetime = $attrs['endDate'];
 				$end_time     = ! empty( $attrs['endTime'] ) ? $attrs['endTime'] : '23:59:59';
 				$end_datetime .= ' ' . $end_time;
-				update_post_meta( (int) $post_id, '_datamachine_event_end_datetime', $end_datetime );
 			} elseif ( ! empty( $attrs['endTime'] ) ) {
-				// End time but no end date: same day as start.
 				$end_datetime = $attrs['startDate'] . ' ' . $attrs['endTime'];
-				update_post_meta( (int) $post_id, '_datamachine_event_end_datetime', $end_datetime );
 			} else {
-				// No end data: remove stale meta rather than fabricate.
-				delete_post_meta( (int) $post_id, '_datamachine_event_end_datetime' );
+				$end_datetime = null;
 			}
+
+			\DataMachineEvents\Core\EventDatesTable::upsert( (int) $post_id, $start_datetime, $end_datetime );
 
 			++$fixed;
 			\WP_CLI::log( sprintf( 'Synced: %d — %s', $post_id, $event['title'] ?? '' ) );

--- a/inc/Cli/Check/CleanDuplicatesCommand.php
+++ b/inc/Cli/Check/CleanDuplicatesCommand.php
@@ -177,7 +177,8 @@ class CleanDuplicatesCommand {
 	private function find_duplicates( array $events ): array {
 		$by_date = array();
 		foreach ( $events as $event ) {
-			$start_meta = get_post_meta( $event->ID, '_datamachine_event_datetime', true );
+			$dates      = \DataMachineEvents\Core\EventDatesTable::get( $event->ID );
+			$start_meta = $dates ? $dates->start_datetime : '';
 			$date       = $start_meta ? substr( $start_meta, 0, 10 ) : '';
 
 			if ( empty( $date ) ) {

--- a/inc/Cli/Check/EventQueryTrait.php
+++ b/inc/Cli/Check/EventQueryTrait.php
@@ -23,40 +23,41 @@ trait EventQueryTrait {
 	 * @return \WP_Post[] Array of post objects.
 	 */
 	private function query_events( string $scope, int $days_ahead = 90 ): array {
+		$order = 'ASC';
+		if ( 'past' === $scope ) {
+			$order = 'DESC';
+		}
+
 		$args = array(
 			'post_type'      => Event_Post_Type::POST_TYPE,
 			'post_status'    => 'publish',
 			'posts_per_page' => -1,
-			'orderby'        => 'meta_value',
-			'meta_key'       => Event_Post_Type::EVENT_DATE_META_KEY,
-			'order'          => 'ASC',
+			'orderby'        => 'none',
+			'order'          => $order,
 		);
 
 		$now = current_time( 'Y-m-d H:i:s' );
 
-		if ( 'upcoming' === $scope ) {
-			$end_date           = gmdate( 'Y-m-d H:i:s', strtotime( "+{$days_ahead} days" ) );
-			$args['meta_query'] = array(
-				array(
-					'key'     => Event_Post_Type::EVENT_DATE_META_KEY,
-					'value'   => array( $now, $end_date ),
-					'compare' => 'BETWEEN',
-					'type'    => 'DATETIME',
-				),
-			);
-		} elseif ( 'past' === $scope ) {
-			$args['meta_query'] = array(
-				array(
-					'key'     => Event_Post_Type::EVENT_DATE_META_KEY,
-					'value'   => $now,
-					'compare' => '<',
-					'type'    => 'DATETIME',
-				),
-			);
-			$args['order'] = 'DESC';
-		}
+		$event_date_filter = function ( $clauses ) use ( $scope, $now, $days_ahead, $order ) {
+			global $wpdb;
+			$table = \DataMachineEvents\Core\EventDatesTable::table_name();
+			if ( strpos( $clauses['join'], $table ) === false ) {
+				$clauses['join'] .= " INNER JOIN {$table} AS ed ON {$wpdb->posts}.ID = ed.post_id";
+			}
+			if ( 'upcoming' === $scope ) {
+				$end_date = gmdate( 'Y-m-d H:i:s', strtotime( "+{$days_ahead} days" ) );
+				$clauses['where'] .= $wpdb->prepare( ' AND ed.start_datetime BETWEEN %s AND %s', $now, $end_date );
+			} elseif ( 'past' === $scope ) {
+				$clauses['where'] .= $wpdb->prepare( ' AND ed.start_datetime < %s', $now );
+			}
+			$clauses['orderby'] = 'ed.start_datetime ' . $order;
+			return $clauses;
+		};
+		add_filter( 'posts_clauses', $event_date_filter );
 
 		$query = new \WP_Query( $args );
+
+		remove_filter( 'posts_clauses', $event_date_filter );
 
 		return $query->posts;
 	}

--- a/inc/Core/DuplicateDetection/EventDuplicateStrategy.php
+++ b/inc/Core/DuplicateDetection/EventDuplicateStrategy.php
@@ -24,7 +24,6 @@ namespace DataMachineEvents\Core\DuplicateDetection;
 use DataMachine\Core\Database\PostIdentityIndex\PostIdentityIndex;
 use DataMachineEvents\Utilities\EventIdentifierGenerator;
 use DataMachineEvents\Core\Event_Post_Type;
-use const DataMachineEvents\Core\EVENT_DATETIME_META_KEY;
 use const DataMachineEvents\Core\EVENT_TICKET_URL_META_KEY;
 use function DataMachineEvents\Core\datamachine_normalize_ticket_url;
 use function DataMachineEvents\Core\datamachine_extract_ticket_identity;
@@ -209,7 +208,8 @@ class EventDuplicateStrategy {
 			}
 
 			// Check time window.
-			$existing_datetime = get_post_meta( $post_id, EVENT_DATETIME_META_KEY, true );
+			$candidate_dates   = \DataMachineEvents\Core\EventDatesTable::get( $post_id );
+			$existing_datetime = $candidate_dates ? $candidate_dates->start_datetime : '';
 			if ( ! self::isWithinTimeWindow( $startDate, $existing_datetime ) ) {
 				continue;
 			}
@@ -313,7 +313,8 @@ class EventDuplicateStrategy {
 				continue;
 			}
 
-			$existing_datetime = get_post_meta( $post_id, EVENT_DATETIME_META_KEY, true );
+			$candidate_dates   = \DataMachineEvents\Core\EventDatesTable::get( $post_id );
+			$existing_datetime = $candidate_dates ? $candidate_dates->start_datetime : '';
 			if ( ! self::isWithinTimeWindow( $startDate, $existing_datetime ) ) {
 				continue;
 			}

--- a/inc/Core/DuplicateDetection/EventIdentityWriter.php
+++ b/inc/Core/DuplicateDetection/EventIdentityWriter.php
@@ -14,7 +14,6 @@ namespace DataMachineEvents\Core\DuplicateDetection;
 
 use DataMachine\Core\Database\PostIdentityIndex\PostIdentityIndex;
 use DataMachineEvents\Core\Event_Post_Type;
-use const DataMachineEvents\Core\EVENT_DATETIME_META_KEY;
 use const DataMachineEvents\Core\EVENT_TICKET_URL_META_KEY;
 
 defined( 'ABSPATH' ) || exit;
@@ -25,29 +24,41 @@ class EventIdentityWriter {
 	 * Register hooks to keep identity rows in sync with event posts.
 	 */
 	public static function register(): void {
-		// Update identity row when event meta is saved (covers both create and update).
-		add_action( 'updated_post_meta', array( static::class, 'onMetaChange' ), 10, 4 );
-		add_action( 'added_post_meta', array( static::class, 'onMetaChange' ), 10, 4 );
+		add_action( 'datamachine_event_dates_updated', array( static::class, 'onEventDatesUpdated' ), 10, 3 );
+		// Keep ticket URL meta hook for identity sync.
+		add_action( 'updated_post_meta', array( static::class, 'onTicketUrlMetaChange' ), 10, 4 );
+		add_action( 'added_post_meta', array( static::class, 'onTicketUrlMetaChange' ), 10, 4 );
 	}
 
 	/**
-	 * React to postmeta changes and sync the identity index.
+	 * React to event dates table writes and sync the identity index.
 	 *
-	 * Triggered when _datamachine_event_datetime or _datamachine_ticket_url
-	 * is written/updated. Rebuilds the full identity row from current state.
+	 * @param int         $post_id        Post ID.
+	 * @param string      $start_datetime Start datetime.
+	 * @param string|null $end_datetime   End datetime or null.
+	 */
+	public static function onEventDatesUpdated( int $post_id, string $start_datetime, ?string $end_datetime ): void {
+		$post_type = get_post_type( $post_id );
+		if ( Event_Post_Type::POST_TYPE !== $post_type ) {
+			return;
+		}
+
+		self::syncIdentityRow( $post_id );
+	}
+
+	/**
+	 * React to ticket URL postmeta changes only.
 	 *
 	 * @param int    $meta_id    Meta row ID.
 	 * @param int    $post_id    Post ID.
 	 * @param string $meta_key   Meta key.
 	 * @param mixed  $meta_value Meta value.
 	 */
-	public static function onMetaChange( $meta_id, $post_id, $meta_key, $meta_value ): void {
-		// Only react to event identity meta keys.
-		if ( EVENT_DATETIME_META_KEY !== $meta_key && EVENT_TICKET_URL_META_KEY !== $meta_key ) {
+	public static function onTicketUrlMetaChange( $meta_id, $post_id, $meta_key, $meta_value ): void {
+		if ( EVENT_TICKET_URL_META_KEY !== $meta_key ) {
 			return;
 		}
 
-		// Only for event posts.
 		$post_type = get_post_type( $post_id );
 		if ( Event_Post_Type::POST_TYPE !== $post_type ) {
 			return;
@@ -72,7 +83,8 @@ class EventIdentityWriter {
 			return;
 		}
 
-		$datetime = get_post_meta( $post_id, EVENT_DATETIME_META_KEY, true );
+		$dates = \DataMachineEvents\Core\EventDatesTable::get( $post_id );
+		$datetime = $dates ? $dates->start_datetime : '';
 		if ( empty( $datetime ) ) {
 			return;
 		}

--- a/inc/Core/EventDatesTable.php
+++ b/inc/Core/EventDatesTable.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Event Dates Table
+ *
+ * Manages the dedicated datamachine_event_dates table that replaces
+ * postmeta-based event datetime storage. Provides schema creation via
+ * dbDelta(), backfill from postmeta, and helper read/write functions.
+ *
+ * @package DataMachineEvents\Core
+ * @since   0.23.0
+ */
+
+namespace DataMachineEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class EventDatesTable {
+
+	/**
+	 * Get the full table name for the current site.
+	 *
+	 * @return string
+	 */
+	public static function table_name(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'datamachine_event_dates';
+	}
+
+	/**
+	 * Create the event dates table via dbDelta.
+	 */
+	public static function create_table(): void {
+		global $wpdb;
+
+		$table   = self::table_name();
+		$charset = $wpdb->get_charset_collate();
+
+		$sql = "CREATE TABLE {$table} (
+			post_id        BIGINT UNSIGNED NOT NULL,
+			start_datetime DATETIME NOT NULL,
+			end_datetime   DATETIME DEFAULT NULL,
+			PRIMARY KEY (post_id),
+			KEY start_datetime (start_datetime),
+			KEY end_datetime (end_datetime)
+		) ENGINE=InnoDB {$charset};";
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql );
+	}
+
+	/**
+	 * Check if the table exists.
+	 *
+	 * @return bool
+	 */
+	public static function table_exists(): bool {
+		global $wpdb;
+		$table = self::table_name();
+		return $wpdb->get_var( "SHOW TABLES LIKE '{$table}'" ) === $table;
+	}
+
+	/**
+	 * Upsert an event's dates into the table.
+	 *
+	 * @param int         $post_id        Post ID.
+	 * @param string      $start_datetime MySQL datetime string.
+	 * @param string|null $end_datetime   MySQL datetime string or null.
+	 */
+	public static function upsert( int $post_id, string $start_datetime, ?string $end_datetime = null ): void {
+		global $wpdb;
+
+		$wpdb->replace(
+			self::table_name(),
+			array(
+				'post_id'        => $post_id,
+				'start_datetime' => $start_datetime,
+				'end_datetime'   => $end_datetime,
+			),
+			array( '%d', '%s', $end_datetime ? '%s' : null )
+		);
+	}
+
+	/**
+	 * Delete an event's dates from the table.
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public static function delete( int $post_id ): void {
+		global $wpdb;
+
+		$wpdb->delete(
+			self::table_name(),
+			array( 'post_id' => $post_id ),
+			array( '%d' )
+		);
+	}
+
+	/**
+	 * Get event dates for a single post.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return object|null Object with start_datetime and end_datetime, or null.
+	 */
+	public static function get( int $post_id ): ?object {
+		global $wpdb;
+
+		$table = self::table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$row = $wpdb->get_row(
+			$wpdb->prepare( "SELECT start_datetime, end_datetime FROM {$table} WHERE post_id = %d", $post_id )
+		);
+
+		return $row ?: null;
+	}
+
+	/**
+	 * Backfill the event dates table from postmeta.
+	 *
+	 * @param int           $batch_size Events per batch.
+	 * @param callable|null $progress   Progress callback (receives total processed count).
+	 * @return int Total events backfilled.
+	 */
+	public static function backfill( int $batch_size = 500, ?callable $progress = null ): int {
+		global $wpdb;
+
+		$table    = self::table_name();
+		$total    = 0;
+		$offset   = 0;
+
+		while ( true ) {
+			// Find events with postmeta datetime but no row in event_dates table.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$rows = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT pm_start.post_id,
+							pm_start.meta_value AS start_datetime,
+							pm_end.meta_value AS end_datetime
+					FROM {$wpdb->postmeta} pm_start
+					LEFT JOIN {$table} ed ON pm_start.post_id = ed.post_id
+					LEFT JOIN {$wpdb->postmeta} pm_end
+						ON pm_start.post_id = pm_end.post_id
+						AND pm_end.meta_key = '_datamachine_event_end_datetime'
+					WHERE pm_start.meta_key = '_datamachine_event_datetime'
+						AND ed.post_id IS NULL
+					LIMIT %d",
+					$batch_size
+				)
+			);
+
+			if ( empty( $rows ) ) {
+				break;
+			}
+
+			foreach ( $rows as $row ) {
+				self::upsert(
+					(int) $row->post_id,
+					$row->start_datetime,
+					$row->end_datetime ?: null
+				);
+				++$total;
+			}
+
+			if ( $progress ) {
+				$progress( $total );
+			}
+
+			if ( count( $rows ) < $batch_size ) {
+				break;
+			}
+		}
+
+		return $total;
+	}
+}

--- a/inc/Core/EventSchemaProvider.php
+++ b/inc/Core/EventSchemaProvider.php
@@ -10,8 +10,7 @@
 
 namespace DataMachineEvents\Core;
 
-use const DataMachineEvents\Core\EVENT_DATETIME_META_KEY;
-use const DataMachineEvents\Core\EVENT_END_DATETIME_META_KEY;
+
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -418,7 +417,8 @@ class EventSchemaProvider {
 			return array( '', '' );
 		}
 
-		$start_datetime = get_post_meta( $post_id, EVENT_DATETIME_META_KEY, true );
+		$dates          = \DataMachineEvents\Core\EventDatesTable::get( $post_id );
+		$start_datetime = $dates ? $dates->start_datetime : '';
 		if ( empty( $start_datetime ) ) {
 			return array( '', '' );
 		}
@@ -446,7 +446,8 @@ class EventSchemaProvider {
 			return array( '', '' );
 		}
 
-		$end_datetime = get_post_meta( $post_id, EVENT_END_DATETIME_META_KEY, true );
+		$dates        = \DataMachineEvents\Core\EventDatesTable::get( $post_id );
+		$end_datetime = $dates ? $dates->end_datetime : '';
 		if ( empty( $end_datetime ) ) {
 			return array( '', '' );
 		}

--- a/inc/Core/Event_Post_Type.php
+++ b/inc/Core/Event_Post_Type.php
@@ -206,7 +206,8 @@ class Event_Post_Type {
 			return;
 		}
 
-		$event_datetime = get_post_meta( $post_id, self::EVENT_DATE_META_KEY, true );
+		$dates          = \DataMachineEvents\Core\EventDatesTable::get( $post_id );
+		$event_datetime = $dates ? $dates->start_datetime : '';
 
 		if ( ! $event_datetime ) {
 			echo '<span class="datamachine-no-date">' . esc_html__( 'No date set', 'data-machine-events' ) . '</span>';
@@ -246,8 +247,19 @@ class Event_Post_Type {
 		$orderby = $query->get( 'orderby' );
 
 		if ( 'event_date' === $orderby ) {
-			$query->set( 'meta_key', self::EVENT_DATE_META_KEY );
-			$query->set( 'orderby', 'meta_value' );
+			$sort_direction = $query->get( 'order' ) ?: 'ASC';
+			add_filter(
+				'posts_clauses',
+				function ( $clauses ) use ( $sort_direction ) {
+					global $wpdb;
+					$table = \DataMachineEvents\Core\EventDatesTable::table_name();
+					if ( strpos( $clauses['join'], $table ) === false ) {
+						$clauses['join'] .= " LEFT JOIN {$table} AS ed ON {$wpdb->posts}.ID = ed.post_id";
+					}
+					$clauses['orderby'] = 'ed.start_datetime ' . $sort_direction;
+					return $clauses;
+				}
+			);
 		}
 	}
 

--- a/inc/Core/meta-storage.php
+++ b/inc/Core/meta-storage.php
@@ -208,25 +208,31 @@ function data_machine_events_sync_datetime_meta( $post_id, $post, $update ) {
 			if ( $start_date ) {
 				$effective_start_time = $start_time ? $start_time : '00:00:00';
 				$datetime             = $start_date . ' ' . $effective_start_time;
-				update_post_meta( $post_id, EVENT_DATETIME_META_KEY, $datetime );
 
 				if ( $end_date ) {
-					// Has explicit end date: use sentinel 23:59:59 when no end time provided.
 					$effective_end_time = $end_time ? $end_time : '23:59:59';
 					$end_datetime_val   = $end_date . ' ' . $effective_end_time;
-					update_post_meta( $post_id, EVENT_END_DATETIME_META_KEY, $end_datetime_val );
 				} elseif ( $end_time ) {
-					// Has end time but no end date: same day, store with start date.
 					$end_datetime_val = $start_date . ' ' . $end_time;
-					update_post_meta( $post_id, EVENT_END_DATETIME_META_KEY, $end_datetime_val );
 				} else {
-					// No end date or time: delete stale meta rather than fabricate one.
-					delete_post_meta( $post_id, EVENT_END_DATETIME_META_KEY );
+					$end_datetime_val = null;
 				}
+
+				EventDatesTable::upsert( $post_id, $datetime, $end_datetime_val );
+
+				/**
+				 * Fires after event dates are written to the event_dates table.
+				 *
+				 * Replaces the `updated_post_meta`/`added_post_meta` hooks that
+				 * previously fired from update_post_meta() calls.
+				 *
+				 * @param int         $post_id        Post ID.
+				 * @param string      $start_datetime Start datetime.
+				 * @param string|null $end_datetime   End datetime or null.
+				 */
+				do_action( 'datamachine_event_dates_updated', $post_id, $datetime, $end_datetime_val );
 			} else {
-				// No date found, delete meta if it exists.
-				delete_post_meta( $post_id, EVENT_DATETIME_META_KEY );
-				delete_post_meta( $post_id, EVENT_END_DATETIME_META_KEY );
+				EventDatesTable::delete( $post_id );
 			}
 
 			// Sync ticket URL for duplicate detection queries.
@@ -242,3 +248,13 @@ function data_machine_events_sync_datetime_meta( $post_id, $post, $update ) {
 	}
 }
 add_action( 'save_post', __NAMESPACE__ . '\\data_machine_events_sync_datetime_meta', 10, 3 );
+
+/**
+ * Get event dates from the dedicated event_dates table.
+ *
+ * @param int $post_id Post ID.
+ * @return object|null Object with start_datetime and end_datetime properties, or null.
+ */
+function datamachine_get_event_dates( int $post_id ): ?object {
+	return EventDatesTable::get( $post_id );
+}

--- a/inc/Steps/Upsert/Events/EventUpsert.php
+++ b/inc/Steps/Upsert/Events/EventUpsert.php
@@ -485,16 +485,22 @@ class EventUpsert extends UpdateHandler {
 					'terms'    => $venue_term->term_id,
 				),
 			),
-			'meta_query'     => array(
-				array(
-					'key'     => EVENT_DATETIME_META_KEY,
-					'value'   => $date_only,
-					'compare' => 'LIKE',
-				),
-			),
 		);
 
+		$date_filter = function ( $clauses ) use ( $date_only ) {
+			global $wpdb;
+			$table = \DataMachineEvents\Core\EventDatesTable::table_name();
+			if ( strpos( $clauses['join'], $table ) === false ) {
+				$clauses['join'] .= " INNER JOIN {$table} AS ed ON {$wpdb->posts}.ID = ed.post_id";
+			}
+			$clauses['where'] .= $wpdb->prepare( ' AND DATE(ed.start_datetime) = %s', $date_only );
+			return $clauses;
+		};
+		add_filter( 'posts_clauses', $date_filter );
+
 		$candidates = get_posts( $args );
+
+		remove_filter( 'posts_clauses', $date_filter );
 
 		if ( empty( $candidates ) ) {
 			return null;
@@ -507,7 +513,8 @@ class EventUpsert extends UpdateHandler {
 			}
 
 			// Check time window if both events have time data
-			$existing_datetime = get_post_meta( $candidate->ID, EVENT_DATETIME_META_KEY, true );
+			$candidate_dates   = \DataMachineEvents\Core\EventDatesTable::get( $candidate->ID );
+			$existing_datetime = $candidate_dates ? $candidate_dates->start_datetime : '';
 			if ( ! $this->isWithinTimeWindow( $startDate, $existing_datetime ) ) {
 				do_action(
 					'datamachine_log',
@@ -645,16 +652,24 @@ class EventUpsert extends UpdateHandler {
 		);
 
 		if ( ! empty( $startDate ) ) {
-			$args['meta_query'] = array(
-				array(
-					'key'     => EVENT_DATETIME_META_KEY,
-					'value'   => self::extractDateForQuery( $startDate ),
-					'compare' => 'LIKE',
-				),
-			);
+			$exact_date_only = self::extractDateForQuery( $startDate );
+			$date_filter     = function ( $clauses ) use ( $exact_date_only ) {
+				global $wpdb;
+				$table = \DataMachineEvents\Core\EventDatesTable::table_name();
+				if ( strpos( $clauses['join'], $table ) === false ) {
+					$clauses['join'] .= " INNER JOIN {$table} AS ed ON {$wpdb->posts}.ID = ed.post_id";
+				}
+				$clauses['where'] .= $wpdb->prepare( ' AND DATE(ed.start_datetime) = %s', $exact_date_only );
+				return $clauses;
+			};
+			add_filter( 'posts_clauses', $date_filter );
 		}
 
 		$posts = get_posts( $args );
+
+		if ( ! empty( $startDate ) ) {
+			remove_filter( 'posts_clauses', $date_filter );
+		}
 
 		if ( ! empty( $posts ) ) {
 			$post_id = $posts[0];
@@ -724,27 +739,35 @@ class EventUpsert extends UpdateHandler {
 		}
 
 		// Strategy A: exact match on stored normalized URL
-		$args = array(
+		$ticket_date_only = self::extractDateForQuery( $startDate );
+		$args             = array(
 			'post_type'      => Event_Post_Type::POST_TYPE,
 			'posts_per_page' => 1,
 			'post_status'    => array( 'publish', 'draft', 'pending' ),
 			'fields'         => 'ids',
 			'meta_query'     => array(
-				'relation' => 'AND',
 				array(
 					'key'     => EVENT_TICKET_URL_META_KEY,
 					'value'   => $normalized_url,
 					'compare' => '=',
 				),
-				array(
-					'key'     => EVENT_DATETIME_META_KEY,
-					'value'   => self::extractDateForQuery( $startDate ),
-					'compare' => 'LIKE',
-				),
 			),
 		);
 
+		$ticket_date_filter_a = function ( $clauses ) use ( $ticket_date_only ) {
+			global $wpdb;
+			$table = \DataMachineEvents\Core\EventDatesTable::table_name();
+			if ( strpos( $clauses['join'], $table ) === false ) {
+				$clauses['join'] .= " INNER JOIN {$table} AS ed ON {$wpdb->posts}.ID = ed.post_id";
+			}
+			$clauses['where'] .= $wpdb->prepare( ' AND DATE(ed.start_datetime) = %s', $ticket_date_only );
+			return $clauses;
+		};
+		add_filter( 'posts_clauses', $ticket_date_filter_a );
+
 		$posts = get_posts( $args );
+
+		remove_filter( 'posts_clauses', $ticket_date_filter_a );
 
 		if ( ! empty( $posts ) ) {
 			do_action(
@@ -776,20 +799,27 @@ class EventUpsert extends UpdateHandler {
 			'post_status'    => array( 'publish', 'draft', 'pending' ),
 			'fields'         => 'ids',
 			'meta_query'     => array(
-				'relation' => 'AND',
 				array(
 					'key'     => EVENT_TICKET_URL_META_KEY,
 					'compare' => 'EXISTS',
 				),
-				array(
-					'key'     => EVENT_DATETIME_META_KEY,
-					'value'   => self::extractDateForQuery( $startDate ),
-					'compare' => 'LIKE',
-				),
 			),
 		);
 
+		$ticket_date_filter_b = function ( $clauses ) use ( $ticket_date_only ) {
+			global $wpdb;
+			$table = \DataMachineEvents\Core\EventDatesTable::table_name();
+			if ( strpos( $clauses['join'], $table ) === false ) {
+				$clauses['join'] .= " INNER JOIN {$table} AS ed ON {$wpdb->posts}.ID = ed.post_id";
+			}
+			$clauses['where'] .= $wpdb->prepare( ' AND DATE(ed.start_datetime) = %s', $ticket_date_only );
+			return $clauses;
+		};
+		add_filter( 'posts_clauses', $ticket_date_filter_b );
+
 		$candidates = get_posts( $date_args );
+
+		remove_filter( 'posts_clauses', $ticket_date_filter_b );
 
 		foreach ( $candidates as $candidate_id ) {
 			$stored_url       = get_post_meta( $candidate_id, EVENT_TICKET_URL_META_KEY, true );
@@ -845,16 +875,22 @@ class EventUpsert extends UpdateHandler {
 			'post_type'      => Event_Post_Type::POST_TYPE,
 			'posts_per_page' => 20,
 			'post_status'    => array( 'publish', 'draft', 'pending' ),
-			'meta_query'     => array(
-				array(
-					'key'     => EVENT_DATETIME_META_KEY,
-					'value'   => $date_only,
-					'compare' => 'LIKE',
-				),
-			),
 		);
 
+		$date_filter = function ( $clauses ) use ( $date_only ) {
+			global $wpdb;
+			$table = \DataMachineEvents\Core\EventDatesTable::table_name();
+			if ( strpos( $clauses['join'], $table ) === false ) {
+				$clauses['join'] .= " INNER JOIN {$table} AS ed ON {$wpdb->posts}.ID = ed.post_id";
+			}
+			$clauses['where'] .= $wpdb->prepare( ' AND DATE(ed.start_datetime) = %s', $date_only );
+			return $clauses;
+		};
+		add_filter( 'posts_clauses', $date_filter );
+
 		$candidates = get_posts( $args );
+
+		remove_filter( 'posts_clauses', $date_filter );
 
 		if ( empty( $candidates ) ) {
 			return null;
@@ -865,7 +901,8 @@ class EventUpsert extends UpdateHandler {
 				continue;
 			}
 
-			$existing_datetime = get_post_meta( $candidate->ID, EVENT_DATETIME_META_KEY, true );
+			$candidate_dates   = \DataMachineEvents\Core\EventDatesTable::get( $candidate->ID );
+			$existing_datetime = $candidate_dates ? $candidate_dates->start_datetime : '';
 			if ( ! $this->isWithinTimeWindow( $startDate, $existing_datetime ) ) {
 				continue;
 			}
@@ -1191,7 +1228,8 @@ class EventUpsert extends UpdateHandler {
 			return;
 		}
 
-		$start_datetime = get_post_meta( $post_id, EVENT_DATETIME_META_KEY, true );
+		$dates          = \DataMachineEvents\Core\EventDatesTable::get( $post_id );
+		$start_datetime = $dates ? $dates->start_datetime : '';
 		if ( empty( $start_datetime ) ) {
 			return;
 		}
@@ -1218,7 +1256,8 @@ class EventUpsert extends UpdateHandler {
 			return;
 		}
 
-		$end_datetime = get_post_meta( $post_id, EVENT_END_DATETIME_META_KEY, true );
+		$dates        = \DataMachineEvents\Core\EventDatesTable::get( $post_id );
+		$end_datetime = $dates ? $dates->end_datetime : '';
 		if ( empty( $end_datetime ) ) {
 			return;
 		}


### PR DESCRIPTION
## Summary

Replace `_datamachine_event_datetime` and `_datamachine_event_end_datetime` postmeta with a dedicated `datamachine_event_dates` table. Clean cut — no postmeta fallback.

### Performance

- Upcoming event count on 37K events: **3-9 seconds → 7ms**
- Eliminates expensive postmeta JOINs across all event queries

### What's New

- **`EventDatesTable`** class — schema via `dbDelta()`, `upsert()`, `get()`, `delete()`, `backfill()`
- **`datamachine_get_event_dates()`** global helper for single-post reads
- **`datamachine_event_dates_updated`** action — replaces `updated_post_meta`/`added_post_meta` hooks
- **CLI:** `wp datamachine-events backfill-event-dates`
- Table auto-created on plugin activation

### Migration Scope

| Category | Count | Description |
|----------|-------|-------------|
| New files | 1 | `EventDatesTable.php` |
| Write path | 2 | `meta-storage.php`, `CheckMetaSyncCommand.php` |
| DateFilter | 1 | Rewritten to posts_clauses + parameterless SQL fragments |
| EventQueryBuilder | 1 | Returns cleanup callable, prevents filter leaks |
| meta_query → posts_clauses | 17 | All WP_Query date filtering locations |
| Raw SQL JOINs | 6 | postmeta → event_dates |
| get_post_meta reads | 23 | → `EventDatesTable::get()` |
| Reactive hooks | 1 | `EventIdentityWriter` hooks new action |
| **Total files** | **28** | |

### Backfill

Already run on production (37,294 events). Table verified with sample queries.

### Cross-repo PRs

- Extra-Chill/extrachill-events — 4 files (related-events, location-seo, venue-map, MarketReport)
- Extra-Chill/extrachill-api — 2 files (upcoming-counts, markdown-export)