### PR TITLE
refactor: WeakMap instance guard + delegated pagination listener (#238)

### DIFF
--- a/inc/Blocks/Calendar/src/frontend.ts
+++ b/inc/Blocks/Calendar/src/frontend.ts
@@ -32,6 +32,8 @@ import { initGeoSync, destroyGeoSync } from './modules/geo-sync';
 
 import type { FlatpickrInstance } from './types';
 
+const calendarInstances = new WeakMap< HTMLElement, true >();
+
 document.addEventListener( 'DOMContentLoaded', function () {
 	document
 		.querySelectorAll< HTMLElement >( '.data-machine-events-calendar' )
@@ -39,10 +41,10 @@ document.addEventListener( 'DOMContentLoaded', function () {
 } );
 
 function initCalendarInstance( calendar: HTMLElement ): void {
-	if ( calendar.dataset.dmInitialized === 'true' ) {
+	if ( calendarInstances.has( calendar ) ) {
 		return;
 	}
-	calendar.dataset.dmInitialized = 'true';
+	calendarInstances.set( calendar, true );
 
 	const filterState = getFilterState( calendar );
 

--- a/inc/Blocks/Calendar/src/modules/geo-sync.ts
+++ b/inc/Blocks/Calendar/src/modules/geo-sync.ts
@@ -37,6 +37,7 @@ interface BoundsChangedDetail {
  */
 interface GeoSyncState {
 	handler: ( e: Event ) => void;
+	paginationHandler: ( e: Event ) => void;
 	currentGeo: GeoContext | null;
 }
 
@@ -55,6 +56,7 @@ export function initGeoSync( calendar: HTMLElement ): void {
 
 	const state: GeoSyncState = {
 		handler: createBoundsHandler( calendar ),
+		paginationHandler: createPaginationHandler( calendar ),
 		currentGeo: null,
 	};
 
@@ -64,6 +66,14 @@ export function initGeoSync( calendar: HTMLElement ): void {
 		'data-machine-map-bounds-changed',
 		state.handler
 	);
+
+	// Single delegated pagination listener — registered once at init,
+	// scoped to `.data-machine-events-pagination a` clicks inside this
+	// calendar. Survives `outerHTML` swaps of the pagination container
+	// (and any future in-place updates) without re-binding. Geo state is
+	// looked up at click time from `instances.get(calendar).currentGeo`,
+	// not captured in the closure, so it's always current.
+	calendar.addEventListener( 'click', state.paginationHandler );
 }
 
 /**
@@ -79,6 +89,8 @@ export function destroyGeoSync( calendar: HTMLElement ): void {
 		'data-machine-map-bounds-changed',
 		state.handler
 	);
+
+	calendar.removeEventListener( 'click', state.paginationHandler );
 
 	instances.delete( calendar );
 }
@@ -202,11 +214,10 @@ async function fetchAndUpdate(
 	// frontend.ts in response to the `data-machine-calendar-content-updated`
 	// event that fetchCalendarEvents fires after swapping innerHTML. This
 	// module does not destroy or re-init dynamic UI directly — single owner.
+	//
+	// Pagination clicks are handled by the delegated listener registered
+	// once in initGeoSync — no rebinding needed after content swaps.
 	await fetchCalendarEvents( calendar, params, archiveContext );
-
-	// Re-bind pagination links for REST fetching (geo-sync owns this since
-	// it injects geo params into pagination requests).
-	rebindPagination( calendar, geo );
 }
 
 /**
@@ -247,24 +258,28 @@ function boundsToRadius(
 }
 
 /**
- * Re-bind pagination links after a REST update so they also fetch
- * via REST instead of triggering a page reload.
+ * Build a delegated click handler for pagination links inside the
+ * calendar wrapper. Registered once at init time on the calendar
+ * element itself, so it survives `outerHTML` swaps of the pagination
+ * container (and any future in-place updates) without rebinding.
+ *
+ * Geo state is looked up at click time from `instances.get(calendar)`
+ * — never captured in the closure — so the handler always sees the
+ * latest geo from the most recent map pan.
  */
-function rebindPagination(
-	calendar: HTMLElement,
-	geo: GeoContext
-): void {
-	const paginationContainer = calendar.querySelector< HTMLElement >(
-		'.data-machine-events-pagination'
-	);
-	if ( ! paginationContainer ) {
-		return;
-	}
+function createPaginationHandler(
+	calendar: HTMLElement
+): ( e: Event ) => void {
+	return function ( e: Event ): void {
+		const target = e.target as HTMLElement | null;
+		if ( ! target ) {
+			return;
+		}
 
-	paginationContainer.addEventListener( 'click', function ( e: Event ) {
-		const target = e.target as HTMLElement;
-		const link = target.closest< HTMLAnchorElement >( 'a' );
-		if ( ! link ) {
+		const link = target.closest< HTMLAnchorElement >(
+			'.data-machine-events-pagination a'
+		);
+		if ( ! link || ! calendar.contains( link ) ) {
 			return;
 		}
 
@@ -274,8 +289,10 @@ function rebindPagination(
 		const url = new URL( link.href );
 		const linkParams = new URLSearchParams( url.search );
 
-		// Inject current geo into the pagination request.
-		if ( geo.lat && geo.lng ) {
+		// Inject current geo into the pagination request — read live
+		// from the instance map, not a stale closure capture.
+		const geo = instances.get( calendar )?.currentGeo;
+		if ( geo?.lat && geo.lng ) {
 			linkParams.set( 'lat', geo.lat );
 			linkParams.set( 'lng', geo.lng );
 			linkParams.set( 'radius', String( geo.radius ) );
@@ -286,14 +303,12 @@ function rebindPagination(
 		filterState.updateUrl( linkParams );
 
 		// Module lifecycle handled by frontend.ts via the
-		// `data-machine-calendar-content-updated` event. We only re-bind
-		// pagination here because geo-sync owns the geo-param injection.
+		// `data-machine-calendar-content-updated` event. No rebind here:
+		// this listener is delegated and survives content swaps.
 		fetchCalendarEvents(
 			calendar,
 			linkParams,
 			filterState.getArchiveContext()
-		).then( () => {
-			rebindPagination( calendar, geo );
-		} );
-	} );
+		);
+	};
 }


### PR DESCRIPTION
## Summary

Two per-instance state hygiene fixes in the calendar frontend. Closes #238.

### 1. Top-level guard → `WeakMap`

`frontend.ts` now uses a `WeakMap<HTMLElement, true>` for the calendar instance guard, matching every other module in the calendar (day-loader, geo-sync, lazy-render, carousel). Drops the stringly-typed `dataset.dmInitialized` write — no more dangling DOM attribute, consistent with the rest of the file, and aligned with the WeakMap-as-init-flag pattern the modules already use.

### 2. Delegated pagination listener

`geo-sync.ts` now registers **one** delegated `click` listener at init time on the calendar wrapper, scoped to `.data-machine-events-pagination a` clicks via `closest()`. Replaces `rebindPagination()`, which was called on every `fetchAndUpdate` and only worked by accident — `updatePagination()` in `api-client.ts` does an `outerHTML` swap, which detached the old element (and its handlers) and inserted a fresh one. That contract was never written down. A future in-place pagination update would have silently accumulated handlers, with the failure mode invisible until pagination started firing N requests per click.

Geo state is read at click time from `instances.get(calendar)?.currentGeo` (the geo-sync state map already tracks this), so the handler always sees the latest geo from the most recent map pan — no closure capture, no rebind. `rebindPagination` is deleted.

### Lifecycle contract preserved

The `data-machine-calendar-content-updated` event from #234 is intact — `frontend.ts` remains the single owner of dynamic-module (`lazy-render`, `day-loader`, `carousel`) destroy/init in response to content swaps. Confirmed present in `build/frontend.js`.

## Trace

1. Page load → `initGeoSync` registers one delegated `click` listener on `calendar`.
2. Map pan → `fetchAndUpdate` → `outerHTML` swap of pagination container. Listener is on `calendar`, untouched.
3. Pagination click → bubbles to `calendar`, handler fires **once**, `closest('.data-machine-events-pagination a')` matches, latest `currentGeo` is read, fetch fires.
4. Second map pan → another `outerHTML` swap, listener still untouched.
5. Second pagination click → handler fires **once** again. No accumulation.

## Build verification

- `npm run build` succeeds in `inc/Blocks/Calendar/`.
- `data-machine-calendar-content-updated` present in `build/frontend.js`.
- `rebindPagination` fully removed from source.
- `dataset.dmInitialized` fully removed from source.
- Build artifacts gitignored, not committed.

## Files

- `inc/Blocks/Calendar/src/frontend.ts` — WeakMap instance guard.
- `inc/Blocks/Calendar/src/modules/geo-sync.ts` — delegated pagination listener, drops `rebindPagination`.

## Risk

Low. Both changes are local to the calendar frontend. The delegation pattern is more robust than the old re-bind dance (one listener vs. N), and geo state is read live so it can't go stale.