### PR TITLE
refactor(promoter): collapse find_or_create_promoter onto ResolveTermAbility::resolve()

### DIFF
--- a/inc/Core/Promoter_Taxonomy.php
+++ b/inc/Core/Promoter_Taxonomy.php
@@ -68,9 +68,9 @@ class Promoter_Taxonomy {
 	/**
 	 * Find or create a promoter with given name and metadata
 	 *
-	 * Thin wrapper over DM core's ResolveTermAbility::resolve(). The resolver
-	 * handles term lookup (by ID, name, or slug) and creation in one call;
-	 * this function adds the promoter-specific meta handling on top.
+	 * Composes DM core's ResolveTermAbility (find-or-create the term) with
+	 * MergeTermMetaAbility (write the promoter-specific meta in either
+	 * fill_empty or overwrite mode depending on whether the term existed).
 	 *
 	 * @param string $promoter_name Promoter name (or numeric ID / slug — resolver matches all three)
 	 * @param array  $promoter_data Promoter metadata (url, type, description)
@@ -91,21 +91,21 @@ class Promoter_Taxonomy {
 			$term_args['description'] = $promoter_data['description'];
 		}
 
-		$result = \DataMachine\Abilities\Taxonomy\ResolveTermAbility::resolve(
+		$resolved = \DataMachine\Abilities\Taxonomy\ResolveTermAbility::resolve(
 			$promoter_name,
 			'promoter',
 			true,
 			$term_args
 		);
 
-		if ( empty( $result['success'] ) ) {
+		if ( empty( $resolved['success'] ) ) {
 			do_action(
 				'datamachine_log',
 				'error',
 				'Failed to resolve promoter term',
 				array(
 					'promoter_name' => $promoter_name,
-					'error'         => $result['error'] ?? 'unknown',
+					'error'         => $resolved['error'] ?? 'unknown',
 				)
 			);
 			return array(
@@ -114,13 +114,29 @@ class Promoter_Taxonomy {
 			);
 		}
 
-		$term_id     = (int) $result['term_id'];
-		$was_created = ! empty( $result['created'] );
+		$term_id     = (int) $resolved['term_id'];
+		$was_created = ! empty( $resolved['created'] );
 
-		if ( $was_created ) {
-			self::update_promoter_meta( $term_id, $promoter_data );
-		} elseif ( ! empty( $promoter_data ) ) {
-			self::smart_merge_promoter_meta( $term_id, $promoter_data );
+		if ( ! empty( $promoter_data ) ) {
+			$strategy = $was_created
+				? \DataMachine\Abilities\Taxonomy\MergeTermMetaAbility::STRATEGY_OVERWRITE
+				: \DataMachine\Abilities\Taxonomy\MergeTermMetaAbility::STRATEGY_FILL_EMPTY;
+
+			// Description was already applied by ResolveTermAbility on the create
+			// path (via wp_insert_term args). Only the existing-term path needs
+			// the merge to consider description, in fill_empty mode.
+			$merge_description = ( ! $was_created && isset( $promoter_data['description'] ) )
+				? (string) $promoter_data['description']
+				: null;
+
+			\DataMachine\Abilities\Taxonomy\MergeTermMetaAbility::merge(
+				$term_id,
+				'promoter',
+				$promoter_data,
+				self::$meta_fields,
+				$strategy,
+				$merge_description
+			);
 		}
 
 		return array(
@@ -130,43 +146,13 @@ class Promoter_Taxonomy {
 	}
 
 	/**
-	 * Smartly merge new promoter data into existing promoter
-	 * Only updates fields that are currently empty in the database
-	 *
-	 * @param int $term_id Promoter term ID
-	 * @param array $promoter_data New promoter data
-	 */
-	private static function smart_merge_promoter_meta( $term_id, $promoter_data ) {
-		foreach ( self::$meta_fields as $data_key => $meta_key ) {
-			if ( empty( $promoter_data[ $data_key ] ) ) {
-				continue;
-			}
-
-			$existing_value = get_term_meta( $term_id, $meta_key, true );
-
-			if ( empty( $existing_value ) ) {
-				update_term_meta( $term_id, $meta_key, sanitize_text_field( $promoter_data[ $data_key ] ) );
-			}
-		}
-
-		if ( ! empty( $promoter_data['description'] ) ) {
-			$term = get_term( $term_id, 'promoter' );
-			if ( $term && empty( $term->description ) ) {
-				wp_update_term(
-					$term_id,
-					'promoter',
-					array(
-						'description' => sanitize_textarea_field( $promoter_data['description'] ),
-					)
-				);
-			}
-		}
-	}
-
-	/**
 	 * Update promoter term meta with promoter data
 	 *
-	 * @param int $term_id Promoter term ID
+	 * Thin wrapper over MergeTermMetaAbility for backwards compatibility with
+	 * any external callers. Uses the overwrite strategy to preserve the
+	 * historical "write every supplied field" semantics.
+	 *
+	 * @param int   $term_id       Promoter term ID
 	 * @param array $promoter_data Promoter data array
 	 * @return bool Success status
 	 */
@@ -175,13 +161,15 @@ class Promoter_Taxonomy {
 			return false;
 		}
 
-		foreach ( self::$meta_fields as $data_key => $meta_key ) {
-			if ( array_key_exists( $data_key, $promoter_data ) ) {
-				update_term_meta( $term_id, $meta_key, sanitize_text_field( $promoter_data[ $data_key ] ) );
-			}
-		}
+		$result = \DataMachine\Abilities\Taxonomy\MergeTermMetaAbility::merge(
+			(int) $term_id,
+			'promoter',
+			$promoter_data,
+			self::$meta_fields,
+			\DataMachine\Abilities\Taxonomy\MergeTermMetaAbility::STRATEGY_OVERWRITE
+		);
 
-		return true;
+		return ! empty( $result['success'] );
 	}
 
 	/**

--- a/inc/Core/Promoter_Taxonomy.php
+++ b/inc/Core/Promoter_Taxonomy.php
@@ -68,50 +68,44 @@ class Promoter_Taxonomy {
 	/**
 	 * Find or create a promoter with given name and metadata
 	 *
-	 * @param string $promoter_name Promoter name
-	 * @param array $promoter_data Promoter metadata (url, type)
+	 * Thin wrapper over DM core's ResolveTermAbility::resolve(). The resolver
+	 * handles term lookup (by ID, name, or slug) and creation in one call;
+	 * this function adds the promoter-specific meta handling on top.
+	 *
+	 * @param string $promoter_name Promoter name (or numeric ID / slug — resolver matches all three)
+	 * @param array  $promoter_data Promoter metadata (url, type, description)
 	 * @return array Array with keys: term_id, was_created
 	 */
 	public static function find_or_create_promoter( $promoter_name, $promoter_data = array() ) {
-		$promoter_name = trim( $promoter_name );
+		$promoter_name = trim( (string) $promoter_name );
 
-		if ( empty( $promoter_name ) ) {
+		if ( '' === $promoter_name ) {
 			return array(
 				'term_id'     => null,
 				'was_created' => false,
 			);
 		}
 
-		$existing = get_term_by( 'name', $promoter_name, 'promoter' );
-
-		if ( $existing ) {
-			$term_id = $existing->term_id;
-
-			if ( ! empty( $promoter_data ) ) {
-				self::smart_merge_promoter_meta( $term_id, $promoter_data );
-			}
-
-			return array(
-				'term_id'     => $term_id,
-				'was_created' => false,
-			);
-		}
-
 		$term_args = array();
 		if ( ! empty( $promoter_data['description'] ) ) {
-			$term_args['description'] = sanitize_textarea_field( $promoter_data['description'] );
+			$term_args['description'] = $promoter_data['description'];
 		}
 
-		$result = wp_insert_term( $promoter_name, 'promoter', $term_args );
+		$result = \DataMachine\Abilities\Taxonomy\ResolveTermAbility::resolve(
+			$promoter_name,
+			'promoter',
+			true,
+			$term_args
+		);
 
-		if ( is_wp_error( $result ) ) {
+		if ( empty( $result['success'] ) ) {
 			do_action(
 				'datamachine_log',
 				'error',
-				'Failed to create promoter term',
+				'Failed to resolve promoter term',
 				array(
 					'promoter_name' => $promoter_name,
-					'error'         => $result->get_error_message(),
+					'error'         => $result['error'] ?? 'unknown',
 				)
 			);
 			return array(
@@ -120,13 +114,18 @@ class Promoter_Taxonomy {
 			);
 		}
 
-		$term_id = $result['term_id'];
+		$term_id     = (int) $result['term_id'];
+		$was_created = ! empty( $result['created'] );
 
-		self::update_promoter_meta( $term_id, $promoter_data );
+		if ( $was_created ) {
+			self::update_promoter_meta( $term_id, $promoter_data );
+		} elseif ( ! empty( $promoter_data ) ) {
+			self::smart_merge_promoter_meta( $term_id, $promoter_data );
+		}
 
 		return array(
 			'term_id'     => $term_id,
-			'was_created' => true,
+			'was_created' => $was_created,
 		);
 	}
 


### PR DESCRIPTION
## Summary

`Promoter_Taxonomy::find_or_create_promoter()` was a near-duplicate of DM core's `ResolveTermAbility::resolve()`. Both:

- match a flat taxonomy term by name/slug
- create the term if not found
- return a `term_id` + "was created" signal

The only non-core delta was the promoter-specific metadata handling (`smart_merge_promoter_meta()` on hit, `update_promoter_meta()` on create), which belongs as a post-resolution step on top of the resolver — not duplicated inside it.

This collapses the function onto the resolver. ~60 lines → ~30 lines.

Closes Extra-Chill/data-machine#1164.

## Stacked on Extra-Chill/data-machine#1217

This PR depends on Extra-Chill/data-machine#1217, which adds the optional 4th `args` parameter to `ResolveTermAbility::resolve()`. That's how `description` flows through to `wp_insert_term()` on the create path.

Marked **draft** until #1217 merges. Will convert to ready-for-review once it lands.

## Public signature preserved

The three call sites all destructure `\$result['term_id']` (and one also reads `\$result['was_created']`). None of them need to change:

- `inc/Steps/Upsert/Events/Promoter.php:42`
- `inc/Steps/Upsert/Events/EventUpsert.php:1242`
- `inc/Steps/Upsert/Events/EventUpsert.php:1456`

## Behaviour deltas (capability gains, not regressions)

- **Now also resolves by numeric ID and by slug** if the input happens to match. Previously the function was name-only (`get_term_by('name', ...)`). Calls that pass a name still match by name first, so existing behaviour is preserved end-to-end.
- **Description is now sanitised inside the resolver's whitelist** (`sanitize_textarea_field`) instead of locally. End result is identical.

## Out of scope

`Venue_Taxonomy::find_or_create_venue()` is NOT collapsed. It carries domain-specific fuzzy matching ("The" prefix toggle, address-based match, normalised-name match) that doesn't generalise to `ResolveTermAbility`'s identifier model. Issue #1164 calls this out explicitly.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafted the refactor against the prior-art shape, audited the three call sites for signature compatibility, and wrote this PR description. Chris reviewed the diff.