### PR TITLE
fix(tools): canonical JSON Schema for chat tools

### DIFF
--- a/inc/Api/Chat/Tools/EventHealthCheck.php
+++ b/inc/Api/Chat/Tools/EventHealthCheck.php
@@ -30,21 +30,21 @@ class EventHealthCheck extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Check events for data quality issues: missing start time, suspicious midnight start, late night start (midnight-4am), suspicious 11:59pm end time, missing venue, missing description, or missing venue timezone. Returns counts and lists of problematic events.',
 			'parameters'  => array(
-				'scope'      => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Which events to check: "upcoming" (default), "all", or "past"',
-					'enum'        => array( 'upcoming', 'all', 'past' ),
-				),
-				'days_ahead' => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Days to look ahead for upcoming scope (default: 90)',
-				),
-				'limit'      => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Max events to return per issue category (default: 25)',
+				'type'       => 'object',
+				'properties' => array(
+					'scope'      => array(
+						'type'        => 'string',
+						'description' => 'Which events to check: "upcoming" (default), "all", or "past"',
+						'enum'        => array( 'upcoming', 'all', 'past' ),
+					),
+					'days_ahead' => array(
+						'type'        => 'integer',
+						'description' => 'Days to look ahead for upcoming scope (default: 90)',
+					),
+					'limit'      => array(
+						'type'        => 'integer',
+						'description' => 'Max events to return per issue category (default: 25)',
+					),
 				),
 			),
 		);

--- a/inc/Api/Chat/Tools/EventQualityAudit.php
+++ b/inc/Api/Chat/Tools/EventQualityAudit.php
@@ -30,36 +30,33 @@ class EventQualityAudit extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Run a unified event quality audit: missing start date, missing start time, missing venue, probable duplicate groups, and culprit flows.',
 			'parameters'  => array(
-				'scope'      => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Which events to check: upcoming (default), all, or past.',
-					'enum'        => array( 'upcoming', 'all', 'past' ),
-				),
-				'days_ahead' => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Days to look ahead for upcoming scope (default: 90).',
-				),
-				'flow_id'    => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Optional flow ID filter.',
-				),
-				'location_term_id' => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Optional location term ID filter.',
-				),
-				'issue'      => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Optional issue filter: all, missing_start_date, missing_start_time, missing_venue, or duplicates.',
-				),
-				'limit'      => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Max rows to return per category (default: 25).',
+				'type'       => 'object',
+				'properties' => array(
+					'scope'            => array(
+						'type'        => 'string',
+						'description' => 'Which events to check: upcoming (default), all, or past.',
+						'enum'        => array( 'upcoming', 'all', 'past' ),
+					),
+					'days_ahead'       => array(
+						'type'        => 'integer',
+						'description' => 'Days to look ahead for upcoming scope (default: 90).',
+					),
+					'flow_id'          => array(
+						'type'        => 'integer',
+						'description' => 'Optional flow ID filter.',
+					),
+					'location_term_id' => array(
+						'type'        => 'integer',
+						'description' => 'Optional location term ID filter.',
+					),
+					'issue'            => array(
+						'type'        => 'string',
+						'description' => 'Optional issue filter: all, missing_start_date, missing_start_time, missing_venue, or duplicates.',
+					),
+					'limit'            => array(
+						'type'        => 'integer',
+						'description' => 'Max rows to return per category (default: 25).',
+					),
 				),
 			),
 		);

--- a/inc/Api/Chat/Tools/FindBrokenTimezoneEvents.php
+++ b/inc/Api/Chat/Tools/FindBrokenTimezoneEvents.php
@@ -29,21 +29,21 @@ class FindBrokenTimezoneEvents extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Find events where venue has no timezone or coordinates. Also separately notes events with no venue assigned. Returns actual timezone/coordinates values when present.',
 			'parameters'  => array(
-				'scope'      => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Which events to check: "upcoming" (default), "all", or "past"',
-					'enum'        => array( 'upcoming', 'all', 'past' ),
-				),
-				'days_ahead' => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Days to look ahead for upcoming scope (default: 90)',
-				),
-				'limit'      => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Max events to return (default: 50)',
+				'type'       => 'object',
+				'properties' => array(
+					'scope'      => array(
+						'type'        => 'string',
+						'description' => 'Which events to check: "upcoming" (default), "all", or "past"',
+						'enum'        => array( 'upcoming', 'all', 'past' ),
+					),
+					'days_ahead' => array(
+						'type'        => 'integer',
+						'description' => 'Days to look ahead for upcoming scope (default: 90)',
+					),
+					'limit'      => array(
+						'type'        => 'integer',
+						'description' => 'Max events to return (default: 50)',
+					),
 				),
 			),
 		);

