### PR TITLE
feat(integration): public API for downstream consumers

### DIFF
--- a/data-machine-events.php
+++ b/data-machine-events.php
@@ -51,6 +51,10 @@ if ( ! function_exists( 'data_machine_events_sanitize_query_params' ) ) {
 	}
 }
 
+// Public integration API — stable function surface for downstream plugins/themes.
+// See docs/integration-api.md.
+require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/public-api.php';
+
 // Load event dates sync (monitors Event Details block saves → datamachine_event_dates table).
 require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Core/event-dates-sync.php';
 require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Core/EventDatesTable.php';
@@ -224,10 +228,32 @@ class DATAMACHINE_Events {
 
 		add_action( 'init', array( $this, 'init_data_machine_integration' ), 25 );
 
+		// Fire the public integration loaded action. Consumers gate filter
+		// registration / rendering on `did_action('data_machine_events_loaded')`
+		// instead of class_exists() against internal classes.
+		// See inc/public-api.php and docs/integration-api.md.
+		add_action( 'init', array( $this, 'fire_loaded_action' ), 30 );
+
 		// Initialize admin bar for all logged-in users
 		if ( class_exists( 'DataMachineEvents\\Admin\\Admin_Bar' ) ) {
 			new \DataMachineEvents\Admin\Admin_Bar();
 		}
+	}
+
+	/**
+	 * Fire the public `data_machine_events_loaded` action.
+	 *
+	 * Hooked at init priority 30 so it runs after post types (priority 0),
+	 * blocks (priority 15), taxonomies (priority 20), and the Data Machine
+	 * integration (priority 25). Consumers should hook their own filter
+	 * registrations on this action — or gate them on
+	 * `did_action('data_machine_events_loaded')` — rather than checking for
+	 * the existence of internal classes.
+	 *
+	 * @since 0.32.0
+	 */
+	public function fire_loaded_action(): void {
+		do_action( 'data_machine_events_loaded' );
 	}
 
 	private function init_hooks() {

--- a/docs/integration-api.md
+++ b/docs/integration-api.md
@@ -1,0 +1,226 @@
+# Public Integration API
+
+Stable function and action surface for downstream plugins and themes that
+consume Data Machine Events. **Consumers should target this contract — not
+internal classes — for forward-compatibility.**
+
+## Stability promise
+
+Everything in this document is part of the supported public API. Breaking
+changes are governed by semver and called out in `docs/CHANGELOG.md`.
+
+Anything **not** in this document is internal. That includes (non-exhaustive):
+
+- Every PHP class under `DataMachineEvents\…` (e.g. `Blocks\Calendar\…`,
+  `Core\…`, `Steps\…`, `Abilities\…`).
+- File paths under `inc/` and `inc/Blocks/Calendar/`.
+- Block-render template files under `inc/Blocks/Calendar/templates/`.
+
+Internal classes may be renamed, moved across namespaces, or refactored at
+any time. **Do not gate consumer code on `class_exists()` against an internal
+class name.** That pattern has produced repeated silent breakage in
+downstream plugins (renames early-return guards without a fatal, so the
+integration just stops working without any visible signal).
+
+## How to consume the API
+
+### 1. Gate on the loaded action, not on classes
+
+```php
+// Bad — couples to an internal class name. Renames break this silently.
+if ( class_exists( '\DataMachineEvents\Blocks\Calendar\Taxonomy\Badges' ) ) {
+    add_filter( 'data_machine_events_badge_classes', 'my_callback', 10, 4 );
+}
+
+// Good — gates on the documented public action.
+add_action( 'data_machine_events_loaded', function () {
+    add_filter( 'data_machine_events_badge_classes', 'my_callback', 10, 4 );
+} );
+
+// Also good — for code that runs after init priority 30 you can use:
+if ( data_machine_events_is_loaded() ) {
+    echo data_machine_events_render_taxonomy_badges( $post_id );
+}
+```
+
+### 2. Call public functions, not internal classes
+
+```php
+// Bad — couples to an internal class.
+$data = \DataMachineEvents\Blocks\Calendar\Data\EventHydrator::parse_event_data( $post );
+
+// Good — uses the public function.
+$data = data_machine_events_parse_event_data( $post );
+```
+
+## Public actions
+
+### `data_machine_events_loaded`
+
+Fired once at `init` priority 30, after post types (0), blocks (15),
+taxonomies (20), and Data Machine integration (25) have registered. Consumers
+should hook here to register filters or perform any setup that depends on
+events infrastructure being available.
+
+```php
+add_action( 'data_machine_events_loaded', function () {
+    add_filter( 'data_machine_events_badge_classes', 'my_callback', 10, 4 );
+    add_filter( 'data_machine_events_excluded_taxonomies', 'my_exclude', 10, 2 );
+} );
+```
+
+`did_action( 'data_machine_events_loaded' )` returns truthy from any code
+running after `init` priority 30.
+
+## Public filters
+
+These filters are part of the supported API surface. Their names and
+signatures are stable.
+
+### Calendar block filters
+
+| Filter | Signature | Purpose |
+|---|---|---|
+| `data_machine_events_badge_wrapper_classes` | `(array $classes, int $post_id)` | Modify wrapper `<div>` classes on the badge container. |
+| `data_machine_events_badge_classes` | `(array $classes, string $taxonomy, WP_Term $term, int $post_id)` | Modify per-badge CSS classes. |
+| `data_machine_events_excluded_taxonomies` | `(array $excluded, string $context)` | Exclude taxonomies from badge / modal display. `$context` is `'badge'` or `'modal'`. |
+| `data_machine_events_more_info_button_classes` | `(array $classes)` | Modify CSS classes on the calendar card "More Info" link. |
+| `data_machine_events_modal_button_classes` | `(array $classes, string $variant)` | Modify CSS classes on filter modal buttons. `$variant` is `'primary'` or `'secondary'`. |
+| `data_machine_events_calendar_query_args` | `(array $args, array $params)` | Modify the WP_Query args used by the calendar block. |
+
+### Event Details block filters
+
+| Filter | Signature | Purpose |
+|---|---|---|
+| `data_machine_events_ticket_button_classes` | `(array $classes)` | Modify CSS classes on the ticket button. |
+| `data_machine_events_max_occurrence_display` | `(int $max)` | Cap on multi-occurrence display rows. |
+| `data_machine_events_non_ticket_price_patterns` | `(array $patterns)` | Strings that suppress the ticket button. |
+
+### Events Map block filters
+
+| Filter | Signature | Purpose |
+|---|---|---|
+| `data_machine_events_map_center` | `(array $center, array $context)` | Override the map's initial center coordinates. |
+| `data_machine_events_map_user_location` | `(?array $location, array $context)` | Provide a default user location override. |
+| `data_machine_events_map_show_location_search` | `(bool $show, array $context)` | Toggle the location search input. |
+| `data_machine_events_map_summary` | `(string $html, array $venues, array $context)` | Inject custom summary HTML above the map. |
+
+### Event Details / button-row actions
+
+| Action | Signature | Purpose |
+|---|---|---|
+| `data_machine_events_after_price_display` | `(int $post_id, string $price)` | Render extra UI after the price line. |
+| `data_machine_events_action_buttons` | `(int $post_id, string $ticket_url)` | Add buttons to the event action row (alongside the ticket button). |
+| `data_machine_events_map_after_summary` | `(array $venues, array $context)` | Render extra UI after the map summary block. |
+
+## Public functions
+
+All functions are global (no namespace) and idempotently declared with
+`function_exists()` guards.
+
+### `data_machine_events_is_loaded(): bool`
+
+Returns true once the `data_machine_events_loaded` action has fired.
+Convenience wrapper around `did_action()`.
+
+### `data_machine_events_parse_event_data( WP_Post $post ): ?array`
+
+Parse and hydrate event data for a given event post. Returns the event's
+block-attribute payload (start/end dates and times, venue, promoter,
+performer, ticket URL, price, etc.) hydrated from the authoritative storage
+layer. Returns `null` if the post has no parseable Event Details block.
+
+```php
+$data = data_machine_events_parse_event_data( $post );
+if ( $data ) {
+    echo esc_html( $data['startDate'] );
+    echo esc_html( $data['venue'] ?? '' );
+}
+```
+
+### `data_machine_events_render_taxonomy_badges( int $post_id ): string`
+
+Render the calendar block's taxonomy badge markup for an event post. Returns
+HTML; empty string when no taxonomies apply. Honors all badge filters above.
+
+### `data_machine_events_group_by_date( array $paged_events, bool $show_past = false, string $date_start = '', string $date_end = '' ): array`
+
+Group a list of events by date. Wraps the calendar block's date grouper so
+callers can produce calendar-shaped output without importing the internal
+class.
+
+### `data_machine_events_query_events( array $params ): array`
+
+Convenience wrapper around `EventDateQueryAbilities::executeQueryEvents()`
+for callers that need a list of event posts filtered by scope, taxonomy
+filters, and date range.
+
+Pass-through parameters mirror the underlying ability:
+
+| Param | Type | Notes |
+|---|---|---|
+| `scope` | string | e.g. `'upcoming'`, `'past'`. |
+| `tax_filters` | array | `[ taxonomy_slug => [ term_id, … ] ]`. |
+| `exclude` | int[] | Post IDs to exclude. |
+| `per_page` | int | |
+| `order` | string | `'ASC'` \| `'DESC'`. |
+| `date_start` | string | ISO date. |
+| `date_end` | string | ISO date. |
+
+Returns `[ 'posts' => WP_Post[], 'total' => int, … ]`.
+
+### `data_machine_events_get_event_datetime( int $post_id ): string`
+
+Return the start datetime string for an event, or empty string when no row
+exists for the post in the `datamachine_event_dates` table. Equivalent to
+calling the existing `datamachine_get_event_dates()` and reading
+`start_datetime`.
+
+### Pre-existing helpers (kept stable)
+
+These functions predate this document and remain part of the public API:
+
+- `datamachine_get_event_dates( int $post_id ): ?object` — full event-dates
+  row from the `datamachine_event_dates` table.
+- `datamachine_get_event_timing( int $post_id ): string` — `'upcoming'` |
+  `'ongoing'` | `'past'`.
+
+## Public constants
+
+| Constant | Value | Use instead of |
+|---|---|---|
+| `DATA_MACHINE_EVENTS_POST_TYPE` | `'data_machine_events'` | `\DataMachineEvents\Core\Event_Post_Type::POST_TYPE` |
+| `DATA_MACHINE_EVENTS_VENUE_TAXONOMY` | `'venue'` | Hardcoded `'venue'` strings or `Venue_Taxonomy::TAXONOMY` references |
+| `DATA_MACHINE_EVENTS_PROMOTER_TAXONOMY` | `'promoter'` | Hardcoded `'promoter'` strings or `Promoter_Taxonomy::TAXONOMY` references |
+| `DATA_MACHINE_EVENTS_VERSION` | semver string | Plugin version. |
+
+## Migration guide
+
+Replacing legacy `class_exists()` guards in a downstream consumer:
+
+```php
+// Before — couples to an internal class.
+function my_plugin_init_calendar_integration() {
+    if ( ! class_exists( '\DataMachineEvents\Blocks\Calendar\Taxonomy\Badges' ) ) {
+        return;
+    }
+
+    add_filter( 'data_machine_events_badge_classes', 'my_callback', 10, 4 );
+}
+add_action( 'init', 'my_plugin_init_calendar_integration' );
+
+// After — gates on the public action.
+add_action( 'data_machine_events_loaded', function () {
+    add_filter( 'data_machine_events_badge_classes', 'my_callback', 10, 4 );
+} );
+```
+
+```php
+// Before — direct internal-class call.
+if ( class_exists( '\DataMachineEvents\Blocks\Calendar\Data\EventHydrator' ) ) {
+    $event_data = \DataMachineEvents\Blocks\Calendar\Data\EventHydrator::parse_event_data( $post );
+}
+
+// After — public function.
+$event_data = data_machine_events_parse_event_data( $post );
+```

--- a/inc/public-api.php
+++ b/inc/public-api.php
@@ -1,0 +1,214 @@
+<?php
+/**
+ * Data Machine Events — Public Integration API
+ *
+ * Stable, namespace-free function surface for downstream plugins and themes
+ * to consume Data Machine Events data without coupling to internal classes.
+ *
+ * **Stability contract:** every function and constant declared in this file
+ * is part of the supported public API. Internal classes
+ * (`DataMachineEvents\Blocks\Calendar\…`, `DataMachineEvents\Core\…`, etc.)
+ * are NOT public. They may be renamed, moved, or refactored at any time.
+ * Consumers should call the functions in this file and gate registration on
+ * the `data_machine_events_loaded` action — never on `class_exists()` against
+ * an internal class name.
+ *
+ * @package DataMachineEvents
+ * @since   0.32.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Public post type slug for events.
+ *
+ * Use this constant instead of `\DataMachineEvents\Core\Event_Post_Type::POST_TYPE`.
+ *
+ * @since 0.32.0
+ */
+if ( ! defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ) ) {
+	define( 'DATA_MACHINE_EVENTS_POST_TYPE', 'data_machine_events' );
+}
+
+/**
+ * Public taxonomy slug for venues.
+ *
+ * @since 0.32.0
+ */
+if ( ! defined( 'DATA_MACHINE_EVENTS_VENUE_TAXONOMY' ) ) {
+	define( 'DATA_MACHINE_EVENTS_VENUE_TAXONOMY', 'venue' );
+}
+
+/**
+ * Public taxonomy slug for promoters.
+ *
+ * @since 0.32.0
+ */
+if ( ! defined( 'DATA_MACHINE_EVENTS_PROMOTER_TAXONOMY' ) ) {
+	define( 'DATA_MACHINE_EVENTS_PROMOTER_TAXONOMY', 'promoter' );
+}
+
+if ( ! function_exists( 'data_machine_events_is_loaded' ) ) {
+	/**
+	 * Whether the Data Machine Events plugin has finished bootstrapping.
+	 *
+	 * Equivalent to `did_action( 'data_machine_events_loaded' )` but reads
+	 * more clearly at consumer sites. Use this to gate filter registrations
+	 * and rendering calls instead of `class_exists()` against internal classes.
+	 *
+	 * @since 0.32.0
+	 *
+	 * @return bool True once the `data_machine_events_loaded` action has fired.
+	 */
+	function data_machine_events_is_loaded(): bool {
+		return (bool) did_action( 'data_machine_events_loaded' );
+	}
+}
+
+if ( ! function_exists( 'data_machine_events_parse_event_data' ) ) {
+	/**
+	 * Parse and hydrate event data for a given event post.
+	 *
+	 * Returns the event's block-attribute payload (start/end dates and times,
+	 * venue, promoter, performer, ticket URL, price, etc.) hydrated from the
+	 * authoritative storage layer. Returns null if the post has no parseable
+	 * Event Details block / startDate.
+	 *
+	 * Replaces direct calls to
+	 * `\DataMachineEvents\Blocks\Calendar\Data\EventHydrator::parse_event_data()`
+	 * (and its predecessor `Calendar_Query::parse_event_data()`).
+	 *
+	 * @since 0.32.0
+	 *
+	 * @param \WP_Post $post Event post object.
+	 * @return array|null Event data array or null when no startDate is present.
+	 */
+	function data_machine_events_parse_event_data( \WP_Post $post ): ?array {
+		if ( ! class_exists( '\DataMachineEvents\Blocks\Calendar\Data\EventHydrator' ) ) {
+			return null;
+		}
+
+		return \DataMachineEvents\Blocks\Calendar\Data\EventHydrator::parse_event_data( $post );
+	}
+}
+
+if ( ! function_exists( 'data_machine_events_render_taxonomy_badges' ) ) {
+	/**
+	 * Render taxonomy badge markup for an event post.
+	 *
+	 * Outputs the wrapped HTML used on calendar event cards: a `<div>` wrapper
+	 * containing an `<a>` (or `<span>` when term has no link) per public taxonomy
+	 * term. Honors `data_machine_events_excluded_taxonomies`,
+	 * `data_machine_events_badge_wrapper_classes`, and
+	 * `data_machine_events_badge_classes` filters.
+	 *
+	 * Replaces direct calls to
+	 * `\DataMachineEvents\Blocks\Calendar\Taxonomy\Badges::render_taxonomy_badges()`.
+	 *
+	 * @since 0.32.0
+	 *
+	 * @param int $post_id Event post ID.
+	 * @return string Rendered badge HTML, or empty string when no taxonomies apply.
+	 */
+	function data_machine_events_render_taxonomy_badges( int $post_id ): string {
+		if ( ! class_exists( '\DataMachineEvents\Blocks\Calendar\Taxonomy\Badges' ) ) {
+			return '';
+		}
+
+		return (string) \DataMachineEvents\Blocks\Calendar\Taxonomy\Badges::render_taxonomy_badges( $post_id );
+	}
+}
+
+if ( ! function_exists( 'data_machine_events_group_by_date' ) ) {
+	/**
+	 * Group a list of events by date.
+	 *
+	 * Wraps the calendar block's `DateGrouper::group_events_by_date()` so callers
+	 * can produce calendar-shaped output without importing the internal class.
+	 *
+	 * @since 0.32.0
+	 *
+	 * @param array  $paged_events Array of event entries (each with a `post` key).
+	 * @param bool   $show_past    Whether to include past dates in the grouping.
+	 * @param string $date_start   Optional ISO start date (YYYY-MM-DD) for range scoping.
+	 * @param string $date_end     Optional ISO end date (YYYY-MM-DD) for range scoping.
+	 * @return array Date-grouped events keyed by date string.
+	 */
+	function data_machine_events_group_by_date(
+		array $paged_events,
+		bool $show_past = false,
+		string $date_start = '',
+		string $date_end = ''
+	): array {
+		if ( ! class_exists( '\DataMachineEvents\Blocks\Calendar\Grouping\DateGrouper' ) ) {
+			return array();
+		}
+
+		return \DataMachineEvents\Blocks\Calendar\Grouping\DateGrouper::group_events_by_date(
+			$paged_events,
+			$show_past,
+			$date_start,
+			$date_end
+		);
+	}
+}
+
+if ( ! function_exists( 'data_machine_events_query_events' ) ) {
+	/**
+	 * Query events through the canonical Date Query Abilities path.
+	 *
+	 * Convenience wrapper around `EventDateQueryAbilities::executeQueryEvents()`
+	 * for callers that need a list of event posts filtered by scope, taxonomy
+	 * filters, and date range without coupling to the abilities class directly.
+	 *
+	 * Pass-through parameters mirror `executeQueryEvents()`:
+	 * - `scope`        (string)  e.g. `'upcoming'`, `'past'`.
+	 * - `tax_filters`  (array)   `[ taxonomy_slug => [ term_id, … ] ]`.
+	 * - `exclude`      (array)   Post IDs to exclude.
+	 * - `per_page`     (int)
+	 * - `order`        (string)  `'ASC'` | `'DESC'`.
+	 * - `date_start`   (string)  ISO date.
+	 * - `date_end`     (string)  ISO date.
+	 *
+	 * @since 0.32.0
+	 *
+	 * @param array $params Query parameters; see above.
+	 * @return array { posts: WP_Post[], total: int, … } as returned by the ability.
+	 */
+	function data_machine_events_query_events( array $params ): array {
+		if ( ! class_exists( '\DataMachineEvents\Abilities\EventDateQueryAbilities' ) ) {
+			return array(
+				'posts' => array(),
+				'total' => 0,
+			);
+		}
+
+		$ability = new \DataMachineEvents\Abilities\EventDateQueryAbilities();
+		return $ability->executeQueryEvents( $params );
+	}
+}
+
+if ( ! function_exists( 'data_machine_events_get_event_datetime' ) ) {
+	/**
+	 * Get the start datetime for an event, formatted as a string.
+	 *
+	 * Convenience wrapper around the existing `datamachine_get_event_dates()`
+	 * helper. Returns the `start_datetime` value or empty string when no row
+	 * exists for the post.
+	 *
+	 * @since 0.32.0
+	 *
+	 * @param int $post_id Event post ID.
+	 * @return string MySQL-format datetime or empty string.
+	 */
+	function data_machine_events_get_event_datetime( int $post_id ): string {
+		if ( ! function_exists( 'datamachine_get_event_dates' ) ) {
+			return '';
+		}
+
+		$dates = datamachine_get_event_dates( $post_id );
+		return $dates && ! empty( $dates->start_datetime ) ? (string) $dates->start_datetime : '';
+	}
+}


