### PR TITLE
fix(schema): declare array items for upsert_event tool to satisfy OpenAI strict mode

### DIFF
--- a/inc/Core/EventSchemaProvider.php
+++ b/inc/Core/EventSchemaProvider.php
@@ -87,6 +87,7 @@ class EventSchemaProvider {
 		),
 		'occurrenceDates' => array(
 			'type'            => 'array',
+			'items'           => array( 'type' => 'string' ),
 			'required'        => false,
 			'description'     => 'For recurring events: array of specific dates (YYYY-MM-DD) when the event occurs within the start/end range. If provided, event displays only on these dates instead of every day in the range.',
 			'schema_property' => null,
@@ -329,6 +330,15 @@ class EventSchemaProvider {
 
 			if ( ! empty( $field['enum'] ) ) {
 				$param['enum'] = $field['enum'];
+			}
+
+			// JSON Schema requires `items` on every array type, and OpenAI's
+			// strict tool schema validation rejects arrays without it.
+			// Propagate `items` from the field declaration; default to a string
+			// array when the declaration is incomplete to avoid emitting an
+			// invalid schema that would fail at runtime.
+			if ( 'array' === ( $field['type'] ?? '' ) ) {
+				$param['items'] = $field['items'] ?? array( 'type' => 'string' );
 			}
 
 			$params[ $key ] = $param;


### PR DESCRIPTION
## Production fire

Every event ingestion flow on events.extrachill.com has been failing since the wp-ai-client cutover (DM 0.103.x) with:

\`\`\`
Bad Request (400) - Invalid schema for function 'upsert_event':
In context=('properties', 'occurrenceDates'), array schema missing items.
\`\`\`

OpenAI's strict tool schema validation requires \`items\` on every array type. The legacy ai-http-client tolerated the omission silently; wp-ai-client does not (correctly — this was always invalid JSON Schema).

## Impact

\`occurrenceDates\` is a field on the \`upsert_event\` tool — the AI's primary path for writing events into WordPress. Without it working, no events get ingested:

\`\`\`
status                        count   recent flows affected
failed - ai_processing_failed  N      Dice.fm, Squarespace, Universal scrapers
completed_no_items             N      everything else (dedup says nothing new)
new events created in 4h:      0
\`\`\`

## Fix

### 1. Declare \`items\` on \`occurrenceDates\` in EventSchemaProvider

\`occurrenceDates\` stores ISO date strings (YYYY-MM-DD), so:

\`\`\`php
'occurrenceDates' => array(
    'type'            => 'array',
    'items'           => array( 'type' => 'string' ),  // ← added
    'required'        => false,
    'description'     => 'For recurring events: array of specific dates (YYYY-MM-DD)...',
    'schema_property' => null,
),
\`\`\`

### 2. Harden \`fieldsToToolParameters()\` to always emit \`items\` for arrays

Defensive: any future array field that forgets to declare \`items\` will get a sensible default instead of producing an invalid schema.

\`\`\`php
if ( 'array' === ( \$field['type'] ?? '' ) ) {
    \$param['items'] = \$field['items'] ?? array( 'type' => 'string' );
}
\`\`\`

## Verification

After applying, the generated schema for \`upsert_event\` validates cleanly against OpenAI's strict mode. Event ingestion flows resume on next pipeline tick.

## Out of scope

Several **output** schemas in DM-events ability declarations (DiceFmTest, EventHealthAbilities, BatchTimeFixAbilities) also have \`type: array\` without \`items\`. Those are descriptive-only metadata for ability returns and don't go to OpenAI as tool definitions — they're not blocking production. Worth a separate cleanup PR for completeness.

Refs: extrachill.com production incident May 1 2026 ~19:00 UTC after wp-ai-client cutover deploy.