### PR TITLE
Merge fix/unbounded-calendar-queries into main

### DIFF
--- a/inc/Steps/EventImport/Handlers/WebScraper/Extractors/WeeblyExtractor.php
+++ b/inc/Steps/EventImport/Handlers/WebScraper/Extractors/WeeblyExtractor.php
@@ -2,17 +2,20 @@
 /**
  * Weebly Events extractor.
  *
- * Extracts event data from Weebly sites that use repeating image+text block
- * patterns for event listings. Common with small bar/venue sites on Weebly.
+ * Supports two Weebly listing patterns:
+ *
+ * Pattern A — per-block events (original):
+ *   Separate .paragraph divs, each containing one event with a date header
+ *   like "Friday April 10th", followed by artist names, price, and time.
+ *
+ * Pattern B — multi-artist showcase schedule (new):
+ *   A single .paragraph div containing ALL events, separated by date headers
+ *   like "Barn Jam April 22" or "May 6 Barn Jam". Each date header is followed
+ *   by time+artist lines such as "5:50 Eliza Grace". This pattern is common
+ *   for weekly showcase series at small venues (e.g. Awendaw Green Barn Jams).
  *
  * Detection: looks for Weebly-specific CSS classes (.wsite-) or the
  * "Site powered by Weebly" meta tag.
- *
- * Event blocks are .paragraph divs containing structured text:
- *   - Line 1: "Friday April 10th" (day + date)
- *   - Middle lines: artist names / event description
- *   - Price line: "$15 Cover"
- *   - Time line: "Doors at 8pm"
  *
  * @package DataMachineEvents\Steps\EventImport\Handlers\WebScraper\Extractors
  * @since   0.28.0
@@ -27,9 +30,24 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WeeblyExtractor extends BaseExtractor {
 
 	/**
-	 * Minimum .paragraph blocks that look like events to confirm extraction.
+	 * Minimum .paragraph blocks that look like events to confirm Pattern A extraction.
 	 */
 	private const MIN_EVENT_BLOCKS = 3;
