### PR TITLE
fix(upsert): canonical JSON Schema for handler tool registrations

### DIFF
--- a/inc/Core/DynamicToolParametersTrait.php
+++ b/inc/Core/DynamicToolParametersTrait.php
@@ -38,9 +38,14 @@ trait DynamicToolParametersTrait {
 	 * Excludes parameters that already have values in engine data,
 	 * preventing the AI from seeing or providing redundant values.
 	 *
+	 * Returns a canonical JSON Schema fragment shaped as
+	 * `{ properties: {...}, required?: [...] }`. Composers merge multiple
+	 * fragments at the registration site to build a full
+	 * `{ type: 'object', properties, required }` schema.
+	 *
 	 * @param array $handler_config Handler configuration
 	 * @param array $engine_data Engine data snapshot
-	 * @return array Filtered parameter definitions
+	 * @return array Canonical fragment with `properties` and optional `required`.
 	 */
 	public static function getToolParameters( array $handler_config, array $engine_data = array() ): array {
 		return static::filterByEngineData( static::getAllParameters(), $engine_data );
@@ -49,25 +54,51 @@ trait DynamicToolParametersTrait {
 	/**
 	 * Filter parameters based on engine data presence.
 	 *
-	 * @param array $parameters All available parameters
+	 * Operates on canonical fragments. Properties whose key matches an
+	 * engine-aware key with a non-empty engine_data value are removed
+	 * from `properties` and the corresponding entry is removed from
+	 * `required`.
+	 *
+	 * @param array $fragment Canonical fragment with `properties` and optional `required`.
 	 * @param array $engine_data Engine data snapshot
-	 * @return array Filtered parameters
+	 * @return array Filtered canonical fragment
 	 */
-	protected static function filterByEngineData( array $parameters, array $engine_data ): array {
+	protected static function filterByEngineData( array $fragment, array $engine_data ): array {
 		if ( empty( $engine_data ) ) {
-			return $parameters;
+			return $fragment;
+		}
+
+		$properties = $fragment['properties'] ?? array();
+		$required   = $fragment['required'] ?? array();
+
+		if ( ! is_array( $properties ) ) {
+			return $fragment;
 		}
 
 		$engine_aware = static::getEngineAwareKeys();
 		$filtered     = array();
 
-		foreach ( $parameters as $key => $definition ) {
+		foreach ( $properties as $key => $definition ) {
 			if ( in_array( $key, $engine_aware, true ) && ! empty( $engine_data[ $key ] ) ) {
 				continue;
 			}
 			$filtered[ $key ] = $definition;
 		}
 
-		return $filtered;
+		$result = array( 'properties' => $filtered );
+
+		if ( is_array( $required ) && ! empty( $required ) ) {
+			$still_required = array_values(
+				array_filter(
+					$required,
+					static fn( $name ) => is_string( $name ) && array_key_exists( $name, $filtered )
+				)
+			);
+			if ( ! empty( $still_required ) ) {
+				$result['required'] = $still_required;
+			}
+		}
+
+		return $result;
 	}
 }

--- a/inc/Core/EventSchemaProvider.php
+++ b/inc/Core/EventSchemaProvider.php
@@ -218,7 +218,7 @@ class EventSchemaProvider {
 	/**
 	 * Get all possible tool parameters (trait implementation).
 	 *
-	 * @return array Complete parameter definitions
+	 * @return array Canonical fragment with `properties` and optional `required`.
 	 */
 	protected static function getAllParameters(): array {
 		return self::fieldsToToolParameters( self::getAllFields() );
@@ -239,18 +239,18 @@ class EventSchemaProvider {
 	 * Get core event tool parameters, filtered by engine data.
 	 *
 	 * @param array $engine_data Engine data snapshot
-	 * @return array Filtered core parameter definitions
+	 * @return array Canonical fragment with `properties` and optional `required`.
 	 */
 	public static function getCoreToolParameters( array $engine_data = array() ): array {
-		$params = self::fieldsToToolParameters( self::CORE_FIELDS );
-		return static::filterByEngineData( $params, $engine_data );
+		$fragment = self::fieldsToToolParameters( self::CORE_FIELDS );
+		return static::filterByEngineData( $fragment, $engine_data );
 	}
 
 	/**
 	 * Get schema enrichment tool parameters, filtered by engine data.
 	 *
 	 * @param array $engine_data Engine data snapshot
-	 * @return array Filtered schema parameter definitions
+	 * @return array Canonical fragment with `properties` and optional `required`.
 	 */
 	public static function getSchemaToolParameters( array $engine_data = array() ): array {
 		$schema_fields = array_merge(
@@ -260,19 +260,19 @@ class EventSchemaProvider {
 			self::STATUS_FIELDS,
 			self::TYPE_FIELDS
 		);
-		$params        = self::fieldsToToolParameters( $schema_fields );
-		return static::filterByEngineData( $params, $engine_data );
+		$fragment      = self::fieldsToToolParameters( $schema_fields );
+		return static::filterByEngineData( $fragment, $engine_data );
 	}
 
 	/**
 	 * Get all tool parameters, filtered by engine data.
 	 *
 	 * @param array $engine_data Engine data snapshot
-	 * @return array Filtered parameter definitions
+	 * @return array Canonical fragment with `properties` and optional `required`.
 	 */
 	public static function getAllToolParameters( array $engine_data = array() ): array {
-		$params = self::fieldsToToolParameters( self::getAllFields() );
-		return static::filterByEngineData( $params, $engine_data );
+		$fragment = self::fieldsToToolParameters( self::getAllFields() );
+		return static::filterByEngineData( $fragment, $engine_data );
 	}
 
 	public static function getFieldKeys( string $category = 'all' ): array {
@@ -318,18 +318,29 @@ class EventSchemaProvider {
 		return $event_data;
 	}
 
+	/**
+	 * Convert a field definition map into a canonical JSON Schema fragment.
+	 *
+	 * Returns `{ properties: {...}, required: [...] }`. The `required` key is
+	 * omitted when no field declares `required => true` so we do not emit
+	 * an empty `required: []` (which OpenAI's strict tool-schema validator
+	 * rejects in some configurations).
+	 *
+	 * @param array $fields Field declarations keyed by parameter name.
+	 * @return array Canonical fragment with `properties` and optional `required`.
+	 */
 	private static function fieldsToToolParameters( array $fields ): array {
-		$params = array();
+		$properties = array();
+		$required   = array();
 
 		foreach ( $fields as $key => $field ) {
-			$param = array(
+			$property = array(
 				'type'        => $field['type'],
-				'required'    => $field['required'] ?? false,
 				'description' => $field['description'],
 			);
 
 			if ( ! empty( $field['enum'] ) ) {
-				$param['enum'] = $field['enum'];
+				$property['enum'] = $field['enum'];
 			}
 
 			// JSON Schema requires `items` on every array type, and OpenAI's
@@ -338,13 +349,22 @@ class EventSchemaProvider {
 			// array when the declaration is incomplete to avoid emitting an
 			// invalid schema that would fail at runtime.
 			if ( 'array' === ( $field['type'] ?? '' ) ) {
-				$param['items'] = $field['items'] ?? array( 'type' => 'string' );
+				$property['items'] = $field['items'] ?? array( 'type' => 'string' );
 			}
 
-			$params[ $key ] = $param;
+			$properties[ $key ] = $property;
+
+			if ( ! empty( $field['required'] ) ) {
+				$required[] = $key;
+			}
 		}
 
-		return $params;
+		$fragment = array( 'properties' => $properties );
+		if ( ! empty( $required ) ) {
+			$fragment['required'] = $required;
+		}
+
+		return $fragment;
 	}
 
 	public static function generateSchemaOrg( array $event_data, array $venue_data, array $organizer_data = array(), int $post_id = 0 ): array {

--- a/inc/Core/VenueParameterProvider.php
+++ b/inc/Core/VenueParameterProvider.php
@@ -21,57 +21,46 @@ class VenueParameterProvider {
 	private const TOOL_PARAMETERS = array(
 		'venue'            => array(
 			'type'        => 'string',
-			'required'    => false,
 			'description' => 'Venue name where the event takes place',
 		),
 		'venueAddress'     => array(
 			'type'        => 'string',
-			'required'    => false,
 			'description' => 'Street address of the venue',
 		),
 		'venueCity'        => array(
 			'type'        => 'string',
-			'required'    => false,
 			'description' => 'City where the venue is located',
 		),
 		'venueState'       => array(
 			'type'        => 'string',
-			'required'    => false,
 			'description' => 'State/province where the venue is located',
 		),
 		'venueZip'         => array(
 			'type'        => 'string',
-			'required'    => false,
 			'description' => 'Postal/zip code of the venue',
 		),
 		'venueCountry'     => array(
 			'type'        => 'string',
-			'required'    => false,
 			'description' => 'Country where the venue is located',
 		),
 		'venuePhone'       => array(
 			'type'        => 'string',
-			'required'    => false,
 			'description' => 'Phone number of the venue',
 		),
 		'venueWebsite'     => array(
 			'type'        => 'string',
-			'required'    => false,
 			'description' => 'Website URL of the venue',
 		),
 		'venueCoordinates' => array(
 			'type'        => 'string',
-			'required'    => false,
 			'description' => 'GPS coordinates (latitude,longitude format)',
 		),
 		'venueCapacity'    => array(
 			'type'        => 'string',
-			'required'    => false,
 			'description' => 'Maximum venue capacity',
 		),
 		'venueTimezone'    => array(
 			'type'        => 'string',
-			'required'    => false,
 			'description' => 'IANA timezone identifier (e.g., America/Chicago, America/Los_Angeles)',
 		),
 	);
@@ -91,12 +80,16 @@ class VenueParameterProvider {
 	);
 
 	/**
-	 * Get all possible venue tool parameters.
+	 * Get all possible venue tool parameters as a canonical fragment.
 	 *
-	 * @return array Complete parameter definitions
+	 * No venue parameter is required at the schema level — venue presence
+	 * is enforced upstream via engine data / handler config, not via the
+	 * tool schema.
+	 *
+	 * @return array Canonical fragment with `properties`.
 	 */
 	protected static function getAllParameters(): array {
-		return self::TOOL_PARAMETERS;
+		return array( 'properties' => self::TOOL_PARAMETERS );
 	}
 
 	/**
@@ -116,13 +109,13 @@ class VenueParameterProvider {
 	 *
 	 * @param array $handler_config Handler configuration
 	 * @param array $engine_data Engine data snapshot
-	 * @return array Tool parameter definitions (empty if venue data exists)
+	 * @return array Canonical fragment, or empty array when venue is pre-configured.
 	 */
 	public static function getToolParameters( array $handler_config, array $engine_data = array() ): array {
 		if ( self::hasVenueData( $handler_config, $engine_data ) ) {
 			return array();
 		}
-		return static::filterByEngineData( self::TOOL_PARAMETERS, $engine_data );
+		return static::filterByEngineData( array( 'properties' => self::TOOL_PARAMETERS ), $engine_data );
 	}
 
 	/**

--- a/inc/Steps/Upsert/Events/EventUpsertFilters.php
+++ b/inc/Steps/Upsert/Events/EventUpsertFilters.php
@@ -66,43 +66,108 @@ class EventUpsertFilters {
 	/**
 	 * Generate dynamic event tool based on taxonomy, venue settings, and engine data.
 	 *
-	 * All parameter methods filter by engine data - if a value exists in engine data,
-	 * the parameter is excluded from the tool definition so the AI doesn't see it.
+	 * Composes a canonical JSON Schema (`{ type: object, properties, required }`)
+	 * for the `upsert_event` tool from four fragment sources. Each fragment
+	 * provider returns either:
+	 *   - canonical fragment: `{ properties: {...}, required?: [...] }`
+	 *     (EventSchemaProvider, VenueParameterProvider), or
+	 *   - flat property bag: `{ name => def, ... }` with no top-level
+	 *     `properties`/`required` keys (TaxonomyHandler in data-machine core).
+	 *
+	 * The flat shape is treated as a degenerate fragment with no required
+	 * fields. This keeps EventUpsertFilters tolerant of TaxonomyHandler's
+	 * existing return shape until data-machine core converts it to the
+	 * canonical fragment shape.
+	 *
+	 * All parameter methods filter by engine data - if a value exists in
+	 * engine data, the parameter is excluded from the tool definition so
+	 * the AI doesn't see it.
 	 *
 	 * @param array $handler_config Handler configuration
 	 * @param array $engine_data Engine data snapshot
-	 * @return array Tool definition
+	 * @return array Tool definition with canonical JSON Schema parameters.
 	 */
 	private static function getDynamicEventTool( array $handler_config, array $engine_data = array() ): array {
 		$ue_config = $handler_config['upsert_event'] ?? $handler_config;
 
-		$tool = array(
-			'class'       => EventUpsert::class,
-			'method'      => 'handle_tool_call',
-			'handler'     => 'upsert_event',
-			'description' => 'Create or update WordPress event post. Automatically finds existing events by title, venue, and date. Updates if data changed, skips if unchanged, creates if new.',
-			'parameters'  => array(),
+		$fragments = array(
+			// Core event parameters (title, dates, description) - filtered by engine data.
+			EventSchemaProvider::getCoreToolParameters( $engine_data ),
+			// Schema enrichment parameters (performer, organizer, status, etc.) - filtered by engine data.
+			EventSchemaProvider::getSchemaToolParameters( $engine_data ),
+			// Taxonomy parameters - config-driven (ai_decides vs skip vs preselected).
+			// Owned by data-machine core; currently returns a flat property bag.
+			TaxonomyHandler::getTaxonomyToolParameters( $ue_config, Event_Post_Type::POST_TYPE ),
+			// Venue parameters - filtered by engine data.
+			VenueParameterProvider::getToolParameters( $ue_config, $engine_data ),
 		);
 
-		// Core event parameters (title, dates, description) - filtered by engine data
-		$core_params        = EventSchemaProvider::getCoreToolParameters( $engine_data );
-		$tool['parameters'] = array_merge( $tool['parameters'], $core_params );
+		$parameters = self::composeCanonicalParameters( $fragments );
 
-		// Schema enrichment parameters (performer, organizer, status, etc.) - filtered by engine data
-		$schema_params      = EventSchemaProvider::getSchemaToolParameters( $engine_data );
-		$tool['parameters'] = array_merge( $tool['parameters'], $schema_params );
+		return array(
+			'class'          => EventUpsert::class,
+			'method'         => 'handle_tool_call',
+			'handler'        => 'upsert_event',
+			'description'    => 'Create or update WordPress event post. Automatically finds existing events by title, venue, and date. Updates if data changed, skips if unchanged, creates if new.',
+			'parameters'     => $parameters,
+			'handler_config' => $ue_config,
+		);
+	}
 
-		// Taxonomy parameters - config-driven (ai_decides vs skip vs preselected)
-		$taxonomy_params    = TaxonomyHandler::getTaxonomyToolParameters( $ue_config, Event_Post_Type::POST_TYPE );
-		$tool['parameters'] = array_merge( $tool['parameters'], $taxonomy_params );
+	/**
+	 * Compose canonical JSON Schema parameters from a list of fragments.
+	 *
+	 * Each fragment is either:
+	 *   - canonical: `{ properties: {...}, required?: [...] }`, or
+	 *   - flat property bag: `{ name => def, ... }` (treated as
+	 *     `{ properties: <bag> }` with no required fields).
+	 *
+	 * Empty fragments are skipped.
+	 *
+	 * @param array $fragments List of provider fragments.
+	 * @return array Canonical JSON Schema: `{ type: object, properties, required? }`.
+	 */
+	private static function composeCanonicalParameters( array $fragments ): array {
+		$properties = array();
+		$required   = array();
 
-		// Venue parameters - filtered by engine data
-		$venue_params       = VenueParameterProvider::getToolParameters( $ue_config, $engine_data );
-		$tool['parameters'] = array_merge( $tool['parameters'], $venue_params );
+		foreach ( $fragments as $fragment ) {
+			if ( ! is_array( $fragment ) || empty( $fragment ) ) {
+				continue;
+			}
 
-		$tool['handler_config'] = $ue_config;
+			if ( isset( $fragment['properties'] ) && is_array( $fragment['properties'] ) ) {
+				$properties = array_merge( $properties, $fragment['properties'] );
+				if ( isset( $fragment['required'] ) && is_array( $fragment['required'] ) ) {
+					$required = array_merge( $required, $fragment['required'] );
+				}
+				continue;
+			}
 
-		return $tool;
+			// Legacy flat property bag (e.g. data-machine core's TaxonomyHandler).
+			// Treat the entire fragment as the properties map; no required fields.
+			$properties = array_merge( $properties, $fragment );
+		}
+
+		$required = array_values(
+			array_unique(
+				array_filter(
+					$required,
+					static fn( $name ) => is_string( $name ) && array_key_exists( $name, $properties )
+				)
+			)
+		);
+
+		$parameters = array(
+			'type'       => 'object',
+			'properties' => $properties,
+		);
+
+		if ( ! empty( $required ) ) {
+			$parameters['required'] = $required;
+		}
+
+		return $parameters;
 	}
 }
 


### PR DESCRIPTION
## Why

Follow-up to #232 (chat tools canonical schemas).

[Data Machine 0.106.1 PR #1900](https://github.com/Extra-Chill/data-machine/pull/1900) (\"Require canonical AI tool schemas\") removes the auto-normalization layer in `RequestBuilder::normalizeToolParameters` that previously converted legacy property-keyed parameter shapes into canonical JSON Schema before sending to providers. After 0.106.1, whatever a tool registration emits is sent to OpenAI as the tool schema literal — so handler-stage tools must already be canonical.

PR #232 converted the **chat tools** (static schemas in `inc/Api/Chat/Tools/`). This PR completes the work for the **handler-stage `upsert_event` tool** registered via the `dm_handlers` filter, whose schema is **assembled at runtime** by merging output from four provider methods.

## ⚠ Backwards-compatibility warning

**This PR is NOT backwards-compatible with DM 0.103.x at the provider return-shape level.** `EventSchemaProvider::getCoreToolParameters()`, `EventSchemaProvider::getSchemaToolParameters()`, `EventSchemaProvider::getAllToolParameters()`, and `VenueParameterProvider::getToolParameters()` now return canonical fragments (`{ properties, required? }`) instead of flat property bags (`{ name => def }`).

The only consumer of these methods inside this plugin is `EventUpsertFilters::getDynamicEventTool()`, which is updated in the same commit. There are no tests pinning the old shape (verified via `grep -rn ... tests/`).

**Must merge + deploy in lockstep with the DM 0.106.1 upgrade** so the runtime schema shape matches what the provider expects. Canonical schemas are accepted by both 0.103.x (via the soon-to-be-removed normalizer passthrough) and 0.106.1+, so this PR can ship cleanly ahead of or alongside the DM bump.

## Caller audit

Ran:
\`\`\`
grep -rn 'getCoreToolParameters\|getSchemaToolParameters\|getTaxonomyToolParameters\|VenueParameterProvider::getToolParameters' inc/ tests/
grep -rn 'registerAITools\|register_tool\|registerTool' inc/Steps/
\`\`\`

| Symbol | Caller (this repo) | Caller (other repos) | Action |
|---|---|---|---|
| \`EventSchemaProvider::getCoreToolParameters\` | \`EventUpsertFilters\` | none | converted (this PR) |
| \`EventSchemaProvider::getSchemaToolParameters\` | \`EventUpsertFilters\` | none | converted (this PR) |
| \`EventSchemaProvider::getAllToolParameters\` | none in inc/ or tests/ | unknown | converted (this PR) |
| \`VenueParameterProvider::getToolParameters\` | \`EventUpsertFilters\` | none | converted (this PR) |
| \`TaxonomyHandler::getTaxonomyToolParameters\` | \`EventUpsertFilters\` | **\`data-machine\` core: \`Steps/Publish/Handlers/WordPress/WordPress.php\`** | **NOT touched** — see below |
| Handler tool registrations under \`inc/Steps/\` | only \`EventUpsertFilters\` (one site) | n/a | covered |

### Cross-repo: \`TaxonomyHandler\` lives in data-machine core

\`TaxonomyHandler::getTaxonomyToolParameters()\` is owned by the data-machine plugin (\`inc/Core/WordPress/TaxonomyHandler.php\`), not this repo. It is also called from data-machine's own \`WordPress.php\` publish handler, which itself emits a legacy property-keyed schema with per-property \`required => true|false\` booleans. **I did not modify those files** per the orchestrator constraint to not touch other repos.

To stay decoupled, \`EventUpsertFilters::composeCanonicalParameters()\` accepts **both** shapes:
- canonical fragment (\`{ properties: {...}, required?: [...] }\`) — used by my providers
- flat property bag (\`{ name => def, ... }\`) — used by data-machine's \`TaxonomyHandler\`

The flat shape is treated as a degenerate fragment with no required fields. As long as data-machine's \`TaxonomyHandler\` continues to emit valid property definitions (each with \`type\`, \`description\`, and \`items\` for arrays — confirmed by reading the source), this PR works whether or not data-machine core is ever updated to canonical fragments.

### 🚩 Blocker for orchestrator review (out of scope here)

**\`data-machine\` core's WordPress publish handler (\`Steps/Publish/Handlers/WordPress/WordPress.php\`, around line 47–80) still emits a legacy property-keyed schema with per-property \`required\` booleans.** That handler will fail OpenAI validation on DM 0.106.1 the same way the upsert_event handler would have failed without this PR. Needs a sibling fix in the data-machine repo before 0.106.1 can deploy cleanly to any site that uses the WordPress publish handler. **This PR does not address that** — surfacing it here for tracking.

## Files changed

- \`inc/Core/DynamicToolParametersTrait.php\` — \`filterByEngineData()\` now operates on canonical fragments and prunes filtered keys from both \`properties\` and \`required\`.
- \`inc/Core/EventSchemaProvider.php\` — \`fieldsToToolParameters()\` emits canonical fragments. Per-property \`required => true\` booleans are aggregated into a top-level \`required[]\` array. \`required\` key omitted when empty. Per-property \`required\` keys removed.
- \`inc/Core/VenueParameterProvider.php\` — \`TOOL_PARAMETERS\` constant cleaned up (removed redundant \`required => false\`). \`getToolParameters()\` and \`getAllParameters()\` return canonical fragments.
- \`inc/Steps/Upsert/Events/EventUpsertFilters.php\` — \`getDynamicEventTool()\` composes fragments via new \`composeCanonicalParameters()\` private helper. Output is a canonical \`{ type: object, properties, required? }\` schema.

## Test plan

- [x] **PHP syntax**: \`php -l\` clean on all 4 changed files.
- [x] **homeboy lint**: \`homeboy lint --path . --changed-since main\` reports zero findings on any of the 4 edited files (only pre-existing baseline noise in unrelated \`UniversalWebScraper.php\` etc., consistent with PR #232).
- [x] **Functional smoke test** — ran a script that loads the providers, calls each method, and verifies:
  - \`getCoreToolParameters()\` returns \`{ properties: 7 keys, required: ['title','startTime','description'] }\`
  - \`occurrenceDates\` carries \`items: { type: 'string' }\`
  - Engine-data filter on \`startTime\` removes it from both \`properties\` and \`required\` (final \`required: ['title','description']\`)
  - \`getToolParameters()\` from \`VenueParameterProvider\` returns a fragment with 11 properties and no \`required\` key (correct — venue presence enforced upstream).
- [x] **End-to-end composition test** — simulated the full \`EventUpsertFilters\` path with a flat-shape \`TaxonomyHandler\` mock. Result: 33 merged properties, correct \`required: ['title','startTime','description']\`, all array types carry \`items\`, no spurious required entries from venue/taxonomy fragments. Final shape is canonical \`{ type: object, properties, required }\`.
- [ ] **Live tool call** — exercise the upsert_event handler in a flow run on DM 0.103.14 (current production) to confirm canonical schema passes the (still-active) normalizer; then again post-DM-0.106.1 to confirm passthrough acceptance.

## Constraints honored

- Branched off \`main\`, no commits to \`main\`.
- No \`CHANGELOG.md\` or version-constant edits — homeboy owns those.
- No deploy, no release.
- No edits in \`wp-content/plugins/\` on the VPS.
- No additional minions spawned.
- No edits in other repos (\`data-machine\`, etc.). Cross-repo concern surfaced as a blocker note above.