### PR TITLE
feat: migrate ability categories for pipeline tool scoping

### DIFF
--- a/data-machine-events.php
+++ b/data-machine-events.php
@@ -276,6 +276,10 @@ class DATAMACHINE_Events {
 		// Notify submitters when their submitted events are published.
 		\DataMachineEvents\Core\SubmissionNotification::register();
 
+		// Register ability categories first — must happen before any ability registration.
+		require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Abilities/AbilityCategories.php';
+		\DataMachineEvents\Abilities\AbilityCategories::ensure_registered();
+
 		// Load chat tools - self-register via ToolRegistrationTrait
 		new \DataMachineEvents\Api\Chat\Tools\VenueHealthCheck();
 		new \DataMachineEvents\Api\Chat\Tools\UpdateVenue();

--- a/inc/Abilities/AbilityCategories.php
+++ b/inc/Abilities/AbilityCategories.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Ability Categories
+ *
+ * Centralized registration of Data Machine Events ability categories.
+ * Follows the same pattern as Data Machine core's AbilityCategories.
+ *
+ * @package DataMachineEvents\Abilities
+ * @since 0.29.0
+ */
+
+namespace DataMachineEvents\Abilities;
+
+defined( 'ABSPATH' ) || exit;
+
+class AbilityCategories {
+
+	/**
+	 * Category slug constants for use in ability registrations.
+	 */
+	public const EVENTS   = 'datamachine-events/events';
+	public const VENUES   = 'datamachine-events/venues';
+	public const TESTING  = 'datamachine-events/testing';
+	public const SETTINGS = 'datamachine-events/settings';
+
+	private static bool $registered = false;
+
+	/**
+	 * Register all Data Machine Events ability categories.
+	 *
+	 * Safe to call multiple times — uses a static guard.
+	 */
+	public static function register(): void {
+		if ( self::$registered ) {
+			return;
+		}
+
+		$categories = array(
+			self::EVENTS   => array(
+				'label'       => __( 'Events', 'data-machine-events' ),
+				'description' => __( 'Event CRUD, queries, health checks, quality audits, updates, and date operations.', 'data-machine-events' ),
+			),
+			self::VENUES   => array(
+				'label'       => __( 'Venues', 'data-machine-events' ),
+				'description' => __( 'Venue CRUD, health checks, geocoding, map queries, and duplicate detection.', 'data-machine-events' ),
+			),
+			self::TESTING  => array(
+				'label'       => __( 'Testing', 'data-machine-events' ),
+				'description' => __( 'Handler testing and scraper compatibility checks.', 'data-machine-events' ),
+			),
+			self::SETTINGS => array(
+				'label'       => __( 'Settings', 'data-machine-events' ),
+				'description' => __( 'Plugin settings read and write.', 'data-machine-events' ),
+			),
+		);
+
+		foreach ( $categories as $slug => $args ) {
+			wp_register_ability_category( $slug, $args );
+		}
+
+		self::$registered = true;
+	}
+
+	/**
+	 * Ensure categories are registered.
+	 *
+	 * Handles timing: if the categories_init hook already fired, registers
+	 * immediately. Otherwise hooks into it.
+	 */
+	public static function ensure_registered(): void {
+		if ( self::$registered ) {
+			return;
+		}
+
+		if ( did_action( 'wp_abilities_api_categories_init' ) ) {
+			self::register();
+		} else {
+			add_action( 'wp_abilities_api_categories_init', array( self::class, 'register' ) );
+		}
+	}
+}

--- a/inc/Abilities/BatchTimeFixAbilities.php
+++ b/inc/Abilities/BatchTimeFixAbilities.php
@@ -45,7 +45,7 @@ class BatchTimeFixAbilities {
 				array(
 					'label'               => __( 'Batch Time Fix', 'data-machine-events' ),
 					'description'         => __( 'Batch fix event times with offset correction or explicit replacement', 'data-machine-events' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-events/events',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'venue' ),

--- a/inc/Abilities/CalendarAbilities.php
+++ b/inc/Abilities/CalendarAbilities.php
@@ -43,7 +43,7 @@ class CalendarAbilities {
 				array(
 					'label'               => __( 'Get Calendar Page', 'data-machine-events' ),
 					'description'         => __( 'Query paginated calendar events with optional filtering and HTML rendering', 'data-machine-events' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-events/events',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/DiceFmTest.php
+++ b/inc/Abilities/DiceFmTest.php
@@ -29,7 +29,7 @@ class DiceFmTest {
 					array(
 						'label'               => __( 'Test Dice FM', 'data-machine-events' ),
 						'description'         => __( 'Test Dice FM API handler with raw response data', 'data-machine-events' ),
-						'category'            => 'datamachine',
+						'category'            => 'datamachine-events/testing',
 						'input_schema'        => array(
 							'type'       => 'object',
 							'required'   => array( 'city' ),

--- a/inc/Abilities/DuplicateDetectionAbilities.php
+++ b/inc/Abilities/DuplicateDetectionAbilities.php
@@ -145,7 +145,7 @@ class DuplicateDetectionAbilities {
 			array(
 				'label'               => __( 'Venues Match', 'data-machine-events' ),
 				'description'         => __( 'Compare two venue names for semantic equivalence. Handles HTML entities, parenthetical stage names, dash-separated qualifiers, and article removal.', 'data-machine-events' ),
-				'category'            => 'datamachine',
+				'category'            => 'datamachine-events/venues',
 				'input_schema'        => array(
 					'type'       => 'object',
 					'required'   => array( 'venue1', 'venue2' ),
@@ -198,7 +198,7 @@ class DuplicateDetectionAbilities {
 			array(
 				'label'               => __( 'Find Duplicate Event', 'data-machine-events' ),
 				'description'         => __( 'Search for an existing event that matches the given title, venue, and date using fuzzy matching. Returns the matching post ID or null.', 'data-machine-events' ),
-				'category'            => 'datamachine',
+				'category'            => 'datamachine-events/venues',
 				'input_schema'        => array(
 					'type'       => 'object',
 					'required'   => array( 'title', 'startDate' ),

--- a/inc/Abilities/EncodingFixAbilities.php
+++ b/inc/Abilities/EncodingFixAbilities.php
@@ -44,7 +44,7 @@ class EncodingFixAbilities {
 				array(
 					'label'               => __( 'Fix Encoding', 'data-machine-events' ),
 					'description'         => __( 'Fix Unicode encoding issues in event block attributes', 'data-machine-events' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-events/events',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/EventDateQueryAbilities.php
+++ b/inc/Abilities/EventDateQueryAbilities.php
@@ -42,7 +42,7 @@ class EventDateQueryAbilities {
 				array(
 					'label'               => __( 'Query Events', 'data-machine-events' ),
 					'description'         => __( 'Query events filtered by date scope, taxonomy, geo, and search. The single primitive for all event date queries.', 'data-machine-events' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-events/events',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/EventHealthAbilities.php
+++ b/inc/Abilities/EventHealthAbilities.php
@@ -41,7 +41,7 @@ class EventHealthAbilities {
 				array(
 					'label'               => __( 'Event Health Check', 'data-machine-events' ),
 					'description'         => __( 'Scan events for data quality issues', 'data-machine-events' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-events/events',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/EventQualityAuditAbilities.php
+++ b/inc/Abilities/EventQualityAuditAbilities.php
@@ -39,7 +39,7 @@ class EventQualityAuditAbilities {
 				array(
 					'label'               => __( 'Event Quality Audit', 'data-machine-events' ),
 					'description'         => __( 'Unified event quality audit with flow-aware diagnostics.', 'data-machine-events' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-events/events',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/EventQueryAbilities.php
+++ b/inc/Abilities/EventQueryAbilities.php
@@ -39,7 +39,7 @@ class EventQueryAbilities {
 				array(
 					'label'               => __( 'Get Venue Events', 'data-machine-events' ),
 					'description'         => __( 'Query events for a specific venue', 'data-machine-events' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-events/events',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'venue' ),

--- a/inc/Abilities/EventScraperTest.php
+++ b/inc/Abilities/EventScraperTest.php
@@ -28,7 +28,7 @@ class EventScraperTest {
 					array(
 						'label'               => __( 'Test Event Scraper', 'data-machine-events' ),
 						'description'         => __( 'Test universal web scraper compatibility with a target URL', 'data-machine-events' ),
-						'category'            => 'datamachine',
+						'category'            => 'datamachine-events/testing',
 						'input_schema'        => array(
 							'type'       => 'object',
 							'required'   => array( 'target_url' ),

--- a/inc/Abilities/EventUpdateAbilities.php
+++ b/inc/Abilities/EventUpdateAbilities.php
@@ -62,7 +62,7 @@ class EventUpdateAbilities {
 				array(
 					'label'               => __( 'Update Event', 'data-machine-events' ),
 					'description'         => __( 'Update event details including dates, times, venue, and metadata', 'data-machine-events' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-events/events',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/FilterAbilities.php
+++ b/inc/Abilities/FilterAbilities.php
@@ -40,7 +40,7 @@ class FilterAbilities {
 				array(
 					'label'               => __( 'Get Filter Options', 'data-machine-events' ),
 					'description'         => __( 'Get available taxonomy filter options with event counts, supporting geo-filtering, cross-filtering, and archive context', 'data-machine-events' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-events/events',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/GeocodingAbilities.php
+++ b/inc/Abilities/GeocodingAbilities.php
@@ -72,7 +72,7 @@ class GeocodingAbilities {
 			array(
 				'label'               => __( 'Geocode Address', 'data-machine-events' ),
 				'description'         => __( 'Geocode an address string to lat/lng coordinates via OpenStreetMap Nominatim. Results are cached for 30 days.', 'data-machine-events' ),
-				'category'            => 'datamachine',
+				'category'            => 'datamachine-events/venues',
 				'input_schema'        => array(
 					'type'       => 'object',
 					'required'   => array( 'query' ),
@@ -160,7 +160,7 @@ class GeocodingAbilities {
 			array(
 				'label'               => __( 'Geocode Search', 'data-machine-events' ),
 				'description'         => __( 'Search for addresses via Nominatim and return multiple results with full address details. Used for autocomplete UIs.', 'data-machine-events' ),
-				'category'            => 'datamachine',
+				'category'            => 'datamachine-events/venues',
 				'input_schema'        => array(
 					'type'       => 'object',
 					'required'   => array( 'query' ),
@@ -271,7 +271,7 @@ class GeocodingAbilities {
 			array(
 				'label'               => __( 'Geocode Venues', 'data-machine-events' ),
 				'description'         => __( 'Batch geocode venues that have an address but are missing coordinates. Respects Nominatim rate limits.', 'data-machine-events' ),
-				'category'            => 'datamachine',
+				'category'            => 'datamachine-events/venues',
 				'input_schema'        => array(
 					'type'       => 'object',
 					'properties' => array(
@@ -453,7 +453,7 @@ class GeocodingAbilities {
 			array(
 				'label'               => __( 'Audit Venues', 'data-machine-events' ),
 				'description'         => __( 'Audit venue data quality: geocoding coverage, missing addresses, missing timezones. Returns a comprehensive data quality report.', 'data-machine-events' ),
-				'category'            => 'datamachine',
+				'category'            => 'datamachine-events/venues',
 				'input_schema'        => array(
 					'type'       => 'object',
 					'properties' => array(

--- a/inc/Abilities/MetaSyncAbilities.php
+++ b/inc/Abilities/MetaSyncAbilities.php
@@ -40,7 +40,7 @@ class MetaSyncAbilities {
 				array(
 					'label'               => __( 'Find Missing Meta Sync', 'data-machine-events' ),
 					'description'         => __( 'Detect events where block has data but meta sync failed', 'data-machine-events' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-events/events',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -82,7 +82,7 @@ class MetaSyncAbilities {
 				array(
 					'label'               => __( 'Resync Event Meta', 'data-machine-events' ),
 					'description'         => __( 'Re-trigger meta sync for specified events', 'data-machine-events' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-events/events',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/SettingsAbilities.php
+++ b/inc/Abilities/SettingsAbilities.php
@@ -73,7 +73,7 @@ class SettingsAbilities {
 			array(
 				'label'               => __( 'Get Settings', 'data-machine-events' ),
 				'description'         => __( 'Read plugin settings. Returns all settings or a specific key.', 'data-machine-events' ),
-				'category'            => 'datamachine',
+				'category'            => 'datamachine-events/settings',
 				'input_schema'        => array(
 					'type'       => 'object',
 					'properties' => array(
@@ -139,7 +139,7 @@ class SettingsAbilities {
 			array(
 				'label'               => __( 'Update Setting', 'data-machine-events' ),
 				'description'         => __( 'Update a single plugin setting. Validates and sanitizes the value.', 'data-machine-events' ),
-				'category'            => 'datamachine',
+				'category'            => 'datamachine-events/settings',
 				'input_schema'        => array(
 					'type'       => 'object',
 					'required'   => array( 'key', 'value' ),

--- a/inc/Abilities/TicketUrlResyncAbilities.php
+++ b/inc/Abilities/TicketUrlResyncAbilities.php
@@ -45,7 +45,7 @@ class TicketUrlResyncAbilities {
 				array(
 					'label'               => __( 'Resync Ticket URLs', 'data-machine-events' ),
 					'description'         => __( 'Re-normalize ticket URL meta from block content', 'data-machine-events' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-events/events',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/TicketmasterTest.php
+++ b/inc/Abilities/TicketmasterTest.php
@@ -30,7 +30,7 @@ class TicketmasterTest {
 					array(
 						'label'               => __( 'Test Ticketmaster', 'data-machine-events' ),
 						'description'         => __( 'Test Ticketmaster API handler with raw response data', 'data-machine-events' ),
-						'category'            => 'datamachine',
+						'category'            => 'datamachine-events/testing',
 						'input_schema'        => array(
 							'type'       => 'object',
 							'required'   => array( 'classification_type' ),

--- a/inc/Abilities/TimezoneAbilities.php
+++ b/inc/Abilities/TimezoneAbilities.php
@@ -39,7 +39,7 @@ class TimezoneAbilities {
 				array(
 					'label'               => __( 'Find Events with Missing Timezone', 'data-machine-events' ),
 					'description'         => __( 'Find events where venue has no timezone or coordinates', 'data-machine-events' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-events/events',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array(),
@@ -112,7 +112,7 @@ class TimezoneAbilities {
 				array(
 					'label'               => __( 'Fix Event Timezone', 'data-machine-events' ),
 					'description'         => __( 'Update venue timezone with geocoding support. Supports batch updates with inline errors.', 'data-machine-events' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-events/events',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array(),

--- a/inc/Abilities/UpcomingCountAbilities.php
+++ b/inc/Abilities/UpcomingCountAbilities.php
@@ -36,7 +36,7 @@ class UpcomingCountAbilities {
 				array(
 					'label'               => __( 'Get Upcoming Event Counts', 'data-machine-events' ),
 					'description'         => __( 'Count upcoming events grouped by taxonomy term. Returns terms sorted by event count descending.', 'data-machine-events' ),
-					'category'            => 'datamachine',
+					'category'            => 'datamachine-events/events',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'taxonomy' ),

--- a/inc/Abilities/VenueAbilities.php
+++ b/inc/Abilities/VenueAbilities.php
@@ -81,7 +81,7 @@ class VenueAbilities {
 			array(
 				'label'               => __( 'Venue Health Check', 'data-machine-events' ),
 				'description'         => __( 'Scan venues for data quality issues: missing address, coordinates, timezone, or website. Also detects suspicious websites where a ticket URL was mistakenly stored as venue website.', 'data-machine-events' ),
-				'category'            => 'datamachine',
+				'category'            => 'datamachine-events/venues',
 				'input_schema'        => array(
 					'type'       => 'object',
 					'properties' => array(
@@ -148,7 +148,7 @@ class VenueAbilities {
 			array(
 				'label'               => __( 'Update Venue', 'data-machine-events' ),
 				'description'         => __( 'Update a venue name and/or meta fields. Address changes trigger automatic geocoding.', 'data-machine-events' ),
-				'category'            => 'datamachine',
+				'category'            => 'datamachine-events/venues',
 				'input_schema'        => array(
 					'type'       => 'object',
 					'required'   => array( 'venue' ),
@@ -233,7 +233,7 @@ class VenueAbilities {
 			array(
 				'label'               => __( 'Get Venue', 'data-machine-events' ),
 				'description'         => __( 'Get venue details by term ID', 'data-machine-events' ),
-				'category'            => 'datamachine',
+				'category'            => 'datamachine-events/venues',
 				'input_schema'        => array(
 					'type'       => 'object',
 					'required'   => array( 'id' ),
@@ -279,7 +279,7 @@ class VenueAbilities {
 			array(
 				'label'               => __( 'Check Duplicate Venue', 'data-machine-events' ),
 				'description'         => __( 'Check if a venue with the given name already exists', 'data-machine-events' ),
-				'category'            => 'datamachine',
+				'category'            => 'datamachine-events/venues',
 				'input_schema'        => array(
 					'type'       => 'object',
 					'required'   => array( 'name' ),

--- a/inc/Abilities/VenueMapAbilities.php
+++ b/inc/Abilities/VenueMapAbilities.php
@@ -58,7 +58,7 @@ class VenueMapAbilities {
 			array(
 				'label'               => __( 'List Venues', 'data-machine-events' ),
 				'description'         => __( 'List venues with coordinates for map rendering. Supports geo proximity and viewport bounds filtering.', 'data-machine-events' ),
-				'category'            => 'datamachine',
+				'category'            => 'datamachine-events/venues',
 				'input_schema'        => array(
 					'type'       => 'object',
 					'properties' => array(

--- a/inc/Api/Chat/Tools/EventHealthCheck.php
+++ b/inc/Api/Chat/Tools/EventHealthCheck.php
@@ -21,7 +21,7 @@ use DataMachineEvents\Abilities\EventHealthAbilities;
 class EventHealthCheck extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'event_health_check', array( $this, 'getToolDefinition' ), array( 'chat' ) );
+		$this->registerTool( 'event_health_check', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'ability' => 'data-machine-events/event-health-check' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Api/Chat/Tools/EventQualityAudit.php
+++ b/inc/Api/Chat/Tools/EventQualityAudit.php
@@ -21,7 +21,7 @@ use DataMachineEvents\Abilities\EventQualityAuditAbilities;
 class EventQualityAudit extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'event_quality_audit', array( $this, 'getToolDefinition' ), array( 'chat' ) );
+		$this->registerTool( 'event_quality_audit', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'ability' => 'data-machine-events/event-quality-audit' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Api/Chat/Tools/FindBrokenTimezoneEvents.php
+++ b/inc/Api/Chat/Tools/FindBrokenTimezoneEvents.php
@@ -20,7 +20,7 @@ use DataMachineEvents\Abilities\TimezoneAbilities;
 class FindBrokenTimezoneEvents extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'find_broken_timezone_events', array( $this, 'getToolDefinition' ), array( 'chat' ) );
+		$this->registerTool( 'find_broken_timezone_events', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'ability' => 'data-machine-events/find-broken-timezone-events' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Api/Chat/Tools/FixEventTimezone.php
+++ b/inc/Api/Chat/Tools/FixEventTimezone.php
@@ -20,7 +20,7 @@ use DataMachineEvents\Abilities\TimezoneAbilities;
 class FixEventTimezone extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'fix_event_timezone', array( $this, 'getToolDefinition' ), array( 'chat' ) );
+		$this->registerTool( 'fix_event_timezone', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'ability' => 'data-machine-events/fix-event-timezone' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Api/Chat/Tools/GetVenueEvents.php
+++ b/inc/Api/Chat/Tools/GetVenueEvents.php
@@ -20,7 +20,7 @@ use DataMachineEvents\Abilities\EventQueryAbilities;
 class GetVenueEvents extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'get_venue_events', array( $this, 'getToolDefinition' ), array( 'chat' ) );
+		$this->registerTool( 'get_venue_events', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'ability' => 'data-machine-events/get-venue-events' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Api/Chat/Tools/TestEventScraper.php
+++ b/inc/Api/Chat/Tools/TestEventScraper.php
@@ -20,7 +20,7 @@ use DataMachineEvents\Abilities\EventScraperTest;
 class TestEventScraper extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'test_event_scraper', array( $this, 'getToolDefinition' ), array( 'chat' ) );
+		$this->registerTool( 'test_event_scraper', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'ability' => 'data-machine-events/test-event-scraper' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Api/Chat/Tools/UpdateEvent.php
+++ b/inc/Api/Chat/Tools/UpdateEvent.php
@@ -21,7 +21,7 @@ use DataMachineEvents\Abilities\EventUpdateAbilities;
 class UpdateEvent extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'update_event', array( $this, 'getToolDefinition' ), array( 'chat' ) );
+		$this->registerTool( 'update_event', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'ability' => 'data-machine-events/update-event' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Api/Chat/Tools/UpdateVenue.php
+++ b/inc/Api/Chat/Tools/UpdateVenue.php
@@ -20,7 +20,7 @@ use DataMachineEvents\Abilities\VenueAbilities;
 class UpdateVenue extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'update_venue', array( $this, 'getToolDefinition' ), array( 'chat' ) );
+		$this->registerTool( 'update_venue', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'ability' => 'data-machine-events/update-venue' ) );
 	}
 
 	public function getToolDefinition(): array {

--- a/inc/Api/Chat/Tools/VenueHealthCheck.php
+++ b/inc/Api/Chat/Tools/VenueHealthCheck.php
@@ -21,7 +21,7 @@ use DataMachineEvents\Abilities\VenueAbilities;
 class VenueHealthCheck extends BaseTool {
 
 	public function __construct() {
-		$this->registerTool( 'venue_health_check', array( $this, 'getToolDefinition' ), array( 'chat' ) );
+		$this->registerTool( 'venue_health_check', array( $this, 'getToolDefinition' ), array( 'chat' ), array( 'ability' => 'data-machine-events/venue-health-check' ) );
 	}
 
 	public function getToolDefinition(): array {


### PR DESCRIPTION
## Summary

- Migrates all abilities from the flat `'datamachine'` category to **4 semantic subcategories** under the `datamachine-events/` namespace
- Adds `ability` metadata to all 9 chat tools for category-based tool scoping
- New `AbilityCategories.php` centralizes category registration

## Context

Data Machine core [PR #1052](https://github.com/Extra-Chill/data-machine/pull/1052) split the flat `datamachine` category into 18 subcategories and removed the old single category registration. This left all `data-machine-events` abilities orphaned — their `'category' => 'datamachine'` pointed to a category that no longer existed.

## Categories

| Category | Slug | Abilities |
|----------|------|-----------|
| Events | `datamachine-events/events` | 13 files, 20 ability registrations |
| Venues | `datamachine-events/venues` | 4 files, 10 ability registrations |
| Testing | `datamachine-events/testing` | 3 files, 3 ability registrations |
| Settings | `datamachine-events/settings` | 1 file, 2 ability registrations |

## Files Changed (32)

- **New:** `inc/Abilities/AbilityCategories.php` — category registration with constants
- **Modified:** `data-machine-events.php` — wire `ensure_registered()` before ability loading
- **Modified:** 20 ability files — category string migration
- **Modified:** 9 chat tool files — add `ability` metadata to `registerTool()` calls

## Backward Compatible

No pipeline or chat behavior changes. Category-based tool filtering only activates when a pipeline explicitly declares `tool_categories`.