### PR TITLE
refactor: single helper for calendar REST URL/param construction (#237)

### DIFF
--- a/inc/Blocks/Calendar/src/modules/api-client.ts
+++ b/inc/Blocks/Calendar/src/modules/api-client.ts
@@ -4,12 +4,124 @@
 
 import type {
 	ArchiveContext,
+	CalendarRequest,
 	CalendarResponse,
 	DateContext,
 	FilterResponse,
 	GeoContext,
 	TaxFilters,
 } from '../types';
+
+/* ------------------------------------------------------------------ */
+/*  Calendar REST request builder — single source of truth             */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Canonical passthrough list of calendar URL params.
+ *
+ * Every calendar URL param the REST endpoint understands lives here.
+ * `buildCalendarRequest()` reads these from `window.location.search`
+ * so re-fetches (geo-sync map pan, day-loader prefetch, pagination
+ * rebind) preserve every relevant URL param by default.
+ *
+ * Adding a new calendar URL param means adding it both here and to
+ * the `CalendarRequest` interface in `../types.ts`.
+ *
+ * `tax_filter[*]` is dynamic and walked separately — not in this list.
+ */
+const CALENDAR_PASSTHROUGH_KEYS: ( keyof CalendarRequest )[] = [
+	'event_search',
+	'scope',
+	'past',
+	'paged',
+	'date_start',
+	'date_end',
+];
+
+/**
+ * Build a URLSearchParams for the calendar REST endpoint.
+ *
+ * Single helper used by every JS module that hits
+ * `/wp-json/datamachine/v1/events/calendar`. Replaces the three
+ * separate URL builders that previously drifted (api-client,
+ * day-loader, geo-sync) — each had its own `passthrough` list and
+ * they silently disagreed (notably `scope` survived day-loader
+ * fetches but got dropped by geo-sync re-fetches).
+ *
+ * Order of operations:
+ *   1. Passthrough every canonical calendar param from
+ *      `window.location.search` (one source of truth).
+ *   2. Passthrough every `tax_filter[*]` entry from the URL.
+ *   3. Apply `archiveContext` (sets `archive_taxonomy` /
+ *      `archive_term_id` if both present).
+ *   4. Apply `geoContext` (sets `lat`/`lng`/`radius`/`radius_unit`
+ *      if `lat` and `lng` are present).
+ *   5. Apply `overrides` last — explicit per-caller params win
+ *      (e.g. day-loader sets `date_start`/`date_end` for a single
+ *      day, geo-sync injects fresh `lat`/`lng` from the bounds-
+ *      changed event).
+ *
+ * Callers that need to drop a param after building (e.g. geo-sync
+ * resets `paged` on geo change) can `params.delete( 'paged' )` on
+ * the returned object — the helper intentionally does not encode
+ * deletion semantics so the override semantics stay simple.
+ */
+export function buildCalendarRequest( opts: {
+	archiveContext?: Partial< ArchiveContext >;
+	geoContext?: Partial< GeoContext >;
+	overrides?: Partial< CalendarRequest >;
+} = {} ): URLSearchParams {
+	const params = new URLSearchParams();
+	const urlParams = new URLSearchParams( window.location.search );
+
+	// 1. Canonical passthrough.
+	CALENDAR_PASSTHROUGH_KEYS.forEach( ( key ) => {
+		const val = urlParams.get( key );
+		if ( val ) {
+			params.set( key, val );
+		}
+	} );
+
+	// 2. Tax filters (dynamic key family).
+	for ( const [ key, value ] of urlParams.entries() ) {
+		if ( key.startsWith( 'tax_filter[' ) ) {
+			params.append( key, value );
+		}
+	}
+
+	// 3. Archive context.
+	const archiveContext = opts.archiveContext ?? {};
+	if ( archiveContext.taxonomy && archiveContext.term_id ) {
+		params.set( 'archive_taxonomy', archiveContext.taxonomy );
+		params.set( 'archive_term_id', String( archiveContext.term_id ) );
+	}
+
+	// 4. Geo context.
+	const geoContext = opts.geoContext ?? {};
+	if ( geoContext.lat && geoContext.lng ) {
+		params.set( 'lat', geoContext.lat );
+		params.set( 'lng', geoContext.lng );
+		if ( geoContext.radius !== undefined && geoContext.radius !== null ) {
+			params.set( 'radius', String( geoContext.radius ) );
+		}
+		if ( geoContext.radius_unit ) {
+			params.set( 'radius_unit', geoContext.radius_unit );
+		}
+	}
+
+	// 5. Per-caller overrides win.
+	const overrides = opts.overrides ?? {};
+	( Object.keys( overrides ) as ( keyof CalendarRequest )[] ).forEach(
+		( key ) => {
+			const val = overrides[ key ];
+			if ( val !== undefined && val !== null && val !== '' ) {
+				params.set( key, String( val ) );
+			}
+		}
+	);
+
+	return params;
+}
 
 export async function fetchCalendarEvents(
 	calendar: HTMLElement,

--- a/inc/Blocks/Calendar/src/modules/day-loader.ts
+++ b/inc/Blocks/Calendar/src/modules/day-loader.ts
@@ -14,6 +14,7 @@
  */
 
 import type { ArchiveContext } from '../types';
+import { buildCalendarRequest } from './api-client';
 import { initLazyRender } from './lazy-render';
 import { initCarousel } from './carousel';
 
@@ -148,42 +149,26 @@ async function fetchDayHtml(
 	archiveContext: Partial< ArchiveContext >,
 	geoContext: GeoContextData
 ): Promise< string | null > {
-	const params = new URLSearchParams();
-	params.set( 'date_start', date );
-	params.set( 'date_end', date );
-
-	// Preserve current page filters from URL.
-	const urlParams = new URLSearchParams( window.location.search );
-	const passthrough = [ 'event_search', 'scope', 'past' ];
-	passthrough.forEach( function ( key ) {
-		const val = urlParams.get( key );
-		if ( val ) {
-			params.set( key, val );
-		}
+	// Build via the shared helper so passthrough (event_search, scope,
+	// past, paged, tax_filter[*]) and archive/geo context stay consistent
+	// across all calendar REST callers. Per-day overrides win — date_start
+	// and date_end pin the request to this single day.
+	const params = buildCalendarRequest( {
+		archiveContext,
+		geoContext: {
+			lat: geoContext.lat,
+			lng: geoContext.lng,
+			// `radius` is typed as `number` on GeoContext but flows here as a
+			// wire string sourced from `data-geo-radius`. Cast at the helper
+			// boundary; the helper stringifies before writing the param.
+			radius: geoContext.radius as unknown as number,
+			radius_unit: geoContext.radius_unit as 'mi' | 'km',
+		},
+		overrides: {
+			date_start: date,
+			date_end: date,
+		},
 	} );
-
-	// Preserve taxonomy filters.
-	urlParams.forEach( function ( value, key ) {
-		if ( key.startsWith( 'tax_filter' ) ) {
-			params.append( key, value );
-		}
-	} );
-
-	if ( archiveContext.taxonomy && archiveContext.term_id ) {
-		params.set( 'archive_taxonomy', archiveContext.taxonomy );
-		params.set( 'archive_term_id', String( archiveContext.term_id ) );
-	}
-
-	if ( geoContext.lat && geoContext.lng ) {
-		params.set( 'lat', geoContext.lat );
-		params.set( 'lng', geoContext.lng );
-		if ( geoContext.radius ) {
-			params.set( 'radius', geoContext.radius );
-		}
-		if ( geoContext.radius_unit ) {
-			params.set( 'radius_unit', geoContext.radius_unit );
-		}
-	}
 
 	const response = await fetch(
 		`/wp-json/datamachine/v1/events/calendar?${ params.toString() }`,

--- a/inc/Blocks/Calendar/src/modules/geo-sync.ts
+++ b/inc/Blocks/Calendar/src/modules/geo-sync.ts
@@ -13,7 +13,7 @@
  * @since 0.14.0
  */
 
-import { fetchCalendarEvents } from './api-client';
+import { buildCalendarRequest, fetchCalendarEvents } from './api-client';
 import { getFilterState } from './filter-state';
 
 import type { GeoContext } from '../types';
@@ -149,39 +149,15 @@ async function fetchAndUpdate(
 	const filterState = getFilterState( calendar );
 	const archiveContext = filterState.getArchiveContext();
 
-	const params = new URLSearchParams();
-
-	// Geo params.
-	if ( geo.lat && geo.lng ) {
-		params.set( 'lat', geo.lat );
-		params.set( 'lng', geo.lng );
-		params.set( 'radius', String( geo.radius ) );
-		params.set( 'radius_unit', geo.radius_unit );
-	}
-
-	// Preserve existing filters from URL.
-	const urlParams = new URLSearchParams( window.location.search );
-
-	const passthroughKeys = [
-		'event_search',
-		'date_start',
-		'date_end',
-		'past',
-		'paged',
-	];
-	passthroughKeys.forEach( ( key ) => {
-		const val = urlParams.get( key );
-		if ( val ) {
-			params.set( key, val );
-		}
+	// Build via the shared helper so passthrough stays consistent with
+	// day-loader and api-client (notably `scope` now survives geo
+	// re-fetches — see #237). Geo lives in `geoContext` so the helper
+	// applies it consistently. `paged` is intentionally cleared after
+	// the helper runs because a viewport change resets pagination.
+	const params = buildCalendarRequest( {
+		archiveContext,
+		geoContext: geo,
 	} );
-
-	// Taxonomy filters.
-	for ( const [ key, value ] of urlParams.entries() ) {
-		if ( key.startsWith( 'tax_filter[' ) ) {
-			params.append( key, value );
-		}
-	}
 
 	// Reset to page 1 on geo change.
 	params.delete( 'paged' );

--- a/inc/Blocks/Calendar/src/types.ts
+++ b/inc/Blocks/Calendar/src/types.ts
@@ -67,6 +67,40 @@ export interface TaxonomyData {
 }
 
 /* ------------------------------------------------------------------ */
+/*  REST API request shape                                             */
+/* ------------------------------------------------------------------ */
+
+/**
+ * The complete set of calendar URL params understood by the
+ * `/wp-json/datamachine/v1/events/calendar` endpoint, expressed as
+ * URL-wire strings (everything that ends up in URLSearchParams is a
+ * string at the network boundary).
+ *
+ * This is the single source of truth used by `buildCalendarRequest()`
+ * to drive passthrough from `window.location.search` and to type the
+ * `overrides` map. Adding a new calendar URL param means adding it
+ * here once.
+ *
+ * `tax_filter[*]` is intentionally not modeled here — it's a dynamic
+ * key family, not a fixed param, and `buildCalendarRequest()` walks
+ * `urlParams.entries()` to passthrough every `tax_filter[...]` key.
+ */
+export interface CalendarRequest {
+	event_search: string;
+	scope: string;
+	past: string;
+	paged: string;
+	date_start: string;
+	date_end: string;
+	archive_taxonomy: string;
+	archive_term_id: string;
+	lat: string;
+	lng: string;
+	radius: string;
+	radius_unit: string;
+}
+
+/* ------------------------------------------------------------------ */
 /*  REST API responses                                                 */
 /* ------------------------------------------------------------------ */
 


### PR DESCRIPTION
Closes #237.

## Summary

Three calendar JS modules each constructed `/wp-json/datamachine/v1/events/calendar?...` URLs with their own `URLSearchParams` logic and subtly different passthrough lists. The lists silently disagreed, so URL state diverged from calendar state depending on which module fetched which day.

This PR replaces all three duplicate URL builders with a single canonical helper, `buildCalendarRequest()` in `api-client.ts`.

## Drift evidence (from #237)

| param | api-client | day-loader | geo-sync |
|---|---|---|---|
| `event_search` | (delegated) | passthrough | passthrough |
| `date_start` | (delegated) | (sets explicitly) | passthrough |
| `date_end` | (delegated) | (sets explicitly) | passthrough |
| `past` | (delegated) | passthrough | passthrough |
| `scope` | (delegated) | passthrough | **NOT preserved** |
| `paged` | (delegated) | (no concept) | passthrough then deleted |
| `tax_filter[*]` | (delegated) | preserved | preserved |
| `archive_*` | from arg | from arg | from arg (via api-client) |
| `lat`/`lng`/`radius`/`radius_unit` | from arg | from arg | from arg |

User-visible failure: visit a calendar with `?scope=upcoming` on a location archive, pan the map, geo-sync re-fetches without `scope` and silently drops it from the History API URL too. The next day-loader prefetch then disagrees about whether `scope` is active. Behavior depends on which module fetched which day.

## What the helper does

`buildCalendarRequest({ archiveContext, geoContext, overrides })` returns a `URLSearchParams` for the calendar REST endpoint. Order of operations:

1. Passthrough every canonical calendar URL param from `window.location.search` (one source of truth: `CALENDAR_PASSTHROUGH_KEYS`).
2. Passthrough every `tax_filter[*]` entry from the URL (dynamic key family, walked once).
3. Apply `archiveContext` (`archive_taxonomy` / `archive_term_id` if both present).
4. Apply `geoContext` (`lat`/`lng`/`radius`/`radius_unit` if `lat` and `lng` are present).
5. Apply `overrides` last — explicit per-caller params win.

Callers that need to drop a param after building (e.g. geo-sync resets `paged` on viewport change) call `params.delete( 'paged' )` on the returned object. The helper intentionally does not encode deletion semantics so override semantics stay simple.

Adding a new calendar URL param is now a two-edit change: append to `CALENDAR_PASSTHROUGH_KEYS` and add a field to `CalendarRequest`. The `scope`-vs-`paged` drift becomes structurally impossible.

## Files changed

- `inc/Blocks/Calendar/src/modules/api-client.ts` — added `buildCalendarRequest()` and `CALENDAR_PASSTHROUGH_KEYS` const. `fetchCalendarEvents()` contract unchanged (still takes pre-built `URLSearchParams`).
- `inc/Blocks/Calendar/src/modules/day-loader.ts` — `fetchDayHtml()` now calls the helper; `date_start`/`date_end` come through `overrides`. The local 60-line URL-building block is gone.
- `inc/Blocks/Calendar/src/modules/geo-sync.ts` — `fetchAndUpdate()` now calls the helper; the explicit geo `URLSearchParams.set()` block, the `passthroughKeys` list, and the `tax_filter[*]` walker are all gone. `params.delete( 'paged' )` retained as the explicit page-1 reset on viewport change.
- `inc/Blocks/Calendar/src/types.ts` — added `CalendarRequest` interface as the canonical wire-format param shape used by the helper's `overrides` map. Documented that `tax_filter[*]` is intentionally not modeled (dynamic key family).

Net diff: +175 / -68 across the four files. No build artifacts committed (`build/` is gitignored).

## Verification

- `npm run build` is clean (`webpack 5.104.1 compiled successfully`).
- `grep -c data-machine-calendar-content-updated build/frontend.js` returns `1` — the single-dispatcher contract from #234 survives untouched.
- `npx tsc --noEmit` reports zero new errors in the four touched files. Pre-existing JSX/flatpickr typing errors elsewhere are unrelated.
- After the refactor, `scope` (and every other URL param in `CALENDAR_PASSTHROUGH_KEYS`) survives geo-sync map-pan re-fetches because both day-loader and geo-sync now share the same passthrough list.

## Notes

- `rebindPagination()` in geo-sync is intentionally left alone. It walks `link.href`'s own `URLSearchParams` (PHP-rendered, complete by construction) rather than `window.location.search`, so it isn't part of the drift bug. Folding it into the helper would be a behavior change, not a refactor.
- The PHP-side `CalendarRequest` value object referenced in #237 is a separate sister issue and out of scope here.