### PR TITLE
fix: coerce findExistingEventViaAbility null to 0 for buildEventData

### DIFF
--- a/inc/Steps/Upsert/Events/EventUpsert.php
+++ b/inc/Steps/Upsert/Events/EventUpsert.php
@@ -151,7 +151,9 @@ class EventUpsert extends UpsertHandler {
 		EngineData $engine
 	): array {
 		// 1. Find existing event via domain-specific duplicate detection.
-		$existing_post_id = $this->findExistingEventViaAbility( $title, $venue, $startDate, $ticketUrl );
+		// findExistingEventViaAbility() returns ?int — null means no existing post.
+		// Normalize to int (0 = no match) so downstream type contracts hold.
+		$existing_post_id = (int) $this->findExistingEventViaAbility( $title, $venue, $startDate, $ticketUrl );
 
 		// 2. Build event data.
 		$event_data = $this->buildEventData( $parameters, $handler_config, $engine, $existing_post_id );


### PR DESCRIPTION
## Summary

Fixes a TypeError in \`EventUpsert::executeUpsertWithinLock()\` that crashes every upsert where duplicate detection returns no match.

\`\`\`
EventUpsert::buildEventData(): Argument #4 (\$existing_post_id) must be of type int, null given
\`\`\`

## Root cause

\`findExistingEventViaAbility()\` returns \`?int\` — \`null\` when no existing post is found. The result was passed directly to \`buildEventData()\` whose 4th parameter is typed \`int\`, producing a fatal type error. The downstream \`if (\$existing_post_id > 0)\` check on line 180 already assumes the no-match case maps to 0, so the fix is to cast at the call site.

## Discovery context

Surfaced while recovering from [data-machine#1228](https://github.com/Extra-Chill/data-machine/pull/1228) (the retention asymmetry fix). When previously orphaned events were re-ingested via the \`processed-items cleanup-orphans\` recovery path, every NEW event (the ones with no existing post to match) crashed at this site. Pre-existing bug, just rarely exercised because most ingestion flows hit existing posts via dedup.

## Fix

One line: cast to \`int\` at the call site so \`null\` → \`0\`.

## Verification

After merge + deploy, re-run the previously failed Pour House children:
\`\`\`
wp datamachine processed-items cleanup-orphans --flow=9 --yes --url=events.extrachill.com
wp datamachine flow run 9 --url=events.extrachill.com
\`\`\`
The 5 \`throwable_exception_in_step_execution\` failures from job 391320's children should not recur.