--- a/inc/Api/Chat/Tools/FixEventTimezone.php
+++ b/inc/Api/Chat/Tools/FixEventTimezone.php
@@ -29,25 +29,25 @@ class FixEventTimezone extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Fix event timezone by updating venue metadata. Supports batch updates. Event times remain as-is (8pm stays 8pm) regardless of timezone. Calls geocoding if venue lacks coordinates. Returns inline errors and continues processing.',
 			'parameters'  => array(
-				'event'       => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Single event post ID to fix',
-				),
-				'events'      => array(
-					'type'        => 'array',
-					'required'    => false,
-					'description' => 'Array of event updates. Each item must have "event" (post ID) and optionally "timezone" and "auto_derive".',
-				),
-				'timezone'    => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'IANA timezone identifier (e.g., "America/Chicago"). If omitted and auto_derive is false, no change is made.',
-				),
-				'auto_derive' => array(
-					'type'        => 'boolean',
-					'required'    => false,
-					'description' => 'If true, derive timezone from venue coordinates via GeoNames API (requires GeoNames username configured). Default: false.',
+				'type'       => 'object',
+				'properties' => array(
+					'event'       => array(
+						'type'        => 'integer',
+						'description' => 'Single event post ID to fix',
+					),
+					'events'      => array(
+						'type'        => 'array',
+						'description' => 'Array of event updates. Each item must have "event" (post ID) and optionally "timezone" and "auto_derive".',
+						'items'       => array( 'type' => 'object' ),
+					),
+					'timezone'    => array(
+						'type'        => 'string',
+						'description' => 'IANA timezone identifier (e.g., "America/Chicago"). If omitted and auto_derive is false, no change is made.',
+					),
+					'auto_derive' => array(
+						'type'        => 'boolean',
+						'description' => 'If true, derive timezone from venue coordinates via GeoNames API (requires GeoNames username configured). Default: false.',
+					),
 				),
 			),
 		);

--- a/inc/Api/Chat/Tools/GetVenueEvents.php
+++ b/inc/Api/Chat/Tools/GetVenueEvents.php
@@ -29,31 +29,30 @@ class GetVenueEvents extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Get events attached to a specific venue. Useful for investigating venue terms before merging or cleanup.',
 			'parameters'  => array(
-				'venue'            => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Venue identifier (term ID, name, or slug)',
+				'type'       => 'object',
+				'properties' => array(
+					'venue'            => array(
+						'type'        => 'string',
+						'description' => 'Venue identifier (term ID, name, or slug)',
+					),
+					'limit'            => array(
+						'type'        => 'integer',
+						'description' => 'Maximum events to return (default: 25, max: 100)',
+					),
+					'status'           => array(
+						'type'        => 'string',
+						'description' => 'Post status filter: any, publish, future, draft (default: any)',
+					),
+					'published_before' => array(
+						'type'        => 'string',
+						'description' => 'Only return events published before this date (YYYY-MM-DD format)',
+					),
+					'published_after'  => array(
+						'type'        => 'string',
+						'description' => 'Only return events published after this date (YYYY-MM-DD format)',
+					),
 				),
-				'limit'            => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Maximum events to return (default: 25, max: 100)',
-				),
-				'status'           => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Post status filter: any, publish, future, draft (default: any)',
-				),
-				'published_before' => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Only return events published before this date (YYYY-MM-DD format)',
-				),
-				'published_after'  => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Only return events published after this date (YYYY-MM-DD format)',
-				),
+				'required'   => array( 'venue' ),
 			),
 		);
 	}

--- a/inc/Api/Chat/Tools/TestEventScraper.php
+++ b/inc/Api/Chat/Tools/TestEventScraper.php
@@ -29,11 +29,14 @@ class TestEventScraper extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Test universal web scraper compatibility with a target URL. Returns structured JSON with event data, extraction method, and coverage warnings.',
 			'parameters'  => array(
-				'target_url' => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Target URL to test scraper against',
+				'type'       => 'object',
+				'properties' => array(
+					'target_url' => array(
+						'type'        => 'string',
+						'description' => 'Target URL to test scraper against',
+					),
 				),
+				'required'   => array( 'target_url' ),
 			),
 		);
 	}

