### PR TITLE
refactor: CalendarRequest value object dedups request shape (#236)

### DIFF
--- a/inc/Api/Controllers/Calendar.php
+++ b/inc/Api/Controllers/Calendar.php
@@ -12,6 +12,7 @@ defined( 'ABSPATH' ) || exit;
 
 use WP_REST_Request;
 use DataMachineEvents\Abilities\CalendarAbilities;
+use DataMachineEvents\Blocks\Calendar\Query\CalendarRequest;
 
 /**
  * Calendar API controller
@@ -25,27 +26,9 @@ class Calendar {
 	 * @return \WP_REST_Response
 	 */
 	public function calendar( WP_REST_Request $request ) {
-		$abilities = new CalendarAbilities();
-		$result    = $abilities->executeGetCalendarPage(
-			array(
-				'paged'            => $request->get_param( 'paged' ) ?? 1,
-				'past'             => '1' === $request->get_param( 'past' ),
-				'event_search'     => $request->get_param( 'event_search' ) ?? '',
-				'date_start'       => $request->get_param( 'date_start' ) ?? '',
-				'date_end'         => $request->get_param( 'date_end' ) ?? '',
-				'scope'            => $request->get_param( 'scope' ) ?? '',
-				'tax_filter'       => $request->get_param( 'tax_filter' ) ?? array(),
-				'archive_taxonomy' => $request->get_param( 'archive_taxonomy' ) ?? '',
-				'archive_term_id'  => $request->get_param( 'archive_term_id' ) ?? 0,
-				'geo_lat'          => $request->get_param( 'lat' ) ?? '',
-				'geo_lng'          => $request->get_param( 'lng' ) ?? '',
-				'geo_radius'       => $request->get_param( 'radius' ) ?? 25,
-				'geo_radius_unit'  => $request->get_param( 'radius_unit' ) ?? 'mi',
-				'include_html'     => true,
-				'include_gaps'     => true,
-				'progressive'      => true,
-			)
-		);
+		$calendar_request = CalendarRequest::fromRestRequest( $request );
+		$abilities        = new CalendarAbilities();
+		$result           = $abilities->executeGetCalendarPage( $calendar_request->toAbilitiesArgs() );
 
 		return rest_ensure_response(
 			array(

--- a/inc/Blocks/Calendar/Query/CalendarRequest.php
+++ b/inc/Blocks/Calendar/Query/CalendarRequest.php
@@ -1,0 +1,334 @@
+<?php
+/**
+ * Calendar Request Value Object
+ *
+ * Single source of truth for the calendar request param shape.
+ * Owns sanitization, defaults, and the wire-format-to-abilities-format
+ * rename (`lat` → `geo_lat`, `lng` → `geo_lng`, `radius` → `geo_radius`,
+ * `radius_unit` → `geo_radius_unit`).
+ *
+ * Two named constructors handle the two input sources:
+ * - {@see fromQueryArgs()} for `$_GET` (block render path).
+ * - {@see fromRestRequest()} for {@see \WP_REST_Request} (REST controller path).
+ *
+ * One serializer ({@see toAbilitiesArgs()}) emits the canonical args dict
+ * consumed by `CalendarAbilities::executeGetCalendarPage()`, including the
+ * `include_html`, `include_gaps`, and `progressive` flags that were
+ * previously hardcoded in two places.
+ *
+ * Adding a new calendar request param means editing exactly this file.
+ *
+ * @package DataMachineEvents\Blocks\Calendar\Query
+ * @since   0.10.0
+ */
+
+namespace DataMachineEvents\Blocks\Calendar\Query;
+
+use WP_REST_Request;
+use WP_Term;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Immutable calendar request value object.
+ */
+final class CalendarRequest {
+
+	/**
+	 * Default geo radius when none provided (matches the legacy default in
+	 * both render.php and the REST controller).
+	 */
+	private const DEFAULT_GEO_RADIUS = 25;
+
+	/**
+	 * Default geo radius unit when none provided.
+	 */
+	private const DEFAULT_GEO_RADIUS_UNIT = 'mi';
+
+	/**
+	 * Default page when none provided.
+	 */
+	private const DEFAULT_PAGED = 1;
+
+	private int $paged;
+	private bool $past;
+	private string $event_search;
+	private string $date_start;
+	private string $date_end;
+	private string $scope;
+
+	/** @var array<string,int[]> Sanitized taxonomy filter map. */
+	private array $tax_filter;
+
+	private string $archive_taxonomy;
+	private int $archive_term_id;
+	private string $geo_lat;
+	private string $geo_lng;
+	private int $geo_radius;
+	private string $geo_radius_unit;
+
+	/**
+	 * @param array<string,int[]> $tax_filter
+	 */
+	private function __construct(
+		int $paged,
+		bool $past,
+		string $event_search,
+		string $date_start,
+		string $date_end,
+		string $scope,
+		array $tax_filter,
+		string $archive_taxonomy,
+		int $archive_term_id,
+		string $geo_lat,
+		string $geo_lng,
+		int $geo_radius,
+		string $geo_radius_unit
+	) {
+		$this->paged            = $paged;
+		$this->past             = $past;
+		$this->event_search     = $event_search;
+		$this->date_start       = $date_start;
+		$this->date_end         = $date_end;
+		$this->scope            = $scope;
+		$this->tax_filter       = $tax_filter;
+		$this->archive_taxonomy = $archive_taxonomy;
+		$this->archive_term_id  = $archive_term_id;
+		$this->geo_lat          = $geo_lat;
+		$this->geo_lng          = $geo_lng;
+		$this->geo_radius       = $geo_radius;
+		$this->geo_radius_unit  = $geo_radius_unit;
+	}
+
+	/**
+	 * Build a request from raw `$_GET` (or any associative array of query args)
+	 * plus the optional archive term context resolved from `is_tax()`.
+	 *
+	 * Sanitization is applied to every input regardless of source, because
+	 * `$_GET` is untrusted and the legacy render.php pipeline always
+	 * sanitized inline.
+	 *
+	 * @param array<string,mixed> $get          Typically `$_GET`. Values are unslashed before sanitization.
+	 * @param WP_Term|null        $archive_term Optional taxonomy archive context.
+	 */
+	public static function fromQueryArgs( array $get, ?WP_Term $archive_term = null ): self {
+		$paged        = isset( $get['paged'] ) ? max( 1, (int) absint( $get['paged'] ) ) : self::DEFAULT_PAGED;
+		$past         = isset( $get['past'] ) && '1' === (string) $get['past'];
+		$event_search = isset( $get['event_search'] ) ? sanitize_text_field( wp_unslash( $get['event_search'] ) ) : '';
+		$date_start   = isset( $get['date_start'] ) ? sanitize_text_field( wp_unslash( $get['date_start'] ) ) : '';
+		$date_end     = isset( $get['date_end'] ) ? sanitize_text_field( wp_unslash( $get['date_end'] ) ) : '';
+		$scope        = isset( $get['scope'] ) ? sanitize_key( wp_unslash( $get['scope'] ) ) : '';
+
+		$geo_lat         = isset( $get['lat'] ) ? sanitize_text_field( wp_unslash( $get['lat'] ) ) : '';
+		$geo_lng         = isset( $get['lng'] ) ? sanitize_text_field( wp_unslash( $get['lng'] ) ) : '';
+		$geo_radius      = isset( $get['radius'] ) ? absint( $get['radius'] ) : self::DEFAULT_GEO_RADIUS;
+		$geo_radius_unit = isset( $get['radius_unit'] ) ? sanitize_key( wp_unslash( $get['radius_unit'] ) ) : self::DEFAULT_GEO_RADIUS_UNIT;
+
+		$tax_filter_raw = isset( $get['tax_filter'] ) ? wp_unslash( $get['tax_filter'] ) : array();
+		$tax_filter     = self::sanitize_tax_filter( $tax_filter_raw );
+
+		$archive_taxonomy = '';
+		$archive_term_id  = 0;
+		if ( $archive_term instanceof WP_Term ) {
+			$archive_taxonomy = sanitize_key( $archive_term->taxonomy );
+			$archive_term_id  = absint( $archive_term->term_id );
+		}
+
+		return new self(
+			$paged,
+			$past,
+			$event_search,
+			$date_start,
+			$date_end,
+			$scope,
+			$tax_filter,
+			$archive_taxonomy,
+			$archive_term_id,
+			$geo_lat,
+			$geo_lng,
+			$geo_radius,
+			$geo_radius_unit
+		);
+	}
+
+	/**
+	 * Build a request from a {@see WP_REST_Request}.
+	 *
+	 * Sanitization is applied here even though `Routes.php` declares an
+	 * `args` schema, because (a) the geo params currently lack a schema and
+	 * (b) defense-in-depth — the value object is the contract, not the route
+	 * registration.
+	 */
+	public static function fromRestRequest( WP_REST_Request $request ): self {
+		$paged_raw    = $request->get_param( 'paged' );
+		$paged        = null === $paged_raw ? self::DEFAULT_PAGED : max( 1, (int) absint( $paged_raw ) );
+		$past         = '1' === (string) $request->get_param( 'past' );
+		$event_search = sanitize_text_field( (string) ( $request->get_param( 'event_search' ) ?? '' ) );
+		$date_start   = sanitize_text_field( (string) ( $request->get_param( 'date_start' ) ?? '' ) );
+		$date_end     = sanitize_text_field( (string) ( $request->get_param( 'date_end' ) ?? '' ) );
+		$scope        = sanitize_key( (string) ( $request->get_param( 'scope' ) ?? '' ) );
+
+		$geo_lat         = sanitize_text_field( (string) ( $request->get_param( 'lat' ) ?? '' ) );
+		$geo_lng         = sanitize_text_field( (string) ( $request->get_param( 'lng' ) ?? '' ) );
+		$radius_raw      = $request->get_param( 'radius' );
+		$geo_radius      = null === $radius_raw ? self::DEFAULT_GEO_RADIUS : absint( $radius_raw );
+		$radius_unit_raw = $request->get_param( 'radius_unit' );
+		$geo_radius_unit = null === $radius_unit_raw || '' === $radius_unit_raw
+			? self::DEFAULT_GEO_RADIUS_UNIT
+			: sanitize_key( (string) $radius_unit_raw );
+
+		$tax_filter = self::sanitize_tax_filter( $request->get_param( 'tax_filter' ) );
+
+		$archive_taxonomy = sanitize_key( (string) ( $request->get_param( 'archive_taxonomy' ) ?? '' ) );
+		$archive_term_id  = absint( $request->get_param( 'archive_term_id' ) ?? 0 );
+
+		return new self(
+			$paged,
+			$past,
+			$event_search,
+			$date_start,
+			$date_end,
+			$scope,
+			$tax_filter,
+			$archive_taxonomy,
+			$archive_term_id,
+			$geo_lat,
+			$geo_lng,
+			$geo_radius,
+			$geo_radius_unit
+		);
+	}
+
+	/**
+	 * Serialize to the args dict consumed by
+	 * `CalendarAbilities::executeGetCalendarPage()`.
+	 *
+	 * The `include_html`, `include_gaps`, and `progressive` flags are
+	 * always true here — they were hardcoded copies in render.php and
+	 * Calendar.php before this refactor; the value object is now their
+	 * single home.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public function toAbilitiesArgs(): array {
+		return array(
+			'paged'            => $this->paged,
+			'past'             => $this->past,
+			'event_search'     => $this->event_search,
+			'date_start'       => $this->date_start,
+			'date_end'         => $this->date_end,
+			'scope'            => $this->scope,
+			'tax_filter'       => $this->tax_filter,
+			'archive_taxonomy' => $this->archive_taxonomy,
+			'archive_term_id'  => $this->archive_term_id,
+			'geo_lat'          => $this->geo_lat,
+			'geo_lng'          => $this->geo_lng,
+			'geo_radius'       => $this->geo_radius,
+			'geo_radius_unit'  => $this->geo_radius_unit,
+			'include_html'     => true,
+			'include_gaps'     => true,
+			'progressive'      => true,
+		);
+	}
+
+	/* ------------------------------------------------------------------ */
+	/*  Accessors                                                          */
+	/* ------------------------------------------------------------------ */
+	/*  Render.php still needs raw access to a few fields for its own       */
+	/*  template wiring (data attrs, filter-bar params, etc).               */
+	/* ------------------------------------------------------------------ */
+
+	public function paged(): int {
+		return $this->paged;
+	}
+
+	public function past(): bool {
+		return $this->past;
+	}
+
+	public function eventSearch(): string {
+		return $this->event_search;
+	}
+
+	public function dateStart(): string {
+		return $this->date_start;
+	}
+
+	public function dateEnd(): string {
+		return $this->date_end;
+	}
+
+	public function scope(): string {
+		return $this->scope;
+	}
+
+	/** @return array<string,int[]> */
+	public function taxFilter(): array {
+		return $this->tax_filter;
+	}
+
+	public function archiveTaxonomy(): string {
+		return $this->archive_taxonomy;
+	}
+
+	public function archiveTermId(): int {
+		return $this->archive_term_id;
+	}
+
+	public function geoLat(): string {
+		return $this->geo_lat;
+	}
+
+	public function geoLng(): string {
+		return $this->geo_lng;
+	}
+
+	public function geoRadius(): int {
+		return $this->geo_radius;
+	}
+
+	public function geoRadiusUnit(): string {
+		return $this->geo_radius_unit;
+	}
+
+	/* ------------------------------------------------------------------ */
+	/*  Internal                                                           */
+	/* ------------------------------------------------------------------ */
+
+	/**
+	 * Sanitize the `tax_filter` map to `array<string,int[]>` with no empty
+	 * sub-arrays. Accepts the same shapes the legacy render.php and REST
+	 * route-args sanitizer accepted.
+	 *
+	 * @param mixed $raw
+	 * @return array<string,int[]>
+	 */
+	private static function sanitize_tax_filter( $raw ): array {
+		if ( ! is_array( $raw ) ) {
+			return array();
+		}
+
+		$clean = array();
+		foreach ( $raw as $taxonomy_slug => $term_ids ) {
+			$taxonomy_slug = sanitize_key( (string) $taxonomy_slug );
+			if ( '' === $taxonomy_slug ) {
+				continue;
+			}
+			$term_ids   = (array) $term_ids;
+			$clean_ids  = array();
+			foreach ( $term_ids as $term_id ) {
+				$term_id = absint( $term_id );
+				if ( $term_id > 0 ) {
+					$clean_ids[] = $term_id;
+				}
+			}
+			if ( ! empty( $clean_ids ) ) {
+				$clean[ $taxonomy_slug ] = $clean_ids;
+			}
+		}
+
+		return $clean;
+	}
+}

--- a/inc/Blocks/Calendar/render.php
+++ b/inc/Blocks/Calendar/render.php
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use DataMachineEvents\Abilities\CalendarAbilities;
 use DataMachineEvents\Abilities\FilterAbilities;
-use DataMachineEvents\Blocks\Calendar\Query\ScopeResolver;
+use DataMachineEvents\Blocks\Calendar\Query\CalendarRequest;
 
 if ( wp_is_json_request() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
 	return '';
@@ -25,88 +25,57 @@ if ( wp_is_json_request() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
 
 $show_search = $attributes['showSearch'] ?? true;
 
-$current_page = 1;
-if ( isset( $_GET['paged'] ) && absint( $_GET['paged'] ) > 0 ) {
-	$current_page = absint( $_GET['paged'] );
-} elseif ( get_query_var( 'paged' ) ) {
-	$current_page = max( 1, (int) get_query_var( 'paged' ) );
-}
-
-$show_past = isset( $_GET['past'] ) && '1' === $_GET['past'];
-
-$search_query    = isset( $_GET['event_search'] ) ? sanitize_text_field( wp_unslash( $_GET['event_search'] ) ) : '';
-$date_start      = isset( $_GET['date_start'] ) ? sanitize_text_field( wp_unslash( $_GET['date_start'] ) ) : '';
-$date_end        = isset( $_GET['date_end'] ) ? sanitize_text_field( wp_unslash( $_GET['date_end'] ) ) : '';
-$geo_lat         = isset( $_GET['lat'] ) ? sanitize_text_field( wp_unslash( $_GET['lat'] ) ) : '';
-$geo_lng         = isset( $_GET['lng'] ) ? sanitize_text_field( wp_unslash( $_GET['lng'] ) ) : '';
-$geo_radius      = isset( $_GET['radius'] ) ? absint( $_GET['radius'] ) : 25;
-$geo_radius_unit = isset( $_GET['radius_unit'] ) ? sanitize_key( wp_unslash( $_GET['radius_unit'] ) ) : 'mi';
-$tax_filters_raw = isset( $_GET['tax_filter'] ) ? wp_unslash( $_GET['tax_filter'] ) : array();
-$tax_filters     = array();
-
-if ( is_array( $tax_filters_raw ) ) {
-	foreach ( $tax_filters_raw as $taxonomy_slug => $term_ids ) {
-		$taxonomy_slug = sanitize_key( $taxonomy_slug );
-		$term_ids      = (array) $term_ids;
-		$clean_ids     = array();
-		foreach ( $term_ids as $term_id ) {
-			$term_id = absint( $term_id );
-			if ( $term_id > 0 ) {
-				$clean_ids[] = $term_id;
-			}
-		}
-		if ( ! empty( $clean_ids ) ) {
-			$tax_filters[ $taxonomy_slug ] = $clean_ids;
-		}
+// Resolve archive term context first so the value object can pick it up.
+$archive_term = null;
+if ( is_tax() ) {
+	$queried = get_queried_object();
+	if ( $queried instanceof WP_Term ) {
+		$archive_term = $queried;
 	}
 }
 
-// Resolve scope: URL ?scope= param takes priority, then block attribute, then empty (default).
-$scope = '';
-if ( isset( $_GET['scope'] ) ) {
-	$scope = sanitize_key( wp_unslash( $_GET['scope'] ) );
-} elseif ( ! empty( $attributes['defaultDateRange'] ) && 'current' !== $attributes['defaultDateRange'] ) {
-	$scope = $attributes['defaultDateRange'];
+// CalendarRequest::fromQueryArgs() owns sanitization + unslashing.
+// We only need to layer on two non-`$_GET` fallbacks before handing the
+// array off:
+//   1. `paged` falls back to the WP query var when `?paged=` is absent.
+//   2. `scope` falls back to the block's `defaultDateRange` attribute.
+// Passing the raw `$_GET` shape (still slashed) is intentional — the
+// value object will `wp_unslash()` each value as it sanitizes.
+// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+$query_args = $_GET;
+if ( ! isset( $query_args['paged'] ) || absint( $query_args['paged'] ) < 1 ) {
+	$query_var_paged = (int) get_query_var( 'paged' );
+	if ( $query_var_paged > 0 ) {
+		$query_args['paged'] = $query_var_paged;
+	}
 }
+if ( ! isset( $query_args['scope'] ) && ! empty( $attributes['defaultDateRange'] ) && 'current' !== $attributes['defaultDateRange'] ) {
+	$query_args['scope'] = (string) $attributes['defaultDateRange'];
+}
+
+$request = CalendarRequest::fromQueryArgs( $query_args, $archive_term );
+
+// Local aliases used by template includes / data attrs further down.
+$current_page    = $request->paged();
+$show_past       = $request->past();
+$search_query    = $request->eventSearch();
+$date_start      = $request->dateStart();
+$date_end        = $request->dateEnd();
+$scope           = $request->scope();
+$tax_filters     = $request->taxFilter();
+$geo_lat         = $request->geoLat();
+$geo_lng         = $request->geoLng();
+$geo_radius      = $request->geoRadius();
+$geo_radius_unit = $request->geoRadiusUnit();
 
 $archive_context = array(
-	'taxonomy'  => '',
-	'term_id'   => 0,
-	'term_name' => '',
+	'taxonomy'  => $request->archiveTaxonomy(),
+	'term_id'   => $request->archiveTermId(),
+	'term_name' => $archive_term instanceof WP_Term ? $archive_term->name : '',
 );
-
-if ( is_tax() ) {
-	$term = get_queried_object();
-	if ( $term && isset( $term->taxonomy ) && isset( $term->term_id ) ) {
-		$archive_context = array(
-			'taxonomy'  => $term->taxonomy,
-			'term_id'   => $term->term_id,
-			'term_name' => $term->name,
-		);
-	}
-}
 
 $abilities = new CalendarAbilities();
-$result    = $abilities->executeGetCalendarPage(
-	array(
-		'paged'            => $current_page,
-		'past'             => $show_past,
-		'event_search'     => $search_query,
-		'date_start'       => $date_start,
-		'date_end'         => $date_end,
-		'scope'            => $scope,
-		'tax_filter'       => $tax_filters,
-		'archive_taxonomy' => $archive_context['taxonomy'],
-		'archive_term_id'  => $archive_context['term_id'],
-		'geo_lat'          => $geo_lat,
-		'geo_lng'          => $geo_lng,
-		'geo_radius'       => $geo_radius,
-		'geo_radius_unit'  => $geo_radius_unit,
-		'include_html'     => true,
-		'include_gaps'     => true,
-		'progressive'      => true,
-	)
-);
+$result    = $abilities->executeGetCalendarPage( $request->toAbilitiesArgs() );
 
 $current_page        = $result['current_page'];
 $max_pages           = $result['max_pages'];


### PR DESCRIPTION
## Summary

The calendar request param dictionary was constructed **three times** across `render.php`, the REST controller, and the JS callers with no single source of truth — the same drift-prone anti-pattern that produced the geo-sync race fixed in #233/#234.

This PR introduces `DataMachineEvents\Blocks\Calendar\Query\CalendarRequest` as the **single home** for calendar-request sanitization, defaults, and the `lat`→`geo_lat` wire-format rename.

This is the **PHP half**. The TS-side mirror (refactoring `api-client.ts` / `day-loader.ts` / `geo-sync.ts` to share a typed builder) is tracked in #237.

## The three duplication sites (PHP — addressed here)

| Site | Before | After |
| --- | --- | --- |
| `inc/Blocks/Calendar/render.php` | ~80 lines of inline `\$_GET` sanitization + dict construction (lines 26–109) | 1 fromQueryArgs() call + accessors for template wiring |
| `inc/Api/Controllers/Calendar.php` | 22-line dict + inline `lat`→`geo_lat` rename (lines 27–48) | 2 lines: fromRestRequest() + toAbilitiesArgs() |
| `inc/Blocks/Calendar/src/modules/*.ts` | Three slightly-different inline `URLSearchParams` constructions | **Stubbed only** as a `CalendarRequest` interface in `src/types.ts`. Caller refactor handled in #237. |

## Value object API

```php
namespace DataMachineEvents\Blocks\Calendar\Query;

final class CalendarRequest {
    public static function fromQueryArgs( array \$get, ?\WP_Term \$archive_term ): self;
    public static function fromRestRequest( \WP_REST_Request \$request ): self;
    public function toAbilitiesArgs(): array; // includes include_html/include_gaps/progressive
    // plus accessors used by render.php for template wiring (paged(), eventSearch(), …)
}
```

Sanitization, defaults, and the `lat`/`lng`/`radius`/`radius_unit` → `geo_*` rename live in **exactly one place**. Adding a new calendar param is a one-file edit.

## Before / after line counts

```
inc/Api/Controllers/Calendar.php   : 70 → 53 lines  (−17, dict + rename gone)
inc/Blocks/Calendar/render.php     : 243 → 209 lines (−34, ~80 inline sanitize lines collapse)
inc/Blocks/Calendar/Query/         : +CalendarRequest.php (320 lines, all-new single source of truth)
```

The render.php "after" is still a chunky template — but the calendar-request-construction part of it (the interesting bug-prone part) is gone, replaced by one fromQueryArgs() call and a few accessor reads for template wiring.

## Sanitization parity

Per the issue's "do not regress sanitization" note: `CalendarRequest` applies the **render.php-grade** sanitization pipeline (absint / sanitize_text_field+wp_unslash / sanitize_key, plus the `tax_filter` hygiene loop) regardless of input source. The REST path no longer relies solely on `Routes.php` schema validation — defense-in-depth.

The geo params (`lat`/`lng`/`radius`/`radius_unit`) lacked any schema in `Routes.php` previously and were fully unsanitized on the REST side. They now go through the same sanitizer as the block render path.

## Hardcoded flag elimination

`include_html: true`, `include_gaps: true`, `progressive: true` were copy-pasted in **both** `render.php:107` and `Calendar.php:46` — a textbook drift hazard (they aren't part of the abilities contract; they're magic constants). They now live in `CalendarRequest::toAbilitiesArgs()` only.

## Verification

- `php -l` clean on all changed files.
- `homeboy lint --path . --changed-since main` shows only the standing baseline (`UpsertFilters.php`, `EventSchemaProvider.php`) — **zero findings in the changed files**.
- Standalone smoke harness confirmed `fromQueryArgs()` and `fromRestRequest()` produce **identical** `toAbilitiesArgs()` output for equivalent inputs covering paged/past/search/dates/scope/geo/tax_filter/archive context. Defaults verified (`paged=1`, `geo_radius=25`, `geo_radius_unit='mi'`, all three flags `true`).
- `vendor/bin/phpunit` not runnable in worktree (no phpunit dev-dep + tests use `WP_UnitTestCase`); the existing `CalendarBlockTest` covers block registration only and is unaffected.

## Out of scope

- TS-side URL construction dedup → #237 (interface stub added here so the API is obvious).
- The optional `args` schema expansion for the geo params on the REST route → noted in the issue as "side benefit", deliberately deferred so this PR stays focused on the value-object dedup. The value object now applies the sanitization regardless of whether the route schema does.

Closes #236 (PHP half — TS side handled in #237).