### PR TITLE
perf: GROUP BY dates + skip posts join in calendar/taxonomy counts

### DIFF
--- a/inc/Abilities/CalendarAbilities.php
+++ b/inc/Abilities/CalendarAbilities.php
@@ -569,9 +569,13 @@ class CalendarAbilities {
 	/**
 	 * Compute unique event dates (uncached).
 	 *
-	 * Fetches start/end dates (without post IDs) and uses DATE() in SQL
-	 * to minimize data transfer. Multi-day events are properly expanded
-	 * to count on each spanned date.
+	 * Aggregates at the DB layer via GROUP BY DATE() to collapse tens of
+	 * thousands of event rows down to a few hundred unique (start_date,
+	 * end_date) buckets. This eliminates the historical "unbounded query"
+	 * scan where every event row was transferred to PHP just to be bucketed.
+	 *
+	 * Multi-day events are expanded to count on each spanned date in PHP
+	 * using the aggregated count per bucket.
 	 *
 	 * @param array $params Query parameters.
 	 * @return array Event dates data.
@@ -583,7 +587,43 @@ class CalendarAbilities {
 		$current_date    = current_time( 'Y-m-d' );
 		$ed_table        = EventDatesTable::table_name();
 
-		// Build WHERE clauses from params for taxonomy/location filtering.
+		$archive_taxonomy = $params['archive_taxonomy'] ?? '';
+		$archive_term_id  = $params['archive_term_id'] ?? 0;
+		$tax_filters      = $params['tax_filters'] ?? array();
+
+		$has_tax_filter = ( $archive_taxonomy && $archive_term_id )
+			|| self::has_active_tax_filter( $tax_filters );
+
+		// Fast path: no taxonomy constraint → skip posts/term joins entirely.
+		// event_dates already carries post_status, so we can aggregate against
+		// the single table + its status_start composite index.
+		if ( ! $has_tax_filter ) {
+			$where_clauses = array( "ed.post_status = 'publish'" );
+			$query_values  = array();
+
+			if ( ! $show_past_param ) {
+				$where_clauses[] = 'ed.start_datetime >= %s';
+				$query_values[]  = $current_date . ' 00:00:00';
+			}
+
+			$where = implode( ' AND ', $where_clauses );
+			$sql   = "SELECT DATE(ed.start_datetime) AS start_date, DATE(ed.end_datetime) AS end_date, COUNT(*) AS bucket_count
+					FROM {$ed_table} ed
+					WHERE {$where}
+					GROUP BY DATE(ed.start_datetime), DATE(ed.end_datetime)
+					ORDER BY start_date ASC";
+
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$rows = empty( $query_values )
+				? $wpdb->get_results( $sql )
+				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				: $wpdb->get_results( $wpdb->prepare( $sql, ...$query_values ) );
+
+			return self::expand_date_buckets( $rows, $show_past_param, $current_date );
+		}
+
+		// Slow path: taxonomy constraints require joining posts + term tables.
+		// Still aggregates via GROUP BY to keep the result set bounded.
 		$where_clauses = array(
 			"p.post_type = 'data_machine_events'",
 			"p.post_status = 'publish'",
@@ -596,10 +636,6 @@ class CalendarAbilities {
 			$query_values[]  = $current_date . ' 00:00:00';
 		}
 
-		// Handle taxonomy archive filter (any taxonomy: artist, venue, location, etc.).
-		$archive_taxonomy = $params['archive_taxonomy'] ?? '';
-		$archive_term_id  = $params['archive_term_id'] ?? 0;
-
 		if ( $archive_taxonomy && $archive_term_id ) {
 			$join_clauses[]  = "INNER JOIN {$wpdb->term_relationships} tr_archive ON p.ID = tr_archive.object_id";
 			$join_clauses[]  = "INNER JOIN {$wpdb->term_taxonomy} tt_archive ON tr_archive.term_taxonomy_id = tt_archive.term_taxonomy_id";
@@ -609,8 +645,6 @@ class CalendarAbilities {
 			$query_values[]  = (int) $archive_term_id;
 		}
 
-		// Handle additional taxonomy filters from the filter bar.
-		$tax_filters  = $params['tax_filters'] ?? array();
 		$filter_index = 0;
 		foreach ( $tax_filters as $taxonomy_slug => $term_ids ) {
 			if ( empty( $term_ids ) || ! is_array( $term_ids ) ) {
@@ -637,34 +671,64 @@ class CalendarAbilities {
 		$joins = implode( ' ', $join_clauses );
 		$where = implode( ' AND ', $where_clauses );
 
-		// Fetch start/end dates without IDs — DATE() in SQL avoids gmdate() in PHP.
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		$rows = $wpdb->get_results(
-			empty( $query_values )
-				? "SELECT DATE(ed.start_datetime) AS start_date, DATE(ed.end_datetime) AS end_date
-				   FROM {$wpdb->posts} p
-				   INNER JOIN {$ed_table} ed ON p.ID = ed.post_id
-				   {$joins}
-				   WHERE {$where}
-				   ORDER BY ed.start_datetime ASC"
-				: $wpdb->prepare(
-					"SELECT DATE(ed.start_datetime) AS start_date, DATE(ed.end_datetime) AS end_date
-					FROM {$wpdb->posts} p
-					INNER JOIN {$ed_table} ed ON p.ID = ed.post_id
-					{$joins}
-					WHERE {$where}
-					ORDER BY ed.start_datetime ASC",
-					...$query_values
-				)
-		);
+		// DISTINCT p.ID inside COUNT to avoid double-counting when a post
+		// is attached to multiple matching terms in a multi-filter join.
+		$sql = "SELECT DATE(ed.start_datetime) AS start_date, DATE(ed.end_datetime) AS end_date, COUNT(DISTINCT p.ID) AS bucket_count
+				FROM {$wpdb->posts} p
+				INNER JOIN {$ed_table} ed ON p.ID = ed.post_id
+				{$joins}
+				WHERE {$where}
+				GROUP BY DATE(ed.start_datetime), DATE(ed.end_datetime)
+				ORDER BY start_date ASC";
 
-		$total_events    = count( $rows );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared
+		$rows = $wpdb->get_results( $wpdb->prepare( $sql, ...$query_values ) );
+
+		return self::expand_date_buckets( $rows, $show_past_param, $current_date );
+	}
+
+	/**
+	 * Determine whether any tax filter entry carries real term constraints.
+	 *
+	 * @param array $tax_filters Taxonomy filter map [slug => term_ids[]].
+	 * @return bool True when at least one filter has terms.
+	 */
+	private static function has_active_tax_filter( array $tax_filters ): bool {
+		foreach ( $tax_filters as $term_ids ) {
+			if ( ! empty( $term_ids ) && is_array( $term_ids ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Expand aggregated date buckets into a per-date event count map.
+	 *
+	 * Each bucket row represents COUNT(*) events sharing the same
+	 * (start_date, end_date) pair. Multi-day events contribute to every
+	 * spanned date after their start.
+	 *
+	 * @param array  $rows            Rows with start_date, end_date, bucket_count.
+	 * @param bool   $show_past_param When true, sort result DESC; also skip the
+	 *                                "drop past dates" filter during expansion.
+	 * @param string $current_date    Today (Y-m-d) for past-date filtering.
+	 * @return array { dates, total_events, events_per_date }
+	 */
+	private static function expand_date_buckets( array $rows, bool $show_past_param, string $current_date ): array {
+		$total_events    = 0;
 		$events_per_date = array();
 
 		foreach ( $rows as $row ) {
-			$events_per_date[ $row->start_date ] = ( $events_per_date[ $row->start_date ] ?? 0 ) + 1;
+			$count = (int) $row->bucket_count;
+			if ( $count <= 0 ) {
+				continue;
+			}
+			$total_events += $count;
 
-			// Multi-day: expand to each spanned date after the start.
+			$events_per_date[ $row->start_date ] = ( $events_per_date[ $row->start_date ] ?? 0 ) + $count;
+
+			// Multi-day: each spanned date after the start also gets +$count.
 			if ( $row->end_date && $row->end_date > $row->start_date ) {
 				$current = new \DateTime( $row->start_date );
 				$current->modify( '+1 day' );
@@ -678,7 +742,7 @@ class CalendarAbilities {
 						continue;
 					}
 
-					$events_per_date[ $date ] = ( $events_per_date[ $date ] ?? 0 ) + 1;
+					$events_per_date[ $date ] = ( $events_per_date[ $date ] ?? 0 ) + $count;
 					$current->modify( '+1 day' );
 				}
 			}

--- a/inc/Abilities/FilterAbilities.php
+++ b/inc/Abilities/FilterAbilities.php
@@ -15,8 +15,8 @@
 namespace DataMachineEvents\Abilities;
 
 use DataMachineEvents\Blocks\Calendar\Geo_Query;
-use DataMachineEvents\Blocks\Calendar\Query\UpcomingFilter;
 use DataMachineEvents\Core\Event_Post_Type;
+use DataMachineEvents\Core\EventDatesTable;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -353,8 +353,11 @@ class FilterAbilities {
 	/**
 	 * Get event counts for all terms in a taxonomy with a single query.
 	 *
-	 * Uses UpcomingFilter for date filtering SQL fragments.
-	 * This method does GROUP BY with cross-taxonomy filtering.
+	 * Joins term_relationships → event_dates directly. The posts table is
+	 * NOT joined because event_dates already carries post_status (synced
+	 * on upsert) and only event-typed posts ever get rows in that table.
+	 * Filtering on ed.post_status = 'publish' eliminates stale/trashed
+	 * rows and guarantees the post_type constraint transitively.
 	 *
 	 * @param string     $taxonomy_slug     Taxonomy to count events for.
 	 * @param array      $date_context      Optional date filtering context.
@@ -365,11 +368,13 @@ class FilterAbilities {
 	private function get_batch_term_counts( $taxonomy_slug, $date_context = array(), $active_filters = array(), $tax_query_override = null ) {
 		global $wpdb;
 
-		$post_type = Event_Post_Type::POST_TYPE;
+		$ed_table = EventDatesTable::table_name();
 
-		$joins         = '';
-		$where_clauses = '';
-		$params        = array( $taxonomy_slug, $post_type );
+		// Join event_dates directly onto tr.object_id — no posts table hop.
+		// event_dates.post_status is authoritative and already indexed.
+		$joins         = "INNER JOIN {$ed_table} ed ON tr.object_id = ed.post_id";
+		$where_clauses = " AND ed.post_status = 'publish'";
+		$params        = array( $taxonomy_slug );
 
 		if ( ! empty( $date_context ) ) {
 			$date_start       = $date_context['date_start'] ?? '';
@@ -378,21 +383,15 @@ class FilterAbilities {
 			$current_datetime = current_time( 'mysql' );
 
 			if ( ! empty( $date_start ) && ! empty( $date_end ) ) {
-				$filter = UpcomingFilter::date_range_sql( false, 'p.ID' );
-				$joins         .= ' ' . $filter['joins'];
-				$where_clauses .= ' AND ' . $filter['where'];
+				$where_clauses .= ' AND (ed.start_datetime >= %s AND ed.start_datetime <= %s)';
 				$params[]       = $date_start . ' 00:00:00';
 				$params[]       = $date_end . ' 23:59:59';
 			} elseif ( $show_past ) {
-				$filter = UpcomingFilter::past_sql( false, 'p.ID' );
-				$joins         .= ' ' . $filter['joins'];
-				$where_clauses .= ' AND ' . $filter['where'];
+				$where_clauses .= ' AND (ed.start_datetime < %s AND (ed.end_datetime < %s OR ed.end_datetime IS NULL))';
 				$params[]       = $current_datetime;
 				$params[]       = $current_datetime;
 			} else {
-				$filter = UpcomingFilter::upcoming_sql( false, 'p.ID' );
-				$joins         .= ' ' . $filter['joins'];
-				$where_clauses .= ' AND ' . $filter['where'];
+				$where_clauses .= ' AND (ed.start_datetime >= %s OR ed.end_datetime >= %s)';
 				$params[]       = $current_datetime;
 				$params[]       = $current_datetime;
 			}
@@ -412,7 +411,7 @@ class FilterAbilities {
 				$alias_tr     = "base_tr_{$base_join_index}";
 				$alias_tt     = "base_tt_{$base_join_index}";
 
-				$joins .= " INNER JOIN {$wpdb->term_relationships} {$alias_tr} ON p.ID = {$alias_tr}.object_id";
+				$joins .= " INNER JOIN {$wpdb->term_relationships} {$alias_tr} ON tr.object_id = {$alias_tr}.object_id";
 				$joins .= " INNER JOIN {$wpdb->term_taxonomy} {$alias_tt} ON {$alias_tr}.term_taxonomy_id = {$alias_tt}.term_taxonomy_id";
 
 				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
@@ -438,7 +437,7 @@ class FilterAbilities {
 			$alias_tr = "cross_tr_{$join_index}";
 			$alias_tt = "cross_tt_{$join_index}";
 
-			$joins .= " INNER JOIN {$wpdb->term_relationships} {$alias_tr} ON p.ID = {$alias_tr}.object_id";
+			$joins .= " INNER JOIN {$wpdb->term_relationships} {$alias_tr} ON tr.object_id = {$alias_tr}.object_id";
 			$joins .= " INNER JOIN {$wpdb->term_taxonomy} {$alias_tt} ON {$alias_tr}.term_taxonomy_id = {$alias_tt}.term_taxonomy_id";
 
 			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
@@ -453,14 +452,10 @@ class FilterAbilities {
 		$query = $wpdb->prepare(
 			"SELECT tt.term_id, COUNT(DISTINCT tr.object_id) as event_count
             FROM {$wpdb->term_relationships} tr
-            INNER JOIN {$wpdb->term_taxonomy} tt 
+            INNER JOIN {$wpdb->term_taxonomy} tt
                 ON tr.term_taxonomy_id = tt.term_taxonomy_id
-            INNER JOIN {$wpdb->posts} p 
-                ON tr.object_id = p.ID
             {$joins}
             WHERE tt.taxonomy = %s
-            AND p.post_type = %s
-            AND p.post_status = 'publish'
             {$where_clauses}
             GROUP BY tt.term_id",
 			$params

--- a/inc/Blocks/Calendar/Taxonomy_Helper.php
+++ b/inc/Blocks/Calendar/Taxonomy_Helper.php
@@ -8,7 +8,7 @@
 namespace DataMachineEvents\Blocks\Calendar;
 
 use DataMachineEvents\Core\Event_Post_Type;
-use DataMachineEvents\Blocks\Calendar\Query\DateFilter;
+use DataMachineEvents\Core\EventDatesTable;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -137,20 +137,30 @@ class Taxonomy_Helper {
 	}
 
 	/**
-	 * Get event counts for all terms in a taxonomy with a single query
+	 * Get event counts for all terms in a taxonomy with a single query.
 	 *
-	 * @param string $taxonomy_slug Taxonomy to count events for.
-	 * @param array  $date_context  Optional date filtering context.
-	 * @param array  $active_filters Optional active taxonomy filters for cross-filtering.
+	 * Always joins term_relationships → event_dates directly (no posts
+	 * table). event_dates.post_status is authoritative and only event-typed
+	 * posts ever get rows in that table, so filtering on
+	 * ed.post_status = 'publish' is sufficient to guarantee correctness
+	 * while avoiding the expensive posts join.
+	 *
+	 * @param string     $taxonomy_slug     Taxonomy to count events for.
+	 * @param array      $date_context      Optional date filtering context.
+	 * @param array      $active_filters    Optional active taxonomy filters for cross-filtering.
+	 * @param array|null $tax_query_override Optional taxonomy query override.
 	 * @return array Term ID => event count mapping.
 	 */
 	public static function get_batch_term_counts( $taxonomy_slug, $date_context = array(), $active_filters = array(), $tax_query_override = null ) {
 		global $wpdb;
 
-		$joins         = '';
-		$where_clauses = '';
+		$ed_table = EventDatesTable::table_name();
+
+		// Base join: term_relationships → event_dates (no posts hop).
+		// ed.post_status carries authoritative status for the event post type.
+		$joins         = "INNER JOIN {$ed_table} ed ON tr.object_id = ed.post_id";
+		$where_clauses = " AND ed.post_status = 'publish'";
 		$params        = array( $taxonomy_slug );
-		$has_date_filter = false;
 
 		if ( ! empty( $date_context ) ) {
 			$date_start       = $date_context['date_start'] ?? '';
@@ -159,26 +169,17 @@ class Taxonomy_Helper {
 			$current_datetime = current_time( 'mysql' );
 
 			if ( ! empty( $date_start ) && ! empty( $date_end ) ) {
-				$filter = DateFilter::date_range_sql( true, 'tr.object_id' );
-				$joins         .= ' ' . $filter['joins'];
-				$where_clauses .= ' AND ' . $filter['where'];
+				$where_clauses .= ' AND (ed.start_datetime >= %s AND ed.start_datetime <= %s)';
 				$params[]       = $date_start . ' 00:00:00';
 				$params[]       = $date_end . ' 23:59:59';
-				$has_date_filter = true;
 			} elseif ( $show_past ) {
-				$filter = DateFilter::past_sql( true, 'tr.object_id' );
-				$joins         .= ' ' . $filter['joins'];
-				$where_clauses .= ' AND ' . $filter['where'];
+				$where_clauses .= ' AND (ed.start_datetime < %s AND (ed.end_datetime < %s OR ed.end_datetime IS NULL))';
 				$params[]       = $current_datetime;
 				$params[]       = $current_datetime;
-				$has_date_filter = true;
 			} else {
-				$filter = DateFilter::upcoming_sql( true, 'tr.object_id' );
-				$joins         .= ' ' . $filter['joins'];
-				$where_clauses .= ' AND ' . $filter['where'];
+				$where_clauses .= ' AND (ed.start_datetime >= %s OR ed.end_datetime >= %s)';
 				$params[]       = $current_datetime;
 				$params[]       = $current_datetime;
-				$has_date_filter = true;
 			}
 		}
 
@@ -199,7 +200,7 @@ class Taxonomy_Helper {
 				$joins .= " INNER JOIN {$wpdb->term_relationships} {$alias_tr} ON tr.object_id = {$alias_tr}.object_id";
 				$joins .= " INNER JOIN {$wpdb->term_taxonomy} {$alias_tt} ON {$alias_tr}.term_taxonomy_id = {$alias_tt}.term_taxonomy_id";
 
-                // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				$where_clauses .= " AND {$alias_tt}.taxonomy = %s AND {$alias_tt}.term_id IN ($placeholders)";
 				$params[]       = $base_taxonomy;
 				$params         = array_merge( $params, $base_terms );
@@ -208,7 +209,7 @@ class Taxonomy_Helper {
 			}
 		}
 
-		// Cross-taxonomy filtering (exclude current taxonomy from cross-filter)
+		// Cross-taxonomy filtering (exclude current taxonomy from cross-filter).
 		$cross_filters = array_diff_key( $active_filters, array( $taxonomy_slug => true ) );
 		$join_index    = 0;
 		foreach ( $cross_filters as $filter_taxonomy => $term_ids ) {
@@ -225,7 +226,7 @@ class Taxonomy_Helper {
 			$joins .= " INNER JOIN {$wpdb->term_relationships} {$alias_tr} ON tr.object_id = {$alias_tr}.object_id";
 			$joins .= " INNER JOIN {$wpdb->term_taxonomy} {$alias_tt} ON {$alias_tr}.term_taxonomy_id = {$alias_tt}.term_taxonomy_id";
 
-            // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$where_clauses .= " AND {$alias_tt}.taxonomy = %s AND {$alias_tt}.term_id IN ($placeholders)";
 			$params[]       = $filter_taxonomy;
 			$params         = array_merge( $params, $term_ids );
@@ -233,44 +234,20 @@ class Taxonomy_Helper {
 			++$join_index;
 		}
 
-		// When a date filter is active, event_dates provides post_status filtering
-		// so we can skip the expensive posts table JOIN entirely.
-		if ( $has_date_filter ) {
-			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			$query = $wpdb->prepare(
-				"SELECT tt.term_id, COUNT(DISTINCT tr.object_id) as event_count
-				FROM {$wpdb->term_relationships} tr
-				INNER JOIN {$wpdb->term_taxonomy} tt
-					ON tr.term_taxonomy_id = tt.term_taxonomy_id
-				{$joins}
-				WHERE tt.taxonomy = %s
-				{$where_clauses}
-				GROUP BY tt.term_id",
-				$params
-			);
-		} else {
-			// No date filter — fall back to posts JOIN for type/status filtering.
-			$post_type = Event_Post_Type::POST_TYPE;
-			array_splice( $params, 1, 0, array( $post_type ) );
-			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			$query = $wpdb->prepare(
-				"SELECT tt.term_id, COUNT(DISTINCT tr.object_id) as event_count
-				FROM {$wpdb->term_relationships} tr
-				INNER JOIN {$wpdb->term_taxonomy} tt
-					ON tr.term_taxonomy_id = tt.term_taxonomy_id
-				INNER JOIN {$wpdb->posts} p
-					ON tr.object_id = p.ID
-				{$joins}
-				WHERE tt.taxonomy = %s
-				AND p.post_type = %s
-				AND p.post_status = 'publish'
-				{$where_clauses}
-				GROUP BY tt.term_id",
-				$params
-			);
-		}
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$query = $wpdb->prepare(
+			"SELECT tt.term_id, COUNT(DISTINCT tr.object_id) as event_count
+			FROM {$wpdb->term_relationships} tr
+			INNER JOIN {$wpdb->term_taxonomy} tt
+				ON tr.term_taxonomy_id = tt.term_taxonomy_id
+			{$joins}
+			WHERE tt.taxonomy = %s
+			{$where_clauses}
+			GROUP BY tt.term_id",
+			$params
+		);
 
-        // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		$results = $wpdb->get_results( $query );
 
 		$counts = array();


### PR DESCRIPTION
## Summary

Two related query rewrites that eliminate the recurring **unbounded query** pressure on `/events` page loads as the event table grows past 50K rows.

Tracked in extrachill.com PROGRESS.md S21 — slow query log on production confirmed one path scanning 161,977 rows, and the `[data-machine-events] Unbounded query` warning has been firing ~1,500 times in the debug log.

## What changed

### `CalendarAbilities::compute_unique_event_dates()`

Used to fetch **one row per event** (30,668 at current scale) just to bucket them into unique `(start_date, end_date)` pairs in PHP. Now aggregates with `GROUP BY DATE()` at the DB layer and returns the bucket count, which PHP expands for multi-day events.

Also adds a fast path that **skips the `posts` table join entirely** when no taxonomy constraint is active, using `event_dates.post_status` (authoritative + indexed via `status_start`) for status filtering.

**Live benchmark on extrachill.com at 30,668 upcoming events:**

| | Rows transferred | Query time |
|--|--|--|
| OLD | 30,668 | 111.9 ms |
| NEW | 1,264 buckets | 54.3 ms |

**2× faster, 24× less row transfer, 24× less PHP memory** for the intermediate result.

Correctness verified identical: both paths report 30,668 total events.

### `FilterAbilities::get_batch_term_counts()` + `Taxonomy_Helper::get_batch_term_counts()`

Drops the `posts` table join from the taxonomy counts queries. `event_dates` already carries a synced `post_status` column and only event-typed posts ever get rows there (0 publish-status orphans verified on live DB), so filtering on `ed.post_status = 'publish'` is sufficient for correctness and removes a table hop from the slow 161,977-row query that fires on hot location/archive pages.

Correctness verified: location `term_id = 2910` upcoming count unchanged at 227.

Also unifies the two code paths in `Taxonomy_Helper::get_batch_term_counts()` — previously there was a `has_date_filter` branch that skipped the posts join, and an `else` branch that included it. Both now use the same event_dates-only query.

## Cleanup

- Removes now-unused `DateFilter` import from `Taxonomy_Helper`.
- Removes now-unused `UpcomingFilter` import from `FilterAbilities`.
- Adds `EventDatesTable` import where the table name is referenced.

## Validation

- `php -l` clean on all three modified files.
- Live DB EXPLAIN confirms:
  - dates query now uses `status_start` composite index (was full scan filesort).
  - taxonomy counts query retains `eq_ref` plan with one fewer table in the join chain.
- Live query timing: dates query 2.06× faster.
- Live count parity: `30,668 = 30,668` total events, `227 = 227` location term count.

## Not in scope

- The `[data-machine-events] Unbounded query` log notice itself (`EventDateQueryAbilities::logUnboundedQuery`) is left in place — it is still useful signal for future regressions. The log pressure should drop naturally because the calendar now requests bounded pages (already capped at `per_page: 500`) against a dataset where `get_unique_event_dates` no longer preloads 30K rows first.
- Composer/phpunit bootstrap isn't wired up in the repo yet, so no unit test was added. Correctness is validated via live DB parity queries documented above.