### PR TITLE
refactor: rename executeUpdate() → executeUpsert()

### DIFF
--- a/inc/Steps/Upsert/Events/EventUpsert.php
+++ b/inc/Steps/Upsert/Events/EventUpsert.php
@@ -55,7 +55,7 @@ class EventUpsert extends UpsertHandler {
 	 * @param array $handler_config Handler configuration
 	 * @return array Tool call result with action: created|updated|no_change
 	 */
-	protected function executeUpdate( array $parameters, array $handler_config ): array {
+	protected function executeUpsert( array $parameters, array $handler_config ): array {
 		// Get engine data FIRST (before validation)
 		$job_id = (int) ( $parameters['job_id'] ?? 0 );
 		$engine = $parameters['engine'] ?? null;
@@ -123,7 +123,7 @@ class EventUpsert extends UpsertHandler {
 	/**
 	 * Execute the find-or-create logic within an advisory lock.
 	 *
-	 * Separated from executeUpdate() so the lock boundary is clear:
+	 * Separated from executeUpsert() so the lock boundary is clear:
 	 * the lock is held from before findExistingEvent() through the
 	 * completion of createEventPost() or updateEventPost().
 	 *


### PR DESCRIPTION
Companion to [data-machine#1105](https://github.com/Extra-Chill/data-machine/pull/1105).

Renames `EventUpsert::executeUpdate()` → `executeUpsert()` to match the renamed abstract method in `UpsertHandler`.

Must be merged and released after data-machine#1105.