--- a/inc/Api/Chat/Tools/UpdateEvent.php
+++ b/inc/Api/Chat/Tools/UpdateEvent.php
@@ -30,83 +30,73 @@ class UpdateEvent extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Update event details. Accepts a single event or batch of events. Only post IDs are accepted for event identification. Venue must be an existing venue term ID.',
 			'parameters'  => array(
-				'event'           => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Single event post ID to update',
-				),
-				'events'          => array(
-					'type'        => 'array',
-					'required'    => false,
-					'description' => 'Array of event updates. Each item must have "event" (post ID) plus fields to update.',
-				),
-				'startDate'       => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Start date (any parseable format, normalized to YYYY-MM-DD)',
-				),
-				'startTime'       => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Start time (any parseable format like "8pm", "20:00", normalized to HH:MM)',
-				),
-				'endDate'         => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'End date (any parseable format, normalized to YYYY-MM-DD)',
-				),
-				'endTime'         => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'End time (any parseable format, normalized to HH:MM)',
-				),
-				'venue'           => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Existing venue term ID to assign',
-				),
-				'description'     => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Event description (HTML allowed)',
-				),
-				'price'           => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Ticket price (e.g., "$25" or "$20 adv / $25 door")',
-				),
-				'ticketUrl'       => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'URL to purchase tickets',
-				),
-				'performer'       => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Performer name',
-				),
-				'performerType'   => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Performer type: Person, PerformingGroup, or MusicGroup',
-					'enum'        => array( 'Person', 'PerformingGroup', 'MusicGroup' ),
-				),
-				'eventStatus'     => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Event status',
-					'enum'        => array( 'EventScheduled', 'EventPostponed', 'EventCancelled', 'EventRescheduled' ),
-				),
-				'eventType'       => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Event type for Schema.org',
-					'enum'        => array( 'Event', 'MusicEvent', 'Festival', 'ComedyEvent', 'DanceEvent', 'TheaterEvent', 'SportsEvent', 'ExhibitionEvent' ),
-				),
-				'occurrenceDates' => array(
-					'type'        => 'array',
-					'required'    => false,
-					'description' => 'Array of specific dates (YYYY-MM-DD) when the event occurs. For recurring events within a date range.',
+				'type'       => 'object',
+				'properties' => array(
+					'event'           => array(
+						'type'        => 'integer',
+						'description' => 'Single event post ID to update',
+					),
+					'events'          => array(
+						'type'        => 'array',
+						'description' => 'Array of event updates. Each item must have "event" (post ID) plus fields to update.',
+						'items'       => array( 'type' => 'object' ),
+					),
+					'startDate'       => array(
+						'type'        => 'string',
+						'description' => 'Start date (any parseable format, normalized to YYYY-MM-DD)',
+					),
+					'startTime'       => array(
+						'type'        => 'string',
+						'description' => 'Start time (any parseable format like "8pm", "20:00", normalized to HH:MM)',
+					),
+					'endDate'         => array(
+						'type'        => 'string',
+						'description' => 'End date (any parseable format, normalized to YYYY-MM-DD)',
+					),
+					'endTime'         => array(
+						'type'        => 'string',
+						'description' => 'End time (any parseable format, normalized to HH:MM)',
+					),
+					'venue'           => array(
+						'type'        => 'integer',
+						'description' => 'Existing venue term ID to assign',
+					),
+					'description'     => array(
+						'type'        => 'string',
+						'description' => 'Event description (HTML allowed)',
+					),
+					'price'           => array(
+						'type'        => 'string',
+						'description' => 'Ticket price (e.g., "$25" or "$20 adv / $25 door")',
+					),
+					'ticketUrl'       => array(
+						'type'        => 'string',
+						'description' => 'URL to purchase tickets',
+					),
+					'performer'       => array(
+						'type'        => 'string',
+						'description' => 'Performer name',
+					),
+					'performerType'   => array(
+						'type'        => 'string',
+						'description' => 'Performer type: Person, PerformingGroup, or MusicGroup',
+						'enum'        => array( 'Person', 'PerformingGroup', 'MusicGroup' ),
+					),
+					'eventStatus'     => array(
+						'type'        => 'string',
+						'description' => 'Event status',
+						'enum'        => array( 'EventScheduled', 'EventPostponed', 'EventCancelled', 'EventRescheduled' ),
+					),
+					'eventType'       => array(
+						'type'        => 'string',
+						'description' => 'Event type for Schema.org',
+						'enum'        => array( 'Event', 'MusicEvent', 'Festival', 'ComedyEvent', 'DanceEvent', 'TheaterEvent', 'SportsEvent', 'ExhibitionEvent' ),
+					),
+					'occurrenceDates' => array(
+						'type'        => 'array',
+						'description' => 'Array of specific dates (YYYY-MM-DD) when the event occurs. For recurring events within a date range.',
+						'items'       => array( 'type' => 'string' ),
+					),
 				),
 			),
 		);

