### PR TITLE
fix: cap unbounded calendar queries, enable progressive REST rendering

### DIFF
--- a/inc/Abilities/CalendarAbilities.php
+++ b/inc/Abilities/CalendarAbilities.php
@@ -275,6 +275,7 @@ class CalendarAbilities {
 			'tax_filters' => $query_params['tax_filters'],
 			'search'      => $query_params['search_query'],
 			'order'       => $query_params['show_past'] ? 'DESC' : 'ASC',
+			'per_page'    => 500, // Safety cap — prevents loading 17K+ posts when date boundaries are empty.
 		);
 
 		// Date range overrides scope.

--- a/inc/Api/Controllers/Calendar.php
+++ b/inc/Api/Controllers/Calendar.php
@@ -43,6 +43,7 @@ class Calendar {
 				'geo_radius_unit'  => $request->get_param( 'radius_unit' ) ?? 'mi',
 				'include_html'     => true,
 				'include_gaps'     => true,
+				'progressive'      => true,
 			)
 		);
 


### PR DESCRIPTION
## Problem

The calendar ability loads up to **17K+ WP_Post objects** in a single query when date boundaries come back empty (stale cache, edge-case filter combos). This causes massive Redis MGET calls (14K+ keys) and PHP-FPM pressure (`pm.max_children` reached 5+ times).

752 instances of `Unbounded query` in the current debug log, with the worst hitting **17,132 posts** in a single request (`scope: past | tax: location`).

## Root Cause

Two issues:

1. **`CalendarAbilities::executeGetCalendarPage()` passes `per_page: -1` (unlimited)** to `EventDateQueryAbilities::executeQueryEvents()`. When page boundaries are empty, the query loads ALL matching events as full `WP_Post` objects.

2. **REST API calendar controller doesn't pass `progressive: true`**. The `render.php` path uses progressive rendering (only loads first day's events), but the REST API path loads the entire 5-day page window. For busy locations (Charleston with 2,137 events), this means hundreds of posts per AJAX pagination call.

## Changes

### Fix 1: `per_page` safety cap (`CalendarAbilities.php`)
Adds `per_page: 500` to the `$ability_input` array. This is a hard ceiling:
- Normal pages (20-100 events) — **no change**
- Edge cases with empty boundaries — capped at 500 instead of 17K
- Zero risk of regression — only prevents loading more than 500 posts

### Fix 2: Progressive rendering for REST (`Calendar.php`)
Adds `'progressive' => true` to the REST controller's ability call. The frontend JS already supports deferred date loading via `deferred_dates` — the render.php path was using it, but the REST path wasn't. This means:
- REST pagination now only loads first day's events
- Remaining days load via subsequent AJAX calls
- Consistent behavior between SSR and REST paths

## Not Included (needs more testing)

- **Empty-boundary early return** — returning empty when `date_boundaries` has no dates (needs testing that all callers handle empty results gracefully)
- **Past-event date swap fix** — the reversed `range_start`/`range_end` at lines 231-232 may be compensating for something; changing it risks breaking past-events pagination

## Verification

The `logUnboundedQuery` diagnostic is still in place. After deploying, the 17K+ entries should disappear — worst case becomes 500 posts (the cap).