### PR TITLE
refactor(EventUpsert): delegate to DM core upsert-post ability

### DIFF
--- a/inc/Steps/Upsert/Events/EventUpsert.php
+++ b/inc/Steps/Upsert/Events/EventUpsert.php
@@ -125,7 +125,12 @@ class EventUpsert extends UpsertHandler {
 	 *
 	 * Separated from executeUpsert() so the lock boundary is clear:
 	 * the lock is held from before findExistingEvent() through the
-	 * completion of createEventPost() or updateEventPost().
+	 * completion of the DM core upsert and post-processing.
+	 *
+	 * Domain-specific identity resolution (fuzzy title/venue/date matching,
+	 * ticket URL canonical matching) is kept here. The actual create/update/no_change
+	 * decision is delegated to datamachine/upsert-post, which handles content hash
+	 * comparison and provenance stamping.
 	 *
 	 * @param string     $title         Event title.
 	 * @param string     $venue         Venue name.
@@ -145,94 +150,120 @@ class EventUpsert extends UpsertHandler {
 		array $handler_config,
 		EngineData $engine
 	): array {
-		// Search for existing event via the core duplicate detection system.
-		// This uses the PostIdentityIndex (indexed lookups) instead of
-		// postmeta LIKE scans. Falls back to the old findExistingEvent()
-		// method if the identity index table doesn't exist yet.
+		// 1. Find existing event via domain-specific duplicate detection.
 		$existing_post_id = $this->findExistingEventViaAbility( $title, $venue, $startDate, $ticketUrl );
 
-		if ( $existing_post_id ) {
-			// Event exists - check if data changed
-			$existing_data = $this->extractEventData( $existing_post_id );
+		// 2. Build event data.
+		$event_data = $this->buildEventData( $parameters, $handler_config, $engine, $existing_post_id );
 
-			if ( $this->hasDataChanged( $existing_data, $parameters ) ) {
-				// UPDATE existing event
-				$this->updateEventPost( $existing_post_id, $parameters, $handler_config, $engine );
+		// 3. Generate block content and compute hash for idempotency.
+		$block_content = $this->generate_event_block_content( $event_data, $parameters );
+		$content_hash  = md5( $block_content );
 
-				// Sync identity index after update.
-				EventIdentityWriter::syncIdentityRow( $existing_post_id, $title, datamachine_normalize_ticket_url( $ticketUrl ) ?: null );
+		// 4. Resolve post author and status.
+		$post_author = $this->resolvePostAuthor( $handler_config, $engine );
+		$post_status = WordPressSettingsResolver::getPostStatus( $handler_config );
 
-				do_action(
-					'datamachine_log',
-					'info',
-					'Event Upsert: Updated existing event',
-					array(
-						'post_id' => $existing_post_id,
-						'title'   => $title,
-					)
-				);
+		// 5. Build meta input.
+		$meta_input = $this->buildEventMetaInput( $event_data, $parameters, $engine );
 
-				return $this->successResponse(
-					array(
-						'post_id'  => $existing_post_id,
-						'post_url' => get_permalink( $existing_post_id ),
-						'action'   => 'updated',
-					)
-				);
-			} else {
-				// SKIP - no changes detected
-				do_action(
-					'datamachine_log',
-					'debug',
-					'Event Upsert: Skipped event (no changes)',
-					array(
-						'post_id' => $existing_post_id,
-						'title'   => $title,
-					)
-				);
+		// 6. Delegate to DM core upsert ability.
+		$upsert_input = array(
+			'post_type'    => Event_Post_Type::POST_TYPE,
+			'title'        => $event_data['title'],
+			'content'      => $block_content,
+			'content_hash' => $content_hash,
+			'post_status'  => $post_status,
+			'meta_input'   => $meta_input,
+		);
 
-				return $this->successResponse(
-					array(
-						'post_id'  => $existing_post_id,
-						'post_url' => get_permalink( $existing_post_id ),
-						'action'   => 'no_change',
-					)
-				);
-			}
+		if ( $existing_post_id > 0 ) {
+			$upsert_input['post_id'] = $existing_post_id;
 		} else {
-			// CREATE new event
-			$post_id = $this->createEventPost( $parameters, $handler_config, $engine );
+			$upsert_input['post_author'] = $post_author;
+		}
 
-			if ( is_wp_error( $post_id ) || ! $post_id ) {
-				return $this->errorResponse(
-					'Event post creation failed',
-					array(
-						'title' => $title,
-					)
-				);
-			}
+		$ability = wp_get_ability( 'datamachine/upsert-post' );
+		if ( ! $ability ) {
+			return $this->errorResponse( 'datamachine/upsert-post ability not available' );
+		}
 
-			// Write identity index row for new event.
-			EventIdentityWriter::syncIdentityRow( $post_id, $title, datamachine_normalize_ticket_url( $ticketUrl ) ?: null );
+		$result = $ability->execute( $upsert_input );
 
-			do_action(
-				'datamachine_log',
-				'info',
-				'Event Upsert: Created new event',
-				array(
-					'post_id' => $post_id,
-					'title'   => $title,
-				)
+		if ( empty( $result['success'] ) ) {
+			return $this->errorResponse(
+				$result['error'] ?? 'Event upsert failed',
+				array( 'title' => $title )
 			);
+		}
 
+		$post_id = (int) $result['post_id'];
+		$action  = $result['action'];
+
+		// 7. no_change: nothing else to do.
+		if ( 'no_change' === $action ) {
 			return $this->successResponse(
 				array(
 					'post_id'  => $post_id,
 					'post_url' => get_permalink( $post_id ),
-					'action'   => 'created',
+					'action'   => 'no_change',
 				)
 			);
 		}
+
+		// 8. Post-upsert event-specific processing (create and update paths).
+		$this->processEventFeaturedImage( $post_id, $handler_config, $engine );
+		$this->processVenue( $post_id, $parameters, $engine );
+		$this->processPromoter( $post_id, $parameters, $engine, $handler_config );
+
+		// Map performer to artist taxonomy if not explicitly provided.
+		if ( empty( $parameters['artist'] ) && ! empty( $event_data['performer'] ) ) {
+			$parameters['artist'] = $event_data['performer'];
+		}
+
+		$handler_config_for_tax                          = $handler_config;
+		$handler_config_for_tax['taxonomy_venue_selection']    = 'skip';
+		$handler_config_for_tax['taxonomy_promoter_selection'] = 'skip';
+		$engine_data_array                                     = $engine instanceof EngineData ? $engine->all() : array();
+		$this->taxonomy_handler->processTaxonomies( $post_id, $parameters, $handler_config_for_tax, $engine_data_array );
+
+		do_action( 'datamachine_event_taxonomy_processed', $post_id );
+
+		// 9. Sync identity index (title or ticket URL may have changed).
+		EventIdentityWriter::syncIdentityRow( $post_id, $title, datamachine_normalize_ticket_url( $ticketUrl ) ?: null );
+
+		// 10. Sync engine data for pipeline continuation (create path only).
+		$job_id = (int) ( $parameters['job_id'] ?? 0 );
+		if ( 'created' === $action && $job_id ) {
+			datamachine_merge_engine_data(
+				$job_id,
+				array(
+					'event_id'  => $post_id,
+					'event_url' => get_permalink( $post_id ),
+				)
+			);
+		}
+
+		// 11. Log and return.
+		$log_level = 'created' === $action ? 'info' : 'info';
+		$log_msg   = 'created' === $action ? 'Created new event' : 'Updated existing event';
+		do_action(
+			'datamachine_log',
+			$log_level,
+			"Event Upsert: {$log_msg}",
+			array(
+				'post_id' => $post_id,
+				'title'   => $title,
+			)
+		);
+
+		return $this->successResponse(
+			array(
+				'post_id'  => $post_id,
+				'post_url' => get_permalink( $post_id ),
+				'action'   => $action,
+			)
+		);
 	}
 
 	/**
@@ -943,145 +974,6 @@ class EventUpsert extends UpsertHandler {
 	}
 
 	/**
-	 * Compare existing and incoming event data
-	 *
-	 * @param array $existing Existing event attributes
-	 * @param array $incoming Incoming event parameters
-	 * @return bool True if data changed, false if identical
-	 */
-	private function hasDataChanged( array $existing, array $incoming ): bool {
-		// Fields to compare
-		$compare_fields = array(
-			'startDate',
-			'endDate',
-			'startTime',
-			'endTime',
-			'venue',
-			'address',
-			'price',
-			'ticketUrl',
-			'performer',
-			'performerType',
-			'organizer',
-			'organizerType',
-			'organizerUrl',
-			'eventStatus',
-			'previousStartDate',
-			'priceCurrency',
-			'offerAvailability',
-		);
-
-		foreach ( $compare_fields as $field ) {
-			$existing_value = trim( (string) ( $existing[ $field ] ?? '' ) );
-			$incoming_value = trim( (string) ( $incoming[ $field ] ?? '' ) );
-
-			if ( $existing_value !== $incoming_value ) {
-				do_action(
-					'datamachine_log',
-					'debug',
-					"Event Upsert: Field changed: {$field}",
-					array(
-						'existing' => $existing_value,
-						'incoming' => $incoming_value,
-					)
-				);
-				return true;
-			}
-		}
-
-		// Check description (may be in inner blocks)
-		$existing_description = trim( (string) ( $existing['description'] ?? '' ) );
-		$incoming_description = trim( (string) ( $incoming['description'] ?? '' ) );
-
-		if ( $existing_description !== $incoming_description ) {
-			do_action( 'datamachine_log', 'debug', 'Event Upsert: Description changed' );
-			return true;
-		}
-
-		return false; // No changes detected
-	}
-
-	/**
-	 * Create new event post
-	 *
-	 * @param array $parameters Event parameters (AI-provided, already filtered at definition time)
-	 * @param array $handler_config Handler configuration
-	 * @param EngineData $engine Engine snapshot helper
-	 * @return int|WP_Error Post ID on success
-	 */
-	private function createEventPost( array $parameters, array $handler_config, EngineData $engine ): int|\WP_Error {
-		$job_id      = (int) ( $parameters['job_id'] ?? 0 );
-		$post_status = WordPressSettingsResolver::getPostStatus( $handler_config );
-		$post_author = $this->resolvePostAuthor( $handler_config, $engine );
-
-		// Build event data: engine data takes precedence, then AI params
-		$event_data = $this->buildEventData( $parameters, $handler_config, $engine );
-
-		$post_data = array(
-			'post_type'    => Event_Post_Type::POST_TYPE,
-			'post_title'   => $event_data['title'],
-			'post_status'  => $post_status,
-			'post_author'  => $post_author,
-			'post_content' => $this->generate_event_block_content( $event_data, $parameters ),
-		);
-
-		$post_id = wp_insert_post( $post_data );
-
-		if ( is_wp_error( $post_id ) || ! $post_id ) {
-			return $post_id;
-		}
-
-		// Store submission metadata when event was user-submitted.
-		$submission = $engine->get( 'submission' );
-		if ( is_array( $submission ) ) {
-			if ( ! empty( $submission['user_id'] ) ) {
-				update_post_meta( $post_id, '_datamachine_submitted_by', (int) $submission['user_id'] );
-			}
-			if ( ! empty( $submission['contact_name'] ) ) {
-				update_post_meta( $post_id, '_datamachine_submitter_name', sanitize_text_field( $submission['contact_name'] ) );
-			}
-			if ( ! empty( $submission['contact_email'] ) ) {
-				update_post_meta( $post_id, '_datamachine_submitter_email', sanitize_email( $submission['contact_email'] ) );
-			}
-		}
-
-		$this->processEventFeaturedImage( $post_id, $handler_config, $engine );
-		$this->processVenue( $post_id, $parameters, $engine );
-		$this->processPromoter( $post_id, $parameters, $engine, $handler_config );
-
-		// Map performer to artist taxonomy if not explicitly provided
-		if ( empty( $parameters['artist'] ) && ! empty( $event_data['performer'] ) ) {
-			$parameters['artist'] = $event_data['performer'];
-		}
-
-		$handler_config_for_tax = $handler_config;
-
-		$handler_config_for_tax['taxonomy_venue_selection']    = 'skip';
-		$handler_config_for_tax['taxonomy_promoter_selection'] = 'skip';
-		$engine_data_array                                     = $engine instanceof EngineData ? $engine->all() : array();
-		$this->taxonomy_handler->processTaxonomies( $post_id, $parameters, $handler_config_for_tax, $engine_data_array );
-
-		/**
-		 * Fires after all taxonomy terms have been assigned to an event.
-		 *
-		 * @param int $post_id Event post ID.
-		 */
-		do_action( 'datamachine_event_taxonomy_processed', $post_id );
-
-		if ( $job_id ) {
-			datamachine_merge_engine_data(
-				$job_id,
-				array(
-					'event_id'  => $post_id,
-					'event_url' => get_permalink( $post_id ),
-				)
-			);
-		}
-
-		return $post_id;
-	}
-
-	/**
 	 * Resolve post author for event creation.
 	 *
 	 * When an event is submitted by a logged-in user (via the event submission form),
@@ -1111,47 +1003,33 @@ class EventUpsert extends UpsertHandler {
 	}
 
 	/**
-	 * Update existing event post
+	 * Build meta_input array for the DM core upsert ability.
 	 *
-	 * @param int $post_id Existing post ID
-	 * @param array $parameters Event parameters (AI-provided, already filtered at definition time)
-	 * @param array $handler_config Handler configuration
-	 * @param EngineData $engine Engine snapshot helper
+	 * Currently handles submission metadata only. Event-specific meta
+	 * (datetimes, ticket URL) is managed by event-dates-sync hooks.
+	 *
+	 * @param array      $event_data Event data.
+	 * @param array      $parameters Tool parameters.
+	 * @param EngineData $engine     Engine data.
+	 * @return array Meta key/value pairs.
 	 */
-	private function updateEventPost( int $post_id, array $parameters, array $handler_config, EngineData $engine ): void {
-		// Build event data: engine data takes precedence, then AI params
-		$event_data = $this->buildEventData( $parameters, $handler_config, $engine );
+	private function buildEventMetaInput( array $event_data, array $parameters, EngineData $engine ): array {
+		$meta_input = array();
 
-		wp_update_post(
-			array(
-				'ID'           => $post_id,
-				'post_title'   => $event_data['title'],
-				'post_content' => $this->generate_event_block_content( $event_data, $parameters ),
-			)
-		);
-
-		$this->processEventFeaturedImage( $post_id, $handler_config, $engine );
-		$this->processVenue( $post_id, $parameters, $engine );
-		$this->processPromoter( $post_id, $parameters, $engine, $handler_config );
-
-		// Map performer to artist taxonomy if not explicitly provided
-		if ( empty( $parameters['artist'] ) && ! empty( $event_data['performer'] ) ) {
-			$parameters['artist'] = $event_data['performer'];
+		$submission = $engine->get( 'submission' );
+		if ( is_array( $submission ) ) {
+			if ( ! empty( $submission['user_id'] ) ) {
+				$meta_input['_datamachine_submitted_by'] = (int) $submission['user_id'];
+			}
+			if ( ! empty( $submission['contact_name'] ) ) {
+				$meta_input['_datamachine_submitter_name'] = sanitize_text_field( $submission['contact_name'] );
+			}
+			if ( ! empty( $submission['contact_email'] ) ) {
+				$meta_input['_datamachine_submitter_email'] = sanitize_email( $submission['contact_email'] );
+			}
 		}
 
-		$handler_config_for_tax = $handler_config;
-
-		$handler_config_for_tax['taxonomy_venue_selection']    = 'skip';
-		$handler_config_for_tax['taxonomy_promoter_selection'] = 'skip';
-		$engine_data_array                                     = $engine instanceof EngineData ? $engine->all() : array();
-		$this->taxonomy_handler->processTaxonomies( $post_id, $parameters, $handler_config_for_tax, $engine_data_array );
-
-		/**
-		 * Fires after all taxonomy terms have been assigned to an event.
-		 *
-		 * @param int $post_id Event post ID.
-		 */
-		do_action( 'datamachine_event_taxonomy_processed', $post_id );
+		return $meta_input;
 	}
 
 	/**
@@ -1165,7 +1043,7 @@ class EventUpsert extends UpsertHandler {
 	 * @param EngineData $engine Engine data helper
 	 * @return array Merged event data
 	 */
-	private function buildEventData( array $parameters, array $handler_config, EngineData $engine ): array {
+	private function buildEventData( array $parameters, array $handler_config, EngineData $engine, int $existing_post_id = 0 ): array {
 		$event_data = array(
 			'title'       => sanitize_text_field( $parameters['title'] ?? $engine->get( 'title' ) ?? '' ),
 			'description' => $parameters['description'] ?? '',
@@ -1200,7 +1078,7 @@ class EventUpsert extends UpsertHandler {
 		}
 
 		// Persist datetime values from meta as system-level fallbacks
-		$resolved_post_id = $engine->get( 'post_id' ) ?? $parameters['post_id'] ?? 0;
+		$resolved_post_id = $existing_post_id > 0 ? $existing_post_id : ( $engine->get( 'post_id' ) ?? $parameters['post_id'] ?? 0 );
 		if ( ! empty( $resolved_post_id ) ) {
 			$this->hydrateStartDateFromMeta( (int) $resolved_post_id, $event_data );
 			$this->hydrateEndDateFromMeta( (int) $resolved_post_id, $event_data );


### PR DESCRIPTION
## Summary

Refactors `EventUpsert` to delegate the create/update/no_change decision to DM core's `datamachine/upsert-post` ability (shipped in data-machine#1167 / v0.77.0).

## What changed

- **Removed:** `createEventPost()`, `updateEventPost()`, `hasDataChanged()` — replaced by single call to `datamachine/upsert-post`
- **Added:** `buildEventMetaInput()` — extracts submission metadata for core upsert
- **Modified:** `buildEventData()` — accepts optional `$existing_post_id` for datetime hydration on update path
- **Modified:** `executeUpsertWithinLock()` — domain-specific identity resolution → core upsert → post-upsert event processing

## What stayed (domain-specific)

- Fuzzy identity resolution (`findExistingEventViaAbility`, `findExistingEvent`, all find* helpers)
- Advisory locks by `(date, normalized_title)`
- Venue/promoter taxonomy assignment with smart merging
- Featured image processing
- Block content generation (`generate_event_block_content`)
- Submission metadata handling

## Size

`EventUpsert.php`: 1,701 → 1,579 lines (-122)

## Depends on

- Extra-Chill/data-machine#1167 (merged in v0.77.0)
- Extra-Chill/data-machine#XXX (post_author support for upsert-post — adds `post_author` param to core ability)

## Closes

- Extra-Chill/data-machine-events#208