### PR TITLE
refactor(venue): collapse meta-write helpers onto MergeTermMetaAbility

### DIFF
--- a/inc/Core/Venue_Taxonomy.php
+++ b/inc/Core/Venue_Taxonomy.php
@@ -301,33 +301,29 @@ class Venue_Taxonomy {
 	 * Smartly merge new venue data into existing venue
 	 * Only updates fields that are currently empty in the database
 	 *
+	 * Composes MergeTermMetaAbility (fill_empty strategy) with the
+	 * venue-specific post-write side effects (geocoding, timezone derivation).
+	 *
 	 * @param int $term_id Venue term ID
 	 * @param array $venue_data New venue data
 	 */
 	private static function smart_merge_venue_meta( $term_id, $venue_data ) {
-		$address_fields    = array( 'address', 'city', 'state', 'zip', 'country' );
-		$address_updated   = false;
-		$coordinates_added = false;
+		$result = \DataMachine\Abilities\Taxonomy\MergeTermMetaAbility::merge(
+			(int) $term_id,
+			'venue',
+			$venue_data,
+			self::$meta_fields,
+			\DataMachine\Abilities\Taxonomy\MergeTermMetaAbility::STRATEGY_FILL_EMPTY
+		);
 
-		foreach ( self::$meta_fields as $data_key => $meta_key ) {
-			if ( empty( $venue_data[ $data_key ] ) ) {
-				continue;
-			}
-
-			$existing_value = get_term_meta( $term_id, $meta_key, true );
-
-			if ( empty( $existing_value ) ) {
-				update_term_meta( $term_id, $meta_key, sanitize_text_field( $venue_data[ $data_key ] ) );
-
-				if ( in_array( $data_key, $address_fields, true ) ) {
-					$address_updated = true;
-				}
-
-				if ( 'coordinates' === $data_key ) {
-					$coordinates_added = true;
-				}
-			}
+		if ( empty( $result['success'] ) ) {
+			return;
 		}
+
+		$updated         = $result['updated'] ?? array();
+		$address_fields  = array( 'address', 'city', 'state', 'zip', 'country' );
+		$address_updated = (bool) array_intersect( $updated, $address_fields );
+		$coordinates_added = in_array( 'coordinates', $updated, true );
 
 		if ( $address_updated ) {
 			self::maybe_geocode_venue( $term_id );
@@ -346,6 +342,10 @@ class Venue_Taxonomy {
 	 * This allows updating only changed fields without overwriting unchanged ones.
 	 * Automatically geocodes address to coordinates if address fields are updated.
 	 *
+	 * Composes MergeTermMetaAbility (overwrite strategy) with the venue-specific
+	 * post-write side effects (clear-and-regeocode on address change, derive
+	 * timezone when coordinates land).
+	 *
 	 * @param int $term_id Venue term ID
 	 * @param array $venue_data Venue data array (can contain subset of fields)
 	 * @return bool Success status
@@ -355,33 +355,27 @@ class Venue_Taxonomy {
 			return false;
 		}
 
-		$address_fields    = array( 'address', 'city', 'state', 'zip', 'country' );
-		$address_changed   = false;
-		$coordinates_added = false;
+		$result = \DataMachine\Abilities\Taxonomy\MergeTermMetaAbility::merge(
+			(int) $term_id,
+			'venue',
+			$venue_data,
+			self::$meta_fields,
+			\DataMachine\Abilities\Taxonomy\MergeTermMetaAbility::STRATEGY_OVERWRITE
+		);
 
-		foreach ( self::$meta_fields as $data_key => $meta_key ) {
-			if ( array_key_exists( $data_key, $venue_data ) ) {
-				$new_value = sanitize_text_field( $venue_data[ $data_key ] );
-				$old_value = get_term_meta( $term_id, $meta_key, true );
-
-				if ( in_array( $data_key, $address_fields, true ) ) {
-					if ( $new_value !== $old_value ) {
-						$address_changed = true;
-					}
-				}
-
-				if ( 'coordinates' === $data_key && empty( $old_value ) && ! empty( $new_value ) ) {
-					$coordinates_added = true;
-				}
-
-				update_term_meta( $term_id, $meta_key, $new_value );
-			}
+		if ( empty( $result['success'] ) ) {
+			return false;
 		}
+
+		$updated         = $result['updated'] ?? array();
+		$address_fields  = array( 'address', 'city', 'state', 'zip', 'country' );
+		$address_changed = (bool) array_intersect( $updated, $address_fields );
+		$coordinates_set = in_array( 'coordinates', $updated, true );
 
 		if ( $address_changed ) {
 			delete_term_meta( $term_id, '_venue_coordinates' );
 			self::maybe_geocode_venue( $term_id );
-		} elseif ( $coordinates_added ) {
+		} elseif ( $coordinates_set ) {
 			$coordinates = get_term_meta( $term_id, '_venue_coordinates', true );
 			if ( ! empty( $coordinates ) ) {
 				self::maybe_derive_timezone( $term_id, $coordinates );


### PR DESCRIPTION
## Summary

`Venue_Taxonomy` carried two ~30-line meta-write helpers that duplicated the fill_empty / overwrite shape DM core now provides via `MergeTermMetaAbility` (Extra-Chill/data-machine#1218):

- `smart_merge_venue_meta()` → fill_empty strategy + geocode/timezone post-write
- `update_venue_meta()` → overwrite strategy + clear-and-regeocode + timezone

This PR collapses the meta-write half of both onto `MergeTermMetaAbility::merge()` and uses its `updated[]` output to drive the venue-specific post-write side effects without re-reading meta.

Stacked on Extra-Chill/data-machine#1217 + Extra-Chill/data-machine#1218. **Marked draft until both DM PRs merge.**

## What stays in `Venue_Taxonomy` (correctly, because it's domain-specific)

The originating issue Extra-Chill/data-machine#1164 explicitly flagged Venue's matching cascade as out-of-scope for the collapse. This PR honours that — only the meta-write half moves:

- The 4-step matcher cascade in `find_or_create_venue` (address-based match, exact name, "The"-prefix toggle, normalised-name match).
- `data_machine_events_normalize_venue_name` filter.
- `find_venue_by_normalized_name` + `normalize_venue_name_for_matching` (also called from `EventDuplicateStrategy`).
- `find_venue_by_address` + `normalize_address_for_matching`.
- The geocoding pipeline (`maybe_geocode_venue`, `geocode_address`, `query_nominatim`, `build_geocode_queries`, `extract_street_from_address`).
- The timezone derivation (`maybe_derive_timezone`).

## Behaviour deltas

Three subtle changes the diff makes; calling them out so reviewers don't have to spot them:

### 1. `update_venue_meta` no longer compares `\$new_value !== \$old_value` before flagging an address change

The two external callers both pre-filter their input to genuinely-changed keys:

- `inc/Abilities/VenueAbilities.php:496` (`update-venue-meta` endpoint) — filters by "key present and non-empty in input"
- `inc/Steps/EventImport/Handlers/VenueFieldsTrait.php:205` — filters by `trim(original) !== trim(new)`

The internal create-path call passes the full \$venue_data for a freshly-created term where every existing meta is empty, so every key is new.

The previous in-helper diff guard was defensive against a class of caller that does not exist. **Net effect: address-pipeline reruns now strictly track "caller asked us to write address fields".**

### 2. `smart_merge_venue_meta` detects "coordinates were added" via `updated[]` instead of `empty(\$old_value)`

With fill_empty strategy these are equivalent — a coordinates write only happens when the existing value was empty.

### 3. `update_venue_meta` detects "coordinates were set" via `updated[]` instead of `empty(\$old) && !empty(\$new)`

With overwrite strategy, a non-empty incoming coordinate is always written. The timezone derivation function itself short-circuits when timezone is already set (`maybe_derive_timezone:438-440`), so calling it redundantly when coordinates are merely re-confirmed is harmless.

## Verification

Reviewed all callers of the two helpers:

| Caller | Pre-filtered? | Behaviour preserved? |
|--------|---------------|----------------------|
| `Venue_Taxonomy::find_or_create_venue:113` (smart_merge) | n/a | yes — fill_empty strategy matches old loop |
| `Venue_Taxonomy::find_or_create_venue:156` (smart_merge) | n/a | yes |
| `Venue_Taxonomy::find_or_create_venue:187` (update_venue_meta, create path) | fresh term | yes — all keys are writes |
| `VenueAbilities::execute_update_venue_meta:496` | yes (non-empty filter) | yes |
| `VenueFieldsTrait::process_venue_settings:205` | yes (trim diff filter) | yes |

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Audited the meta-write helpers, the geocoding side-effect contract, and every external caller. Drafted the refactor and this PR description with explicit behaviour-delta call-outs. Chris reviewed the design call (collapse meta only, leave matching alone) and the diff.