### PR TITLE
fix(abilities): flatten category slugs for WP 7.0 compatibility

### DIFF
--- a/inc/Abilities/AbilityCategories.php
+++ b/inc/Abilities/AbilityCategories.php
@@ -18,10 +18,10 @@ class AbilityCategories {
 	/**
 	 * Category slug constants for use in ability registrations.
 	 */
-	public const EVENTS   = 'datamachine-events/events';
-	public const VENUES   = 'datamachine-events/venues';
-	public const TESTING  = 'datamachine-events/testing';
-	public const SETTINGS = 'datamachine-events/settings';
+	public const EVENTS   = 'datamachine-events-events';
+	public const VENUES   = 'datamachine-events-venues';
+	public const TESTING  = 'datamachine-events-testing';
+	public const SETTINGS = 'datamachine-events-settings';
 
 	private static bool $registered = false;
 

--- a/inc/Abilities/BatchTimeFixAbilities.php
+++ b/inc/Abilities/BatchTimeFixAbilities.php
@@ -45,7 +45,7 @@ class BatchTimeFixAbilities {
 				array(
 					'label'               => __( 'Batch Time Fix', 'data-machine-events' ),
 					'description'         => __( 'Batch fix event times with offset correction or explicit replacement', 'data-machine-events' ),
-					'category'            => 'datamachine-events/events',
+					'category'            => 'datamachine-events-events',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'venue' ),

--- a/inc/Abilities/CalendarAbilities.php
+++ b/inc/Abilities/CalendarAbilities.php
@@ -44,7 +44,7 @@ class CalendarAbilities {
 				array(
 					'label'               => __( 'Get Calendar Page', 'data-machine-events' ),
 					'description'         => __( 'Query paginated calendar events with optional filtering and HTML rendering', 'data-machine-events' ),
-					'category'            => 'datamachine-events/events',
+					'category'            => 'datamachine-events-events',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/DiceFmTest.php
+++ b/inc/Abilities/DiceFmTest.php
@@ -29,7 +29,7 @@ class DiceFmTest {
 					array(
 						'label'               => __( 'Test Dice FM', 'data-machine-events' ),
 						'description'         => __( 'Test Dice FM API handler with raw response data', 'data-machine-events' ),
-						'category'            => 'datamachine-events/testing',
+						'category'            => 'datamachine-events-testing',
 						'input_schema'        => array(
 							'type'       => 'object',
 							'required'   => array( 'city' ),

--- a/inc/Abilities/DuplicateDetectionAbilities.php
+++ b/inc/Abilities/DuplicateDetectionAbilities.php
@@ -145,7 +145,7 @@ class DuplicateDetectionAbilities {
 			array(
 				'label'               => __( 'Venues Match', 'data-machine-events' ),
 				'description'         => __( 'Compare two venue names for semantic equivalence. Handles HTML entities, parenthetical stage names, dash-separated qualifiers, and article removal.', 'data-machine-events' ),
-				'category'            => 'datamachine-events/venues',
+				'category'            => 'datamachine-events-venues',
 				'input_schema'        => array(
 					'type'       => 'object',
 					'required'   => array( 'venue1', 'venue2' ),
@@ -198,7 +198,7 @@ class DuplicateDetectionAbilities {
 			array(
 				'label'               => __( 'Find Duplicate Event', 'data-machine-events' ),
 				'description'         => __( 'Search for an existing event that matches the given title, venue, and date using fuzzy matching. Returns the matching post ID or null.', 'data-machine-events' ),
-				'category'            => 'datamachine-events/venues',
+				'category'            => 'datamachine-events-venues',
 				'input_schema'        => array(
 					'type'       => 'object',
 					'required'   => array( 'title', 'startDate' ),

--- a/inc/Abilities/EncodingFixAbilities.php
+++ b/inc/Abilities/EncodingFixAbilities.php
@@ -44,7 +44,7 @@ class EncodingFixAbilities {
 				array(
 					'label'               => __( 'Fix Encoding', 'data-machine-events' ),
 					'description'         => __( 'Fix Unicode encoding issues in event block attributes', 'data-machine-events' ),
-					'category'            => 'datamachine-events/events',
+					'category'            => 'datamachine-events-events',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/EventDateQueryAbilities.php
+++ b/inc/Abilities/EventDateQueryAbilities.php
@@ -42,7 +42,7 @@ class EventDateQueryAbilities {
 				array(
 					'label'               => __( 'Query Events', 'data-machine-events' ),
 					'description'         => __( 'Query events filtered by date scope, taxonomy, geo, and search. The single primitive for all event date queries.', 'data-machine-events' ),
-					'category'            => 'datamachine-events/events',
+					'category'            => 'datamachine-events-events',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/EventHealthAbilities.php
+++ b/inc/Abilities/EventHealthAbilities.php
@@ -41,7 +41,7 @@ class EventHealthAbilities {
 				array(
 					'label'               => __( 'Event Health Check', 'data-machine-events' ),
 					'description'         => __( 'Scan events for data quality issues', 'data-machine-events' ),
-					'category'            => 'datamachine-events/events',
+					'category'            => 'datamachine-events-events',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/EventQualityAuditAbilities.php
+++ b/inc/Abilities/EventQualityAuditAbilities.php
@@ -39,7 +39,7 @@ class EventQualityAuditAbilities {
 				array(
 					'label'               => __( 'Event Quality Audit', 'data-machine-events' ),
 					'description'         => __( 'Unified event quality audit with flow-aware diagnostics.', 'data-machine-events' ),
-					'category'            => 'datamachine-events/events',
+					'category'            => 'datamachine-events-events',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/EventQueryAbilities.php
+++ b/inc/Abilities/EventQueryAbilities.php
@@ -39,7 +39,7 @@ class EventQueryAbilities {
 				array(
 					'label'               => __( 'Get Venue Events', 'data-machine-events' ),
 					'description'         => __( 'Query events for a specific venue', 'data-machine-events' ),
-					'category'            => 'datamachine-events/events',
+					'category'            => 'datamachine-events-events',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'venue' ),

--- a/inc/Abilities/EventScraperTest.php
+++ b/inc/Abilities/EventScraperTest.php
@@ -28,7 +28,7 @@ class EventScraperTest {
 					array(
 						'label'               => __( 'Test Event Scraper', 'data-machine-events' ),
 						'description'         => __( 'Test universal web scraper compatibility with a target URL', 'data-machine-events' ),
-						'category'            => 'datamachine-events/testing',
+						'category'            => 'datamachine-events-testing',
 						'input_schema'        => array(
 							'type'       => 'object',
 							'required'   => array( 'target_url' ),

--- a/inc/Abilities/EventUpdateAbilities.php
+++ b/inc/Abilities/EventUpdateAbilities.php
@@ -62,7 +62,7 @@ class EventUpdateAbilities {
 				array(
 					'label'               => __( 'Update Event', 'data-machine-events' ),
 					'description'         => __( 'Update event details including dates, times, venue, and metadata', 'data-machine-events' ),
-					'category'            => 'datamachine-events/events',
+					'category'            => 'datamachine-events-events',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/FilterAbilities.php
+++ b/inc/Abilities/FilterAbilities.php
@@ -40,7 +40,7 @@ class FilterAbilities {
 				array(
 					'label'               => __( 'Get Filter Options', 'data-machine-events' ),
 					'description'         => __( 'Get available taxonomy filter options with event counts, supporting geo-filtering, cross-filtering, and archive context', 'data-machine-events' ),
-					'category'            => 'datamachine-events/events',
+					'category'            => 'datamachine-events-events',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/GeocodingAbilities.php
+++ b/inc/Abilities/GeocodingAbilities.php
@@ -72,7 +72,7 @@ class GeocodingAbilities {
 			array(
 				'label'               => __( 'Geocode Address', 'data-machine-events' ),
 				'description'         => __( 'Geocode an address string to lat/lng coordinates via OpenStreetMap Nominatim. Results are cached for 30 days.', 'data-machine-events' ),
-				'category'            => 'datamachine-events/venues',
+				'category'            => 'datamachine-events-venues',
 				'input_schema'        => array(
 					'type'       => 'object',
 					'required'   => array( 'query' ),
@@ -160,7 +160,7 @@ class GeocodingAbilities {
 			array(
 				'label'               => __( 'Geocode Search', 'data-machine-events' ),
 				'description'         => __( 'Search for addresses via Nominatim and return multiple results with full address details. Used for autocomplete UIs.', 'data-machine-events' ),
-				'category'            => 'datamachine-events/venues',
+				'category'            => 'datamachine-events-venues',
 				'input_schema'        => array(
 					'type'       => 'object',
 					'required'   => array( 'query' ),
@@ -271,7 +271,7 @@ class GeocodingAbilities {
 			array(
 				'label'               => __( 'Geocode Venues', 'data-machine-events' ),
 				'description'         => __( 'Batch geocode venues that have an address but are missing coordinates. Respects Nominatim rate limits.', 'data-machine-events' ),
-				'category'            => 'datamachine-events/venues',
+				'category'            => 'datamachine-events-venues',
 				'input_schema'        => array(
 					'type'       => 'object',
 					'properties' => array(
@@ -453,7 +453,7 @@ class GeocodingAbilities {
 			array(
 				'label'               => __( 'Audit Venues', 'data-machine-events' ),
 				'description'         => __( 'Audit venue data quality: geocoding coverage, missing addresses, missing timezones. Returns a comprehensive data quality report.', 'data-machine-events' ),
-				'category'            => 'datamachine-events/venues',
+				'category'            => 'datamachine-events-venues',
 				'input_schema'        => array(
 					'type'       => 'object',
 					'properties' => array(

--- a/inc/Abilities/MetaSyncAbilities.php
+++ b/inc/Abilities/MetaSyncAbilities.php
@@ -40,7 +40,7 @@ class MetaSyncAbilities {
 				array(
 					'label'               => __( 'Find Missing Meta Sync', 'data-machine-events' ),
 					'description'         => __( 'Detect events where block has data but meta sync failed', 'data-machine-events' ),
-					'category'            => 'datamachine-events/events',
+					'category'            => 'datamachine-events-events',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(
@@ -82,7 +82,7 @@ class MetaSyncAbilities {
 				array(
 					'label'               => __( 'Resync Event Meta', 'data-machine-events' ),
 					'description'         => __( 'Re-trigger meta sync for specified events', 'data-machine-events' ),
-					'category'            => 'datamachine-events/events',
+					'category'            => 'datamachine-events-events',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/SettingsAbilities.php
+++ b/inc/Abilities/SettingsAbilities.php
@@ -73,7 +73,7 @@ class SettingsAbilities {
 			array(
 				'label'               => __( 'Get Settings', 'data-machine-events' ),
 				'description'         => __( 'Read plugin settings. Returns all settings or a specific key.', 'data-machine-events' ),
-				'category'            => 'datamachine-events/settings',
+				'category'            => 'datamachine-events-settings',
 				'input_schema'        => array(
 					'type'       => 'object',
 					'properties' => array(
@@ -139,7 +139,7 @@ class SettingsAbilities {
 			array(
 				'label'               => __( 'Update Setting', 'data-machine-events' ),
 				'description'         => __( 'Update a single plugin setting. Validates and sanitizes the value.', 'data-machine-events' ),
-				'category'            => 'datamachine-events/settings',
+				'category'            => 'datamachine-events-settings',
 				'input_schema'        => array(
 					'type'       => 'object',
 					'required'   => array( 'key', 'value' ),

--- a/inc/Abilities/TicketUrlResyncAbilities.php
+++ b/inc/Abilities/TicketUrlResyncAbilities.php
@@ -45,7 +45,7 @@ class TicketUrlResyncAbilities {
 				array(
 					'label'               => __( 'Resync Ticket URLs', 'data-machine-events' ),
 					'description'         => __( 'Re-normalize ticket URL meta from block content', 'data-machine-events' ),
-					'category'            => 'datamachine-events/events',
+					'category'            => 'datamachine-events-events',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'properties' => array(

--- a/inc/Abilities/TicketmasterTest.php
+++ b/inc/Abilities/TicketmasterTest.php
@@ -30,7 +30,7 @@ class TicketmasterTest {
 					array(
 						'label'               => __( 'Test Ticketmaster', 'data-machine-events' ),
 						'description'         => __( 'Test Ticketmaster API handler with raw response data', 'data-machine-events' ),
-						'category'            => 'datamachine-events/testing',
+						'category'            => 'datamachine-events-testing',
 						'input_schema'        => array(
 							'type'       => 'object',
 							'required'   => array( 'classification_type' ),

--- a/inc/Abilities/TimezoneAbilities.php
+++ b/inc/Abilities/TimezoneAbilities.php
@@ -39,7 +39,7 @@ class TimezoneAbilities {
 				array(
 					'label'               => __( 'Find Events with Missing Timezone', 'data-machine-events' ),
 					'description'         => __( 'Find events where venue has no timezone or coordinates', 'data-machine-events' ),
-					'category'            => 'datamachine-events/events',
+					'category'            => 'datamachine-events-events',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array(),
@@ -112,7 +112,7 @@ class TimezoneAbilities {
 				array(
 					'label'               => __( 'Fix Event Timezone', 'data-machine-events' ),
 					'description'         => __( 'Update venue timezone with geocoding support. Supports batch updates with inline errors.', 'data-machine-events' ),
-					'category'            => 'datamachine-events/events',
+					'category'            => 'datamachine-events-events',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array(),

--- a/inc/Abilities/UpcomingCountAbilities.php
+++ b/inc/Abilities/UpcomingCountAbilities.php
@@ -36,7 +36,7 @@ class UpcomingCountAbilities {
 				array(
 					'label'               => __( 'Get Upcoming Event Counts', 'data-machine-events' ),
 					'description'         => __( 'Count upcoming events grouped by taxonomy term. Returns terms sorted by event count descending.', 'data-machine-events' ),
-					'category'            => 'datamachine-events/events',
+					'category'            => 'datamachine-events-events',
 					'input_schema'        => array(
 						'type'       => 'object',
 						'required'   => array( 'taxonomy' ),

--- a/inc/Abilities/VenueAbilities.php
+++ b/inc/Abilities/VenueAbilities.php
@@ -81,7 +81,7 @@ class VenueAbilities {
 			array(
 				'label'               => __( 'Venue Health Check', 'data-machine-events' ),
 				'description'         => __( 'Scan venues for data quality issues: missing address, coordinates, timezone, or website. Also detects suspicious websites where a ticket URL was mistakenly stored as venue website.', 'data-machine-events' ),
-				'category'            => 'datamachine-events/venues',
+				'category'            => 'datamachine-events-venues',
 				'input_schema'        => array(
 					'type'       => 'object',
 					'properties' => array(
@@ -148,7 +148,7 @@ class VenueAbilities {
 			array(
 				'label'               => __( 'Update Venue', 'data-machine-events' ),
 				'description'         => __( 'Update a venue name and/or meta fields. Address changes trigger automatic geocoding.', 'data-machine-events' ),
-				'category'            => 'datamachine-events/venues',
+				'category'            => 'datamachine-events-venues',
 				'input_schema'        => array(
 					'type'       => 'object',
 					'required'   => array( 'venue' ),
@@ -233,7 +233,7 @@ class VenueAbilities {
 			array(
 				'label'               => __( 'Get Venue', 'data-machine-events' ),
 				'description'         => __( 'Get venue details by term ID', 'data-machine-events' ),
-				'category'            => 'datamachine-events/venues',
+				'category'            => 'datamachine-events-venues',
 				'input_schema'        => array(
 					'type'       => 'object',
 					'required'   => array( 'id' ),
@@ -279,7 +279,7 @@ class VenueAbilities {
 			array(
 				'label'               => __( 'Check Duplicate Venue', 'data-machine-events' ),
 				'description'         => __( 'Check if a venue with the given name already exists', 'data-machine-events' ),
-				'category'            => 'datamachine-events/venues',
+				'category'            => 'datamachine-events-venues',
 				'input_schema'        => array(
 					'type'       => 'object',
 					'required'   => array( 'name' ),

--- a/inc/Abilities/VenueMapAbilities.php
+++ b/inc/Abilities/VenueMapAbilities.php
@@ -58,7 +58,7 @@ class VenueMapAbilities {
 			array(
 				'label'               => __( 'List Venues', 'data-machine-events' ),
 				'description'         => __( 'List venues with coordinates for map rendering. Supports geo proximity and viewport bounds filtering.', 'data-machine-events' ),
-				'category'            => 'datamachine-events/venues',
+				'category'            => 'datamachine-events-venues',
 				'input_schema'        => array(
 					'type'       => 'object',
 					'properties' => array(


### PR DESCRIPTION
## Summary

WordPress 7.0 RC2 tightened the Abilities API category slug validation regex to `/^[a-z0-9]+(?:-[a-z0-9]+)*$/`, rejecting any slug containing a forward slash. The `datamachine-events/events`, `datamachine-events/venues`, etc. category slugs that worked silently on 6.9 now fail registration on 7.0+, and every ability assigned to those categories logs `category is not registered` notices on every init.

On a busy production site (extrachill.com network), this generates **~13,000 notices per few minutes** and was filling debug.log to multi-GB scale within hours of the WP 7.0 upgrade.

## Fix

Flatten the four category slugs to match Data Machine core's pattern of `<plugin>-<category>` (e.g. `datamachine-content`, `datamachine-media`):

```
datamachine-events/events   →  datamachine-events-events
datamachine-events/venues   →  datamachine-events-venues
datamachine-events/testing  →  datamachine-events-testing
datamachine-events/settings →  datamachine-events-settings
```

## Scope

- 22 PHP files touched (1 constants file + 21 ability files)
- 35 string-literal replacements
- All ability **names** (e.g. `data-machine-events/get-venue-events`) keep their `namespace/name` slash format — that is still valid and required by the Abilities API name regex.
- Abilities are not persisted in the database, so this is a purely code-side fix. No data migration needed.
- Tests and docs do not reference the old category slugs (only ability names + block names, neither affected).

## Verification

```bash
# Before fix:
$ tail -1000 wp-content/debug.log | grep -c "Ability category"
~900

# After deploy:
$ tail -1000 wp-content/debug.log | grep -c "Ability category"
0
```

Refs: data-machine-events#216