### PR TITLE
fix: single-owner module lifecycle on calendar content swaps (#233)

### DIFF
--- a/inc/Blocks/Calendar/src/frontend.ts
+++ b/inc/Blocks/Calendar/src/frontend.ts
@@ -79,7 +79,13 @@ function initCalendarInstance( calendar: HTMLElement ): void {
 
 	filterState.updateFilterCountBadge();
 
-	// Listen for external content updates (e.g., discovery page scope switching).
+	// Single owner for dynamic-module lifecycle when `.data-machine-events-content`
+	// is replaced. Fired by api-client.fetchCalendarEvents after every innerHTML
+	// swap (geo-sync re-fetch, pagination, scope switching, etc.). Modules that
+	// touch the content region must NOT drive their own destroy/init cycle —
+	// they register here, and only here. This is the architectural fix for the
+	// race where geo-sync forgot to re-init day-loader after a content swap,
+	// leaving deferred date shells permanently un-hydrated on location archives.
 	calendar.addEventListener(
 		'data-machine-calendar-content-updated',
 		function () {

--- a/inc/Blocks/Calendar/src/modules/api-client.ts
+++ b/inc/Blocks/Calendar/src/modules/api-client.ts
@@ -52,6 +52,18 @@ export async function fetchCalendarEvents(
 			updatePagination( calendar, data.pagination );
 			updateCounter( calendar, content, data.counter );
 			updateNavigation( calendar, content, data.navigation );
+
+			// Notify lifecycle owners (frontend.ts) that the content region was
+			// replaced, so they can re-init dynamic modules (lazy-render,
+			// day-loader, carousel) on the new DOM. This is the single point
+			// of truth for content-swap notifications — every module that
+			// touches `.data-machine-events-content` should rely on this event,
+			// not drive its own destroy/init cycle.
+			calendar.dispatchEvent(
+				new CustomEvent( 'data-machine-calendar-content-updated', {
+					bubbles: false,
+				} )
+			);
 		}
 
 		return data;

--- a/inc/Blocks/Calendar/src/modules/geo-sync.ts
+++ b/inc/Blocks/Calendar/src/modules/geo-sync.ts
@@ -15,8 +15,6 @@
 
 import { fetchCalendarEvents } from './api-client';
 import { getFilterState } from './filter-state';
-import { initLazyRender, destroyLazyRender } from './lazy-render';
-import { initCarousel, destroyCarousel } from './carousel';
 
 import type { GeoContext } from '../types';
 
@@ -200,17 +198,14 @@ async function fetchAndUpdate(
 		label: '',
 	} );
 
-	// Clean up existing dynamic UI before re-fetch.
-	destroyLazyRender( calendar );
-	destroyCarousel( calendar );
-
+	// Module lifecycle (lazy-render, day-loader, carousel) is driven by
+	// frontend.ts in response to the `data-machine-calendar-content-updated`
+	// event that fetchCalendarEvents fires after swapping innerHTML. This
+	// module does not destroy or re-init dynamic UI directly — single owner.
 	await fetchCalendarEvents( calendar, params, archiveContext );
 
-	// Re-initialize dynamic UI on new DOM.
-	initLazyRender( calendar );
-	initCarousel( calendar );
-
-	// Re-bind pagination links for REST fetching.
+	// Re-bind pagination links for REST fetching (geo-sync owns this since
+	// it injects geo params into pagination requests).
 	rebindPagination( calendar, geo );
 }
 
@@ -290,16 +285,14 @@ function rebindPagination(
 		const filterState = getFilterState( calendar );
 		filterState.updateUrl( linkParams );
 
-		destroyLazyRender( calendar );
-		destroyCarousel( calendar );
-
+		// Module lifecycle handled by frontend.ts via the
+		// `data-machine-calendar-content-updated` event. We only re-bind
+		// pagination here because geo-sync owns the geo-param injection.
 		fetchCalendarEvents(
 			calendar,
 			linkParams,
 			filterState.getArchiveContext()
 		).then( () => {
-			initLazyRender( calendar );
-			initCarousel( calendar );
 			rebindPagination( calendar, geo );
 		} );
 	} );


### PR DESCRIPTION
## Summary

Fixes #233. Architectural fix: makes `api-client.fetchCalendarEvents` the single dispatcher of `data-machine-calendar-content-updated` and `frontend.ts`'s listener the single owner of dynamic-module lifecycle. `geo-sync` (and any future consumer that swaps `.data-machine-events-content.innerHTML`) no longer hand-drives destroy/init for individual modules.

## The bug

On location taxonomy archives (the only place where the EventsMap block is rendered alongside the calendar), only the first day's events render. Days 2..N stay as deferred skeleton shells forever.

Two pipelines were racing:

- **Pipeline A** — progressive day-loader: server renders day 1 fully + deferred shells, `day-loader.ts` prefetches each shell sequentially via REST.
- **Pipeline B** — geo-sync: when an EventsMap is on the page, `frontend.ts` enables `geo-sync`, which listens for `data-machine-map-bounds-changed` events and swaps `.data-machine-events-content.innerHTML` with a fresh response.

EventsMap fires `dispatchBoundsChanged` 200ms after mount on every page load (not just on user interaction). `geo-sync.fetchAndUpdate` then calls `destroyLazyRender` + `destroyCarousel`, swaps innerHTML, calls `initLazyRender` + `initCarousel` — but **never touched day-loader**. New deferred shells from the geo-sync response sat in the DOM with no observer, no fetcher, and no path to hydration.

## The fix

Single dispatcher, single listener, single lifecycle owner.

- `api-client.fetchCalendarEvents` — the only function that swaps `.data-machine-events-content.innerHTML` — now dispatches `data-machine-calendar-content-updated` after the swap.
- `frontend.ts` already had a listener for that event that destroys+inits all three modules (lazy-render, day-loader, carousel). The listener was dormant because nothing fired the event from inside the calendar; only `extrachill-events/assets/js/discovery.js` fired it externally for scope switches.
- `geo-sync.fetchAndUpdate` and `geo-sync.rebindPagination` no longer call `destroyLazyRender`/`destroyCarousel`/`initLazyRender`/`initCarousel`. They only own the work that's actually theirs: geo-param injection and pagination re-binding.

Adding a future module that hydrates inside `.data-machine-events-content` is now one line in the `frontend.ts` listener. Consumers don't import other modules. They don't know what other modules exist. They just dispatch the event.

## Why this isn't a bandaid

The minimum-effort fix would be to add `destroyDayLoader` + `initDayLoader` calls inside `geo-sync` next to the existing `lazyRender` + `carousel` calls. That fixes the visible symptom. It does not fix the design problem: every consumer that swaps innerHTML has to remember to drive every other module's lifecycle by hand. The next module added would re-introduce the same bug class.

This PR makes the calendar wrapper the single owner of module lifecycle. The bug class is gone, not just the bug.

## Side benefit: discovery scope switching

`extrachill-events/assets/js/discovery.js:282` already dispatched `data-machine-calendar-content-updated` after swapping calendar content for scope switches. The listener already destroyed+inited all three modules including day-loader, so discovery scope switching was probably half-broken in the same way (day-loader running on stale shells), just less visible because users don't typically switch scope and then count rendered days. Discovery now also benefits from this fix automatically.

## Files changed

- `inc/Blocks/Calendar/src/modules/api-client.ts` — dispatch the lifecycle event after innerHTML swap.
- `inc/Blocks/Calendar/src/modules/geo-sync.ts` — drop direct module destroy/init; remove unused imports.
- `inc/Blocks/Calendar/src/frontend.ts` — clarify the listener's role with a doc comment.

Build artifacts (`inc/Blocks/Calendar/build/frontend.js` etc) are gitignored; rebuilt locally and verified the new `dispatchEvent` call is present in the bundle.

## Testing plan

Manual: `events.extrachill.com/location/austin/`, `/charleston/`, `/asheville/` — confirm all visible days hydrate, not just the first. Then geo-pan the map, confirm calendar updates and all visible days hydrate. Then click pagination, confirm same.

Future: `homeboy trace` scenario asserting `[data-deferred="true"]` shell count == 0 five seconds after page load on location archives. Tracked in the issue.

Closes #233