--- a/inc/Api/Chat/Tools/UpdateVenue.php
+++ b/inc/Api/Chat/Tools/UpdateVenue.php
@@ -29,71 +29,62 @@ class UpdateVenue extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Update a venue name and/or meta fields. Address changes trigger automatic geocoding.',
 			'parameters'  => array(
-				'venue'       => array(
-					'type'        => 'string',
-					'required'    => true,
-					'description' => 'Venue identifier (term ID, name, or slug)',
+				'type'       => 'object',
+				'properties' => array(
+					'venue'       => array(
+						'type'        => 'string',
+						'description' => 'Venue identifier (term ID, name, or slug)',
+					),
+					'name'        => array(
+						'type'        => 'string',
+						'description' => 'New venue name',
+					),
+					'description' => array(
+						'type'        => 'string',
+						'description' => 'Venue description',
+					),
+					'address'     => array(
+						'type'        => 'string',
+						'description' => 'Street address',
+					),
+					'city'        => array(
+						'type'        => 'string',
+						'description' => 'City',
+					),
+					'state'       => array(
+						'type'        => 'string',
+						'description' => 'State/region',
+					),
+					'zip'         => array(
+						'type'        => 'string',
+						'description' => 'Postal/ZIP code',
+					),
+					'country'     => array(
+						'type'        => 'string',
+						'description' => 'Country',
+					),
+					'phone'       => array(
+						'type'        => 'string',
+						'description' => 'Phone number',
+					),
+					'website'     => array(
+						'type'        => 'string',
+						'description' => 'Website URL',
+					),
+					'capacity'    => array(
+						'type'        => 'string',
+						'description' => 'Venue capacity',
+					),
+					'coordinates' => array(
+						'type'        => 'string',
+						'description' => 'GPS coordinates as "lat,lng"',
+					),
+					'timezone'    => array(
+						'type'        => 'string',
+						'description' => 'IANA timezone identifier (e.g., America/New_York)',
+					),
 				),
-				'name'        => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'New venue name',
-				),
-				'description' => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Venue description',
-				),
-				'address'     => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Street address',
-				),
-				'city'        => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'City',
-				),
-				'state'       => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'State/region',
-				),
-				'zip'         => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Postal/ZIP code',
-				),
-				'country'     => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Country',
-				),
-				'phone'       => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Phone number',
-				),
-				'website'     => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Website URL',
-				),
-				'capacity'    => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'Venue capacity',
-				),
-				'coordinates' => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'GPS coordinates as "lat,lng"',
-				),
-				'timezone'    => array(
-					'type'        => 'string',
-					'required'    => false,
-					'description' => 'IANA timezone identifier (e.g., America/New_York)',
-				),
+				'required'   => array( 'venue' ),
 			),
 		);
 	}

