### PR TITLE
Fix event dedup falsely matching recurring series as duplicates

### DIFF
--- a/inc/Steps/Upsert/Events/EventUpsert.php
+++ b/inc/Steps/Upsert/Events/EventUpsert.php
@@ -279,6 +279,37 @@ class EventUpsert extends UpsertHandler {
 		if ( is_array( $result ) && 'duplicate' === ( $result['verdict'] ?? '' ) ) {
 			$post_id = (int) ( $result['match']['post_id'] ?? 0 );
 			if ( $post_id > 0 ) {
+				// Verify the matched post has the same startDate. The core
+				// duplicate check matches on title similarity alone and does
+				// not consider event dates. Recurring series events (e.g.
+				// weekly "Barn Jam" at Awendaw Green) share the same title
+				// and venue but have different dates — these are distinct
+				// events, not duplicates.
+				// See: https://github.com/Extra-Chill/data-machine/issues/1108
+				if ( ! empty( $startDate ) ) {
+					$existing_data      = $this->extractEventData( $post_id );
+					$existing_startDate = $existing_data['startDate'] ?? '';
+
+					if ( ! empty( $existing_startDate ) && $existing_startDate !== $startDate ) {
+						do_action(
+							'datamachine_log',
+							'info',
+							'Event Upsert: Ability matched title but startDate differs — treating as new event (recurring series)',
+							array(
+								'title'              => $title,
+								'venue'              => $venue,
+								'incoming_startDate' => $startDate,
+								'existing_startDate' => $existing_startDate,
+								'existing_post_id'   => $post_id,
+							)
+						);
+
+						// Fall through to legacy date-aware lookup which
+						// searches by venue + date + fuzzy title.
+						return $this->findExistingEvent( $title, $venue, $startDate, $ticketUrl );
+					}
+				}
+
 				return $post_id;
 			}
 		}

--- a/tests/Unit/EventUpsertTest.php
+++ b/tests/Unit/EventUpsertTest.php
@@ -177,4 +177,70 @@ class EventUpsertTest extends WP_UnitTestCase {
 
 		$this->assertSame( 'date_only', $result );
 	}
+
+	/**
+	 * Verify that recurring series events with the same title but different
+	 * dates are treated as distinct events, not duplicates.
+	 *
+	 * The legacy findExistingEvent() method correctly uses venue + date +
+	 * fuzzy title matching. This test verifies that the method returns null
+	 * for a different date at the same venue with the same title.
+	 *
+	 * @see https://github.com/Extra-Chill/data-machine/issues/1108
+	 */
+	public function test_find_existing_event_distinguishes_recurring_series_by_date(): void {
+		$method = new \ReflectionMethod( $this->handler, 'findExistingEvent' );
+		$method->setAccessible( true );
+
+		$venue_name = 'Recurring Venue ' . uniqid();
+
+		// Create venue term.
+		$venue_term = wp_insert_term( $venue_name, 'venue' );
+		$this->assertNotWPError( $venue_term );
+
+		// Create existing event: "Barn Jam" on April 22.
+		$existing_post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Barn Jam',
+				'post_type'    => 'data_machine_events',
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:data-machine-events/event-details {"startDate":"2026-04-22","venue":"' . $venue_name . '"} --><div class="wp-block-data-machine-events-event-details"></div><!-- /wp:data-machine-events/event-details -->',
+			)
+		);
+		$this->assertGreaterThan( 0, $existing_post_id );
+		wp_set_object_terms( $existing_post_id, array( $venue_term['term_id'] ), 'venue' );
+
+		// Search for "Barn Jam" at same venue but DIFFERENT date — should NOT match.
+		$result = $method->invoke(
+			$this->handler,
+			'Barn Jam',
+			$venue_name,
+			'2026-05-06',
+			''
+		);
+
+		$this->assertNull(
+			$result,
+			'findExistingEvent should NOT match same-title event on a different date (recurring series)'
+		);
+
+		// Search for "Barn Jam" at same venue and SAME date — should match.
+		$result_same_date = $method->invoke(
+			$this->handler,
+			'Barn Jam',
+			$venue_name,
+			'2026-04-22',
+			''
+		);
+
+		$this->assertSame(
+			$existing_post_id,
+			$result_same_date,
+			'findExistingEvent should match same-title event on the same date'
+		);
+
+		// Cleanup.
+		wp_delete_post( $existing_post_id, true );
+		wp_delete_term( $venue_term['term_id'], 'venue' );
+	}
 }


### PR DESCRIPTION
## Summary

The ability-based duplicate check (`datamachine/check-duplicate`) matches on title similarity alone. For recurring series events like weekly "Barn Jam" at Awendaw Green, every instance matches the first post regardless of date — causing N-1 events to silently update the first post instead of creating new ones.

## The Bug

`findExistingEventViaAbility()` calls the core duplicate check ability, which runs `checkPublishedPosts()` → `SimilarityEngine::titlesMatch()`. This returns "duplicate" on title match (score: 1.0) without considering the `context.startDate` that was passed. The legacy `findExistingEvent()` method correctly uses venue + date + fuzzy title, but it's never reached because the ability short-circuits.

**Before:** "Barn Jam" on May 6 → ability finds existing April 22 "Barn Jam" → updates it → no new post created.

**After:** "Barn Jam" on May 6 → ability finds April 22 "Barn Jam" → startDate mismatch detected → falls back to legacy date-aware lookup → no match → creates new May 6 post.

## Fix

After `datamachine/check-duplicate` returns a match, verify the matched post's `startDate` matches the incoming `startDate`. If dates differ, log it as a recurring series and fall back to the date-aware `findExistingEvent()`.

## Changes

| File | Change |
|------|--------|
| `inc/Steps/Upsert/Events/EventUpsert.php` | Add startDate verification after ability match |
| `tests/Unit/EventUpsertTest.php` | Test that recurring series events are not falsely deduped |

Related: data-machine#1108 (AI conversation never completes)