+
+	/**
+	 * Minimum showcase date headers to confirm Pattern B extraction.
+	 */
+	private const MIN_SHOWCASE_HEADERS = 2;
+
+	/**
+	 * Regex for month names (full and abbreviated).
+	 */
+	private const MONTH_PATTERN = '(?:January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)';
+
+	/**
+	 * Regex for day-of-week names.
+	 */
+	private const DOW_PATTERN = '(?:Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday)';
 
 	public function canExtract( string $html ): bool {
 		// Weebly fingerprint: CSS classes or powered-by text.
@@ -45,7 +63,25 @@ class WeeblyExtractor extends BaseExtractor {
 		$paragraph_count = substr_count( $html, 'class="paragraph"' )
 			+ substr_count( $html, "class='paragraph'" );
 
-		return $paragraph_count >= self::MIN_EVENT_BLOCKS;
+		if ( $paragraph_count < 1 ) {
+			return false;
+		}
+
+		// Check for Pattern A: multiple paragraph blocks with date headers.
+		$blocks = $this->extractParagraphBlocks( $html );
+		$event_blocks = array_filter( $blocks, array( $this, 'isPatternABlock' ) );
+		if ( count( $event_blocks ) >= self::MIN_EVENT_BLOCKS ) {
+			return true;
+		}
+
+		// Check for Pattern B: a single block with multiple showcase date headers.
+		foreach ( $blocks as $lines ) {
+			if ( $this->countShowcaseDateHeaders( $lines ) >= self::MIN_SHOWCASE_HEADERS ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	public function extract( string $html, string $source_url ): array {
@@ -54,27 +90,32 @@ class WeeblyExtractor extends BaseExtractor {
 			return array();
 		}
 
-		// Filter to only blocks that start with a date line.
-		$event_blocks = array_filter( $blocks, array( $this, 'isEventBlock' ) );
-
-		if ( count( $event_blocks ) < self::MIN_EVENT_BLOCKS ) {
-			return array();
-		}
-
 		$page_venue = \DataMachineEvents\Steps\EventImport\Handlers\WebScraper\PageVenueExtractor::extract( $html, $source_url );
 
 		$parsed   = wp_parse_url( $source_url );
 		$base_url = ( $parsed['scheme'] ?? 'https' ) . '://' . ( $parsed['host'] ?? '' );
 
-		$events = array();
-		foreach ( $event_blocks as $lines ) {
-			$event = $this->parseEventBlock( $lines, $base_url, $page_venue );
-			if ( ! empty( $event['title'] ) && ! empty( $event['startDate'] ) ) {
-				$events[] = $event;
+		// Try Pattern A first: separate blocks with individual date headers.
+		$event_blocks = array_filter( $blocks, array( $this, 'isPatternABlock' ) );
+		if ( count( $event_blocks ) >= self::MIN_EVENT_BLOCKS ) {
+			$events = array();
+			foreach ( $event_blocks as $lines ) {
+				$event = $this->parsePatternABlock( $lines, $base_url, $page_venue );
+				if ( ! empty( $event['title'] ) && ! empty( $event['startDate'] ) ) {
+					$events[] = $event;
+				}
+			}
+			return $events;
+		}
+
+		// Try Pattern B: single block with multi-artist showcase schedule.
+		foreach ( $blocks as $lines ) {
+			if ( $this->countShowcaseDateHeaders( $lines ) >= self::MIN_SHOWCASE_HEADERS ) {
+				return $this->parseShowcaseBlock( $lines, $page_venue );
 			}
 		}
 
-		return $events;
+		return array();
 	}
 
 	public function getMethod(): string {
@@ -142,55 +183,44 @@ class WeeblyExtractor extends BaseExtractor {
 	}
 
 	// ────────────────────────────────────────────────────────────────────────────
-	// Event Block Parsing
+	// Pattern A: Per-Block Events
 	// ────────────────────────────────────────────────────────────────────────────
 
 	/**
-	 * Check if a block of text lines starts with a date pattern.
+	 * Check if a block of text lines starts with a Pattern A date header.
 	 *
-	 * Matches patterns like "Friday April 10th", "Saturday April 11th",
-	 * "Wednesday April 15th", etc.
+	 * Matches "Friday April 10th", "Saturday April 11th", etc.
 	 *
 	 * @param array $lines Text lines from a paragraph block.
 	 * @return bool True if the block starts with a date line.
 	 */
-	private function isEventBlock( array $lines ): bool {
+	private function isPatternABlock( array $lines ): bool {
 		if ( empty( $lines ) ) {
 			return false;
 		}
 
 		return (bool) preg_match(
-			'/^(?:Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday)\s+(?:January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2}(?:st|nd|rd|th)?/i',
+			'/^' . self::DOW_PATTERN . '\s+' . self::MONTH_PATTERN . '\s+\d{1,2}(?:st|nd|rd|th)?/i',
 			$lines[0]
 		);
 	}
 
 	/**
-	 * Parse a single event block into a normalized event array.
+	 * Parse a Pattern A event block into a normalized event array.
 	 *
 	 * Block structure:
 	 *   Line 0: "Friday April 10th"
 	 *   Lines 1..N-2: Artist names / event description
-	 *   Line N-1 or N: "$15 Cover" or "Doors at 8pm"
-	 *   Line N: "Doors at 8pm"
+	 *   Price line: "$15 Cover"
+	 *   Time line: "Doors at 8pm"
 	 *
-	 * @param array  $lines     Text lines from the paragraph block.
-	 * @param string $base_url  Site base URL for resolving images.
+	 * @param array  $lines      Text lines from the paragraph block.
+	 * @param string $base_url   Site base URL for resolving images.
 	 * @param array  $page_venue Venue info from page context.
 	 * @return array Normalized event data.
 	 */
-	private function parseEventBlock( array $lines, string $base_url, array $page_venue ): array {
-		$event = array(
-			'title'        => '',
-			'description'  => '',
-			'startDate'    => '',
-			'startTime'    => '',
-			'venue'        => $page_venue['venue'] ?? '',
-			'venueAddress' => $page_venue['venueAddress'] ?? '',
-			'venueCity'    => $page_venue['venueCity'] ?? '',
-			'venueState'   => $page_venue['venueState'] ?? '',
-			'venueCountry' => $page_venue['venueCountry'] ?? 'US',
-		);
+	private function parsePatternABlock( array $lines, string $base_url, array $page_venue ): array {
+		$event = $this->newEventArray( $page_venue );
 
 		// Parse date from first line.
 		$this->parseDateLine( $event, $lines[0] );
@@ -199,8 +229,8 @@ class WeeblyExtractor extends BaseExtractor {
 		$body_lines = array_slice( $lines, 1 );
 
 		// Extract time and price from body, then the rest is artists/description.
-		$time       = '';
-		$price      = '';
+		$time        = '';
+		$price       = '';
 		$artist_lines = array();
 
 		foreach ( $body_lines as $line ) {
@@ -238,8 +268,302 @@ class WeeblyExtractor extends BaseExtractor {
 		return $event;
 	}
 
+	// ────────────────────────────────────────────────────────────────────────────
+	// Pattern B: Multi-Artist Showcase Schedule
+	// ────────────────────────────────────────────────────────────────────────────
+
 	/**
-	 * Parse a date line like "Friday April 10th" into Y-m-d format.
+	 * Count showcase date headers in a block of lines.
+	 *
+	 * Matches headers like:
+	 *   "Barn Jam April 22"
+	 *   "May 6 Barn Jam"
+	 *   "Open Mic June 15"
+	 *   "April 22"
+	 *   "April 22 Barn Jam"
+	 *
+	 * Must contain a month name + day number to be a date header.
+	 *
+	 * @param array $lines Text lines from a paragraph block.
+	 * @return int Number of showcase date headers found.
+	 */
+	private function countShowcaseDateHeaders( array $lines ): int {
+		$count = 0;
+		foreach ( $lines as $line ) {
+			if ( $this->isShowcaseDateHeader( $line ) ) {
+				++$count;
+			}
+		}
+		return $count;
+	}
+
+	/**
+	 * Check if a line is a showcase date header.
+	 *
+	 * Matches patterns where a month+day appear alongside optional label text
+	 * like "Barn Jam", but NOT lines that start with a time+artist pattern
+	 * (e.g. "5:50 Eliza Grace") or are just URLs.
+	 *
+	 * @param string $line Text line to check.
+	 * @return bool True if this looks like a showcase date header.
+	 */
+	private function isShowcaseDateHeader( string $line ): bool {
+		// Skip lines that start with a time pattern (artist slots).
+		if ( preg_match( '/^\d{1,2}:\d{2}\s/', $line ) ) {
+			return false;
+		}
+
+		// Skip lines that look like URLs or are very short.
+		if ( preg_match( '#^https?://#i', $line ) ) {
+			return false;
+		}
+
+		// Must contain a month name followed by a day number.
+		// Matches: "Barn Jam April 22", "May 6 Barn Jam", "April 22", etc.
+		$month = self::MONTH_PATTERN;
+		return (bool) preg_match(
+			'/\b' . $month . '\s+\d{1,2}\b/i',
+			$line
+		);
+	}
+
+	/**
+	 * Parse a showcase schedule block into multiple events.
+	 *
+	 * Splits the block at date header lines, then parses each sub-event
+	 * for time+artist slots.
+	 *
+	 * @param array $lines      All text lines from the paragraph block.
+	 * @param array $page_venue Venue info from page context.
+	 * @return array Array of normalized event arrays.
+	 */
+	private function parseShowcaseBlock( array $lines, array $page_venue ): array {
+		// Split into sub-events at date header boundaries.
+		$sub_events = $this->splitShowcaseBlock( $lines );
+
+		$events = array();
+		foreach ( $sub_events as $sub_lines ) {
+			$event = $this->parseShowcaseSubEvent( $sub_lines, $page_venue );
+			if ( ! empty( $event['startDate'] ) ) {
+				$events[] = $event;
+			}
+		}
+
+		return $events;
+	}
+
+	/**
+	 * Split a showcase block into sub-event line groups at date headers.
+	 *
+	 * @param array $lines All lines in the block.
+	 * @return array Array of line arrays, one per sub-event.
+	 */
+	private function splitShowcaseBlock( array $lines ): array {
+		$sub_events  = array();
+		$current     = array();
+
+		foreach ( $lines as $line ) {
+			if ( $this->isShowcaseDateHeader( $line ) && ! empty( $current ) ) {
+				$sub_events[] = $current;
+				$current      = array();
+			}
+			$current[] = $line;
+		}
+
+		if ( ! empty( $current ) ) {
+			$sub_events[] = $current;
+		}
+
+		return $sub_events;
+	}
+
+	/**
+	 * Parse a single showcase sub-event (date header + artist slots).
+	 *
+	 * Input format:
+	 *   "Barn Jam April 22"
+	 *   "5:50 Eliza Grace"
+	 *   "https://instagram.com/eliza_grace_music"
+	 *   "6:40 Jarret Forrester"
+	 *   "https://instagram.com/jarretforrestermusic/"
+	 *   ...
+	 *
+	 * Output: one event with all artists listed in the description with times.
+	 *
+	 * @param array $lines      Lines for this sub-event (header + slots).
+	 * @param array $page_venue Venue info from page context.
+	 * @return array Normalized event data.
+	 */
+	private function parseShowcaseSubEvent( array $lines, array $page_venue ): array {
+		$event = $this->newEventArray( $page_venue );
+
+		if ( empty( $lines ) ) {
+			return $event;
+		}
+
+		// First line is the date header.
+		$this->parseShowcaseDateHeader( $event, $lines[0] );
+
+		// Remaining lines: extract time+artist slots, skip URLs.
+		$artists    = array();
+		$first_time = '';
+
+		for ( $i = 1; $i < count( $lines ); $i++ ) {
+			$line = $lines[ $i ];
+
+			// Skip lines that are only a URL (artist links on separate lines).
+			if ( preg_match( '#^https?://#i', $line ) ) {
+				continue;
+			}
+
+			// Match time+artist pattern: "5:50 Eliza Grace" or "5:00 The Band Name"
+			if ( preg_match( '/^(\d{1,2}:\d{2})\s+(.+)$/', $line, $m ) ) {
+				$display_time = $m[1];
+				$artist_name  = $this->stripTrailingUrls( trim( $m[2] ) );
+
+				if ( ! empty( $artist_name ) ) {
+					// Assume PM for evening events (typical showcase hours 5pm-11pm).
+					$hour = (int) explode( ':', $display_time )[0];
+					$parse_time = $display_time;
+					if ( $hour >= 1 && $hour <= 11 ) {
+						$parse_time .= 'pm';
+					}
+					$parsed_time = $this->parseTimeString( $parse_time );
+
+					if ( empty( $first_time ) && ! empty( $parsed_time ) ) {
+						$first_time = $parsed_time;
+					}
+
+					$artists[] = array(
+						'time' => $display_time,
+						'name' => $artist_name,
+					);
+				}
+			}
+		}
+
+		// Build event from extracted data.
+		if ( ! empty( $artists ) ) {
+			// Use a generic title derived from the series name, or first artist.
+			$series_name    = $this->extractSeriesName( $lines[0] );
+			$event['title'] = $series_name ?: $artists[0]['name'];
+
+			// Build description with time+artist lineup.
+			$lineup = array();
+			foreach ( $artists as $artist ) {
+				$lineup[] = $artist['time'] . ' ' . $artist['name'];
+			}
+			$event['description'] = implode( "\n", $lineup );
+		}
+
+		if ( ! empty( $first_time ) ) {
+			$event['startTime'] = $first_time;
+		}
+
+		return $event;
+	}
+
+	/**
+	 * Strip trailing URLs from a text string.
+	 *
+	 * Some Weebly pages have URLs appended to the same line as artist names,
+	 * e.g. "Run River Run https://www.runriverrunband.com/".
+	 *
+	 * @param string $text Text that may contain trailing URLs.
+	 * @return string Text with trailing URLs removed.
+	 */
+	private function stripTrailingUrls( string $text ): string {
+		// Remove URLs that appear after the artist name on the same line.
+		// The /u flag enables UTF-8 mode so \s matches non-breaking spaces (U+00A0).
+		$text = preg_replace( '#\s+https?://\S+#iu', '', $text );
+		return $this->sanitizeText( $text );
+	}
+
+	/**
+	 * Extract the series/show name from a date header line.
+	 *
+	 * "Barn Jam April 22" → "Barn Jam"
+	 * "May 6 Barn Jam" → "Barn Jam"
+	 * "April 22" → "" (no series name)
+	 *
+	 * @param string $header Date header line.
+	 * @return string Series name or empty string.
+	 */
+	private function extractSeriesName( string $header ): string {
+		$month = self::MONTH_PATTERN;
+
+		// Try "Label Month Day" — extract everything before the month.
+		if ( preg_match( '/^(.+?)\s+' . $month . '\s+\d{1,2}/i', $header, $m ) ) {
+			$name = trim( $m[1] );
+			// Filter out things that aren't series names (e.g. year numbers).
+			if ( ! preg_match( '/^\d{4}$/', $name ) ) {
+				return $this->sanitizeText( $name );
+			}
+		}
+
+		// Try "Month Day Label" — extract everything after the day number.
+		if ( preg_match( '/' . $month . '\s+\d{1,2}\s+(.+)$/i', $header, $m ) ) {
+			return $this->sanitizeText( $m[1] );
+		}
+
+		return '';
+	}
+
+	/**
+	 * Parse a showcase date header into startDate.
+	 *
+	 * Handles:
+	 *   "Barn Jam April 22" → 2026-04-22
+	 *   "May 6 Barn Jam" → 2026-05-06
+	 *   "April 22" → 2026-04-22
+	 *
+	 * @param array  $event Event array to update.
+	 * @param string $line  Date header text.
+	 */
+	private function parseShowcaseDateHeader( array &$event, string $line ): void {
+		$month = self::MONTH_PATTERN;
+
+		// Extract month and day from anywhere in the line.
+		if ( ! preg_match( '/(' . $month . ')\s+(\d{1,2})/i', $line, $m ) ) {
+			return;
+		}
+
+		$month_name = $m[1];
+		$day        = $m[2];
+
+		// Use inferDateFromMonthDay which handles year disambiguation.
+		$date = $this->inferDateFromMonthDay( $month_name, $day );
+		if ( ! empty( $date ) ) {
+			$event['startDate'] = $date;
+		}
+	}
+
+	// ────────────────────────────────────────────────────────────────────────────
+	// Shared Utilities
+	// ────────────────────────────────────────────────────────────────────────────
+
+	/**
+	 * Create a new event array with venue defaults.
+	 *
+	 * @param array $page_venue Page-level venue data.
+	 * @return array Event array with defaults populated.
+	 */
+	private function newEventArray( array $page_venue ): array {
+		return array(
+			'title'        => '',
+			'description'  => '',
+			'startDate'    => '',
+			'startTime'    => '',
+			'venue'        => $page_venue['venue'] ?? '',
+			'venueAddress' => $page_venue['venueAddress'] ?? '',
+			'venueCity'    => $page_venue['venueCity'] ?? '',
+			'venueState'   => $page_venue['venueState'] ?? '',
+			'venueCountry' => $page_venue['venueCountry'] ?? 'US',
+		);
+	}
+
+	/**
+	 * Parse a Pattern A date line like "Friday April 10th" into Y-m-d format.
 	 *
 	 * Uses the day-of-week prefix to determine the correct year.
 	 * Tries the current year first; if the resulting weekday doesn't
@@ -254,7 +578,7 @@ class WeeblyExtractor extends BaseExtractor {
 
 		// Extract day-of-week name if present.
 		$day_name = '';
-		if ( preg_match( '/^(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday)\s+/i', $clean, $m ) ) {
+		if ( preg_match( '/^(' . self::DOW_PATTERN . ')\s+/i', $clean, $m ) ) {
 			$day_name = strtolower( $m[1] );
 			$clean    = substr( $clean, strlen( $m[0] ) );
 		}

--- a/tests/Unit/WeeblyExtractorTest.php
+++ b/tests/Unit/WeeblyExtractorTest.php
@@ -1,0 +1,295 @@
+<?php
+/**
+ * Weebly Extractor Tests
+ *
+ * Tests both Pattern A (per-block events) and Pattern B (multi-artist showcase).
+ *
+ * @package DataMachineEvents\Tests\Unit
+ * @since   0.29.0
+ */
+
+namespace DataMachineEvents\Tests\Unit;
+
+use WP_UnitTestCase;
+use DataMachineEvents\Steps\EventImport\Handlers\WebScraper\Extractors\WeeblyExtractor;
+
+class WeeblyExtractorTest extends WP_UnitTestCase {
+
+	private WeeblyExtractor $extractor;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->extractor = new WeeblyExtractor();
+	}
+
+	public function test_getMethod_returns_weebly() {
+		$this->assertEquals( 'weebly', $this->extractor->getMethod() );
+	}
+
+	// ────────────────────────────────────────────────────────────────────────────
+	// Pattern A: Per-Block Events
+	// ────────────────────────────────────────────────────────────────────────────
+
+	public function test_canExtract_detects_pattern_a_weebly_site() {
+		$html = $this->makeWeeblyHtml( '
+			<div class="paragraph">Friday April 10th<br/>Band A<br/>$15 Cover<br/>Doors at 8pm</div>
+			<div class="paragraph">Saturday April 11th<br/>Band B<br/>$10 Cover<br/>Doors at 9pm</div>
+			<div class="paragraph">Sunday April 12th<br/>Band C<br/>$20 Cover<br/>Doors at 7pm</div>
+		' );
+
+		$this->assertTrue( $this->extractor->canExtract( $html ) );
+	}
+
+	public function test_extract_pattern_a_parses_per_block_events() {
+		$html = $this->makeWeeblyHtml( '
+			<div class="paragraph">Friday April 10th<br/>The Headliners<br/>DJ Smooth<br/>$15 Cover<br/>Doors at 8pm</div>
+			<div class="paragraph">Saturday April 11th<br/>Acoustic Night<br/>$10 Cover<br/>Doors at 7pm</div>
+			<div class="paragraph">Sunday April 12th<br/>Jazz Brunch<br/>Doors at 11am</div>
+		' );
+
+		$events = $this->extractor->extract( $html, 'https://example.com/events' );
+
+		$this->assertCount( 3, $events );
+
+		// First event.
+		$this->assertEquals( 'The Headliners', $events[0]['title'] );
+		$this->assertNotEmpty( $events[0]['startDate'] );
+		$this->assertEquals( '20:00', $events[0]['startTime'] );
+
+		// Second event.
+		$this->assertEquals( 'Acoustic Night', $events[1]['title'] );
+		$this->assertEquals( '$10', $events[1]['ticketPrice'] );
+
+		// Third event.
+		$this->assertEquals( 'Jazz Brunch', $events[2]['title'] );
+		$this->assertEquals( '11:00', $events[2]['startTime'] );
+	}
+
+	public function test_extract_pattern_a_skips_non_date_blocks() {
+		$html = $this->makeWeeblyHtml( '
+			<div class="paragraph">Welcome to our venue!</div>
+			<div class="paragraph">Friday April 10th<br/>Band A<br/>Doors at 8pm</div>
+			<div class="paragraph">Saturday April 11th<br/>Band B<br/>Doors at 9pm</div>
+			<div class="paragraph">Sunday April 12th<br/>Band C<br/>Doors at 7pm</div>
+		' );
+
+		$events = $this->extractor->extract( $html, 'https://example.com/events' );
+		$this->assertCount( 3, $events );
+	}
+
+	// ────────────────────────────────────────────────────────────────────────────
+	// Pattern B: Multi-Artist Showcase
+	// ────────────────────────────────────────────────────────────────────────────
+
+	public function test_canExtract_detects_pattern_b_showcase() {
+		$html = $this->makeWeeblyHtml( '
+			<div class="paragraph">
+				Barn Jam April 22<br/>
+				5:50 Eliza Grace<br/>
+				6:40 Jarret Forrester<br/>
+				7:30 The Band<br/>
+				8:20 Run River Run<br/>
+				9:10 Muddy Ruckus<br/>
+				Barn Jam April 29<br/>
+				5:50 LB Beistad<br/>
+				6:40 Mutual Love Club<br/>
+				7:30 The Crazy John String Band<br/>
+				8:20 The Saint Cecilia<br/>
+				9:10 Kick Snare Crash
+			</div>
+		' );
+
+		$this->assertTrue( $this->extractor->canExtract( $html ) );
+	}
+
+	public function test_extract_pattern_b_produces_one_event_per_night() {
+		$html = $this->makeWeeblyHtml( '
+			<div class="paragraph">
+				Barn Jam April 22<br/>
+				5:50 Eliza Grace<br/>
+				6:40 Jarret Forrester<br/>
+				7:30 The Band<br/>
+				8:20 Run River Run<br/>
+				9:10 Muddy Ruckus<br/>
+				Barn Jam April 29<br/>
+				5:50 LB Beistad<br/>
+				6:40 Mutual Love Club<br/>
+				7:30 The Crazy John String Band<br/>
+				8:20 The Saint Cecilia<br/>
+				9:10 Kick Snare Crash
+			</div>
+		' );
+
+		$events = $this->extractor->extract( $html, 'https://example.com/showcase' );
+
+		$this->assertCount( 2, $events );
+
+		// First night — April 22.
+		$first = $events[0];
+		$this->assertEquals( 'Barn Jam', $first['title'] );
+		$this->assertStringContainsString( 'Eliza Grace', $first['description'] );
+		$this->assertStringContainsString( 'Jarret Forrester', $first['description'] );
+		$this->assertStringContainsString( 'Muddy Ruckus', $first['description'] );
+		$this->assertEquals( '17:50', $first['startTime'] );
+
+		// Second night — April 29.
+		$second = $events[1];
+		$this->assertEquals( 'Barn Jam', $second['title'] );
+		$this->assertStringContainsString( 'LB Beistad', $second['description'] );
+		$this->assertStringContainsString( 'Kick Snare Crash', $second['description'] );
+		$this->assertEquals( '17:50', $second['startTime'] );
+	}
+
+	public function test_extract_pattern_b_handles_reversed_date_format() {
+		$html = $this->makeWeeblyHtml( '
+			<div class="paragraph">
+				May 6 Barn Jam<br/>
+				5:50 Kyle Erickson<br/>
+				6:40 The Whipporwills<br/>
+				7:30 Dr T and the Side Effects<br/>
+				May 13 Barn Jam<br/>
+				5:50 Ashley Virginia<br/>
+				6:40 Brian Ashley Jones
+			</div>
+		' );
+
+		$events = $this->extractor->extract( $html, 'https://example.com/showcase' );
+
+		$this->assertCount( 2, $events );
+		$this->assertEquals( 'Barn Jam', $events[0]['title'] );
+		$this->assertEquals( 'Barn Jam', $events[1]['title'] );
+	}
+
+	public function test_extract_pattern_b_skips_url_lines() {
+		$html = $this->makeWeeblyHtml( '
+			<div class="paragraph">
+				Barn Jam April 22<br/>
+				5:50 Eliza Grace<br/>
+				https://www.instagram.com/eliza_grace_music<br/>
+				6:40 Jarret Forrester<br/>
+				https://www.youtube.com/channel/UC7l1t8SQIJf21xhO4LMZePw<br/>
+				Barn Jam April 29<br/>
+				5:50 LB Beistad<br/>
+				https://www.lbbeistad.com/
+			</div>
+		' );
+
+		$events = $this->extractor->extract( $html, 'https://example.com/showcase' );
+
+		$this->assertCount( 2, $events );
+
+		// URLs should not appear in artist names.
+		$this->assertStringNotContainsString( 'instagram.com', $events[0]['description'] );
+		$this->assertStringNotContainsString( 'youtube.com', $events[0]['description'] );
+		$this->assertStringContainsString( 'Eliza Grace', $events[0]['description'] );
+		$this->assertStringContainsString( 'Jarret Forrester', $events[0]['description'] );
+	}
+
+	public function test_extract_pattern_b_handles_year_header_lines() {
+		// The Awendaw Green page has "2026" as a standalone line before events.
+		// This should not crash or produce bad events.
+		$html = $this->makeWeeblyHtml( '
+			<div class="paragraph">
+				2026<br/>
+				Barn Jam April 22<br/>
+				5:50 Eliza Grace<br/>
+				6:40 Jarret Forrester<br/>
+				Barn Jam April 29<br/>
+				5:50 LB Beistad<br/>
+				6:40 Mutual Love Club
+			</div>
+		' );
+
+		$events = $this->extractor->extract( $html, 'https://example.com/showcase' );
+
+		$this->assertCount( 2, $events );
+		$this->assertEquals( 'Barn Jam', $events[0]['title'] );
+		$this->assertEquals( 'Barn Jam', $events[1]['title'] );
+	}
+
+	public function test_extract_pattern_b_lineup_preserves_times() {
+		$html = $this->makeWeeblyHtml( '
+			<div class="paragraph">
+				Barn Jam May 13<br/>
+				5:00 The New Blue of Yale<br/>
+				5:50 Ashley Virginia<br/>
+				6:40 Brian Ashley Jones<br/>
+				7:30 Mount Pom<br/>
+				8:20 Anders Thomsen<br/>
+				9:10 Tanner Dane
+			</div>
+		' );
+
+		$events = $this->extractor->extract( $html, 'https://example.com/showcase' );
+
+		$this->assertCount( 1, $events );
+		$event = $events[0];
+
+		// First artist at 5:00 PM = 17:00.
+		$this->assertEquals( '17:00', $event['startTime'] );
+
+		// Description should list all 6 artists with their times.
+		$this->assertStringContainsString( '5:00 The New Blue of Yale', $event['description'] );
+		$this->assertStringContainsString( '5:50 Ashley Virginia', $event['description'] );
+		$this->assertStringContainsString( '9:10 Tanner Dane', $event['description'] );
+	}
+
+	public function test_extract_pattern_b_uses_fallback_when_no_series_name() {
+		$html = $this->makeWeeblyHtml( '
+			<div class="paragraph">
+				April 22<br/>
+				5:50 Eliza Grace<br/>
+				6:40 Jarret Forrester<br/>
+				May 6<br/>
+				5:50 Kyle Erickson<br/>
+				6:40 The Whipporwills
+			</div>
+		' );
+
+		$events = $this->extractor->extract( $html, 'https://example.com/showcase' );
+
+		$this->assertCount( 2, $events );
+
+		// No series name → use first artist as title.
+		$this->assertEquals( 'Eliza Grace', $events[0]['title'] );
+		$this->assertEquals( 'Kyle Erickson', $events[1]['title'] );
+	}
+
+	// ────────────────────────────────────────────────────────────────────────────
+	// Negative Tests
+	// ────────────────────────────────────────────────────────────────────────────
+
+	public function test_canExtract_rejects_non_weebly_html() {
+		$html = '<html><body><div class="paragraph">Friday April 10th Band A</div></body></html>';
+		$this->assertFalse( $this->extractor->canExtract( $html ) );
+	}
+
+	public function test_extract_returns_empty_for_no_blocks() {
+		$html = $this->makeWeeblyHtml( '<p>No events here</p>' );
+		$this->assertEmpty( $this->extractor->extract( $html, 'https://example.com' ) );
+	}
+
+	// ────────────────────────────────────────────────────────────────────────────
+	// Helpers
+	// ────────────────────────────────────────────────────────────────────────────
+
+	/**
+	 * Wrap content in a minimal Weebly page shell.
+	 *
+	 * @param string $body_html HTML to inject into the body.
+	 * @return string Full page HTML with Weebly fingerprint.
+	 */
+	private function makeWeeblyHtml( string $body_html ): string {
+		return '<!DOCTYPE html>
+<html>
+<head>
+<link rel="stylesheet" type="text/css" href="//cdn11.editmysite.com/css/sites.css?buildtime=1234" />
+</head>
+<body class="wsite-page-events">
+	<div id="wsite-content">
+		' . $body_html . '
+	</div>
+</body>
+</html>';
+	}
+}


### PR DESCRIPTION
Brings the Barn Jams Weebly extractor (PR #203) into main. The previous PR was accidentally targeted at `fix/unbounded-calendar-queries` instead of `main`.