--- a/inc/Api/Chat/Tools/VenueHealthCheck.php
+++ b/inc/Api/Chat/Tools/VenueHealthCheck.php
@@ -30,10 +30,12 @@ class VenueHealthCheck extends BaseTool {
 			'method'      => 'handle_tool_call',
 			'description' => 'Check venues for data quality issues: missing address, coordinates, timezone, or website. Also detects suspicious websites where a ticket URL was mistakenly stored as venue website. Returns counts and lists of problematic venues.',
 			'parameters'  => array(
-				'limit' => array(
-					'type'        => 'integer',
-					'required'    => false,
-					'description' => 'Max venues to return per issue category (default: 25)',
+				'type'       => 'object',
+				'properties' => array(
+					'limit' => array(
+						'type'        => 'integer',
+						'description' => 'Max venues to return per issue category (default: 25)',
+					),
 				),
 			),
 		);


### PR DESCRIPTION
## Why

[Data Machine 0.106.1 PR #1900](https://github.com/Extra-Chill/data-machine/pull/1900) (\"Require canonical AI tool schemas\") removes the auto-normalization layer in `RequestBuilder::normalizeToolParameters` that previously converted legacy property-keyed parameter shapes into canonical JSON Schema on the way to providers. Extension plugins must now ship canonical schemas directly.

This is a **pre-flight fix landed before the DM bump** — canonical schemas already work on DM 0.103.14 (current production on extrachill.com), so this PR can ship and deploy independently of the DM upgrade.

## What changed

Converted all 9 chat tool definitions in `inc/Api/Chat/Tools/` from the legacy shape:

```php
// Legacy
'parameters' => array(
    'venue' => array( 'type' => 'string', 'required' => true, 'description' => '...' ),
)
```

…to canonical JSON Schema:

```php
// Canonical
'parameters' => array(
    'type'       => 'object',
    'properties' => array(
        'venue' => array( 'type' => 'string', 'description' => '...' ),
    ),
    'required'   => array( 'venue' ),
)
```

### Files

- `inc/Api/Chat/Tools/EventHealthCheck.php`
- `inc/Api/Chat/Tools/EventQualityAudit.php`
- `inc/Api/Chat/Tools/FindBrokenTimezoneEvents.php`
- `inc/Api/Chat/Tools/FixEventTimezone.php`
- `inc/Api/Chat/Tools/GetVenueEvents.php`
- `inc/Api/Chat/Tools/TestEventScraper.php`
- `inc/Api/Chat/Tools/UpdateEvent.php`
- `inc/Api/Chat/Tools/UpdateVenue.php`
- `inc/Api/Chat/Tools/VenueHealthCheck.php`

> The original task scoped this to 6 files. The remaining 3 (`EventHealthCheck`, `FindBrokenTimezoneEvents`, `GetVenueEvents`) had identical legacy shapes and would have broken on DM 0.106.1 too — converting all 9 in one PR makes the pre-flight actually pre-flight.

### Conversion rules applied

1. Wrap properties under `{ type: 'object', properties: {...} }`.
2. Move `required => true` properties into a top-level `required[]` array of property names; remove `required` from individual property defs.
3. Drop `required => false` entirely (it was a no-op).
4. Omit `required` key when no properties are required (don't emit empty arrays).
5. **Every `type: array` property gains an `items` schema** (required by OpenAI strict tool-schema validation, see MEMORY.md). Choices made:
   - `FixEventTimezone.events` → `items: { type: object }` (array of update structs)
   - `UpdateEvent.events` → `items: { type: object }` (array of update structs)
   - `UpdateEvent.occurrenceDates` → `items: { type: string }` (array of YYYY-MM-DD date strings)
6. All other property keys (`description`, `enum`) preserved verbatim.

### Required fields summary

- `UpdateVenue`: `venue`
- `TestEventScraper`: `target_url`
- `GetVenueEvents`: `venue`
- All others have no required fields (optional-only schemas).

## Out of scope (intentionally)

- `inc/Steps/Upsert/Events/EventUpsertFilters.php` — verified. Its `parameters` array is built dynamically by merging output from `EventSchemaProvider::getCoreToolParameters()`, `EventSchemaProvider::getSchemaToolParameters()`, `TaxonomyHandler::getTaxonomyToolParameters()`, and `VenueParameterProvider::getToolParameters()`. Those provider methods still emit the legacy property-keyed shape, but the entry point is **handler tool registration**, not chat tools — different code path through Data Machine's pipeline engine. Worth a follow-up audit before DM 0.106.1 deploys, but separate from this PR.

## Backwards compatibility

Canonical schemas are accepted by both DM 0.103.14 (current production) and DM 0.106.1+ (target). The legacy normalization path on 0.103.x silently passes canonical schemas through. No behavior change on the current site.

## Test plan

- [x] PHP syntax check (`php -l`) passes on all 9 edited files.
- [x] `homeboy lint --path . --changed-since main` shows no findings on any of the 9 edited tool files (only pre-existing baseline noise in `UniversalWebScraper.php` and other unrelated files).
- [x] Verified converted schemas match the contract in DM 0.106.1 `RequestBuilder::normalizeToolParameters` passthrough path.
- [ ] Live tool calls in production chat post-merge (manual sanity check on at least `update_venue` and `event_quality_audit`).

## Constraints honored

- Branched off `main`, no commits to `main`.
- No `CHANGELOG.md` edits, no version constant bumps — homeboy owns those.
- No deploy, no release.