### PR DESCRIPTION
## Summary

Adds a stable, namespace-free function/action/constant surface so downstream plugins (extrachill-events, extrachill-api, extrachill-seo, extrachill-multisite) and themes can integrate without coupling to internal class names.

Closes #244.

## Why

Every internal class rename in DM-events has silently broken downstream `class_exists()` guards. No fatal, no admin notice — guards early-return and integrations just stop working. We've hit it twice on the same class in extrachill-events alone:

1. `DataMachineEvents\Core\Taxonomy_Badges` → `DataMachineEvents\Blocks\Calendar\Taxonomy_Badges`
2. `DataMachineEvents\Blocks\Calendar\Taxonomy_Badges` → `DataMachineEvents\Blocks\Calendar\Taxonomy\Badges` (PR #239, fixed downstream in Extra-Chill/extrachill-events#71)

A separate audit also found a fully-stale `Calendar_Query::parse_event_data()` reference in `extrachill-api` and `extrachill-events` — that class was replaced by `EventHydrator` with no public alias, so those consumer code paths have been silently broken for an unknown amount of time.

## What this adds

### `inc/public-api.php` — public wrapper functions

| Function | Wraps |
|---|---|
| `data_machine_events_is_loaded()` | `did_action('data_machine_events_loaded')` |
| `data_machine_events_parse_event_data()` | `EventHydrator::parse_event_data()` |
| `data_machine_events_render_taxonomy_badges()` | `Taxonomy\Badges::render_taxonomy_badges()` |
| `data_machine_events_group_by_date()` | `DateGrouper::group_events_by_date()` |
| `data_machine_events_query_events()` | `EventDateQueryAbilities::executeQueryEvents()` |
| `data_machine_events_get_event_datetime()` | `datamachine_get_event_dates()` start_datetime |

All are global, namespace-free, idempotently declared, and degrade to safe empty/null returns when DM-events isn't loaded.

### Constants

| Constant | Value |
|---|---|
| `DATA_MACHINE_EVENTS_POST_TYPE` | `'data_machine_events'` |
| `DATA_MACHINE_EVENTS_VENUE_TAXONOMY` | `'venue'` |
| `DATA_MACHINE_EVENTS_PROMOTER_TAXONOMY` | `'promoter'` |

### Action

`data_machine_events_loaded` fires once at `init` priority 30 — after post types (0), blocks (15), taxonomies (20), and DM integration (25). Consumers gate registration on this instead of `class_exists()`.

### `docs/integration-api.md`

Stability contract, full public filter list, migration guide from `class_exists()` to `did_action()` + public functions, explicit "everything else is internal" header.

## Stability promise

- Functions, constants, and the loaded action declared in `inc/public-api.php` and `docs/integration-api.md` are versioned per semver. Breaking changes will be called out in the changelog.
- Everything under `DataMachineEvents\…` namespaces remains internal and may be renamed at any time.

## What this does NOT change

- No internal classes touched. Existing `class_exists()` consumers keep working until they migrate.
- No filter renames. The existing `data_machine_events_*` filters are now explicitly part of the documented stable surface; their signatures don't change.
- No behavior change in calendar rendering, badge generation, or query paths — these are pure wrappers.

## Verification

- `php -l` clean on both modified files.
- Smoke test: `data_machine_events_is_loaded()` returns false before init, true after `data_machine_events_loaded` fires; `DATA_MACHINE_EVENTS_POST_TYPE === 'data_machine_events'`.
- The full test suite currently fails to bootstrap in homeboy-playground due to a pre-existing agents-api class-load issue unrelated to this PR (`WP_Agent_Memory_Layer not found`). Will validate on production after release.

## Migration path

Follow-up PRs will migrate consumers one at a time:

1. extrachill-events (largest; most stale guards) — coming in this same session.
2. extrachill-api — separate session, has the broken `Calendar_Query::parse_event_data` references.
3. extrachill-seo and extrachill-multisite — small consumers, mostly schema/OG.

Each migration is independent and revertible.