### PR TITLE
feat: add Wix Events API fallback when warmup data is empty

### DIFF
--- a/inc/Steps/EventImport/Handlers/WebScraper/Extractors/WixEventsExtractor.php
+++ b/inc/Steps/EventImport/Handlers/WebScraper/Extractors/WixEventsExtractor.php
@@ -2,13 +2,18 @@
 /**
  * Wix Events extractor.
  *
- * Extracts event data from Wix platform websites by parsing the embedded
- * wix-warmup-data JSON structure containing event listings.
+ * Extracts event data from Wix platform websites. Uses two strategies:
+ *
+ * 1. Warmup data — parse the embedded wix-warmup-data JSON (fast, no extra HTTP call).
+ * 2. Wix Events API — query /_api/wix-events-web/v1/events with an instance token
+ *    obtained from /_api/v1/access-tokens. Used when warmup data contains no events.
  *
  * @package DataMachineEvents\Steps\EventImport\Handlers\WebScraper\Extractors
  */
 
 namespace DataMachineEvents\Steps\EventImport\Handlers\WebScraper\Extractors;
+
+use DataMachine\Core\HttpClient;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -16,12 +21,56 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class WixEventsExtractor extends BaseExtractor {
 
+	/**
+	 * Wix Events app definition ID prefix.
+	 *
+	 * The full ID varies per site (e.g. 140603ad-af8d-84a5-2c80-a0f60cb47351)
+	 * but always starts with 140603ad.
+	 */
+	private const WIX_EVENTS_APP_PREFIX = '140603ad';
+
+	/**
+	 * Events to request per API call.
+	 */
+	private const API_PAGE_LIMIT = 100;
+
+	/**
+	 * Statuses that indicate a usable (non-canceled) event.
+	 */
+	private const ACTIVE_STATUSES = array( 'ACTIVE', 'SCHEDULED', 'OPEN' );
+
 	public function canExtract( string $html ): bool {
 		return strpos( $html, 'id="wix-warmup-data"' ) !== false
 			|| strpos( $html, "id='wix-warmup-data'" ) !== false;
 	}
 
 	public function extract( string $html, string $source_url ): array {
+		// Strategy 1: warmup data (fast, no extra HTTP call).
+		$events = $this->extractFromWarmupData( $html );
+
+		if ( ! empty( $events ) ) {
+			return $events;
+		}
+
+		// Strategy 2: Wix Events API (handles sites that load events client-side).
+		return $this->extractFromApi( $source_url );
+	}
+
+	public function getMethod(): string {
+		return 'wix_events';
+	}
+
+	// ────────────────────────────────────────────────────────────────────────────
+	// Strategy 1: Warmup Data
+	// ────────────────────────────────────────────────────────────────────────────
+
+	/**
+	 * Extract events from embedded wix-warmup-data JSON.
+	 *
+	 * @param string $html Page HTML.
+	 * @return array Normalized events.
+	 */
+	private function extractFromWarmupData( string $html ): array {
 		if ( ! preg_match( '/<script[^>]+id=["\']wix-warmup-data["\'][^>]*>(.*?)<\/script>/is', $html, $matches ) ) {
 			return array();
 		}
@@ -38,8 +87,160 @@ class WixEventsExtractor extends BaseExtractor {
 			return array();
 		}
 
+		return $this->normalizeRawEvents( $raw_events );
+	}
+
+	// ────────────────────────────────────────────────────────────────────────────
+	// Strategy 2: Wix Events API
+	// ────────────────────────────────────────────────────────────────────────────
+
+	/**
+	 * Fetch events via the Wix Events internal API.
+	 *
+	 * Flow:
+	 *   1. GET /_api/v1/access-tokens → retrieve app instance tokens.
+	 *   2. Find the Wix Events app instance (app ID starting with 140603ad).
+	 *   3. GET /_api/wix-events-web/v1/events?offset=0&limit=N with the
+	 *      instance as the Authorization header.
+	 *   4. Paginate until all events are collected.
+	 *
+	 * @param string $source_url The venue's homepage URL.
+	 * @return array Normalized events.
+	 */
+	private function extractFromApi( string $source_url ): array {
+		$base_url = $this->getBaseUrl( $source_url );
+		if ( empty( $base_url ) ) {
+			return array();
+		}
+
+		$instance_token = $this->getInstanceToken( $base_url );
+		if ( empty( $instance_token ) ) {
+			return array();
+		}
+
+		$raw_events = $this->fetchAllEvents( $base_url, $instance_token );
+
+		return $this->normalizeRawEvents( $raw_events );
+	}
+
+	/**
+	 * Retrieve the Wix Events app instance token from the access-tokens endpoint.
+	 *
+	 * @param string $base_url Site base URL (e.g. https://www.theescondite.com).
+	 * @return string Instance token, or empty string on failure.
+	 */
+	private function getInstanceToken( string $base_url ): string {
+		$result = HttpClient::get(
+			$base_url . '/_api/v1/access-tokens',
+			array(
+				'timeout' => 15,
+				'headers' => array( 'Accept' => 'application/json' ),
+				'context' => 'Wix Extractor — access tokens',
+			)
+		);
+
+		if ( empty( $result['success'] ) || empty( $result['data'] ) ) {
+			return '';
+		}
+
+		$data = json_decode( $result['data'], true );
+		if ( json_last_error() !== JSON_ERROR_NONE || empty( $data['apps'] ) ) {
+			return '';
+		}
+
+		foreach ( $data['apps'] as $app_id => $app_data ) {
+			if ( str_starts_with( $app_id, self::WIX_EVENTS_APP_PREFIX ) && ! empty( $app_data['instance'] ) ) {
+				return $app_data['instance'];
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Fetch all events from the Wix Events API with pagination.
+	 *
+	 * @param string $base_url       Site base URL.
+	 * @param string $instance_token Wix Events app instance token.
+	 * @return array Raw event objects.
+	 */
+	private function fetchAllEvents( string $base_url, string $instance_token ): array {
+		$all_events = array();
+		$offset     = 0;
+
+		while ( true ) {
+			$response = $this->fetchEventsPage( $base_url, $instance_token, $offset );
+			if ( empty( $response ) ) {
+				break;
+			}
+
+			$page_events = $response['events'] ?? array();
+			if ( ! empty( $page_events ) ) {
+				$all_events = array_merge( $all_events, $page_events );
+			}
+
+			$total = (int) ( $response['total'] ?? 0 );
+			if ( $total <= 0 || ( $offset + self::API_PAGE_LIMIT ) >= $total ) {
+				break;
+			}
+
+			$offset += self::API_PAGE_LIMIT;
+		}
+
+		return $all_events;
+	}
+
+	/**
+	 * Fetch a single page of events from the Wix Events API.
+	 *
+	 * @param string $base_url       Site base URL.
+	 * @param string $instance_token Wix Events app instance token.
+	 * @param int    $offset         Pagination offset.
+	 * @return array|null Decoded API response, or null on failure.
+	 */
+	private function fetchEventsPage( string $base_url, string $instance_token, int $offset ): ?array {
+		$url = $base_url . '/_api/wix-events-web/v1/events?offset=' . $offset . '&limit=' . self::API_PAGE_LIMIT;
+
+		$result = HttpClient::get(
+			$url,
+			array(
+				'timeout' => 20,
+				'headers' => array(
+					'Accept'        => 'application/json',
+					'Authorization' => $instance_token,
+				),
+				'context' => 'Wix Extractor — events API',
+			)
+		);
+
+		if ( empty( $result['success'] ) || ( $result['status_code'] ?? 0 ) !== 200 ) {
+			return null;
+		}
+
+		$data = json_decode( $result['data'] ?? '', true );
+		return ( json_last_error() === JSON_ERROR_NONE && is_array( $data ) ) ? $data : null;
+	}
+
+	// ────────────────────────────────────────────────────────────────────────────
+	// Shared normalization (used by both strategies)
+	// ────────────────────────────────────────────────────────────────────────────
+
+	/**
+	 * Normalize an array of raw Wix event objects, filtering out canceled events.
+	 *
+	 * @param array $raw_events Array of raw event objects from warmup data or API.
+	 * @return array Normalized event data.
+	 */
+	private function normalizeRawEvents( array $raw_events ): array {
 		$events = array();
+
 		foreach ( $raw_events as $raw_event ) {
+			// Skip canceled events.
+			$status = $raw_event['status'] ?? '';
+			if ( 'CANCELED' === $status ) {
+				continue;
+			}
+
 			$normalized = $this->normalizeEvent( $raw_event );
 			if ( ! empty( $normalized['title'] ) ) {
 				$events[] = $normalized;
@@ -49,15 +250,15 @@ class WixEventsExtractor extends BaseExtractor {
 		return $events;
 	}
 
-	public function getMethod(): string {
-		return 'wix_events';
-	}
+	// ────────────────────────────────────────────────────────────────────────────
+	// Warmup data helpers
+	// ────────────────────────────────────────────────────────────────────────────
 
 	/**
 	 * Recursively search for Wix events array in JSON structure.
 	 *
-	 * @param array $data JSON data structure
-	 * @return array Events array or empty array
+	 * @param array $data JSON data structure.
+	 * @return array Events array or empty array.
 	 */
 	private function findEventsRecursive( array $data ): array {
 		if ( isset( $data['events'] ) && isset( $data['events']['events'] ) && is_array( $data['events']['events'] ) ) {
@@ -76,11 +277,15 @@ class WixEventsExtractor extends BaseExtractor {
 		return array();
 	}
 
+	// ────────────────────────────────────────────────────────────────────────────
+	// Event normalization
+	// ────────────────────────────────────────────────────────────────────────────
+
 	/**
 	 * Normalize Wix event to standardized format.
 	 *
-	 * @param array $wix_event Raw Wix event object
-	 * @return array Standardized event data
+	 * @param array $wix_event Raw Wix event object.
+	 * @return array Standardized event data.
 	 */
 	private function normalizeEvent( array $wix_event ): array {
 		$event = array(
@@ -98,6 +303,9 @@ class WixEventsExtractor extends BaseExtractor {
 
 	/**
 	 * Parse scheduling data from Wix event.
+	 *
+	 * @param array $event     Event array to update (by reference).
+	 * @param array $wix_event Raw Wix event.
 	 */
 	private function parseScheduling( array &$event, array $wix_event ): void {
 		$scheduling  = $wix_event['scheduling']['config'] ?? array();
@@ -122,6 +330,9 @@ class WixEventsExtractor extends BaseExtractor {
 
 	/**
 	 * Parse location data from Wix event.
+	 *
+	 * @param array $event     Event array to update (by reference).
+	 * @param array $wix_event Raw Wix event.
 	 */
 	private function parseLocation( array &$event, array $wix_event ): void {
 		$location = $wix_event['location'] ?? array();
@@ -161,6 +372,9 @@ class WixEventsExtractor extends BaseExtractor {
 
 	/**
 	 * Parse ticketing data from Wix event.
+	 *
+	 * @param array $event     Event array to update (by reference).
+	 * @param array $wix_event Raw Wix event.
 	 */
 	private function parseTicketing( array &$event, array $wix_event ): void {
 		$registration = $wix_event['registration'] ?? array();
@@ -172,11 +386,33 @@ class WixEventsExtractor extends BaseExtractor {
 
 	/**
 	 * Parse image data from Wix event.
+	 *
+	 * @param array $event     Event array to update (by reference).
+	 * @param array $wix_event Raw Wix event.
 	 */
 	private function parseImage( array &$event, array $wix_event ): void {
 		$main_image = $wix_event['mainImage'] ?? array();
 		if ( ! empty( $main_image['url'] ) ) {
 			$event['imageUrl'] = esc_url_raw( $main_image['url'] );
 		}
+	}
+
+	// ────────────────────────────────────────────────────────────────────────────
+	// Utility
+	// ────────────────────────────────────────────────────────────────────────────
+
+	/**
+	 * Extract scheme + host from a URL.
+	 *
+	 * @param string $url Full URL.
+	 * @return string Base URL (e.g. https://www.example.com), or empty string.
+	 */
+	private function getBaseUrl( string $url ): string {
+		$parts = wp_parse_url( $url );
+		if ( empty( $parts['host'] ) ) {
+			return '';
+		}
+
+		return ( $parts['scheme'] ?? 'https' ) . '://' . $parts['host'];
 	}
 }


### PR DESCRIPTION
## Summary

- Enhanced `WixEventsExtractor` to query the Wix Events API (`/_api/wix-events-web/v1/events`) when warmup data contains no events
- The API fallback authenticates via app instance tokens obtained from `/_api/v1/access-tokens`, locating the Wix Events app by its ID prefix (`140603ad`)
- Both warmup and API strategies share the same event normalization and now filter out `CANCELED` events
- Supports pagination for sites with more than 100 events

## Technical Details

The authentication flow:
1. `GET /_api/v1/access-tokens` → retrieve all app instance tokens for the site
2. Find the app with ID starting `140603ad` (Wix Events app definition)
3. `GET /_api/wix-events-web/v1/events?offset=0&limit=100` with `Authorization: <instance>` header
4. Paginate until all events collected

The API response uses the identical event structure to warmup data (`location`, `scheduling.config`, `title`, `description`, `status`, etc.), so both strategies share the same `normalizeEvent()` method.

## Test Results

| Venue | canExtract | Warmup | API | Active Events |
|-------|-----------|--------|-----|---------------|
| The Escondite | ✅ | 0 (empty) | 4 (all CANCELED) | 0 |
| Power House Bar | ✅ | 0 (empty) | No Wix Events app | 0 |
| Pullman Yards | ✅ | 0 (empty) | 0 in API | 0 |

Also tested warmup path with mock data — correctly parses events, filters CANCELED, and converts UTC times to local timezone.

Closes #193