### PR TITLE
fix: Squarespace timezone regex cannot match nested context JSON

### DIFF
--- a/inc/Core/DateTimeParser.php
+++ b/inc/Core/DateTimeParser.php
@@ -27,6 +27,11 @@ class DateTimeParser {
 	 * Use when API returns UTC times with a separate timezone field.
 	 * Example: Dice.fm returns "2026-01-04T02:30:00Z" with timezone "America/Chicago"
 	 *
+	 * When `$timezone` is empty or invalid, falls back to the site timezone
+	 * (`wp_timezone()`) and emits a `datamachine_log` warning. This prevents
+	 * upstream regex / extractor bugs from silently destroying the date and
+	 * cascading into off-by-one duplicates on the calendar. See #254.
+	 *
 	 * @param string $datetime UTC datetime string (e.g., "2026-01-04T02:30:00Z")
 	 * @param string $timezone Target IANA timezone (e.g., "America/Chicago")
 	 * @return array{date: string, time: string, timezone: string}
@@ -39,7 +44,18 @@ class DateTimeParser {
 		}
 
 		if ( ! self::isValidTimezone( $timezone ) ) {
-			return $result;
+			$fallback = self::siteTimezoneName();
+			do_action(
+				'datamachine_log',
+				'warning',
+				'DateTimeParser::parseUtc received empty/invalid timezone; falling back to site timezone',
+				array(
+					'datetime'         => $datetime,
+					'invalid_timezone' => $timezone,
+					'fallback'         => $fallback,
+				)
+			);
+			$timezone = $fallback;
 		}
 
 		try {
@@ -54,6 +70,32 @@ class DateTimeParser {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Resolve a usable site timezone name for fallbacks.
+	 *
+	 * Prefers `wp_timezone()` when WordPress is loaded, otherwise falls back to
+	 * UTC so the parser still produces a stable result in non-WP contexts.
+	 *
+	 * @return string IANA timezone identifier
+	 */
+	private static function siteTimezoneName(): string {
+		if ( function_exists( 'wp_timezone' ) ) {
+			try {
+				$tz = wp_timezone();
+				if ( $tz instanceof DateTimeZone ) {
+					$name = $tz->getName();
+					if ( ! empty( $name ) ) {
+						return $name;
+					}
+				}
+			} catch ( Exception $e ) {
+				// Fall through to UTC.
+			}
+		}
+
+		return 'UTC';
 	}
 
 	/**

--- a/inc/Steps/EventImport/Handlers/WebScraper/PageVenueExtractor.php
+++ b/inc/Steps/EventImport/Handlers/WebScraper/PageVenueExtractor.php
@@ -381,7 +381,12 @@ class PageVenueExtractor {
 	 */
 	public static function extractTimezone( string $html ): string {
 		// Squarespace context
-		if ( preg_match( '/Static\.SQUARESPACE_CONTEXT\s*=\s*\{[^}]*"timeZone"\s*:\s*"([^"]+)"/s', $html, $matches ) ) {
+		// Non-greedy .*? crosses nested {...} objects in SQUARESPACE_CONTEXT to reach
+		// the first "timeZone" key (always inside the top-level `website` object). The
+		// previous [^}]* form could not cross any `}` boundary, so it never matched
+		// real Squarespace pages whose context JSON contains nested objects before
+		// `website.timeZone` (e.g. betaFeatureFlags, rollups). See #254.
+		if ( preg_match( '/Static\.SQUARESPACE_CONTEXT\s*=\s*\{.*?"timeZone"\s*:\s*"([^"]+)"/s', $html, $matches ) ) {
 			return $matches[1];
 		}
 

--- a/tests/Fixtures/squarespace-royal-american.html
+++ b/tests/Fixtures/squarespace-royal-american.html
@@ -1,0 +1,9494 @@
+<!doctype html>
+<html xmlns:og="http://opengraphprotocol.org/schema/" xmlns:fb="http://www.facebook.com/2008/fbml" lang="en-US"  >
+  <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="initial-scale=1">
+
+    <!-- This is Squarespace. --><!-- theroyalamerican -->
+<base href="">
+<meta charset="utf-8" />
+<title>Schedule &mdash; The Royal American</title>
+<meta http-equiv="Accept-CH" content="Sec-CH-UA-Platform-Version, Sec-CH-UA-Model" /><link rel="icon" type="image/x-icon" href="https://images.squarespace-cdn.com/content/v1/5a04b1b8fe54ef9d6db1a38e/1510777325952-QB1JT0IM0Y7C2ZAO6WVF/favicon.ico?format=100w"/>
+<link rel="canonical" href="http://www.theroyalamerican.com/schedule"/>
+<meta property="og:site_name" content="The Royal American"/>
+<meta property="og:title" content="Schedule &mdash; The Royal American"/>
+<meta property="og:url" content="http://www.theroyalamerican.com/schedule"/>
+<meta property="og:type" content="website"/>
+<meta itemprop="name" content="Schedule — The Royal American"/>
+<meta itemprop="url" content="http://www.theroyalamerican.com/schedule"/>
+<meta name="twitter:title" content="Schedule — The Royal American"/>
+<meta name="twitter:url" content="http://www.theroyalamerican.com/schedule"/>
+<meta name="twitter:card" content="summary"/>
+<meta name="description" content="" />
+<link rel="preconnect" href="https://images.squarespace-cdn.com">
+<link rel="preconnect" href="https://use.typekit.net" crossorigin>
+<link rel="preconnect" href="https://p.typekit.net" crossorigin>
+<script type="text/javascript" src="//use.typekit.net/ik/TXfrivfYi-WzT5VOu1jBQIO9Y6DgXQvXixsFaH3Gwhtfe0jffFHN4UJLFRbh52jhWDmyw2sKwAJtZc9uFemc5AbhZeJUjQwtZs76MPG0iey8ScNojAUydAmk-AFydKoDSWmyScmDSeBRZPoRdhXCdeNRjAUGdaFXOYsGZW4zpABCjAu8Sc8RjAt0jhNlOYsGZW4zpABCjAu8Sc8RjAt0SaBujW48Sagyjh90jhNlOYiaikoX-emkda8ydeBlZW4TjhB0OcFzdPUaiaS0iey8ScNojAUydAmk-AFydKoDSWmyScmDSeBRZPoRdhXK2ho8iWT8-WblZa4ziemD-kJbiY4udWMlZhNX-e8ROWgkdkJmZcjldAmXjPuDZW4TZKuaZAJlSY4zJyiydYs8Scoyie9lZhNX-e8ROAozOQwlZfG4fwZpIMMjgfMfH6qJUutbMg6YJMJ7f6RWz6IbMs6IJMJ7f6RAz6IbMs6BJMJ7fbKrHsMfeM96MKG4fFybIMwjgfMfqMYL7JOUgb.js" async fetchpriority="high" onload="try{Typekit.load();}catch(e){} document.documentElement.classList.remove('wf-loading');"></script>
+<script>document.documentElement.classList.add('wf-loading')</script>
+<style>@keyframes fonts-loading { 0%, 99% { color: transparent; } } html.wf-loading * { animation: fonts-loading 3s; }</style>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=League+Gothic:ital,wght@0,400&family=Heebo:ital,wght@0,300;0,400;0,500;0,700&family=Archivo:ital,wght@0,400;0,700;1,400;1,700"><script type="text/javascript" crossorigin="anonymous" nomodule="nomodule" src="//assets.squarespace.com/@sqs/polyfiller/1.6/legacy.js"></script>
+<script type="text/javascript" crossorigin="anonymous" src="//assets.squarespace.com/@sqs/polyfiller/1.6/modern.js"></script>
+<script data-name="static-context">Static = window.Static || {}; Static.SQUARESPACE_CONTEXT = {"betaFeatureFlags":["i18n_beta_website_locales","enable_modernized_pdp_m3_fluid","campaigns_table_v2","campaigns_new_image_layout_picker","order_status_page_checkout_landing_enabled","enable_modernized_pdp_m3_layout_ux","enable_form_submission_trigger","campaigns_merch_state","campaigns_discount_section_in_blasts","contacts_and_campaigns_redesign","output_template_css_assets","campaigns_thumbnail_layout","marketing_automations","campaigns_discount_section_in_automations","marketing_landing_page","campaigns_import_discounts","modernized-pdp-m2-enabled"],"facebookAppId":"314192535267336","facebookApiVersion":"v6.0","rollups":{"squarespace-announcement-bar":{"js":"//assets.squarespace.com/universal/scripts-compressed/announcement-bar-ff40c577e06da23d-min.en-US.js"},"squarespace-audio-player":{"css":"//assets.squarespace.com/universal/styles-compressed/audio-player-b05f5197a871c566-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/audio-player-c62c91898f92b845-min.en-US.js"},"squarespace-blog-collection-list":{"css":"//assets.squarespace.com/universal/styles-compressed/blog-collection-list-b4046463b72f34e2-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/blog-collection-list-15fe8e2040ce7dfd-min.en-US.js"},"squarespace-calendar-block-renderer":{"css":"//assets.squarespace.com/universal/styles-compressed/calendar-block-renderer-c3fef2a497c8e56b-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/calendar-block-renderer-b810b0a147aa101c-min.en-US.js"},"squarespace-chartjs-helpers":{"css":"//assets.squarespace.com/universal/styles-compressed/chartjs-helpers-96b256171ee039c1-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/chartjs-helpers-c8071a4b9e053ae8-min.en-US.js"},"squarespace-comments":{"css":"//assets.squarespace.com/universal/styles-compressed/comments-e347211c62a7a82c-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/comments-3eca8162c741e03b-min.en-US.js"},"squarespace-custom-css-popup":{"css":"//assets.squarespace.com/universal/styles-compressed/custom-css-popup-7a375365f86cf733-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/custom-css-popup-83de56aea0cc034c-min.en-US.js"},"squarespace-dialog":{"css":"//assets.squarespace.com/universal/styles-compressed/dialog-86aacd645d83874c-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/dialog-8ebd07a474cb5c74-min.en-US.js"},"squarespace-events-collection":{"css":"//assets.squarespace.com/universal/styles-compressed/events-collection-c3fef2a497c8e56b-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/events-collection-adc6248a53b0f183-min.en-US.js"},"squarespace-form-rendering-utils":{"js":"//assets.squarespace.com/universal/scripts-compressed/form-rendering-utils-06651a0417e6f6e8-min.en-US.js"},"squarespace-forms":{"css":"//assets.squarespace.com/universal/styles-compressed/forms-0afd3c6ac30bbab1-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/forms-96b915119d8ed833-min.en-US.js"},"squarespace-gallery-collection-list":{"css":"//assets.squarespace.com/universal/styles-compressed/gallery-collection-list-b4046463b72f34e2-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/gallery-collection-list-8b143e186ac2fb87-min.en-US.js"},"squarespace-image-zoom":{"css":"//assets.squarespace.com/universal/styles-compressed/image-zoom-b4046463b72f34e2-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/image-zoom-8cdcb4f2aa4cc393-min.en-US.js"},"squarespace-pinterest":{"css":"//assets.squarespace.com/universal/styles-compressed/pinterest-b4046463b72f34e2-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/pinterest-587b47a2fb2ecd41-min.en-US.js"},"squarespace-popup-overlay":{"css":"//assets.squarespace.com/universal/styles-compressed/popup-overlay-b742b752f5880972-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/popup-overlay-2712c33514ffcf85-min.en-US.js"},"squarespace-product-quick-view":{"css":"//assets.squarespace.com/universal/styles-compressed/product-quick-view-0afd3c6ac30bbab1-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/product-quick-view-fbc74d5f67d6102f-min.en-US.js"},"squarespace-products-collection-item-v2":{"css":"//assets.squarespace.com/universal/styles-compressed/products-collection-item-v2-b4046463b72f34e2-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/products-collection-item-v2-cde985e705f7f8f3-min.en-US.js"},"squarespace-products-collection-list-v2":{"css":"//assets.squarespace.com/universal/styles-compressed/products-collection-list-v2-b4046463b72f34e2-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/products-collection-list-v2-3ad779aab89e1fdd-min.en-US.js"},"squarespace-search-page":{"css":"//assets.squarespace.com/universal/styles-compressed/search-page-90a67fc09b9b32c6-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/search-page-841e40ecb553fb0a-min.en-US.js"},"squarespace-search-preview":{"js":"//assets.squarespace.com/universal/scripts-compressed/search-preview-0e8905c369bf3b23-min.en-US.js"},"squarespace-simple-liking":{"css":"//assets.squarespace.com/universal/styles-compressed/simple-liking-701bf8bbc05ec6aa-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/simple-liking-920708d91ca1d6da-min.en-US.js"},"squarespace-social-buttons":{"css":"//assets.squarespace.com/universal/styles-compressed/social-buttons-95032e5fa98e47a5-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/social-buttons-a85043f0f147baa0-min.en-US.js"},"squarespace-tourdates":{"css":"//assets.squarespace.com/universal/styles-compressed/tourdates-b4046463b72f34e2-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/tourdates-d7730ed7166efdb7-min.en-US.js"},"squarespace-website-overlays-manager":{"css":"//assets.squarespace.com/universal/styles-compressed/website-overlays-manager-07ea5a4e004e6710-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/website-overlays-manager-45262c84faca739f-min.en-US.js"}},"pageType":1,"website":{"id":"5a04b1b8fe54ef9d6db1a38e","identifier":"theroyalamerican","websiteType":1,"contentModifiedOn":1774276018114,"cloneable":false,"hasBeenCloneable":false,"siteStatus":{},"language":"en-US","translationLocale":"en-US","formattingLocale":"en-US","timeZone":"America/New_York","machineTimeZoneOffset":-14400000,"timeZoneOffset":-14400000,"timeZoneAbbr":"EDT","siteTitle":"The Royal American","fullSiteTitle":"Schedule \u2014 The Royal American","siteDescription":"<p>The Royal American is a restaurant, bar and live music venue located in Downtown Charleston.</p>","logoImageId":"5a0ca0c808522925f05fcd25","shareButtonOptions":{"8":true,"1":true,"7":true,"2":true},"logoImageUrl":"//images.squarespace-cdn.com/content/v1/5a04b1b8fe54ef9d6db1a38e/1510777032320-FAAMJFSFVU91JWY27N8K/The-Royal-American-Logo---white.png","authenticUrl":"http://www.theroyalamerican.com","internalUrl":"http://theroyalamerican.squarespace.com","baseUrl":"http://www.theroyalamerican.com","primaryDomain":"www.theroyalamerican.com","sslSetting":1,"isHstsEnabled":false,"typekitId":"","statsMigrated":false,"imageMetadataProcessingEnabled":false,"screenshotId":"437e3817ea2af125e06dacea7c5ed04e4f6db9c623c7ccb4742edf4af6360d95","captchaSettings":{"enabledForDonations":false},"showOwnerLogin":false},"websiteSettings":{"id":"5a04b1b8fe54ef9d6db1a391","websiteId":"5a04b1b8fe54ef9d6db1a38e","subjects":[],"country":"US","state":"SC","simpleLikingEnabled":true,"mobileInfoBarSettings":{"isContactEmailEnabled":false,"isContactPhoneNumberEnabled":false,"isLocationEnabled":false,"isBusinessHoursEnabled":false},"announcementBarSettings":{"style":1,"text":""},"commentLikesAllowed":true,"commentAnonAllowed":true,"commentThreaded":true,"commentApprovalRequired":false,"commentAvatarsOn":true,"commentSortType":2,"commentFlagThreshold":0,"commentFlagsAllowed":true,"commentEnableByDefault":true,"commentDisableAfterDaysDefault":0,"disqusShortname":"","commentsEnabled":false,"storeSettings":{"returnPolicy":null,"termsOfService":null,"privacyPolicy":null,"expressCheckout":false,"continueShoppingLinkUrl":"/","useLightCart":false,"showNoteField":false,"shippingCountryDefaultValue":"US","billToShippingDefaultValue":false,"showShippingPhoneNumber":true,"isShippingPhoneRequired":false,"showBillingPhoneNumber":true,"isBillingPhoneRequired":false,"currenciesSupported":["CHF","HKD","MXN","EUR","DKK","USD","CAD","MYR","NOK","THB","AUD","SGD","ILS","PLN","GBP","CZK","SEK","NZD","PHP","RUB"],"defaultCurrency":"USD","selectedCurrency":"USD","measurementStandard":1,"showCustomCheckoutForm":false,"checkoutPageMarketingOptInEnabled":false,"enableMailingListOptInByDefault":false,"sameAsRetailLocation":false,"merchandisingSettings":{"scarcityEnabledOnProductItems":false,"scarcityEnabledOnProductBlocks":false,"scarcityMessageType":"DEFAULT_SCARCITY_MESSAGE","scarcityThreshold":10,"multipleQuantityAllowedForServices":true,"restockNotificationsEnabled":false,"restockNotificationsSuccessText":"","restockNotificationsMailingListSignUpEnabled":false,"relatedProductsEnabled":false,"relatedProductsOrdering":"random","soldOutVariantsDropdownDisabled":false,"productComposerOptedIn":false,"productComposerABTestOptedOut":false,"productReviewsEnabled":false,"displayImportedProductReviewsEnabled":false,"hasOptedToCollectNativeReviews":false},"minimumOrderSubtotalEnabled":false,"addToCartConfirmationType":2,"isLive":false,"multipleQuantityAllowedForServices":true},"useEscapeKeyToLogin":true,"ssBadgeType":1,"ssBadgePosition":4,"ssBadgeVisibility":1,"ssBadgeDevices":1,"pinterestOverlayOptions":{"mode":"disabled"},"userAccountsSettings":{"loginAllowed":false,"signupAllowed":false}},"cookieSettings":{"isCookieBannerEnabled":false,"isRestrictiveCookiePolicyEnabled":false,"cookieBannerText":"","cookieBannerTheme":"","cookieBannerVariant":"","cookieBannerPosition":"","cookieBannerCtaVariant":"","cookieBannerCtaText":"","cookieBannerAcceptType":"OPT_IN","cookieBannerOptOutCtaText":"","cookieBannerHasOptOut":false,"cookieBannerHasManageCookies":true,"cookieBannerManageCookiesLabel":"","cookieBannerSavedPreferencesText":"","cookieBannerSavedPreferencesLayout":"PILL"},"websiteCloneable":false,"collection":{"title":"Schedule","id":"5a04b27e24a6946807ae890e","fullUrl":"/schedule","type":1,"permissionType":1},"subscribed":false,"appDomain":"squarespace.com","templateTweakable":true,"tweakJSON":{"aspect-ratio":"Auto","gallery-arrow-style":"No Background","gallery-aspect-ratio":"3:2 Standard","gallery-auto-crop":"true","gallery-autoplay":"false","gallery-design":"Grid","gallery-info-overlay":"Show on Hover","gallery-loop":"false","gallery-navigation":"Bullets","gallery-show-arrows":"true","gallery-transitions":"Fade","galleryArrowBackground":"rgba(34,34,34,1)","galleryArrowColor":"rgba(255,255,255,1)","galleryAutoplaySpeed":"3","galleryCircleColor":"rgba(255,255,255,1)","galleryInfoBackground":"rgba(0, 0, 0, .7)","galleryThumbnailSize":"100px","gridSize":"350px","gridSpacing":"20px","tweak-blog-list-columns":"3","tweak-blog-list-item-image-aspect-ratio-grid":"2:3 Standard (Vertical)","tweak-blog-list-item-image-aspect-ratio-stacked":"1:1 Square","tweak-blog-list-item-image-show":"true","tweak-blog-list-spacing":"100px","tweak-blog-list-style":"Stacked","tweak-footer-layout":"Stacked","tweak-header-bottom-overlay-on-index-gallery":"false","tweak-index-gallery-apply-bottom-spacing":"true","tweak-index-gallery-autoplay-duration":"2","tweak-index-gallery-autoplay-enable":"true","tweak-index-gallery-fixed-height":"true","tweak-index-gallery-height":"100vh","tweak-index-gallery-indicators":"Lines","tweak-index-gallery-layout":"Packed","tweak-index-gallery-transition":"Fade","tweak-index-gallery-transition-duration":"500","tweak-index-nav-position":"Right","tweak-index-page-apply-bottom-spacing":"false","tweak-index-page-fullscreen":"First Page Only","tweak-index-page-min-height":"100vh","tweak-mobile-breakpoint":"640px","tweak-overlay-parallax-enabled":"false","tweak-overlay-parallax-new-math":"true","tweak-product-item-image-zoom-factor":"1","tweak-product-list-item-hover-behavior":"Fade","tweak-product-list-items-per-row":"3","tweak-related-products-items-per-row":"3","tweak-related-products-title-spacing":"50px","tweak-site-ajax-loading-enable":"false","tweak-site-border-show":"false","tweak-site-border-width":"10px"},"templateId":"55f0aac0e4b0f0a5b7e0b22e","templateVersion":"7","pageFeatures":[1,2,4],"gmRenderKey":"QUl6YVN5Q0JUUk9xNkx1dkZfSUUxcjQ2LVQ0QWVUU1YtMGQ3bXk4","templateScriptsRootUrl":"https://static1.squarespace.com/static/ta/55f0a9b0e4b0f3eb70352f6d/359/scripts/","impersonatedSession":false,"demoCollections":[],"tzData":{"zones":[[-300,"US","E%sT",null]],"rules":{"US":[[1967,2006,null,"Oct","lastSun","2:00","0","S"],[1987,2006,null,"Apr","Sun>=1","2:00","1:00","D"],[2007,"max",null,"Mar","Sun>=8","2:00","1:00","D"],[2007,"max",null,"Nov","Sun>=1","2:00","0","S"]]}},"showAnnouncementBar":false,"recaptchaEnterpriseContext":{"recaptchaEnterpriseSiteKey":"6LdDFQwjAAAAAPigEvvPgEVbb7QBm-TkVJdDTlAv"},"i18nContext":{"timeZoneData":{"id":"America/New_York","name":"Eastern Time"}},"env":"PRODUCTION","visitorFormContext":{"formFieldFormats":{"initialAddressFormat":{"id":0,"type":"ADDRESS","country":"US","labelLocale":"en","fields":[{"type":"FIELD","label":"Address Line 1","identifier":"Line1","length":0,"required":true,"metadata":{"autocomplete":"address-line1"}},{"type":"SEPARATOR","label":"\n","identifier":"Newline","length":0,"required":false,"metadata":{}},{"type":"FIELD","label":"Address Line 2","identifier":"Line2","length":0,"required":false,"metadata":{"autocomplete":"address-line2"}},{"type":"SEPARATOR","label":"\n","identifier":"Newline","length":0,"required":false,"metadata":{}},{"type":"FIELD","label":"City","identifier":"City","length":0,"required":true,"metadata":{"autocomplete":"address-level2"}},{"type":"SEPARATOR","label":",","identifier":"Comma","length":0,"required":false,"metadata":{}},{"type":"SEPARATOR","label":" ","identifier":"Space","length":0,"required":false,"metadata":{}},{"type":"FIELD","label":"State","identifier":"State","length":0,"required":true,"metadata":{"autocomplete":"address-level1"}},{"type":"SEPARATOR","label":" ","identifier":"Space","length":0,"required":false,"metadata":{}},{"type":"FIELD","label":"ZIP Code","identifier":"Zip","length":0,"required":true,"metadata":{"autocomplete":"postal-code"}}]},"countries":[{"name":"Afghanistan","code":"AF","phoneCode":"+93"},{"name":"\u00C5land Islands","code":"AX","phoneCode":"+358"},{"name":"Albania","code":"AL","phoneCode":"+355"},{"name":"Algeria","code":"DZ","phoneCode":"+213"},{"name":"American Samoa","code":"AS","phoneCode":"+1"},{"name":"Andorra","code":"AD","phoneCode":"+376"},{"name":"Angola","code":"AO","phoneCode":"+244"},{"name":"Anguilla","code":"AI","phoneCode":"+1"},{"name":"Antigua & Barbuda","code":"AG","phoneCode":"+1"},{"name":"Argentina","code":"AR","phoneCode":"+54"},{"name":"Armenia","code":"AM","phoneCode":"+374"},{"name":"Aruba","code":"AW","phoneCode":"+297"},{"name":"Ascension Island","code":"AC","phoneCode":"+247"},{"name":"Australia","code":"AU","phoneCode":"+61"},{"name":"Austria","code":"AT","phoneCode":"+43"},{"name":"Azerbaijan","code":"AZ","phoneCode":"+994"},{"name":"Bahamas","code":"BS","phoneCode":"+1"},{"name":"Bahrain","code":"BH","phoneCode":"+973"},{"name":"Bangladesh","code":"BD","phoneCode":"+880"},{"name":"Barbados","code":"BB","phoneCode":"+1"},{"name":"Belarus","code":"BY","phoneCode":"+375"},{"name":"Belgium","code":"BE","phoneCode":"+32"},{"name":"Belize","code":"BZ","phoneCode":"+501"},{"name":"Benin","code":"BJ","phoneCode":"+229"},{"name":"Bermuda","code":"BM","phoneCode":"+1"},{"name":"Bhutan","code":"BT","phoneCode":"+975"},{"name":"Bolivia","code":"BO","phoneCode":"+591"},{"name":"Bosnia & Herzegovina","code":"BA","phoneCode":"+387"},{"name":"Botswana","code":"BW","phoneCode":"+267"},{"name":"Brazil","code":"BR","phoneCode":"+55"},{"name":"British Indian Ocean Territory","code":"IO","phoneCode":"+246"},{"name":"British Virgin Islands","code":"VG","phoneCode":"+1"},{"name":"Brunei","code":"BN","phoneCode":"+673"},{"name":"Bulgaria","code":"BG","phoneCode":"+359"},{"name":"Burkina Faso","code":"BF","phoneCode":"+226"},{"name":"Burundi","code":"BI","phoneCode":"+257"},{"name":"Cambodia","code":"KH","phoneCode":"+855"},{"name":"Cameroon","code":"CM","phoneCode":"+237"},{"name":"Canada","code":"CA","phoneCode":"+1"},{"name":"Cape Verde","code":"CV","phoneCode":"+238"},{"name":"Caribbean Netherlands","code":"BQ","phoneCode":"+599"},{"name":"Cayman Islands","code":"KY","phoneCode":"+1"},{"name":"Central African Republic","code":"CF","phoneCode":"+236"},{"name":"Chad","code":"TD","phoneCode":"+235"},{"name":"Chile","code":"CL","phoneCode":"+56"},{"name":"China","code":"CN","phoneCode":"+86"},{"name":"Christmas Island","code":"CX","phoneCode":"+61"},{"name":"Cocos (Keeling) Islands","code":"CC","phoneCode":"+61"},{"name":"Colombia","code":"CO","phoneCode":"+57"},{"name":"Comoros","code":"KM","phoneCode":"+269"},{"name":"Congo - Brazzaville","code":"CG","phoneCode":"+242"},{"name":"Congo - Kinshasa","code":"CD","phoneCode":"+243"},{"name":"Cook Islands","code":"CK","phoneCode":"+682"},{"name":"Costa Rica","code":"CR","phoneCode":"+506"},{"name":"C\u00F4te d\u2019Ivoire","code":"CI","phoneCode":"+225"},{"name":"Croatia","code":"HR","phoneCode":"+385"},{"name":"Cuba","code":"CU","phoneCode":"+53"},{"name":"Cura\u00E7ao","code":"CW","phoneCode":"+599"},{"name":"Cyprus","code":"CY","phoneCode":"+357"},{"name":"Czechia","code":"CZ","phoneCode":"+420"},{"name":"Denmark","code":"DK","phoneCode":"+45"},{"name":"Djibouti","code":"DJ","phoneCode":"+253"},{"name":"Dominica","code":"DM","phoneCode":"+1"},{"name":"Dominican Republic","code":"DO","phoneCode":"+1"},{"name":"Ecuador","code":"EC","phoneCode":"+593"},{"name":"Egypt","code":"EG","phoneCode":"+20"},{"name":"El Salvador","code":"SV","phoneCode":"+503"},{"name":"Equatorial Guinea","code":"GQ","phoneCode":"+240"},{"name":"Eritrea","code":"ER","phoneCode":"+291"},{"name":"Estonia","code":"EE","phoneCode":"+372"},{"name":"Eswatini","code":"SZ","phoneCode":"+268"},{"name":"Ethiopia","code":"ET","phoneCode":"+251"},{"name":"Falkland Islands","code":"FK","phoneCode":"+500"},{"name":"Faroe Islands","code":"FO","phoneCode":"+298"},{"name":"Fiji","code":"FJ","phoneCode":"+679"},{"name":"Finland","code":"FI","phoneCode":"+358"},{"name":"France","code":"FR","phoneCode":"+33"},{"name":"French Guiana","code":"GF","phoneCode":"+594"},{"name":"French Polynesia","code":"PF","phoneCode":"+689"},{"name":"Gabon","code":"GA","phoneCode":"+241"},{"name":"Gambia","code":"GM","phoneCode":"+220"},{"name":"Georgia","code":"GE","phoneCode":"+995"},{"name":"Germany","code":"DE","phoneCode":"+49"},{"name":"Ghana","code":"GH","phoneCode":"+233"},{"name":"Gibraltar","code":"GI","phoneCode":"+350"},{"name":"Greece","code":"GR","phoneCode":"+30"},{"name":"Greenland","code":"GL","phoneCode":"+299"},{"name":"Grenada","code":"GD","phoneCode":"+1"},{"name":"Guadeloupe","code":"GP","phoneCode":"+590"},{"name":"Guam","code":"GU","phoneCode":"+1"},{"name":"Guatemala","code":"GT","phoneCode":"+502"},{"name":"Guernsey","code":"GG","phoneCode":"+44"},{"name":"Guinea","code":"GN","phoneCode":"+224"},{"name":"Guinea-Bissau","code":"GW","phoneCode":"+245"},{"name":"Guyana","code":"GY","phoneCode":"+592"},{"name":"Haiti","code":"HT","phoneCode":"+509"},{"name":"Honduras","code":"HN","phoneCode":"+504"},{"name":"Hong Kong SAR China","code":"HK","phoneCode":"+852"},{"name":"Hungary","code":"HU","phoneCode":"+36"},{"name":"Iceland","code":"IS","phoneCode":"+354"},{"name":"India","code":"IN","phoneCode":"+91"},{"name":"Indonesia","code":"ID","phoneCode":"+62"},{"name":"Iran","code":"IR","phoneCode":"+98"},{"name":"Iraq","code":"IQ","phoneCode":"+964"},{"name":"Ireland","code":"IE","phoneCode":"+353"},{"name":"Isle of Man","code":"IM","phoneCode":"+44"},{"name":"Israel","code":"IL","phoneCode":"+972"},{"name":"Italy","code":"IT","phoneCode":"+39"},{"name":"Jamaica","code":"JM","phoneCode":"+1"},{"name":"Japan","code":"JP","phoneCode":"+81"},{"name":"Jersey","code":"JE","phoneCode":"+44"},{"name":"Jordan","code":"JO","phoneCode":"+962"},{"name":"Kazakhstan","code":"KZ","phoneCode":"+7"},{"name":"Kenya","code":"KE","phoneCode":"+254"},{"name":"Kiribati","code":"KI","phoneCode":"+686"},{"name":"Kosovo","code":"XK","phoneCode":"+383"},{"name":"Kuwait","code":"KW","phoneCode":"+965"},{"name":"Kyrgyzstan","code":"KG","phoneCode":"+996"},{"name":"Laos","code":"LA","phoneCode":"+856"},{"name":"Latvia","code":"LV","phoneCode":"+371"},{"name":"Lebanon","code":"LB","phoneCode":"+961"},{"name":"Lesotho","code":"LS","phoneCode":"+266"},{"name":"Liberia","code":"LR","phoneCode":"+231"},{"name":"Libya","code":"LY","phoneCode":"+218"},{"name":"Liechtenstein","code":"LI","phoneCode":"+423"},{"name":"Lithuania","code":"LT","phoneCode":"+370"},{"name":"Luxembourg","code":"LU","phoneCode":"+352"},{"name":"Macao SAR China","code":"MO","phoneCode":"+853"},{"name":"Madagascar","code":"MG","phoneCode":"+261"},{"name":"Malawi","code":"MW","phoneCode":"+265"},{"name":"Malaysia","code":"MY","phoneCode":"+60"},{"name":"Maldives","code":"MV","phoneCode":"+960"},{"name":"Mali","code":"ML","phoneCode":"+223"},{"name":"Malta","code":"MT","phoneCode":"+356"},{"name":"Marshall Islands","code":"MH","phoneCode":"+692"},{"name":"Martinique","code":"MQ","phoneCode":"+596"},{"name":"Mauritania","code":"MR","phoneCode":"+222"},{"name":"Mauritius","code":"MU","phoneCode":"+230"},{"name":"Mayotte","code":"YT","phoneCode":"+262"},{"name":"Mexico","code":"MX","phoneCode":"+52"},{"name":"Micronesia","code":"FM","phoneCode":"+691"},{"name":"Moldova","code":"MD","phoneCode":"+373"},{"name":"Monaco","code":"MC","phoneCode":"+377"},{"name":"Mongolia","code":"MN","phoneCode":"+976"},{"name":"Montenegro","code":"ME","phoneCode":"+382"},{"name":"Montserrat","code":"MS","phoneCode":"+1"},{"name":"Morocco","code":"MA","phoneCode":"+212"},{"name":"Mozambique","code":"MZ","phoneCode":"+258"},{"name":"Myanmar (Burma)","code":"MM","phoneCode":"+95"},{"name":"Namibia","code":"NA","phoneCode":"+264"},{"name":"Nauru","code":"NR","phoneCode":"+674"},{"name":"Nepal","code":"NP","phoneCode":"+977"},{"name":"Netherlands","code":"NL","phoneCode":"+31"},{"name":"New Caledonia","code":"NC","phoneCode":"+687"},{"name":"New Zealand","code":"NZ","phoneCode":"+64"},{"name":"Nicaragua","code":"NI","phoneCode":"+505"},{"name":"Niger","code":"NE","phoneCode":"+227"},{"name":"Nigeria","code":"NG","phoneCode":"+234"},{"name":"Niue","code":"NU","phoneCode":"+683"},{"name":"Norfolk Island","code":"NF","phoneCode":"+672"},{"name":"Northern Mariana Islands","code":"MP","phoneCode":"+1"},{"name":"North Korea","code":"KP","phoneCode":"+850"},{"name":"North Macedonia","code":"MK","phoneCode":"+389"},{"name":"Norway","code":"NO","phoneCode":"+47"},{"name":"Oman","code":"OM","phoneCode":"+968"},{"name":"Pakistan","code":"PK","phoneCode":"+92"},{"name":"Palau","code":"PW","phoneCode":"+680"},{"name":"Palestinian Territories","code":"PS","phoneCode":"+970"},{"name":"Panama","code":"PA","phoneCode":"+507"},{"name":"Papua New Guinea","code":"PG","phoneCode":"+675"},{"name":"Paraguay","code":"PY","phoneCode":"+595"},{"name":"Peru","code":"PE","phoneCode":"+51"},{"name":"Philippines","code":"PH","phoneCode":"+63"},{"name":"Poland","code":"PL","phoneCode":"+48"},{"name":"Portugal","code":"PT","phoneCode":"+351"},{"name":"Puerto Rico","code":"PR","phoneCode":"+1"},{"name":"Qatar","code":"QA","phoneCode":"+974"},{"name":"R\u00E9union","code":"RE","phoneCode":"+262"},{"name":"Romania","code":"RO","phoneCode":"+40"},{"name":"Russia","code":"RU","phoneCode":"+7"},{"name":"Rwanda","code":"RW","phoneCode":"+250"},{"name":"Samoa","code":"WS","phoneCode":"+685"},{"name":"San Marino","code":"SM","phoneCode":"+378"},{"name":"S\u00E3o Tom\u00E9 & Pr\u00EDncipe","code":"ST","phoneCode":"+239"},{"name":"Saudi Arabia","code":"SA","phoneCode":"+966"},{"name":"Senegal","code":"SN","phoneCode":"+221"},{"name":"Serbia","code":"RS","phoneCode":"+381"},{"name":"Seychelles","code":"SC","phoneCode":"+248"},{"name":"Sierra Leone","code":"SL","phoneCode":"+232"},{"name":"Singapore","code":"SG","phoneCode":"+65"},{"name":"Sint Maarten","code":"SX","phoneCode":"+1"},{"name":"Slovakia","code":"SK","phoneCode":"+421"},{"name":"Slovenia","code":"SI","phoneCode":"+386"},{"name":"Solomon Islands","code":"SB","phoneCode":"+677"},{"name":"Somalia","code":"SO","phoneCode":"+252"},{"name":"South Africa","code":"ZA","phoneCode":"+27"},{"name":"South Korea","code":"KR","phoneCode":"+82"},{"name":"South Sudan","code":"SS","phoneCode":"+211"},{"name":"Spain","code":"ES","phoneCode":"+34"},{"name":"Sri Lanka","code":"LK","phoneCode":"+94"},{"name":"St. Barth\u00E9lemy","code":"BL","phoneCode":"+590"},{"name":"St. Helena","code":"SH","phoneCode":"+290"},{"name":"St. Kitts & Nevis","code":"KN","phoneCode":"+1"},{"name":"St. Lucia","code":"LC","phoneCode":"+1"},{"name":"St. Martin","code":"MF","phoneCode":"+590"},{"name":"St. Pierre & Miquelon","code":"PM","phoneCode":"+508"},{"name":"St. Vincent & Grenadines","code":"VC","phoneCode":"+1"},{"name":"Sudan","code":"SD","phoneCode":"+249"},{"name":"Suriname","code":"SR","phoneCode":"+597"},{"name":"Svalbard & Jan Mayen","code":"SJ","phoneCode":"+47"},{"name":"Sweden","code":"SE","phoneCode":"+46"},{"name":"Switzerland","code":"CH","phoneCode":"+41"},{"name":"Syria","code":"SY","phoneCode":"+963"},{"name":"Taiwan","code":"TW","phoneCode":"+886"},{"name":"Tajikistan","code":"TJ","phoneCode":"+992"},{"name":"Tanzania","code":"TZ","phoneCode":"+255"},{"name":"Thailand","code":"TH","phoneCode":"+66"},{"name":"Timor-Leste","code":"TL","phoneCode":"+670"},{"name":"Togo","code":"TG","phoneCode":"+228"},{"name":"Tokelau","code":"TK","phoneCode":"+690"},{"name":"Tonga","code":"TO","phoneCode":"+676"},{"name":"Trinidad & Tobago","code":"TT","phoneCode":"+1"},{"name":"Tristan da Cunha","code":"TA","phoneCode":"+290"},{"name":"Tunisia","code":"TN","phoneCode":"+216"},{"name":"T\u00FCrkiye","code":"TR","phoneCode":"+90"},{"name":"Turkmenistan","code":"TM","phoneCode":"+993"},{"name":"Turks & Caicos Islands","code":"TC","phoneCode":"+1"},{"name":"Tuvalu","code":"TV","phoneCode":"+688"},{"name":"U.S. Virgin Islands","code":"VI","phoneCode":"+1"},{"name":"Uganda","code":"UG","phoneCode":"+256"},{"name":"Ukraine","code":"UA","phoneCode":"+380"},{"name":"United Arab Emirates","code":"AE","phoneCode":"+971"},{"name":"United Kingdom","code":"GB","phoneCode":"+44"},{"name":"United States","code":"US","phoneCode":"+1"},{"name":"Uruguay","code":"UY","phoneCode":"+598"},{"name":"Uzbekistan","code":"UZ","phoneCode":"+998"},{"name":"Vanuatu","code":"VU","phoneCode":"+678"},{"name":"Vatican City","code":"VA","phoneCode":"+39"},{"name":"Venezuela","code":"VE","phoneCode":"+58"},{"name":"Vietnam","code":"VN","phoneCode":"+84"},{"name":"Wallis & Futuna","code":"WF","phoneCode":"+681"},{"name":"Western Sahara","code":"EH","phoneCode":"+212"},{"name":"Yemen","code":"YE","phoneCode":"+967"},{"name":"Zambia","code":"ZM","phoneCode":"+260"},{"name":"Zimbabwe","code":"ZW","phoneCode":"+263"}],"initialPhoneFormat":{"id":0,"type":"PHONE_NUMBER","country":"US","labelLocale":"en-US","fields":[{"type":"SEPARATOR","label":"(","identifier":"LeftParen","length":0,"required":false,"metadata":{}},{"type":"FIELD","label":"1","identifier":"1","length":3,"required":false,"metadata":{}},{"type":"SEPARATOR","label":")","identifier":"RightParen","length":0,"required":false,"metadata":{}},{"type":"SEPARATOR","label":" ","identifier":"Space","length":0,"required":false,"metadata":{}},{"type":"FIELD","label":"2","identifier":"2","length":3,"required":false,"metadata":{}},{"type":"SEPARATOR","label":"-","identifier":"Dash","length":0,"required":false,"metadata":{}},{"type":"FIELD","label":"3","identifier":"3","length":14,"required":false,"metadata":{}}]},"initialNameOrder":"GIVEN_FIRST"},"localizedStrings":{"validation":{"noValidSelection":"A valid selection must be made.","invalidUrl":"Must be a valid URL.","stringTooLong":"Value should have a length no longer than {0}.","containsInvalidKey":"{0} contains an invalid key.","invalidTwitterUsername":"Must be a valid Twitter username.","valueOutsideRange":"Value must be in the range {0} to {1}.","invalidPassword":"Passwords should not contain whitespace.","missingRequiredSubfields":"{0} is missing required subfields: {1}","invalidCurrency":"Currency value should be formatted like 1234 or 123.99.","invalidMapSize":"Value should contain exactly {0} elements.","subfieldsRequired":"All fields in {0} are required.","formSubmissionFailed":"Form submission failed. Review the following information: {0}.","invalidCountryCode":"Country code should have an optional plus and up to 4 digits.","invalidDate":"This is not a real date.","required":"{0} is required.","invalidStringLength":"Value should be {0} characters long.","invalidEmail":"Email addresses should follow the format user@domain.com.","invalidListLength":"Value should be {0} elements long.","allEmpty":"Please fill out at least one form field.","missingRequiredQuestion":"Missing a required question.","invalidQuestion":"Contained an invalid question.","captchaFailure":"Captcha validation failed. Please try again.","stringTooShort":"Value should have a length of at least {0}.","invalid":"{0} is not valid.","formErrors":"Form Errors","containsInvalidValue":"{0} contains an invalid value.","invalidUnsignedNumber":"Numbers must contain only digits and no other characters.","invalidName":"Valid names contain only letters, numbers, spaces, ', or - characters."},"submit":"Submit","status":{"title":"{@} Block","learnMore":"Learn more"},"name":{"firstName":"First Name","lastName":"Last Name"},"lightbox":{"openForm":"Open Form"},"likert":{"agree":"Agree","stronglyDisagree":"Strongly Disagree","disagree":"Disagree","stronglyAgree":"Strongly Agree","neutral":"Neutral"},"time":{"am":"AM","second":"Second","pm":"PM","minute":"Minute","amPm":"AM/PM","hour":"Hour"},"notFound":"Form not found.","date":{"yyyy":"YYYY","year":"Year","mm":"MM","day":"Day","month":"Month","dd":"DD"},"phone":{"country":"Country","number":"Number","prefix":"Prefix","areaCode":"Area Code","line":"Line"},"submitError":"Unable to submit form. Please try again later.","address":{"stateProvince":"State/Province","country":"Country","zipPostalCode":"Zip/Postal Code","address2":"Address 2","address1":"Address 1","city":"City"},"email":{"signUp":"Sign up for news and updates"},"required":"(required)","invalidData":"Invalid form data."}}};</script><script type="text/javascript">SQUARESPACE_ROLLUPS = {};</script>
+<script>(function(rollups, name) { if (!rollups[name]) { rollups[name] = {}; } rollups[name].js = ["//assets.squarespace.com/universal/scripts-compressed/visitor-site-error-reporter-a38266454b6c35f7-min.en-US.js"]; })(SQUARESPACE_ROLLUPS, 'squarespace-visitor_site_error_reporter');</script>
+<script crossorigin="anonymous" src="//assets.squarespace.com/universal/scripts-compressed/visitor-site-error-reporter-a38266454b6c35f7-min.en-US.js" ></script><script>(function(rollups, name) { if (!rollups[name]) { rollups[name] = {}; } rollups[name].js = ["//assets.squarespace.com/universal/scripts-compressed/extract-css-runtime-f2004e29fafc047d-min.en-US.js"]; })(SQUARESPACE_ROLLUPS, 'squarespace-extract_css_runtime');</script>
+<script crossorigin="anonymous" src="//assets.squarespace.com/universal/scripts-compressed/extract-css-runtime-f2004e29fafc047d-min.en-US.js" ></script><script>(function(rollups, name) { if (!rollups[name]) { rollups[name] = {}; } rollups[name].js = ["//assets.squarespace.com/universal/scripts-compressed/extract-css-moment-js-vendor-6f2a1f6ec9a41489-min.en-US.js"]; })(SQUARESPACE_ROLLUPS, 'squarespace-extract_css_moment_js_vendor');</script>
+<script crossorigin="anonymous" src="//assets.squarespace.com/universal/scripts-compressed/extract-css-moment-js-vendor-6f2a1f6ec9a41489-min.en-US.js" ></script><script>(function(rollups, name) { if (!rollups[name]) { rollups[name] = {}; } rollups[name].js = ["//assets.squarespace.com/universal/scripts-compressed/cldr-resource-pack-497d1337e70309e7-min.en-US.js"]; })(SQUARESPACE_ROLLUPS, 'squarespace-cldr_resource_pack');</script>
+<script crossorigin="anonymous" src="//assets.squarespace.com/universal/scripts-compressed/cldr-resource-pack-497d1337e70309e7-min.en-US.js" ></script><script>(function(rollups, name) { if (!rollups[name]) { rollups[name] = {}; } rollups[name].js = ["//assets.squarespace.com/universal/scripts-compressed/common-vendors-stable-b8d716935110c7b2-min.en-US.js"]; })(SQUARESPACE_ROLLUPS, 'squarespace-common_vendors_stable');</script>
+<script crossorigin="anonymous" src="//assets.squarespace.com/universal/scripts-compressed/common-vendors-stable-b8d716935110c7b2-min.en-US.js" ></script><script>(function(rollups, name) { if (!rollups[name]) { rollups[name] = {}; } rollups[name].js = ["//assets.squarespace.com/universal/scripts-compressed/common-vendors-a5542c2814272dd7-min.en-US.js"]; })(SQUARESPACE_ROLLUPS, 'squarespace-common_vendors');</script>
+<script crossorigin="anonymous" src="//assets.squarespace.com/universal/scripts-compressed/common-vendors-a5542c2814272dd7-min.en-US.js" ></script><script>(function(rollups, name) { if (!rollups[name]) { rollups[name] = {}; } rollups[name].js = ["//assets.squarespace.com/universal/scripts-compressed/common-5334e169c9772d6c-min.en-US.js"]; })(SQUARESPACE_ROLLUPS, 'squarespace-common');</script>
+<script crossorigin="anonymous" src="//assets.squarespace.com/universal/scripts-compressed/common-5334e169c9772d6c-min.en-US.js" ></script><script>(function(rollups, name) { if (!rollups[name]) { rollups[name] = {}; } rollups[name].js = ["//assets.squarespace.com/universal/scripts-compressed/commerce-cd17439efa931e38-min.en-US.js"]; })(SQUARESPACE_ROLLUPS, 'squarespace-commerce');</script>
+<script crossorigin="anonymous" src="//assets.squarespace.com/universal/scripts-compressed/commerce-cd17439efa931e38-min.en-US.js" ></script><script>(function(rollups, name) { if (!rollups[name]) { rollups[name] = {}; } rollups[name].css = ["//assets.squarespace.com/universal/styles-compressed/commerce-d50e5960dc9fd059-min.en-US.css"]; })(SQUARESPACE_ROLLUPS, 'squarespace-commerce');</script>
+<link rel="stylesheet" type="text/css" href="//assets.squarespace.com/universal/styles-compressed/commerce-d50e5960dc9fd059-min.en-US.css"><script>(function(rollups, name) { if (!rollups[name]) { rollups[name] = {}; } rollups[name].js = ["//assets.squarespace.com/universal/scripts-compressed/performance-c704c05d211c44da-min.en-US.js"]; })(SQUARESPACE_ROLLUPS, 'squarespace-performance');</script>
+<script crossorigin="anonymous" src="//assets.squarespace.com/universal/scripts-compressed/performance-c704c05d211c44da-min.en-US.js" defer ></script><link rel="stylesheet" type="text/css" href="https://definitions.sqspcdn.com/website-component-definition/static-assets/website.components.spacer/ee252eb3-6876-42a2-ac75-8c52de232390_867/website.components.spacer.styles.css"/><link rel="stylesheet" type="text/css" href="https://definitions.sqspcdn.com/website-component-definition/static-assets/website.components.code/af9ceeab-bba8-49f2-9ec7-77d5167c6e43_590/website.components.code.styles.css"/><script src="https://definitions.sqspcdn.com/website-component-definition/static-assets/website.components.code/af9ceeab-bba8-49f2-9ec7-77d5167c6e43_590/website.components.code.visitor.js"></script><script src="https://definitions.sqspcdn.com/website-component-definition/static-assets/website.components.spacer/ee252eb3-6876-42a2-ac75-8c52de232390_867/website.components.spacer.visitor.js"></script><script>Squarespace.load(window);</script>
+<script type="application/ld+json">{"url":"http://www.theroyalamerican.com","name":"The Royal American","description":"<p>The Royal American is a restaurant, bar and live music venue located in Downtown Charleston.</p>","image":"//images.squarespace-cdn.com/content/v1/5a04b1b8fe54ef9d6db1a38e/1510777032320-FAAMJFSFVU91JWY27N8K/The-Royal-American-Logo---white.png","@context":"http://schema.org","@type":"WebSite"}</script><link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/sitecss/5a04b1b8fe54ef9d6db1a38e/313/55f0aac0e4b0f0a5b7e0b22e/5a04b1b8fe54ef9d6db1a3a3/359/site.css?nocustom=true"/><link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/custom-css/5a04b1b8fe54ef9d6db1a38e/5a04b1b8fe54ef9d6db1a3a3/0/custom.css"/><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
+<!-- End of Squarespace Headers -->
+  </head>
+  <body id="collection-5a04b27e24a6946807ae890e" class="tweak-site-width-option-full-background tweak-icon-weight-light   tweak-site-ajax-loading-bar-show ancillary-header-top-left-layout-horizontal ancillary-header-top-center-layout-stacked ancillary-header-top-right-layout-horizontal ancillary-header-bottom-left-layout-horizontal ancillary-header-bottom-center-layout-horizontal ancillary-header-bottom-right-layout-horizontal ancillary-header-branding-position-bottom-left ancillary-header-tagline-position-hide ancillary-header-primary-nav-position-bottom-right ancillary-header-secondary-nav-position-bottom-right ancillary-header-social-position-hide ancillary-header-search-position-hide ancillary-header-cart-position-hide ancillary-header-account-position-hide tweak-header-primary-nav-hover-style-active tweak-header-primary-nav-button-style-solid tweak-header-primary-nav-button-shape-square  tweak-header-secondary-nav-hover-style-button tweak-header-secondary-nav-button-style-outline tweak-header-secondary-nav-button-shape-square tweak-header-search-style-underlined tweak-header-search-placeholder-show tweak-header-cart-style-text tweak-header-account-style-text  tweak-overlay-parallax-new-math tweak-index-nav-style-none tweak-index-nav-position-right tweak-index-nav-text-show tweak-index-page-fullscreen-first-page-only  tweak-index-page-scroll-indicator-icon-and-text tweak-index-page-scroll-indicator-icon-arrow tweak-index-page-scroll-indicator-icon-weight-heavy  tweak-index-gallery-layout-packed tweak-index-gallery-spacing-sides-show tweak-index-gallery-spacing-top-bottom-show tweak-index-gallery-fixed-height tweak-index-gallery-apply-bottom-spacing tweak-index-gallery-hover-style-fade tweak-index-gallery-controls-small-arrows tweak-index-gallery-controls-icon-weight-hairline tweak-index-gallery-indicators-lines tweak-index-gallery-autoplay-enable tweak-index-gallery-transition-fade tweak-index-gallery-content-position-top-left tweak-index-gallery-content-text-alignment-center tweak-footer-show tweak-footer-layout-stacked tweak-footer-layout-columns-auto tweak-footer-stacked-alignment-left    ancillary-mobile-bar-branding-position-top-center ancillary-mobile-bar-menu-icon-position-top-right tweak-mobile-bar-menu-icon-hamburger ancillary-mobile-bar-search-icon-position-hide ancillary-mobile-bar-cart-position-hide tweak-mobile-bar-cart-style-cart ancillary-mobile-bar-account-position-hide tweak-mobile-bar-account-style-text tweak-mobile-overlay-slide-origin-right tweak-mobile-overlay-close-show  tweak-mobile-overlay-menu-primary-button-style-solid tweak-mobile-overlay-menu-primary-button-shape-square tweak-mobile-overlay-menu-secondary-inherit tweak-mobile-overlay-menu-secondary-style-button tweak-mobile-overlay-menu-secondary-button-style-outline tweak-mobile-overlay-menu-secondary-button-shape-square tweak-quote-block-alignment-center tweak-social-icons-style-solid tweak-social-icons-shape-square  tweak-blog-meta-primary-category tweak-blog-meta-secondary-date tweak-blog-list-style-stacked  tweak-blog-list-alignment-center tweak-blog-list-item-image-show tweak-blog-list-item-image-aspect-ratio-grid-23-standard-vertical tweak-blog-list-item-image-aspect-ratio-stacked-11-square tweak-blog-list-item-title-show tweak-blog-list-item-excerpt-show tweak-blog-list-item-body-show tweak-blog-list-item-readmore-inline tweak-blog-list-item-meta-position-above-title tweak-blog-list-pagination-link-label-show  tweak-blog-list-pagination-link-icon-weight-light tweak-blog-item-alignment-center tweak-blog-item-meta-position-above-title tweak-blog-item-share-position-below-content  tweak-blog-item-pagination-link-label-show  tweak-blog-item-pagination-link-meta-hide tweak-blog-item-pagination-link-icon-weight-hairline    event-thumbnail-size-32-standard    event-list-date       event-excerpts  event-item-back-link    gallery-design-grid aspect-ratio-auto lightbox-style-dark gallery-navigation-bullets gallery-info-overlay-show-on-hover gallery-aspect-ratio-32-standard gallery-arrow-style-no-background gallery-transitions-fade gallery-show-arrows gallery-auto-crop   tweak-product-list-image-aspect-ratio-11-square tweak-product-list-item-hover-behavior-fade tweak-product-list-meta-position-under tweak-product-list-mobile-meta-position-under tweak-product-list-meta-alignment-under-center tweak-product-list-meta-alignment-overlay-center-center tweak-product-list-show-title tweak-product-list-show-price tweak-product-list-filter-display-top tweak-product-list-filter-alignment-center tweak-product-item-nav-show-none tweak-product-item-nav-pagination-style-previousnext tweak-product-item-nav-breadcrumb-alignment-left tweak-product-item-nav-pagination-alignment-center tweak-product-item-gallery-position-left tweak-product-item-gallery-design-slideshow tweak-product-item-gallery-aspect-ratio-11-square tweak-product-item-gallery-thumbnail-alignment-center tweak-product-item-details-alignment-left tweak-product-item-details-show-title tweak-product-item-details-show-price tweak-product-item-details-show-excerpt tweak-product-item-details-excerpt-position-below-price  tweak-product-item-details-show-variants  tweak-product-item-details-options-style-square tweak-product-item-details-show-add-to-cart-button tweak-product-item-details-add-to-cart-button-style-outline tweak-product-item-details-add-to-cart-button-shape-square tweak-product-item-details-add-to-cart-button-padding-medium tweak-product-item-image-zoom-enabled tweak-product-item-image-zoom-behavior-click tweak-product-item-lightbox-enabled tweak-related-products-image-aspect-ratio-11-square tweak-related-products-meta-alignment-under-center tweak-product-badge-style-none tweak-product-badge-position-top-right tweak-product-badge-inset-floating newsletter-style-custom hide-opentable-icons opentable-style-dark small-button-style-outline small-button-shape-pill medium-button-style-outline medium-button-shape-pill large-button-style-outline large-button-shape-square image-block-poster-text-alignment-center  image-block-card-content-position-center image-block-card-text-alignment-center  image-block-overlap-content-position-center image-block-overlap-text-alignment-left  image-block-collage-content-position-top image-block-collage-text-alignment-center image-block-stack-dynamic-font-sizing image-block-stack-text-alignment-left button-style-outline button-corner-style-square tweak-product-quick-view-button-style-docked tweak-product-quick-view-button-position-center tweak-product-quick-view-lightbox-excerpt-display-truncate tweak-product-quick-view-lightbox-show-arrows tweak-product-quick-view-lightbox-show-close-button tweak-product-quick-view-lightbox-controls-weight-light tweak-share-buttons-style-icon-only tweak-share-buttons-icons-show    tweak-share-buttons-standard-background-color native-currency-code-usd collection-5a04b27e24a6946807ae890e collection-layout-default collection-type-events view-list mobile-style-available sqs-has-custom-cart has-logo-image has-cart enable-load-effects has-primary-nav" data-controller="HashManager, SiteLoader, MobileClassname">
+
+    <div class="Loader"></div>
+
+    <div class="Mobile" data-nc-base="mobile-bar" data-controller="AncillaryLayout">
+  <div class="Mobile-bar Mobile-bar--top" data-nc-group="top" data-controller="MobileOffset">
+
+    <div data-nc-container="top-left">
+      <a href="/" class="Mobile-bar-branding" data-nc-element="branding" data-content-field="site-title">
+        
+          
+            
+            
+
+
+
+  
+  
+  
+  
+
+  
+  
+    
+  
+
+  
+  <img src="//images.squarespace-cdn.com/content/v1/5a04b1b8fe54ef9d6db1a38e/1510777032320-FAAMJFSFVU91JWY27N8K/The-Royal-American-Logo---white.png" alt="The Royal American" sizes="240px" class="Mobile-bar-branding-logo" style="display:block" srcset="//images.squarespace-cdn.com/content/v1/5a04b1b8fe54ef9d6db1a38e/1510777032320-FAAMJFSFVU91JWY27N8K/The-Royal-American-Logo---white.png?format=100w 100w, //images.squarespace-cdn.com/content/v1/5a04b1b8fe54ef9d6db1a38e/1510777032320-FAAMJFSFVU91JWY27N8K/The-Royal-American-Logo---white.png?format=300w 300w, //images.squarespace-cdn.com/content/v1/5a04b1b8fe54ef9d6db1a38e/1510777032320-FAAMJFSFVU91JWY27N8K/The-Royal-American-Logo---white.png?format=500w 500w, //images.squarespace-cdn.com/content/v1/5a04b1b8fe54ef9d6db1a38e/1510777032320-FAAMJFSFVU91JWY27N8K/The-Royal-American-Logo---white.png?format=750w 750w, //images.squarespace-cdn.com/content/v1/5a04b1b8fe54ef9d6db1a38e/1510777032320-FAAMJFSFVU91JWY27N8K/The-Royal-American-Logo---white.png?format=1000w 1000w, //images.squarespace-cdn.com/content/v1/5a04b1b8fe54ef9d6db1a38e/1510777032320-FAAMJFSFVU91JWY27N8K/The-Royal-American-Logo---white.png?format=1500w 1500w, //images.squarespace-cdn.com/content/v1/5a04b1b8fe54ef9d6db1a38e/1510777032320-FAAMJFSFVU91JWY27N8K/The-Royal-American-Logo---white.png?format=2500w 2500w" loading="lazy" decoding="async" data-loader="sqs">
+
+
+          
+        
+      </a>
+    </div>
+    <div data-nc-container="top-center"></div>
+    <div data-nc-container="top-right"></div>
+  </div>
+  <div class="Mobile-bar Mobile-bar--bottom" data-nc-group="bottom" data-controller="MobileOffset">
+    <div data-nc-container="bottom-left">
+      <button
+        class="Mobile-bar-menu"
+        data-nc-element="menu-icon"
+        data-controller-overlay="menu"
+        data-controller="MobileOverlayToggle"
+        aria-label="Open navigation menu"
+      >
+        <svg class="Icon Icon--hamburger" viewBox="0 0 24 18">
+          <use xlink:href="/assets/ui-icons.svg#hamburger-icon--even" class="use--even"></use>
+          <use xlink:href="/assets/ui-icons.svg#hamburger-icon--odd" class="use--odd"></use>
+        </svg>
+        <svg class="Icon Icon--hotdog" viewBox="0 0 24 14">
+          <use xlink:href="/assets/ui-icons.svg#hotdog-icon--even" class="use--even"></use>
+          <use xlink:href="/assets/ui-icons.svg#hotdog-icon--odd" class="use--odd"></use>
+        </svg>
+        <svg class="Icon Icon--plus" viewBox="0 0 20 20">
+          <use xlink:href="/assets/ui-icons.svg#plus-icon--even" class="use--even"></use>
+          <use xlink:href="/assets/ui-icons.svg#plus-icon--odd" class="use--odd"></use>
+        </svg>
+        <svg class="Icon Icon--dots-horizontal" viewBox="0 0 25 7">
+          <use xlink:href="/assets/ui-icons.svg#dots-horizontal-icon--even" class="use--even"></use>
+          <use xlink:href="/assets/ui-icons.svg#dots-horizontal-icon--odd" class="use--odd"></use>
+        </svg>
+        <svg class="Icon Icon--dots-vertical" viewBox="0 0 7 25">
+          <use xlink:href="/assets/ui-icons.svg#dots-vertical-icon--even" class="use--even"></use>
+          <use xlink:href="/assets/ui-icons.svg#dots-vertical-icon--odd" class="use--odd"></use>
+        </svg>
+        <svg class="Icon Icon--squares-horizontal" viewBox="0 0 25 7">
+          <use xlink:href="/assets/ui-icons.svg#squares-horizontal-icon--even" class="use--even"></use>
+          <use xlink:href="/assets/ui-icons.svg#squares-horizontal-icon--odd" class="use--odd"></use>
+        </svg>
+        <svg class="Icon Icon--squares-vertical" viewBox="0 0 7 25">
+          <use xlink:href="/assets/ui-icons.svg#squares-vertical-icon--even" class="use--even"></use>
+          <use xlink:href="/assets/ui-icons.svg#squares-vertical-icon--odd" class="use--odd"></use>
+        </svg>
+      </button>
+    </div>
+    <div data-nc-container="bottom-center">
+      
+  <a href="/cart" class="Cart sqs-custom-cart" data-nc-element="cart" data-test="template-cart">
+    <span class="Cart-inner">
+      <span class="Cart-label">Cart</span>
+
+      <svg class="Icon Icon--bag-alt" viewBox="0 0 28 28">
+        <use class="use--odd" xlink:href="/assets/ui-icons.svg#bag-icon-alt--odd"></use>
+        <use class="use--even" xlink:href="/assets/ui-icons.svg#bag-icon-alt--even"></use>
+      </svg>
+      <svg class="Icon Icon--bag" viewBox="0 0 34 38">
+        <use class="use--odd" xlink:href="/assets/ui-icons.svg#bag-icon--odd"></use>
+        <use class="use--even" xlink:href="/assets/ui-icons.svg#bag-icon--even"></use>
+      </svg>
+      <svg class="Icon Icon--cart-alt" viewBox="0 0 28 28">
+        <use class="use--odd" xlink:href="/assets/ui-icons.svg#cart-icon-alt--odd"></use>
+        <use class="use--even" xlink:href="/assets/ui-icons.svg#cart-icon-alt--even"></use>
+      </svg>
+      <svg class="Icon Icon--cart" viewBox="0 0 31 26">
+        <use class="use--odd" xlink:href="/assets/ui-icons.svg#cart-icon--odd"></use>
+        <use class="use--even" xlink:href="/assets/ui-icons.svg#cart-icon--even"></use>
+      </svg>
+
+      <span class="sqs-cart-quantity">0</span>
+    </span>
+  </a>
+
+    </div>
+    <div data-nc-container="bottom-right">
+      
+      <a href="/search" class="Mobile-bar-search" data-nc-element="search-icon" aria-label="Search">
+        <svg class="Icon Icon--search" viewBox="0 0 20 20">
+          <use xlink:href="/assets/ui-icons.svg#search-icon"></use>
+        </svg>
+      </a>
+    </div>
+  </div>
+
+  <div class="Mobile-overlay">
+    <div class="Mobile-overlay-menu" data-controller="MobileOverlayFolders">
+      <div class="Mobile-overlay-menu-main">
+        <nav class="Mobile-overlay-nav Mobile-overlay-nav--primary" data-content-field="navigation">
+          
+  
+    
+      
+        
+          <a href="/schedule" class="Mobile-overlay-nav-item">
+            Schedule
+          </a>
+        
+      
+    
+    
+  
+    
+      
+        
+          
+            <a href="/menu" class="Mobile-overlay-nav-item">
+              Menu
+            </a>
+          
+        
+      
+    
+    
+  
+    
+      
+        
+          <a href="/gallery" class="Mobile-overlay-nav-item">
+            Gallery
+          </a>
+        
+      
+    
+    
+  
+    
+      
+        
+          <a href="/about" class="Mobile-overlay-nav-item">
+            About
+          </a>
+        
+      
+    
+    
+  
+    
+      
+        
+          
+            <a href="/gear-list" class="Mobile-overlay-nav-item">
+              Gear List
+            </a>
+          
+        
+      
+    
+    
+  
+    
+      
+        
+          
+            <a href="/contact" class="Mobile-overlay-nav-item">
+              Contact
+            </a>
+          
+        
+      
+    
+    
+  
+
+        </nav>
+        <nav class="Mobile-overlay-nav Mobile-overlay-nav--secondary" data-content-field="navigation">
+          
+        </nav>
+      </div>
+      <div class="Mobile-overlay-folders" data-content-field="navigation">
+        
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+        
+      </div>
+    </div>
+    <button class="Mobile-overlay-close" data-controller="MobileOverlayToggle" aria-label="Close navigation menu">
+      <svg class="Icon Icon--close" viewBox="0 0 16 16">
+        <use xlink:href="/assets/ui-icons.svg#close-icon"></use>
+      </svg>
+    </button>
+    <div class="Mobile-overlay-back" data-controller="MobileOverlayToggle"></div>
+  </div>
+</div>
+
+
+    <div class="Parallax-host-outer">
+      <div class="Parallax-host" data-parallax-host>
+        
+          
+            
+              
+                
+                
+                  
+                
+              
+            
+          
+        
+      </div>
+    </div>
+
+    <div class="Site" data-nc-base="header" data-controller="AncillaryLayout">
+      <div class="sqs-announcement-bar-dropzone"></div>
+
+      <header class="Header Header--top">
+        <div class="Header-inner Header-inner--top" data-nc-group="top">
+          <div data-nc-container="top-left">
+
+            <div class="Header-search" data-nc-element="search">
+              <form class="Header-search-form" action="/search" method="get" role="search">
+                <input class="Header-search-form-input" name="q" type="text" spellcheck="false" value="" autocomplete="off" placeholder="Search" aria-label="Search"/>
+                <button class="Header-search-form-submit" type="submit" data-test="template-search" aria-label="Search">
+                  <svg class="Icon Icon--search--small" viewBox="0 0 15 15">
+                    <use xlink:href="/assets/ui-icons.svg#search-icon--small"></use>
+                  </svg>
+                  <svg class="Icon Icon--search" viewBox="0 0 20 20">
+                    <use xlink:href="/assets/ui-icons.svg#search-icon"></use>
+                  </svg>
+                </button>
+              </form>
+            </div>
+
+          </div>
+          <div data-nc-container="top-center">
+            
+            
+          </div>
+          <div data-nc-container="top-right">
+
+            
+  <a href="/cart" class="Cart sqs-custom-cart" data-nc-element="cart" data-test="template-cart">
+    <span class="Cart-inner">
+      <span class="Cart-label">Cart</span>
+
+      <svg class="Icon Icon--bag-alt" viewBox="0 0 28 28">
+        <use class="use--odd" xlink:href="/assets/ui-icons.svg#bag-icon-alt--odd"></use>
+        <use class="use--even" xlink:href="/assets/ui-icons.svg#bag-icon-alt--even"></use>
+      </svg>
+      <svg class="Icon Icon--bag" viewBox="0 0 34 38">
+        <use class="use--odd" xlink:href="/assets/ui-icons.svg#bag-icon--odd"></use>
+        <use class="use--even" xlink:href="/assets/ui-icons.svg#bag-icon--even"></use>
+      </svg>
+      <svg class="Icon Icon--cart-alt" viewBox="0 0 28 28">
+        <use class="use--odd" xlink:href="/assets/ui-icons.svg#cart-icon-alt--odd"></use>
+        <use class="use--even" xlink:href="/assets/ui-icons.svg#cart-icon-alt--even"></use>
+      </svg>
+      <svg class="Icon Icon--cart" viewBox="0 0 31 26">
+        <use class="use--odd" xlink:href="/assets/ui-icons.svg#cart-icon--odd"></use>
+        <use class="use--even" xlink:href="/assets/ui-icons.svg#cart-icon--even"></use>
+      </svg>
+
+      <span class="sqs-cart-quantity">0</span>
+    </span>
+  </a>
+
+
+          </div>
+        </div>
+      </header>
+
+      <div class="Site-inner">
+
+        <header class="Header Header--bottom">
+          <div class="Header-inner Header-inner--bottom" data-nc-group="bottom">
+            <div data-nc-container="bottom-left">
+              <nav class="Header-nav Header-nav--primary" data-nc-element="primary-nav" data-content-field="navigation">
+                
+  <div class="Header-nav-inner">
+    <a href="/schedule" class="Header-nav-item Header-nav-item--active" data-test="template-nav">Schedule</a><a href="/menu" class="Header-nav-item" data-test="template-nav">Menu</a><a href="/gallery" class="Header-nav-item" data-test="template-nav">Gallery</a><a href="/about" class="Header-nav-item" data-test="template-nav">About</a><a href="/gear-list" class="Header-nav-item" data-test="template-nav">Gear List</a><a href="/contact" class="Header-nav-item" data-test="template-nav">Contact</a>
+  </div>
+
+              </nav>
+            </div>
+            <div data-nc-container="bottom-center">
+
+              <a href="/" class="Header-branding" data-nc-element="branding" data-content-field="site-title">
+                
+                  
+                    
+                    
+                    
+
+
+
+  
+  
+  
+  
+
+  
+  
+    
+  
+
+  
+  <img src="//images.squarespace-cdn.com/content/v1/5a04b1b8fe54ef9d6db1a38e/1510777032320-FAAMJFSFVU91JWY27N8K/The-Royal-American-Logo---white.png" alt="The Royal American" sizes="320px" class="Header-branding-logo" style="display:block" srcset="//images.squarespace-cdn.com/content/v1/5a04b1b8fe54ef9d6db1a38e/1510777032320-FAAMJFSFVU91JWY27N8K/The-Royal-American-Logo---white.png?format=100w 100w, //images.squarespace-cdn.com/content/v1/5a04b1b8fe54ef9d6db1a38e/1510777032320-FAAMJFSFVU91JWY27N8K/The-Royal-American-Logo---white.png?format=300w 300w, //images.squarespace-cdn.com/content/v1/5a04b1b8fe54ef9d6db1a38e/1510777032320-FAAMJFSFVU91JWY27N8K/The-Royal-American-Logo---white.png?format=500w 500w, //images.squarespace-cdn.com/content/v1/5a04b1b8fe54ef9d6db1a38e/1510777032320-FAAMJFSFVU91JWY27N8K/The-Royal-American-Logo---white.png?format=750w 750w, //images.squarespace-cdn.com/content/v1/5a04b1b8fe54ef9d6db1a38e/1510777032320-FAAMJFSFVU91JWY27N8K/The-Royal-American-Logo---white.png?format=1000w 1000w, //images.squarespace-cdn.com/content/v1/5a04b1b8fe54ef9d6db1a38e/1510777032320-FAAMJFSFVU91JWY27N8K/The-Royal-American-Logo---white.png?format=1500w 1500w, //images.squarespace-cdn.com/content/v1/5a04b1b8fe54ef9d6db1a38e/1510777032320-FAAMJFSFVU91JWY27N8K/The-Royal-American-Logo---white.png?format=2500w 2500w" loading="lazy" decoding="async" data-loader="sqs">
+
+
+                  
+                
+              </a>
+              
+
+            </div>
+            <div data-nc-container="bottom-right">
+
+              <nav class="Header-nav Header-nav--secondary" data-nc-element="secondary-nav" data-content-field="navigation">
+                
+              </nav>
+
+            </div>
+          </div>
+        </header>
+
+        <div class="Content-outer">
+          
+            
+              <section class="Intro" data-parallax-original-element data-parallax-id="5a04b27e24a6946807ae890e">
+  <div class="sqs-layout sqs-grid-12 columns-12 Intro-content empty" data-layout-label="Intro" data-type="block-field" data-updated-on="1515628909726" id="5a04b27e24a6946807ae890e_intro"><div class="row sqs-row"><div class="col sqs-col-12 span-12"></div></div></div>
+  
+    
+  
+</section>
+            
+          
+
+          <main class="Main Main--events-list" >
+            
+              <section class="Main-content" data-content-field="main-content">
+                <!-- Event List View -->
+
+  <div class="sqs-events-collection-list">
+
+    <!-- Upcoming Events -->
+
+    <div class="eventlist eventlist--upcoming">
+
+    
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/emma-grace-burton-5-15-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/emma-grace-burton-5-15-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">May</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">15</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to May 16</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/emma-grace-burton-5-15-26" class="eventlist-title-link">Emma Grace Burton</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-05-15">Fri, May 15, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-05-15">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-05-15">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-05-16">Sat, May 16, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-05-16">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-05-16">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Emma%20Grace%20Burton&dates=20260516T010000Z/20260516T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/emma-grace-burton-5-15-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1769797488581" id="item-697cf6e1364d40617d6f89af"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-e1577ce3b5e960d457c1"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Maraluso + Never Really Over<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/emmagraceburton/" target="_blank">✯&nbsp;Emma Grace Burton</a><br><a href="https://www.instagram.com/maralusomusic/" target="_blank">✯&nbsp;Maraluso</a><br><a href="https://www.instagram.com/nro.music/" target="_blank">✯&nbsp;Never Really Over</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/emma-grace-burton-5-15-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="697cf6e1364d40617d6f89af" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/697cf6e1364d40617d6f89af/1770864493767/" data-record-type="12" data-full-url="/schedule/emma-grace-burton-5-15-26" data-title="Emma Grace Burton"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/kenny-george-band-5-16-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/kenny-george-band-5-16-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">May</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">16</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to May 17</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/kenny-george-band-5-16-26" class="eventlist-title-link">Kenny George Band</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-05-16">Sat, May 16, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-05-16">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-05-16">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-05-17">Sun, May 17, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-05-17">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-05-17">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Kenny%20George%20Band&dates=20260517T010000Z/20260517T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/kenny-george-band-5-16-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1766935441458" id="item-69514ae0bd5c89062eb2bcc3"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-9a295db44719950f2680"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Finnegan Bell + The Runout (Duo)<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/kennygeorgeband/" target="_blank">✯&nbsp;Kenny George Band</a><br><a href="https://www.instagram.com/finneganbellmusic/" target="_blank">✯&nbsp;Finnegan Bell</a><br><a href="https://www.instagram.com/therunoutband/" target="_blank">✯&nbsp;The Runout (Duo)</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/kenny-george-band-5-16-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69514ae0bd5c89062eb2bcc3" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69514ae0bd5c89062eb2bcc3/1766935521601/" data-record-type="12" data-full-url="/schedule/kenny-george-band-5-16-26" data-title="Kenny George Band"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/colors-in-corduroy-5-22-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/colors-in-corduroy-5-22-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">May</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">22</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to May 23</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/colors-in-corduroy-5-22-26" class="eventlist-title-link">Colors In Corduroy</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-05-22">Fri, May 22, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-05-22">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-05-22">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-05-23">Sat, May 23, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-05-23">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-05-23">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Colors%20In%20Corduroy&dates=20260523T010000Z/20260523T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/colors-in-corduroy-5-22-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1766935679652" id="item-69514be685910d69cde38ed0"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-06afb1087d50832e77ac"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Shred Flinstone + Camisole<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/colorsincorduroy/" target="_blank">✯&nbsp;Colors In Corduroy</a><br><a href="https://www.instagram.com/shredflintstonetheband/" target="_blank">✯&nbsp;Shred Flinstone</a><br><a href="https://www.instagram.com/camisole.wav/" target="_blank">✯&nbsp;Camisole</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/colors-in-corduroy-5-22-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69514be685910d69cde38ed0" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69514be685910d69cde38ed0/1766935670317/" data-record-type="12" data-full-url="/schedule/colors-in-corduroy-5-22-26" data-title="Colors In Corduroy"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/jeno-judges-5-23-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/jeno-judges-5-23-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">May</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">23</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to May 24</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/jeno-judges-5-23-26" class="eventlist-title-link">Jeno Judges Presents:  A Night of All Star Local Hip Hop</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-05-23">Sat, May 23, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-05-23">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-05-23">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-05-24">Sun, May 24, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-05-24">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-05-24">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Jeno%20Judges%20Presents%3A%20%20A%20Night%20of%20All%20Star%20Local%20Hip%20Hop&dates=20260524T010000Z/20260524T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/jeno-judges-5-23-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1769799857274" id="item-697cf776b3339a748d79478d"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-162421cc082e697f6344"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">Featuring: TWINFLAMETF &amp; G0D$ON + Reese White + Indi’Gxld + Muldrow Ju + Shandu + Raxanne<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/jenojudges/" target="_blank">✯&nbsp;Jeno Judges</a><br><a href="https://www.instagram.com/twinflametf/" target="_blank">✯&nbsp;TWINFLAMETF</a><br><a href="https://www.instagram.com/hunnidbanman?igsh=MWx1MHQ0ajJudW9oYQ%3D%3D" target="_blank">✯&nbsp;G0D$ON</a><br><a href="https://www.instagram.com/reesewhiterw?igsh=Y3EzMmFsNWc1ZDZr" target="_blank">✯&nbsp;Reese White</a><br><a href="https://www.instagram.com/biggxld?igsh=NWVmZGhkZWZnbHBl" target="_blank">✯&nbsp;Indi'Gxld</a><br><a href="https://www.youtube.com/watch?v=0RWp_SxtifU" target="_blank">✯&nbsp;Muldrow Ju</a><br><a href="https://www.instagram.com/mc_shandu?igsh=MThnZWl2Mm1rOG9wcA%3D%3D" target="_blank">✯&nbsp;Shandu</a><br><a href="https://www.instagram.com/sheisrax_?igsh=MXgza3V6OHB1d3B0aQ%3D%3D" target="_blank">✯&nbsp;Raxanne</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/jeno-judges-5-23-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="697cf776b3339a748d79478d" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/697cf776b3339a748d79478d/1769799846991/" data-record-type="12" data-full-url="/schedule/jeno-judges-5-23-26" data-title="Jeno Judges Presents:  A Night of All Star Local Hip Hop"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/campbell-and-sons-5-29-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/campbell-and-sons-5-29-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">May</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">29</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to May 30</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/campbell-and-sons-5-29-26" class="eventlist-title-link">Campbell &amp; Sons</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-05-29">Fri, May 29, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-05-29">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-05-29">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-05-30">Sat, May 30, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-05-30">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-05-30">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Campbell%20%26amp%3B%20Sons&dates=20260530T010000Z/20260530T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/campbell-and-sons-5-29-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1769799967722" id="item-697d00cef203b91d933d1d72"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-94f89cc0c6687e1d54a9"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Macelyn Batten<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/cbrownband/" target="_blank">✯&nbsp;Campbell &amp; Sons</a><br><a href="https://www.instagram.com/macelynbatten/" target="_blank">✯&nbsp;Macelyn Batten</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/campbell-and-sons-5-29-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="697d00cef203b91d933d1d72" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/697d00cef203b91d933d1d72/1777500602539/" data-record-type="12" data-full-url="/schedule/campbell-and-sons-5-29-26" data-title="Campbell &amp;amp; Sons"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/dog-named-squid-5-30-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/dog-named-squid-5-30-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">May</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">30</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to May 31</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/dog-named-squid-5-30-26" class="eventlist-title-link">Dog Named Squid</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-05-30">Sat, May 30, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-05-30">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-05-30">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-05-31">Sun, May 31, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-05-31">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-05-31">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Dog%20Named%20Squid&dates=20260531T010000Z/20260531T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/dog-named-squid-5-30-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1769800106936" id="item-697d011c889dbe1e6c059fd9"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-4dbec03fc59443dc089c"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Owen &amp; The Smokes + The Maple Street Band<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/dognamedsquid/" target="_blank">✯&nbsp;Dog Named Squid</a><br><a href="https://www.instagram.com/thesmokesss/" target="_blank">✯&nbsp;Owen &amp; The Smokes</a><br><a href="https://www.instagram.com/themaplestreetband/" target="_blank">✯&nbsp;The Maple Street Band</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/dog-named-squid-5-30-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="697d011c889dbe1e6c059fd9" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/697d011c889dbe1e6c059fd9/1771337072021/" data-record-type="12" data-full-url="/schedule/dog-named-squid-5-30-26" data-title="Dog Named Squid"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/local-nomad-6-5-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/local-nomad-6-5-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Jun</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">5</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Jun 6</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/local-nomad-6-5-26" class="eventlist-title-link">Babe Club + Local Nomad (Record Release)</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-06-05">Fri, Jun 5, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-06-05">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-06-05">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-06-06">Sat, Jun 6, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-06-06">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-06-06">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Babe%20Club%20%2B%20Local%20Nomad%20%28Record%20Release%29&dates=20260606T010000Z/20260606T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/local-nomad-6-5-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1769803714464" id="item-697d0ec9eb33d678af4092ee"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-9dd595d3edb71e2b3069"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Cassetteqiete<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/joinbabeclub/" target="_blank">✯&nbsp;Babe Club</a><br><a href="https://www.instagram.com/iamlocalnomad/" target="_blank">✯&nbsp;Local Nomad</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/local-nomad-6-5-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="697d0ec9eb33d678af4092ee" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/697d0ec9eb33d678af4092ee/1778159007912/" data-record-type="12" data-full-url="/schedule/local-nomad-6-5-26" data-title="Babe Club + Local Nomad (Record Release)"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/solstice-6-6-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/solstice-6-6-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Jun</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">6</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Jun 7</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/solstice-6-6-26" class="eventlist-title-link">Solstice</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-06-06">Sat, Jun 6, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-06-06">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-06-06">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-06-07">Sun, Jun 7, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-06-07">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-06-07">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Solstice&dates=20260607T010000Z/20260607T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/solstice-6-6-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1769979885918" id="item-697fbfadd8d22f1b56cde54f"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-3d27e72746bd1635ff84"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ The John Wood Band<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/bandsolstice/" target="_blank">✯&nbsp;Solstice</a><br><a href="https://www.instagram.com/johnwoodband/" target="_blank">✯&nbsp;The John Wood Band</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/solstice-6-6-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="697fbfadd8d22f1b56cde54f" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/697fbfadd8d22f1b56cde54f/1773350722615/" data-record-type="12" data-full-url="/schedule/solstice-6-6-26" data-title="Solstice"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/thoroughfare-6-12-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/thoroughfare-6-12-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Jun</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">12</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Jun 13</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/thoroughfare-6-12-26" class="eventlist-title-link">Thoroughfare</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-06-12">Fri, Jun 12, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-06-12">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-06-12">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-06-13">Sat, Jun 13, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-06-13">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-06-13">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Thoroughfare&dates=20260613T010000Z/20260613T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/thoroughfare-6-12-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1770864765649" id="item-698d3f94608da0131712e269"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-c61dc718f2042597346f"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Auroras Hope + The Boonies<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/thoroughfareofficial/?hl=en" target="_blank">✯&nbsp;Thoroughfare</a><br><a href="https://www.instagram.com/theaurorashope/?hl=en" target="_blank">✯&nbsp;Auroras Hope</a><br><a href="https://www.instagram.com/_thebooniesband_/?hl=en" target="_blank">✯&nbsp;The Boonies</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/thoroughfare-6-12-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="698d3f94608da0131712e269" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/698d3f94608da0131712e269/1770864755086/" data-record-type="12" data-full-url="/schedule/thoroughfare-6-12-26" data-title="Thoroughfare"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/kind-hearted-strangers-6-13-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/kind-hearted-strangers-6-13-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Jun</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">13</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Jun 14</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/kind-hearted-strangers-6-13-26" class="eventlist-title-link">Kind Hearted Strangers</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-06-13">Sat, Jun 13, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-06-13">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-06-13">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-06-14">Sun, Jun 14, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-06-14">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-06-14">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Kind%20Hearted%20Strangers&dates=20260614T010000Z/20260614T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/kind-hearted-strangers-6-13-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1773350841732" id="item-69b32f5edc302c612ab150a3"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-f742b693adeeb429321c"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ TBD<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/kindheartedstrangers/" target="_blank">✯&nbsp;Kind Hearted Strangers</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/kind-hearted-strangers-6-13-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69b32f5edc302c612ab150a3" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69b32f5edc302c612ab150a3/1773350829616/" data-record-type="12" data-full-url="/schedule/kind-hearted-strangers-6-13-26" data-title="Kind Hearted Strangers"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/thursday-listening-room-6-18-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/thursday-listening-room-6-18-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Jun</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">18</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Jun 19</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/thursday-listening-room-6-18-26" class="eventlist-title-link">Thursday Listening Room (Early Show)</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-06-18">Thu, Jun 18, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-06-18">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-06-18">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-06-19">Fri, Jun 19, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-06-19">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-06-19">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Thursday%20Listening%20Room%20%28Early%20Show%29&dates=20260619T010000Z/20260619T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/thursday-listening-room-6-18-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1777843215000" id="item-69f7bb13c709a727790a200a"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-85ad5f10412a4e616dfe"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">Featuring special acoustic sets from Justin Jones, Andrew Hellier (of Rotoglow), Jordan Igoe, and Grayson Little!<br>Doors: 7:30pm | $10<br><a href="https://www.instagram.com/justinjonesmusic/" target="_blank">✯&nbsp;Justin Jones</a><br><a href="https://www.instagram.com/rotoglow_dc/" target="_blank">✯&nbsp;Andrew Hellier</a><br><a href="https://www.instagram.com/jordanigoemusic/" target="_blank">✯&nbsp;Jordan Igoe</a><br><a href="https://www.instagram.com/graysonlittle/" target="_blank">✯&nbsp;Grayson Little </a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/thursday-listening-room-6-18-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69f7bb13c709a727790a200a" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69f7bb13c709a727790a200a/1778159106117/" data-record-type="12" data-full-url="/schedule/thursday-listening-room-6-18-26" data-title="Thursday Listening Room (Early Show)"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/lofidels-6-19-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/lofidels-6-19-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Jun</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">19</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Jun 20</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/lofidels-6-19-26" class="eventlist-title-link">Lofidels</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-06-19">Fri, Jun 19, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-06-19">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-06-19">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-06-20">Sat, Jun 20, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-06-20">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-06-20">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Lofidels&dates=20260620T010000Z/20260620T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/lofidels-6-19-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1773351012309" id="item-69b32fc5e6ed87361af8c7d4"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-32c5ff48a64fe97aea61"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Kaizër + DJ DollaMenu<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/lofidels/" target="_blank">✯&nbsp;Lofidels</a><br><a href="https://www.instagram.com/kaizer_iexist/" target="_blank">✯&nbsp;Kaizër</a><br><a href="https://www.instagram.com/kaizer_iexist/" target="_blank">✯&nbsp;DJ DollaMenu</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/lofidels-6-19-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69b32fc5e6ed87361af8c7d4" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69b32fc5e6ed87361af8c7d4/1773351000200/" data-record-type="12" data-full-url="/schedule/lofidels-6-19-26" data-title="Lofidels"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/infinitefreefall-6-20-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/infinitefreefall-6-20-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Jun</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">20</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Jun 21</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/infinitefreefall-6-20-26" class="eventlist-title-link">Infinitefreefall</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-06-20">Sat, Jun 20, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-06-20">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-06-20">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-06-21">Sun, Jun 21, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-06-21">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-06-21">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Infinitefreefall&dates=20260621T010000Z/20260621T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/infinitefreefall-6-20-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1769980093467" id="item-697fbffde7942a2605b40f9b"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-f0e78c457b60ce8990ea"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Scrlett + Overlay<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/infinitefreefall/" target="_blank">✯&nbsp;Infinitefreefall</a><br><a href="https://www.instagram.com/scrlettband" target="_blank">✯&nbsp;Scrlett</a><br><a href="https://www.instagram.com/overlayband/" target="_blank">✯&nbsp;Overlay</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/infinitefreefall-6-20-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="697fbffde7942a2605b40f9b" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/697fbffde7942a2605b40f9b/1773351052216/" data-record-type="12" data-full-url="/schedule/infinitefreefall-6-20-26" data-title="Infinitefreefall"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/five-door-sedan-6-26-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/five-door-sedan-6-26-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Jun</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">26</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Jun 27</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/five-door-sedan-6-26-26" class="eventlist-title-link">Five Door Sedan</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-06-26">Fri, Jun 26, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-06-26">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-06-26">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-06-27">Sat, Jun 27, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-06-27">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-06-27">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Five%20Door%20Sedan&dates=20260627T010000Z/20260627T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/five-door-sedan-6-26-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1771687394356" id="item-6999cd651bb78b409a34d0c2"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-a9732829bb393af7f537"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Bedrumour + Bedroom Division<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/fivedoorsedan/" target="_blank">✯&nbsp;Five Door Sedan</a><br><a href="https://www.instagram.com/bedrumor/?hl=en" target="_blank">✯&nbsp;Bedrumour</a><br><a href="https://www.instagram.com/bedroomdivision/?hl=en" target="_blank">✯&nbsp;Bedroom Division</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/five-door-sedan-6-26-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="6999cd651bb78b409a34d0c2" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/6999cd651bb78b409a34d0c2/1773351165279/" data-record-type="12" data-full-url="/schedule/five-door-sedan-6-26-26" data-title="Five Door Sedan"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/secret-guest-6-27-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/secret-guest-6-27-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Jun</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">27</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Jun 28</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/secret-guest-6-27-26" class="eventlist-title-link">Secret Guest + Winterteeth</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-06-27">Sat, Jun 27, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-06-27">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-06-27">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-06-28">Sun, Jun 28, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-06-28">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-06-28">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Secret%20Guest%20%2B%20Winterteeth&dates=20260628T010000Z/20260628T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/secret-guest-6-27-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1771343120020" id="item-69948c949087000b31cfdedc"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-346dd97611b735f3c641"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Steadman’s Quest<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/secretguestband/" target="_blank">✯&nbsp;Secret Guest</a><br><a href="https://www.instagram.com/winterteethband/" target="_blank">✯&nbsp;Winterteeth</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/secret-guest-6-27-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69948c949087000b31cfdedc" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69948c949087000b31cfdedc/1777500727859/" data-record-type="12" data-full-url="/schedule/secret-guest-6-27-26" data-title="Secret Guest + Winterteeth"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/c-shreve-the-professor-7-3-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/c-shreve-the-professor-7-3-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Jul</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">3</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Jul 4</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/c-shreve-the-professor-7-3-26" class="eventlist-title-link">C. Shreve The Professor</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-07-03">Fri, Jul 3, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-07-03">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-07-03">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-07-04">Sat, Jul 4, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-07-04">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-07-04">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=C.%20Shreve%20The%20Professor&dates=20260704T010000Z/20260704T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/c-shreve-the-professor-7-3-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1774294291234" id="item-69c194c61dc9813ae20d7edb"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-7b2f5bb49f5a2894fb9d"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ TBD<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/seeshreve/" target="_blank">✯&nbsp;C. Shreve The Professor</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/c-shreve-the-professor-7-3-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69c194c61dc9813ae20d7edb" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69c194c61dc9813ae20d7edb/1774294278551/" data-record-type="12" data-full-url="/schedule/c-shreve-the-professor-7-3-26" data-title="C. Shreve The Professor"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/the-ries-brothers-7-10-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/the-ries-brothers-7-10-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Jul</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">10</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Jul 11</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/the-ries-brothers-7-10-26" class="eventlist-title-link">The Ries Brothers</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-07-10">Fri, Jul 10, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-07-10">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-07-10">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-07-11">Sat, Jul 11, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-07-11">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-07-11">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=The%20Ries%20Brothers&dates=20260711T010000Z/20260711T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/the-ries-brothers-7-10-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1774294369993" id="item-69c1951404c07d405de5f1ae"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-3f8e3fc1f897aeae1596"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ TBD<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/riesbrothers/" target="_blank">✯&nbsp;The Ries Brothers</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/the-ries-brothers-7-10-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69c1951404c07d405de5f1ae" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69c1951404c07d405de5f1ae/1774294357272/" data-record-type="12" data-full-url="/schedule/the-ries-brothers-7-10-26" data-title="The Ries Brothers"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/homemade-haircuts-7-11-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/homemade-haircuts-7-11-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Jul</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">11</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Jul 12</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/homemade-haircuts-7-11-26" class="eventlist-title-link">Homemade Haircuts</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-07-11">Sat, Jul 11, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-07-11">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-07-11">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-07-12">Sun, Jul 12, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-07-12">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-07-12">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Homemade%20Haircuts&dates=20260712T010000Z/20260712T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/homemade-haircuts-7-11-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1774294443845" id="item-69c1955db7d0e8037f20001c"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-a17157fff0ae02cf6bda"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Cannon Rogers + Leo Niño<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/homiehaircuts/" target="_blank">✯&nbsp;Homemade Haircuts</a><br><a href="https://www.instagram.com/cannonrogersmusic/" target="_blank">✯&nbsp;Cannon Rogers</a><br><a href="https://www.instagram.com/leonino.mp3/" target="_blank">✯&nbsp;Leo Niño</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/homemade-haircuts-7-11-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69c1955db7d0e8037f20001c" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69c1955db7d0e8037f20001c/1778001492265/" data-record-type="12" data-full-url="/schedule/homemade-haircuts-7-11-26" data-title="Homemade Haircuts"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/lightwatch-7-17-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/lightwatch-7-17-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Jul</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">17</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Jul 18</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/lightwatch-7-17-26" class="eventlist-title-link">Lightwatch</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-07-17">Fri, Jul 17, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-07-17">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-07-17">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-07-18">Sat, Jul 18, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-07-18">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-07-18">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Lightwatch&dates=20260718T010000Z/20260718T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/lightwatch-7-17-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1774294576803" id="item-69c195a597b5e335a4e009ee"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-de690f47e40a08802f52"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Fortune Child + Intension<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/lightwatchofficial/" target="_blank">✯&nbsp;Lightwatch</a><br><a href="https://www.instagram.com/fortunechildmusic/" target="_blank">✯&nbsp;Fortune Child</a><br><a href="https://www.instagram.com/intensionband/" target="_blank">✯&nbsp;Intension</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/lightwatch-7-17-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69c195a597b5e335a4e009ee" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69c195a597b5e335a4e009ee/1774294564092/" data-record-type="12" data-full-url="/schedule/lightwatch-7-17-26" data-title="Lightwatch"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/sophia-7-18-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/sophia-7-18-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Jul</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">18</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Jul 19</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/sophia-7-18-26" class="eventlist-title-link">SOPHIA</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-07-18">Sat, Jul 18, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-07-18">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-07-18">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-07-19">Sun, Jul 19, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-07-19">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-07-19">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=SOPHIA&dates=20260719T010000Z/20260719T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/sophia-7-18-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1777500898173" id="item-69f2827f08964e2f2d79e32c"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-5f4263dba573f175c98a"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ TBD<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/sophiatheband/" target="_blank">✯&nbsp;SOPHIA</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/sophia-7-18-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69f2827f08964e2f2d79e32c" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69f2827f08964e2f2d79e32c/1777502695182/" data-record-type="12" data-full-url="/schedule/sophia-7-18-26" data-title="SOPHIA"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/tennis-courts-7-24-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/tennis-courts-7-24-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Jul</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">24</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Jul 25</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/tennis-courts-7-24-26" class="eventlist-title-link">Tennis Courts</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-07-24">Fri, Jul 24, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-07-24">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-07-24">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-07-25">Sat, Jul 25, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-07-25">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-07-25">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Tennis%20Courts&dates=20260725T010000Z/20260725T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/tennis-courts-7-24-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1774294631667" id="item-69c1962b54643d3ff105f79e"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-17da9900a2fae216eab9"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Cannon Rogers<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/tenniscourts_/" target="_blank">✯&nbsp;Tennis Courts</a><br><a href="https://www.instagram.com/cannonrogersmusic/" target="_blank">✯&nbsp;Cannon Rogers</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/tennis-courts-7-24-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69c1962b54643d3ff105f79e" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69c1962b54643d3ff105f79e/1778001544680/" data-record-type="12" data-full-url="/schedule/tennis-courts-7-24-26" data-title="Tennis Courts"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/the-rowdy-boys-7-25-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/the-rowdy-boys-7-25-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Jul</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">25</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Jul 26</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/the-rowdy-boys-7-25-26" class="eventlist-title-link">The Rowdy Boys </a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-07-25">Sat, Jul 25, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-07-25">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-07-25">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-07-26">Sun, Jul 26, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-07-26">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-07-26">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=The%20Rowdy%20Boys%20&dates=20260726T010000Z/20260726T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/the-rowdy-boys-7-25-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1777500976462" id="item-69f282e1aee4e61f13a12d21"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-f3f19efb3f1b5bba1c6e"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ TBD<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/therowdyboys2021/" target="_blank">✯&nbsp;The Rowdy Boys</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/the-rowdy-boys-7-25-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69f282e1aee4e61f13a12d21" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69f282e1aee4e61f13a12d21/1777500961446/" data-record-type="12" data-full-url="/schedule/the-rowdy-boys-7-25-26" data-title="The Rowdy Boys "></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/chrrry-vanilla-7-31-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/chrrry-vanilla-7-31-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Jul</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">31</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Aug 1</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/chrrry-vanilla-7-31-26" class="eventlist-title-link">Chrrry Vanilla + Whiskey Ginger</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-07-31">Fri, Jul 31, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-07-31">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-07-31">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-08-01">Sat, Aug 1, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-08-01">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-08-01">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Chrrry%20Vanilla%20%2B%20Whiskey%20Ginger&dates=20260801T010000Z/20260801T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/chrrry-vanilla-7-31-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1777502153246" id="item-69f286dce77b4d5db717f034"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-c626760a932d3d80e7b7"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Ded Wed Lock<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/chrrry.vanilla.band/" target="_blank">✯&nbsp;Chrrry Vanilla</a><br><a href="https://www.instagram.com/whiskeygingerrrr/" target="_blank">✯&nbsp;Whiskey Ginger</a><br><a href="https://www.instagram.com/dedwedlock/" target="_blank">✯&nbsp;Ded Wed Lock</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/chrrry-vanilla-7-31-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69f286dce77b4d5db717f034" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69f286dce77b4d5db717f034/1777502138234/" data-record-type="12" data-full-url="/schedule/chrrry-vanilla-7-31-26" data-title="Chrrry Vanilla + Whiskey Ginger"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/acid-hawk-8-1-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/acid-hawk-8-1-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Aug</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">1</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Aug 2</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/acid-hawk-8-1-26" class="eventlist-title-link">Acid Hawk</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-08-01">Sat, Aug 1, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-08-01">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-08-01">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-08-02">Sun, Aug 2, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-08-02">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-08-02">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Acid%20Hawk&dates=20260802T010000Z/20260802T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/acid-hawk-8-1-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1777502327820" id="item-69f287c6bb17cc7b89f3010f"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-735b96958ccb8e89511e"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Genrevolta + Motorcycle Jackson<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/acidhawkband/" target="_blank">✯&nbsp;Acid Hawk</a><br><a href="https://genrevolta.bandcamp.com/album/genrevolta" target="_blank">✯&nbsp;Genrevolta</a><br><a href="https://www.instagram.com/motorcyclejackson843/" target="_blank">✯&nbsp;Motorcycle Jackson</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/acid-hawk-8-1-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69f287c6bb17cc7b89f3010f" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69f287c6bb17cc7b89f3010f/1777502616786/" data-record-type="12" data-full-url="/schedule/acid-hawk-8-1-26" data-title="Acid Hawk"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/gods-8-7-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/gods-8-7-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Aug</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">7</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Aug 8</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/gods-8-7-26" class="eventlist-title-link">gods.</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-08-07">Fri, Aug 7, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-08-07">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-08-07">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-08-08">Sat, Aug 8, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-08-08">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-08-08">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=gods.&dates=20260808T010000Z/20260808T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/gods-8-7-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1777502475482" id="item-69f288cb08964e2f2d7c5f05"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-da2d94f5e0be014ae0d0"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Thoroughfare + Wildsound<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/godstheband/" target="_blank">✯&nbsp;gods.</a><br><a href="https://www.instagram.com/thoroughfareofficial/" target="_blank">✯&nbsp;Thoroughfare</a><br><a href="https://www.instagram.com/thatwildsoundband/" target="_blank">✯&nbsp;Wildsound</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/gods-8-7-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69f288cb08964e2f2d7c5f05" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69f288cb08964e2f2d7c5f05/1778001648365/" data-record-type="12" data-full-url="/schedule/gods-8-7-26" data-title="gods."></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/guilt-ridden-troubadour-8-14-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/guilt-ridden-troubadour-8-14-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Aug</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">14</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Aug 15</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/guilt-ridden-troubadour-8-14-26" class="eventlist-title-link">Guilt Ridden Troubadour</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-08-14">Fri, Aug 14, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-08-14">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-08-14">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-08-15">Sat, Aug 15, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-08-15">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-08-15">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Guilt%20Ridden%20Troubadour&dates=20260815T010000Z/20260815T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/guilt-ridden-troubadour-8-14-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1778001738569" id="item-69fa27092353b0370bd36435"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-4fffe856487ec2d25b0c"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ TBD<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/guiltriddentroubadour/" target="_blank">✯&nbsp;Guilt Ridden Troubadour</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/guilt-ridden-troubadour-8-14-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69fa27092353b0370bd36435" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69fa27092353b0370bd36435/1778001914463/" data-record-type="12" data-full-url="/schedule/guilt-ridden-troubadour-8-14-26" data-title="Guilt Ridden Troubadour"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/cellar-dwellers-8-15-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/cellar-dwellers-8-15-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Aug</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">15</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Aug 16</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/cellar-dwellers-8-15-26" class="eventlist-title-link">Celler Dwellers + Dune Blue</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-08-15">Sat, Aug 15, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-08-15">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-08-15">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-08-16">Sun, Aug 16, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-08-16">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-08-16">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Celler%20Dwellers%20%2B%20Dune%20Blue&dates=20260816T010000Z/20260816T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/cellar-dwellers-8-15-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1777502885023" id="item-69f28a03b7c4621fcbb5293a"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-6227848522c2a13b3f25"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Winterteeth<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/cellerdwellers/" target="_blank">✯&nbsp;Celler Dwellers</a><br><a href="https://www.instagram.com/dunebluemusic/" target="_blank">✯&nbsp;Dune Blue</a><br><a href="https://www.instagram.com/winterteethband/" target="_blank">✯&nbsp;Winterteeth</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/cellar-dwellers-8-15-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69f28a03b7c4621fcbb5293a" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69f28a03b7c4621fcbb5293a/1777502870040/" data-record-type="12" data-full-url="/schedule/cellar-dwellers-8-15-26" data-title="Celler Dwellers + Dune Blue"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/five-door-sedan-8-21-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/five-door-sedan-8-21-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Aug</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">21</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Aug 22</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/five-door-sedan-8-21-26" class="eventlist-title-link">Five Door Sedan </a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-08-21">Fri, Aug 21, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-08-21">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-08-21">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-08-22">Sat, Aug 22, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-08-22">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-08-22">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Five%20Door%20Sedan%20&dates=20260822T010000Z/20260822T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/five-door-sedan-8-21-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1774294704475" id="item-69c19665055de062a6023ebc"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-88bd7bd690e9714f4b9b"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Connor McLaren<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/fivedoorsedan/" target="_blank">✯&nbsp;Five Door Sedan</a><br><a href="https://www.instagram.com/itsconnormclaren/" target="_blank">✯&nbsp;Connor McLaren</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/five-door-sedan-8-21-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69c19665055de062a6023ebc" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69c19665055de062a6023ebc/1774294705122/" data-record-type="12" data-full-url="/schedule/five-door-sedan-8-21-26" data-title="Five Door Sedan "></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/c-shreve-the-professor-8-22-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/c-shreve-the-professor-8-22-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Aug</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">22</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Aug 23</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/c-shreve-the-professor-8-22-26" class="eventlist-title-link">C. Shreve The Professor + King Garbage</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-08-22">Sat, Aug 22, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-08-22">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-08-22">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-08-23">Sun, Aug 23, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-08-23">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-08-23">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=C.%20Shreve%20The%20Professor%20%2B%20King%20Garbage&dates=20260823T010000Z/20260823T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/c-shreve-the-professor-8-22-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1774294800999" id="item-69c196bb125e8b5adce68e89"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-6b13bb0a61676352a78d"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ TBD<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/seeshreve/" target="_blank">✯&nbsp;C. Shreve The Professor</a><br><a href="https://www.instagram.com/kinggarbage/" target="_blank">✯&nbsp;King Garbage</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/c-shreve-the-professor-8-22-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69c196bb125e8b5adce68e89" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69c196bb125e8b5adce68e89/1777500767421/" data-record-type="12" data-full-url="/schedule/c-shreve-the-professor-8-22-26" data-title="C. Shreve The Professor + King Garbage"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/her-pilots-8-28-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/her-pilots-8-28-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Aug</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">28</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Aug 29</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/her-pilots-8-28-26" class="eventlist-title-link">Her Pilots + Safety Coffin</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-08-28">Fri, Aug 28, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-08-28">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-08-28">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-08-29">Sat, Aug 29, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-08-29">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-08-29">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Her%20Pilots%20%2B%20Safety%20Coffin&dates=20260829T010000Z/20260829T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/her-pilots-8-28-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1778001885305" id="item-69fa2753f2047b0d1f25af9a"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-862dfcf9bb1b6374175f"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ TBD<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/herpilots/" target="_blank">✯&nbsp;Her Pilots</a><br><a href="https://www.instagram.com/safety_coffin/" target="_blank">✯&nbsp;Safety Coffin</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/her-pilots-8-28-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69fa2753f2047b0d1f25af9a" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69fa2753f2047b0d1f25af9a/1778001869907/" data-record-type="12" data-full-url="/schedule/her-pilots-8-28-26" data-title="Her Pilots + Safety Coffin"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/never-really-over-9-5-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/never-really-over-9-5-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Sep</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">5</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Sep 6</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/never-really-over-9-5-26" class="eventlist-title-link">Never Really Over</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-09-05">Sat, Sep 5, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-09-05">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-09-05">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-09-06">Sun, Sep 6, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-09-06">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-09-06">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Never%20Really%20Over&dates=20260906T010000Z/20260906T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/never-really-over-9-5-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1778002148909" id="item-69fa28492fd3ec70ab0707ac"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-203d2a719c0e84c35b59"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ TBD<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/nro.music/" target="_blank">✯&nbsp;Never Really Over</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/never-really-over-9-5-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69fa28492fd3ec70ab0707ac" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69fa28492fd3ec70ab0707ac/1778002133516/" data-record-type="12" data-full-url="/schedule/never-really-over-9-5-26" data-title="Never Really Over"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/mommys-little-monster-9-19-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/mommys-little-monster-9-19-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Sep</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">19</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Sep 20</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/mommys-little-monster-9-19-26" class="eventlist-title-link">Mommy's Little Monster (Social Distortion Tribute)</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-09-19">Sat, Sep 19, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-09-19">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-09-19">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-09-20">Sun, Sep 20, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-09-20">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-09-20">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Mommy%27s%20Little%20Monster%20%28Social%20Distortion%20Tribute%29&dates=20260920T010000Z/20260920T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/mommys-little-monster-9-19-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1777503235840" id="item-69f28b73087d022983bbfdc3"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-41c5e51560ff1b2da95f"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ TBD<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/mommyslittlemonstersc/" target="_blank">✯&nbsp;Mommy's Little Monster</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/mommys-little-monster-9-19-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69f28b73087d022983bbfdc3" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69f28b73087d022983bbfdc3/1777503220968/" data-record-type="12" data-full-url="/schedule/mommys-little-monster-9-19-26" data-title="Mommy's Little Monster (Social Distortion Tribute)"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/the-john-wood-band-10-16-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/the-john-wood-band-10-16-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Oct</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">16</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Oct 17</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/the-john-wood-band-10-16-26" class="eventlist-title-link">The John Wood Band</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-10-16">Fri, Oct 16, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-10-16">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-10-16">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-10-17">Sat, Oct 17, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-10-17">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-10-17">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=The%20John%20Wood%20Band&dates=20261017T010000Z/20261017T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/the-john-wood-band-10-16-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1778002395168" id="item-69fa290d16d7560dde6c8ebd"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-944e95cd785ff907612b"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Nick Matthews<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/johnwoodband/" target="_blank">✯&nbsp;The John Wood Band</a><br><a href="https://www.instagram.com/nickmatthewsmusic/" target="_blank">✯&nbsp;Nick Matthews</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/the-john-wood-band-10-16-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69fa290d16d7560dde6c8ebd" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69fa290d16d7560dde6c8ebd/1778002379929/" data-record-type="12" data-full-url="/schedule/the-john-wood-band-10-16-26" data-title="The John Wood Band"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming">
+
+        <a href="/schedule/bike-night-10-29-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/bike-night-10-29-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Oct</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">29</div>
+
+              
+              <div class="eventlist-datetag-time"><span class="event-time-12hr">6:00 PM</span><span class="event-time-24hr">18:00</span></div>
+
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/bike-night-10-29-26" class="eventlist-title-link">+  BIKE NIGHT  + </a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+              <time class="event-date" datetime="2026-10-29">Thursday, October 29, 2026</time>
+            </li>
+
+            <li class="eventlist-meta-item eventlist-meta-time event-meta-item">
+              <span class="event-time-12hr">
+                <time class="event-time-12hr-start" datetime="2026-10-29">6:00 PM</time>
+                <span class="event-datetime-divider"></span>
+                <time class="event-time-12hr-end" datetime="2026-10-29">11:00 PM</time>
+              </span>
+              <span class="event-time-24hr">
+                <time class="event-time-24hr-start" datetime="2026-10-29">18:00</time>
+                <span class="event-datetime-divider"></span>
+                <time class="event-time-12hr-end" datetime="2026-10-29">23:00</time>
+              </span>
+            </li>
+
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=%2B%20%20BIKE%20NIGHT%20%20%2B%20&dates=20261029T220000Z/20261030T030000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/bike-night-10-29-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1774294939319" id="item-69c1975eeaee8a271e33e8d2"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-1c17b4049a16d77fa3e1"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">Brought to you by Riders Law Group!<br>Doors: 6pm | No Cover | All Welcome<br><a href="https://www.riderslawgroup.com" target="_blank">✯&nbsp;Riders Law Group</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/bike-night-10-29-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69c1975eeaee8a271e33e8d2" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69c1975eeaee8a271e33e8d2/1774294926850/" data-record-type="12" data-full-url="/schedule/bike-night-10-29-26" data-title="+  BIKE NIGHT  + "></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming eventlist-event--multiday">
+
+        <a href="/schedule/boogieman-kick-off-party-10-30-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/boogieman-kick-off-party-10-30-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Oct</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">30</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Oct 31</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/boogieman-kick-off-party-10-30-26" class="eventlist-title-link">Boogieman VI Kick-Off Party w/ The Saint Cecilia</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-10-30">Fri, Oct 30, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-10-30">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-10-30">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-10-31">Sat, Oct 31, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-10-31">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-10-31">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Boogieman%20VI%20Kick-Off%20Party%20w%2F%20The%20Saint%20Cecilia&dates=20261031T010000Z/20261031T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/boogieman-kick-off-party-10-30-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1774294868139" id="item-69c1970cfd24d64c78cba868"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-a8eddf6e24151a2c7e3a"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">Special Guests TBD<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/boogiemanfest/" target="_blank">✯&nbsp;Boogieman Halloween Festival </a><br><a href="https://www.instagram.com/thesaintceciliaoficial/" target="_blank">✯&nbsp;The Saint Cecilia</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/boogieman-kick-off-party-10-30-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69c1970cfd24d64c78cba868" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69c1970cfd24d64c78cba868/1777503374782/" data-record-type="12" data-full-url="/schedule/boogieman-kick-off-party-10-30-26" data-title="Boogieman VI Kick-Off Party w/ The Saint Cecilia"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming">
+
+        <a href="/schedule/boogieman-10-31-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/boogieman-10-31-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Oct</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">31</div>
+
+              
+              <div class="eventlist-datetag-time"><span class="event-time-12hr">1:00 PM</span><span class="event-time-24hr">13:00</span></div>
+
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/boogieman-10-31-26" class="eventlist-title-link">6th Annual Boogieman Halloween Festival     </a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+              <time class="event-date" datetime="2026-10-31">Saturday, October 31, 2026</time>
+            </li>
+
+            <li class="eventlist-meta-item eventlist-meta-time event-meta-item">
+              <span class="event-time-12hr">
+                <time class="event-time-12hr-start" datetime="2026-10-31">1:00 PM</time>
+                <span class="event-datetime-divider"></span>
+                <time class="event-time-12hr-end" datetime="2026-10-31">6:00 PM</time>
+              </span>
+              <span class="event-time-24hr">
+                <time class="event-time-24hr-start" datetime="2026-10-31">13:00</time>
+                <span class="event-datetime-divider"></span>
+                <time class="event-time-12hr-end" datetime="2026-10-31">18:00</time>
+              </span>
+            </li>
+
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=6th%20Annual%20Boogieman%20Halloween%20Festival%20%20%20%20%20&dates=20261031T170000Z/20261031T220000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/boogieman-10-31-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1774294978963" id="item-69c197948da60a3bf72fe02c"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-8b281ebcd64302b38ebb"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">Live from our parking lot:  15 Bands on 2 Stages <br>Doors: 12pm  |  Music:  1pm - 11pm<br><a href="https://www.instagram.com/boogiemanfest/" target="_blank">✯&nbsp;Boogieman Halloween Festival</a><br><a href="https://atlas-touring.com" target="_blank">✯&nbsp;Atlas Touring</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/boogieman-10-31-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69c197948da60a3bf72fe02c" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69c197948da60a3bf72fe02c/1777503431905/" data-record-type="12" data-full-url="/schedule/boogieman-10-31-26" data-title="6th Annual Boogieman Halloween Festival     "></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming">
+
+        <a href="/schedule/thrifters-drifters-12-12-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/thrifters-drifters-12-12-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Dec</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">12</div>
+
+              
+              <div class="eventlist-datetag-time"><span class="event-time-12hr">1:00 PM</span><span class="event-time-24hr">13:00</span></div>
+
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/thrifters-drifters-12-12-26" class="eventlist-title-link">Thrifters &amp; Drifters Holiday Market          </a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+              <time class="event-date" datetime="2026-12-12">Saturday, December 12, 2026</time>
+            </li>
+
+            <li class="eventlist-meta-item eventlist-meta-time event-meta-item">
+              <span class="event-time-12hr">
+                <time class="event-time-12hr-start" datetime="2026-12-12">1:00 PM</time>
+                <span class="event-datetime-divider"></span>
+                <time class="event-time-12hr-end" datetime="2026-12-12">7:00 PM</time>
+              </span>
+              <span class="event-time-24hr">
+                <time class="event-time-24hr-start" datetime="2026-12-12">13:00</time>
+                <span class="event-datetime-divider"></span>
+                <time class="event-time-12hr-end" datetime="2026-12-12">19:00</time>
+              </span>
+            </li>
+
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Thrifters%20%26amp%3B%20Drifters%20Holiday%20Market%20%20%20%20%20%20%20%20%20%20&dates=20261212T180000Z/20261213T000000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/thrifters-drifters-12-12-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1774295078340" id="item-69c197f6ad0f8c0f03919a4c"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-d7ae94f02e48c51a1316"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">A Charleston-based market of artisans, collectors and crafters, bringing you a beautiful collection of vintage and locally curated art, jewelry, vintage clothing, crafts and more!!<br>1pm - 5pm |&nbsp;FREE &nbsp;<br><a href="https://thriftersanddrifters.com" target="_blank">✯&nbsp;Thrifters &amp; Drifters</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/thrifters-drifters-12-12-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69c197f6ad0f8c0f03919a4c" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69c197f6ad0f8c0f03919a4c/1774295114414/" data-record-type="12" data-full-url="/schedule/thrifters-drifters-12-12-26" data-title="Thrifters &amp;amp; Drifters Holiday Market          "></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--upcoming">
+
+        <a href="/schedule/14-annual-biker-oyster-roast-12-13-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/14-annual-biker-oyster-roast-12-13-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Dec</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">13</div>
+
+              
+              <div class="eventlist-datetag-time"><span class="event-time-12hr">1:00 PM</span><span class="event-time-24hr">13:00</span></div>
+
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/14-annual-biker-oyster-roast-12-13-26" class="eventlist-title-link">The 14th Annual Royal American Biker Oyster Roast     </a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+              <time class="event-date" datetime="2026-12-13">Sunday, December 13, 2026</time>
+            </li>
+
+            <li class="eventlist-meta-item eventlist-meta-time event-meta-item">
+              <span class="event-time-12hr">
+                <time class="event-time-12hr-start" datetime="2026-12-13">1:00 PM</time>
+                <span class="event-datetime-divider"></span>
+                <time class="event-time-12hr-end" datetime="2026-12-13">5:00 PM</time>
+              </span>
+              <span class="event-time-24hr">
+                <time class="event-time-24hr-start" datetime="2026-12-13">13:00</time>
+                <span class="event-datetime-divider"></span>
+                <time class="event-time-12hr-end" datetime="2026-12-13">17:00</time>
+              </span>
+            </li>
+
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=The%2014th%20Annual%20Royal%20American%20Biker%20Oyster%20Roast%20%20%20%20%20&dates=20261213T180000Z/20261213T220000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/14-annual-biker-oyster-roast-12-13-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1747406056341" id="item-68274caadf387d7fa11dc24a"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-095e0e18ca4f47e8c94d"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">Bikes, booze, oysters, games, live music, burn barrels, vendors, tattoos, the prison bus, and more!! Brought to you by American Biker and The Royal American!  Sponsored by Riders Law Group, and Stardust Tattoo!!<br>1pm - 7pm<br><a href="https://www.americanbiker.biz" target="_blank">✯&nbsp;American Biker</a><br><a href="https://www.facebook.com/Stardusttattoopc/?ref=py_c" target="_blank">✯&nbsp;Stardust Tattoo</a><br><a href="http://riderslawgroup.com" target="_blank">✯&nbsp;Riders Law Group</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/14-annual-biker-oyster-roast-12-13-26" class="eventlist-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="68274caadf387d7fa11dc24a" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/68274caadf387d7fa11dc24a/1774295201724/" data-record-type="12" data-full-url="/schedule/14-annual-biker-oyster-roast-12-13-26" data-title="The 14th Annual Royal American Biker Oyster Roast     "></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+    </div>
+
+
+    <!-- Past Events -->
+
+    
+    <div class="eventlist eventlist--past">
+    <hr class="eventlist-past-upcoming-divider">
+    
+
+    
+
+      <article class="eventlist-event eventlist-event--past eventlist-event--multiday">
+
+        <a href="/schedule/parris-byars-club-5-9-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/parris-byars-club-5-9-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">May</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">9</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to May 10</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/parris-byars-club-5-9-26" class="eventlist-title-link">Parris Byars Club</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-05-09">Sat, May 9, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-05-09">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-05-09">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-05-10">Sun, May 10, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-05-10">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-05-10">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Parris%20Byars%20Club&dates=20260510T010000Z/20260510T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/parris-byars-club-5-9-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1770864393081" id="item-698d3e6cc2bfea775508670c"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-d0e1ae8eaecc1bd85255"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Acid Hawk + Shock Tea<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/parrisbyarsclub/?hl=en" target="_blank">✯&nbsp;Parris Byars Club</a><br><a href="https://www.instagram.com/acidhawkband/" target="_blank">✯&nbsp;Acid Hawk</a><br><a href="https://www.instagram.com/shocktea_/" target="_blank">✯&nbsp;Shock Tea</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/parris-byars-club-5-9-26" class="eventlist-button sqs-editable-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="698d3e6cc2bfea775508670c" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/698d3e6cc2bfea775508670c/1777500535620/" data-record-type="12" data-full-url="/schedule/parris-byars-club-5-9-26" data-title="Parris Byars Club"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--past eventlist-event--multiday">
+
+        <a href="/schedule/mindwater-5-8-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/mindwater-5-8-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">May</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">8</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to May 9</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/mindwater-5-8-26" class="eventlist-title-link">Mindwater</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-05-08">Fri, May 8, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-05-08">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-05-08">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-05-09">Sat, May 9, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-05-09">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-05-09">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Mindwater&dates=20260509T010000Z/20260509T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/mindwater-5-8-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1769979720275" id="item-697fbe0ba0afa94a2ce447a8"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-70f20c3bd8b8decf5041"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Brady Sklar (Daddy’s Beemer) + Cab Driver<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/mindwater/" target="_blank">✯&nbsp;Mindwater</a><br><a href="https://www.instagram.com/bradysklar/" target="_blank">✯&nbsp;Brady Sklar</a><br><a href="https://www.instagram.com/cabdriverband/" target="_blank">✯&nbsp;Cab Driver</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/mindwater-5-8-26" class="eventlist-button sqs-editable-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="697fbe0ba0afa94a2ce447a8" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/697fbe0ba0afa94a2ce447a8/1769979709855/" data-record-type="12" data-full-url="/schedule/mindwater-5-8-26" data-title="Mindwater"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--past eventlist-event--multiday">
+
+        <a href="/schedule/wilmot-5-2-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/wilmot-5-2-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">May</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">2</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to May 3</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/wilmot-5-2-26" class="eventlist-title-link">Wilmot </a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-05-02">Sat, May 2, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-05-02">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-05-02">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-05-03">Sun, May 3, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-05-03">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-05-03">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Wilmot%20&dates=20260503T010000Z/20260503T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/wilmot-5-2-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1769979334232" id="item-697fbda052efe312d5f86dd7"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-ab1c478fab959d166088"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Sunhouse + Lilly Hartle<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/wilmot_music/" target="_blank">✯&nbsp;Wilmot</a><br><a href="https://www.instagram.com/sunhouseband/" target="_blank">✯&nbsp;Sunhouse</a><br><a href="https://www.instagram.com/lilly.hartle/" target="_blank">✯&nbsp;Lilly Hartle</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/wilmot-5-2-26" class="eventlist-button sqs-editable-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="697fbda052efe312d5f86dd7" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/697fbda052efe312d5f86dd7/1777500442450/" data-record-type="12" data-full-url="/schedule/wilmot-5-2-26" data-title="Wilmot "></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--past eventlist-event--multiday">
+
+        <a href="/schedule/winterteeth-5-1-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/winterteeth-5-1-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">May</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">1</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to May 2</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/winterteeth-5-1-26" class="eventlist-title-link">Winterteeth</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-05-01">Fri, May 1, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-05-01">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-05-01">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-05-02">Sat, May 2, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-05-02">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-05-02">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Winterteeth&dates=20260502T010000Z/20260502T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/winterteeth-5-1-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1769796704224" id="item-697cf3b91fa9753610251518"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-7bbe59ef22058a7ed5ef"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Channel Bluff + Nick Matthews<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/winterteethband/" target="_blank">✯&nbsp;Winterteeth</a><br><a href="https://www.instagram.com/channelbluff/" target="_blank">✯&nbsp;Channel Bluff</a><br><a href="https://www.instagram.com/nickmatthewsmusic/" target="_blank">✯&nbsp;Nick Matthews</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/winterteeth-5-1-26" class="eventlist-button sqs-editable-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="697cf3b91fa9753610251518" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/697cf3b91fa9753610251518/1769796693933/" data-record-type="12" data-full-url="/schedule/winterteeth-5-1-26" data-title="Winterteeth"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--past eventlist-event--multiday">
+
+        <a href="/schedule/the-saint-cecilia-4-25-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/the-saint-cecilia-4-25-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Apr</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">25</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Apr 26</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/the-saint-cecilia-4-25-26" class="eventlist-title-link">The Saint Cecilia</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-04-25">Sat, Apr 25, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-04-25">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-04-25">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-04-26">Sun, Apr 26, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-04-26">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-04-26">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=The%20Saint%20Cecilia&dates=20260426T010000Z/20260426T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/the-saint-cecilia-4-25-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1766439078483" id="item-6949b858c7d940036dea1666"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-9f5943adfbb3aa6f4693"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Jack Fortune<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/thesaintceciliaoficial/" target="_blank">✯&nbsp;The Saint Cecilia</a><br><a href="https://www.instagram.com/jackaustinfortune/" target="_blank">✯&nbsp;Jack Fortune</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/the-saint-cecilia-4-25-26" class="eventlist-button sqs-editable-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="6949b858c7d940036dea1666" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/6949b858c7d940036dea1666/1774294118172/" data-record-type="12" data-full-url="/schedule/the-saint-cecilia-4-25-26" data-title="The Saint Cecilia"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--past">
+
+        <a href="/schedule/thrifters-drifters-4-25-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/thrifters-drifters-4-25-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Apr</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">25</div>
+
+              
+              <div class="eventlist-datetag-time"><span class="event-time-12hr">1:00 PM</span><span class="event-time-24hr">13:00</span></div>
+
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/thrifters-drifters-4-25-26" class="eventlist-title-link">Thrifters &amp; Drifters Artisan Market          </a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+              <time class="event-date" datetime="2026-04-25">Saturday, April 25, 2026</time>
+            </li>
+
+            <li class="eventlist-meta-item eventlist-meta-time event-meta-item">
+              <span class="event-time-12hr">
+                <time class="event-time-12hr-start" datetime="2026-04-25">1:00 PM</time>
+                <span class="event-datetime-divider"></span>
+                <time class="event-time-12hr-end" datetime="2026-04-25">7:00 PM</time>
+              </span>
+              <span class="event-time-24hr">
+                <time class="event-time-24hr-start" datetime="2026-04-25">13:00</time>
+                <span class="event-datetime-divider"></span>
+                <time class="event-time-12hr-end" datetime="2026-04-25">19:00</time>
+              </span>
+            </li>
+
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Thrifters%20%26amp%3B%20Drifters%20Artisan%20Market%20%20%20%20%20%20%20%20%20%20&dates=20260425T170000Z/20260425T230000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/thrifters-drifters-4-25-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1771685920367" id="item-6999c801abf2901818a7d309"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-e58b08d8e9d9222b8e1d"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">A Charleston-based market of artisans, collectors and crafters, bringing you a beautiful collection of vintage and locally curated art, jewelry, vintage clothing, crafts and more!!<br>1pm - 5pm |&nbsp;FREE &nbsp;<br><a href="https://thriftersanddrifters.com" target="_blank">✯&nbsp;Thrifters &amp; Drifters</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/thrifters-drifters-4-25-26" class="eventlist-button sqs-editable-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="6999c801abf2901818a7d309" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/6999c801abf2901818a7d309/1774295100368/" data-record-type="12" data-full-url="/schedule/thrifters-drifters-4-25-26" data-title="Thrifters &amp;amp; Drifters Artisan Market          "></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--past eventlist-event--multiday">
+
+        <a href="/schedule/carls-4-24-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/carls-4-24-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Apr</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">24</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Apr 25</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/carls-4-24-26" class="eventlist-title-link">CARLS</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-04-24">Fri, Apr 24, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-04-24">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-04-24">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-04-25">Sat, Apr 25, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-04-25">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-04-25">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=CARLS&dates=20260425T010000Z/20260425T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/carls-4-24-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1761658392711" id="item-6900c5d722bea13a1d9714ff"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-d941f985bcc468a9dc20"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Social Void + The Polar InBetween<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/northbynorthmusic/" target="_blank">✯&nbsp;CARLS</a><br><a href="https://www.instagram.com/socialvoid/" target="_blank">✯&nbsp;Social Void</a><br><a href="https://www.instagram.com/thepolar_inbetween/" target="_blank">✯&nbsp;The Polar InBetween</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/carls-4-24-26" class="eventlist-button sqs-editable-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="6900c5d722bea13a1d9714ff" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/6900c5d722bea13a1d9714ff/1774294064705/" data-record-type="12" data-full-url="/schedule/carls-4-24-26" data-title="CARLS"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--past eventlist-event--multiday">
+
+        <a href="/schedule/oleg-loser-chris-4-18-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/oleg-loser-chris-4-18-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Apr</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">18</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Apr 19</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/oleg-loser-chris-4-18-26" class="eventlist-title-link">Oleg + Loser Chris</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-04-18">Sat, Apr 18, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-04-18">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-04-18">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-04-19">Sun, Apr 19, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-04-19">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-04-19">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Oleg%20%2B%20Loser%20Chris&dates=20260419T010000Z/20260419T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/oleg-loser-chris-4-18-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1773350387172" id="item-69b32caf617e031adc770ca7"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-af578c006e42fa505efe"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ MaB s-BaN + Jinari Kemet<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/loserchrismusic/" target="_blank">✯&nbsp;Loser Chris</a><br><a href="https://www.instagram.com/thepercussionrussian/" target="_blank">✯&nbsp;Oleg</a><br><a href="https://www.instagram.com/mab_s_ban?igsh=MXNpcnI5OWF5ZzZtZA%3D%3D&amp;utm_source=qr" target="_blank">✯&nbsp;MaB s-BaN</a><br><a href="https://www.instagram.com/jinari_kemet?igsh=dGlleXE3OXF5Mzgx" target="_blank">✯&nbsp;Jinari Kemet</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/oleg-loser-chris-4-18-26" class="eventlist-button sqs-editable-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69b32caf617e031adc770ca7" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69b32caf617e031adc770ca7/1773350375253/" data-record-type="12" data-full-url="/schedule/oleg-loser-chris-4-18-26" data-title="Oleg + Loser Chris"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--past eventlist-event--multiday">
+
+        <a href="/schedule/guilt-ridden-troubadour-4-17-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/guilt-ridden-troubadour-4-17-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Apr</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">17</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Apr 18</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/guilt-ridden-troubadour-4-17-26" class="eventlist-title-link">Guilt Ridden Troubadour</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-04-17">Fri, Apr 17, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-04-17">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-04-17">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-04-18">Sat, Apr 18, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-04-18">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-04-18">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Guilt%20Ridden%20Troubadour&dates=20260418T010000Z/20260418T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/guilt-ridden-troubadour-4-17-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1774904174726" id="item-69cae31079172f0ebd78fae3"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-3dacdb91f638d9f65057"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ TBD<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/guiltriddentroubadour/" target="_blank">✯&nbsp;Guilt Ridden Troubadour</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/guilt-ridden-troubadour-4-17-26" class="eventlist-button sqs-editable-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69cae31079172f0ebd78fae3" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69cae31079172f0ebd78fae3/1774904161545/" data-record-type="12" data-full-url="/schedule/guilt-ridden-troubadour-4-17-26" data-title="Guilt Ridden Troubadour"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--past eventlist-event--multiday">
+
+        <a href="/schedule/tom-mackell-4-11-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/tom-mackell-4-11-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Apr</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">11</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Apr 12</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/tom-mackell-4-11-26" class="eventlist-title-link">Tom Mackell</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-04-11">Sat, Apr 11, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-04-11">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-04-11">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-04-12">Sun, Apr 12, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-04-12">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-04-12">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Tom%20Mackell&dates=20260412T010000Z/20260412T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/tom-mackell-4-11-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1769796503675" id="item-697cf29273c532647d7726e2"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-98a799d30302f300f422"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Jack Fortune + AC Scar<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/tommackell/" target="_blank">✯&nbsp;Tom Mackell</a><br><a href="https://www.instagram.com/jackaustinfortune/" target="_blank">✯&nbsp;Jack Fortune</a><br><a href="https://www.instagram.com/highwaterhonky/" target="_blank">✯&nbsp;AC Scar</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/tom-mackell-4-11-26" class="eventlist-button sqs-editable-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="697cf29273c532647d7726e2" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/697cf29273c532647d7726e2/1769796493516/" data-record-type="12" data-full-url="/schedule/tom-mackell-4-11-26" data-title="Tom Mackell"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--past eventlist-event--multiday">
+
+        <a href="/schedule/sounds-of-blackfox-4-10-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/sounds-of-blackfox-4-10-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Apr</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">10</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Apr 11</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/sounds-of-blackfox-4-10-26" class="eventlist-title-link">Sounds of BlackFox</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-04-10">Fri, Apr 10, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-04-10">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-04-10">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-04-11">Sat, Apr 11, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-04-11">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-04-11">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Sounds%20of%20BlackFox&dates=20260411T010000Z/20260411T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/sounds-of-blackfox-4-10-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1770864085214" id="item-698d3a63c9ee0229932520dd"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-b2ce50a6bfff3398f43e"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Royal Tide + Pierce Alexander<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/sobf_official/?hl=en" target="_blank">✯&nbsp;Sounds of BlackFox</a><br><a href="https://www.instagram.com/royaltideband/" target="_blank">✯&nbsp;Royal Tide</a><br><a href="https://www.instagram.com/piercealexandermusic/" target="_blank">✯&nbsp;Pierce Alexander</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/sounds-of-blackfox-4-10-26" class="eventlist-button sqs-editable-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="698d3a63c9ee0229932520dd" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/698d3a63c9ee0229932520dd/1774293968094/" data-record-type="12" data-full-url="/schedule/sounds-of-blackfox-4-10-26" data-title="Sounds of BlackFox"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--past eventlist-event--multiday">
+
+        <a href="/schedule/honeyknife-4-4-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/honeyknife-4-4-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Apr</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">4</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Apr 5</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/honeyknife-4-4-26" class="eventlist-title-link">Scarhaven</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-04-04">Sat, Apr 4, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-04-04">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-04-04">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-04-05">Sun, Apr 5, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-04-05">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-04-05">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Scarhaven&dates=20260405T010000Z/20260405T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/honeyknife-4-4-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1766438995004" id="item-6949b7d5b04ffe279fc66371"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-96fc09b657c75284d2cb"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Auroras Hope + The Boonies<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/honeyknife.band/" target="_blank">✯&nbsp;Honeyknife</a><br><a href="https://www.instagram.com/theaurorashope/?hl=en" target="_blank">✯&nbsp;Auroras Hope</a><br><a href="https://www.instagram.com/_thebooniesband_/" target="_blank">✯&nbsp;The Boonies</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/honeyknife-4-4-26" class="eventlist-button sqs-editable-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="6949b7d5b04ffe279fc66371" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/6949b7d5b04ffe279fc66371/1773349750612/" data-record-type="12" data-full-url="/schedule/honeyknife-4-4-26" data-title="Scarhaven"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--past eventlist-event--multiday">
+
+        <a href="/schedule/mina-roth-4-3-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/mina-roth-4-3-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Apr</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">3</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Apr 4</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/mina-roth-4-3-26" class="eventlist-title-link">Mina Roth</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-04-03">Fri, Apr 3, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-04-03">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-04-03">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-04-04">Sat, Apr 4, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-04-04">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-04-04">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Mina%20Roth&dates=20260404T010000Z/20260404T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/mina-roth-4-3-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1769790572456" id="item-697cdbe50696ff2251b57048"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-6ebabf7e269e14f60d87"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Emma Grace Burton + Eliza Novella<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/itsminaroth/" target="_blank">✯&nbsp;Mina Roth</a><br><a href="https://www.instagram.com/emmagraceburton/" target="_blank">✯&nbsp;Emma Grace Burton</a><br><a href="https://www.instagram.com/elizanovellaa/" target="_blank">✯&nbsp;Eliza Novella</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/mina-roth-4-3-26" class="eventlist-button sqs-editable-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="697cdbe50696ff2251b57048" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/697cdbe50696ff2251b57048/1774293773964/" data-record-type="12" data-full-url="/schedule/mina-roth-4-3-26" data-title="Mina Roth"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--past eventlist-event--multiday">
+
+        <a href="/schedule/recess-party-3-21-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/recess-party-3-21-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Mar</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">21</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Mar 22</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/recess-party-3-21-26" class="eventlist-title-link">Recess Party + Winterteeth</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-03-21">Sat, Mar 21, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-03-21">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-03-21">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-03-22">Sun, Mar 22, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-03-22">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-03-22">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Recess%20Party%20%2B%20Winterteeth&dates=20260322T010000Z/20260322T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/recess-party-3-21-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1766935203831" id="item-69514a44dcc3292c69299a44"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-cf34719afec75c130f43"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Yes Dear<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/recess.party/" target="_blank">✯&nbsp;Recess Party</a><br><a href="https://www.instagram.com/winterteethband/" target="_blank">✯&nbsp;Winterteeth</a><br><a href="https://www.instagram.com/yesdearband/" target="_blank">✯&nbsp;Yes Dear</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/recess-party-3-21-26" class="eventlist-button sqs-editable-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69514a44dcc3292c69299a44" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69514a44dcc3292c69299a44/1769980185087/" data-record-type="12" data-full-url="/schedule/recess-party-3-21-26" data-title="Recess Party + Winterteeth"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--past eventlist-event--multiday">
+
+        <a href="/schedule/daddys-mantra-tour-3-14-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/daddys-mantra-tour-3-14-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Mar</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">14</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Mar 15</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/daddys-mantra-tour-3-14-26" class="eventlist-title-link">"Daddy's Mantra Tour" </a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-03-14">Sat, Mar 14, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-03-14">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-03-14">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-03-15">Sun, Mar 15, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-03-15">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-03-15">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=%22Daddy%27s%20Mantra%20Tour%22%20&dates=20260315T010000Z/20260315T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/daddys-mantra-tour-3-14-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1769790389669" id="item-697cdb918929b76e18641c96"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-7699bbb0d84d098fa683"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Daddy’s Beemer + Mantra<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/dadsbeem/" target="_blank">✯&nbsp;Daddy's Beemer</a><br><a href="https://www.instagram.com/bandmantra/" target="_blank">✯&nbsp;Mantra</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/daddys-mantra-tour-3-14-26" class="eventlist-button sqs-editable-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="697cdb918929b76e18641c96" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/697cdb918929b76e18641c96/1769790379391/" data-record-type="12" data-full-url="/schedule/daddys-mantra-tour-3-14-26" data-title="&quot;Daddy's Mantra Tour&quot; "></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--past">
+
+        <a href="/schedule/thrifters-drifters-3-14-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/thrifters-drifters-3-14-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Mar</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">14</div>
+
+              
+              <div class="eventlist-datetag-time"><span class="event-time-12hr">1:00 PM</span><span class="event-time-24hr">13:00</span></div>
+
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/thrifters-drifters-3-14-26" class="eventlist-title-link">Thrifters &amp; Drifters Artisan Market         </a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+              <time class="event-date" datetime="2026-03-14">Saturday, March 14, 2026</time>
+            </li>
+
+            <li class="eventlist-meta-item eventlist-meta-time event-meta-item">
+              <span class="event-time-12hr">
+                <time class="event-time-12hr-start" datetime="2026-03-14">1:00 PM</time>
+                <span class="event-datetime-divider"></span>
+                <time class="event-time-12hr-end" datetime="2026-03-14">7:00 PM</time>
+              </span>
+              <span class="event-time-24hr">
+                <time class="event-time-24hr-start" datetime="2026-03-14">13:00</time>
+                <span class="event-datetime-divider"></span>
+                <time class="event-time-12hr-end" datetime="2026-03-14">19:00</time>
+              </span>
+            </li>
+
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Thrifters%20%26amp%3B%20Drifters%20Artisan%20Market%20%20%20%20%20%20%20%20%20&dates=20260314T170000Z/20260314T230000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/thrifters-drifters-3-14-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1771685845469" id="item-6999c7a8ea8fb4325eabbfe3"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-87fa64bf40066a3bd3c5"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">A Charleston-based market of artisans, collectors and crafters, bringing you a beautiful collection of vintage and locally curated art, jewelry, vintage clothing, crafts and more!!<br>1pm - 5pm |&nbsp;FREE &nbsp;<br><a href="https://thriftersanddrifters.com" target="_blank">✯&nbsp;Thrifters &amp; Drifters</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/thrifters-drifters-3-14-26" class="eventlist-button sqs-editable-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="6999c7a8ea8fb4325eabbfe3" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/6999c7a8ea8fb4325eabbfe3/1773349788232/" data-record-type="12" data-full-url="/schedule/thrifters-drifters-3-14-26" data-title="Thrifters &amp;amp; Drifters Artisan Market         "></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--past eventlist-event--multiday">
+
+        <a href="/schedule/daddys-mantra-tour-3-13-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/daddys-mantra-tour-3-13-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Mar</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">13</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Mar 14</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/daddys-mantra-tour-3-13-26" class="eventlist-title-link">"Daddy's Mantra Tour"</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-03-13">Fri, Mar 13, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-03-13">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-03-13">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-03-14">Sat, Mar 14, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-03-14">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-03-14">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=%22Daddy%27s%20Mantra%20Tour%22&dates=20260314T010000Z/20260314T060000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/daddys-mantra-tour-3-13-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1769790357959" id="item-697cdb18ea6a101b72f4c213"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-73eb791156f09e12f7e6"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Daddy’s Beemer + Mantra w/ Curly Blue<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/dadsbeem/" target="_blank">✯&nbsp;Daddy's Beemer</a><br><a href="https://www.instagram.com/bandmantra/" target="_blank">✯&nbsp;Mantra</a><br><a href="https://www.instagram.com/curlyblueofficial/" target="_blank">✯&nbsp;Curly Blue</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/daddys-mantra-tour-3-13-26" class="eventlist-button sqs-editable-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="697cdb18ea6a101b72f4c213" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/697cdb18ea6a101b72f4c213/1773353906931/" data-record-type="12" data-full-url="/schedule/daddys-mantra-tour-3-13-26" data-title="&quot;Daddy's Mantra Tour&quot;"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--past eventlist-event--multiday">
+
+        <a href="/schedule/never-really-over-3-7-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/never-really-over-3-7-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Mar</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">7</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Mar 8</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/never-really-over-3-7-26" class="eventlist-title-link">Never Really Over</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-03-07">Sat, Mar 7, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-03-07">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-03-07">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-03-08">Sun, Mar 8, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-03-08">3:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-03-08">03:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Never%20Really%20Over&dates=20260308T020000Z/20260308T070000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/never-really-over-3-7-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1766438847195" id="item-6949b743df0417479737e4da"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-a1665144c3af76a3629c"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ SCHEMA + The Fiori<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/nro.music/" target="_blank">✯&nbsp;Never Really Over</a><br><a href="https://www.instagram.com/schema_/" target="_blank">✯&nbsp;SCHEMA</a><br><a href="https://www.instagram.com/thefioriii/" target="_blank">✯&nbsp;The Fiori</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/never-really-over-3-7-26" class="eventlist-button sqs-editable-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="6949b743df0417479737e4da" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/6949b743df0417479737e4da/1766438838120/" data-record-type="12" data-full-url="/schedule/never-really-over-3-7-26" data-title="Never Really Over"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--past eventlist-event--multiday">
+
+        <a href="/schedule/mids-3-6-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/mids-3-6-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Mar</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">6</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Mar 7</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/mids-3-6-26" class="eventlist-title-link">MIDS</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-03-06">Fri, Mar 6, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-03-06">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-03-06">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-03-07">Sat, Mar 7, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-03-07">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-03-07">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=MIDS&dates=20260307T020000Z/20260307T070000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/mids-3-6-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1769788085361" id="item-697cd257db997f58a57f32e0"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-60f918c6be2ea4832260"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ 2 Slices<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/midstheband/" target="_blank">✯&nbsp;MIDS</a><br><a href="https://www.instagram.com/2slicesofficial/" target="_blank">✯&nbsp;2 Slices</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/mids-3-6-26" class="eventlist-button sqs-editable-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="697cd257db997f58a57f32e0" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/697cd257db997f58a57f32e0/1769788075070/" data-record-type="12" data-full-url="/schedule/mids-3-6-26" data-title="MIDS"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--past eventlist-event--multiday">
+
+        <a href="/schedule/conor-kelly-2-28-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/conor-kelly-2-28-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Feb</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">28</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Mar 1</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/conor-kelly-2-28-26" class="eventlist-title-link">Connor Kelly &amp; The Time Warp</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-02-28">Sat, Feb 28, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-02-28">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-02-28">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-03-01">Sun, Mar 1, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-03-01">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-03-01">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Connor%20Kelly%20%26amp%3B%20The%20Time%20Warp&dates=20260301T020000Z/20260301T070000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/conor-kelly-2-28-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1769787953872" id="item-697cd1e38181555b12a18a9e"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-3ba9cc7c01fc4c27c12f"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Channel Bluff + The Right Ratio<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/connorkellyandthetimewarp/" target="_blank">✯&nbsp;Connor Kelly &amp; The Time Warp</a><br><a href="https://www.google.com/url?opi=89978449&amp;rct=j&amp;sa=t&amp;source=web&amp;url=https%3A%2F%2Fwww.instagram.com%2Fchannelbluff%2F%3Fhl%3Den&amp;usg=AOvVaw0HR-EYKTYGGtVfS7bEzFom&amp;ved=2ahUKEwihxOnx8tKSAxXFAHkGHWdAJMsQFnoECBwQAQ" target="_blank">✯&nbsp;Channel Bluff</a><br><a href="https://www.instagram.com/therightratio_/?hl=en" target="_blank">✯&nbsp;The Right Ratio</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/conor-kelly-2-28-26" class="eventlist-button sqs-editable-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="697cd1e38181555b12a18a9e" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/697cd1e38181555b12a18a9e/1771685759973/" data-record-type="12" data-full-url="/schedule/conor-kelly-2-28-26" data-title="Connor Kelly &amp;amp; The Time Warp"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--past eventlist-event--multiday">
+
+        <a href="/schedule/fudge-2-27-25" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/fudge-2-27-25" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Feb</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">27</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Feb 28</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/fudge-2-27-25" class="eventlist-title-link">FUDGE</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-02-27">Fri, Feb 27, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-02-27">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-02-27">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-02-28">Sat, Feb 28, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-02-28">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-02-28">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=FUDGE&dates=20260228T020000Z/20260228T070000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/fudge-2-27-25?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1763736926206" id="item-69207d22bb56f9671eafeb67"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-6f65ba1446caf9b173a1"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Grace Miller Moody + Jetty<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/thebandfudge/" target="_blank">✯&nbsp;FUDGE</a><br><a href="https://www.instagram.com/gracemillermoody.music/" target="_blank">✯&nbsp;Grace Miller Moody</a><br><a href="https://www.instagram.com/jettytheband/" target="_blank">✯&nbsp;Jetty</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/fudge-2-27-25" class="eventlist-button sqs-editable-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69207d22bb56f9671eafeb67" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69207d22bb56f9671eafeb67/1771685681481/" data-record-type="12" data-full-url="/schedule/fudge-2-27-25" data-title="FUDGE"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--past eventlist-event--multiday">
+
+        <a href="/schedule/c-shreve-the-professor-2-21-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/c-shreve-the-professor-2-21-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Feb</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">21</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Feb 22</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/c-shreve-the-professor-2-21-26" class="eventlist-title-link">C. Shreve The Professor (Album Release)</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-02-21">Sat, Feb 21, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-02-21">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-02-21">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-02-22">Sun, Feb 22, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-02-22">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-02-22">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=C.%20Shreve%20The%20Professor%20%28Album%20Release%29&dates=20260222T020000Z/20260222T070000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/c-shreve-the-professor-2-21-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1766438714281" id="item-6949b6fd126f414d829ae7a3"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-58eaf6fb1ce6abe55c54"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ OC From NC + Dope KNife + Tam The Vibe + Indi’Gxld<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/seeshreve/" target="_blank">✯&nbsp;C. Shreve The Professor</a><br><a href="https://www.instagram.com/ocfromnc/" target="_blank">✯&nbsp;OC From NC</a><br><a href="https://www.instagram.com/knifeisdope/" target="_blank">✯&nbsp;Dope KNife</a><br><a href="https://www.instagram.com/biggxld/" target="_blank">✯&nbsp;Indi'Gxld</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/c-shreve-the-professor-2-21-26" class="eventlist-button sqs-editable-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="6949b6fd126f414d829ae7a3" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/6949b6fd126f414d829ae7a3/1769787764667/" data-record-type="12" data-full-url="/schedule/c-shreve-the-professor-2-21-26" data-title="C. Shreve The Professor (Album Release)"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--past eventlist-event--multiday">
+
+        <a href="/schedule/wilmot-2-14-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/wilmot-2-14-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Feb</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">14</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Feb 15</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/wilmot-2-14-26" class="eventlist-title-link">Wilmot </a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-02-14">Sat, Feb 14, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-02-14">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-02-14">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-02-15">Sun, Feb 15, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-02-15">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-02-15">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Wilmot%20&dates=20260215T020000Z/20260215T070000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/wilmot-2-14-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1763736770039" id="item-69207c8cd7f526676735397e"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-7e7064434a5f8ed2c1f0"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Bedroom Division + The John Wood Band<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/wilmot_music/" target="_blank">✯&nbsp;Wilmot</a><br><a href="https://www.instagram.com/bedroomdivision/" target="_blank">✯&nbsp;Bedroom Division</a><br><a href="https://www.instagram.com/johnwoodmusic/" target="_blank">✯&nbsp;The John Wood Band</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/wilmot-2-14-26" class="eventlist-button sqs-editable-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69207c8cd7f526676735397e" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69207c8cd7f526676735397e/1771117785743/" data-record-type="12" data-full-url="/schedule/wilmot-2-14-26" data-title="Wilmot "></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--past eventlist-event--multiday">
+
+        <a href="/schedule/the-simplicity-2-13-25" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/the-simplicity-2-13-25" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Feb</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">13</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Feb 14</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/the-simplicity-2-13-25" class="eventlist-title-link">The Simplicity + TOUNDS</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-02-13">Fri, Feb 13, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-02-13">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-02-13">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-02-14">Sat, Feb 14, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-02-14">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-02-14">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=The%20Simplicity%20%2B%20TOUNDS&dates=20260214T020000Z/20260214T070000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/the-simplicity-2-13-25?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1763736718818" id="item-69207c09403ff349bdfa025c"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-03313528079d1cb21225"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Reverse Cowgirl<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/thesimplicityisnotgood/" target="_blank">✯&nbsp;The Simplicity</a><br><a href="https://www.instagram.com/itsspelledtounds/" target="_blank">✯&nbsp;TOUNDS</a><br><a href="https://www.instagram.com/reverse_cowgurl/" target="_blank">✯&nbsp;Reverse Cowgirl</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/the-simplicity-2-13-25" class="eventlist-button sqs-editable-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69207c09403ff349bdfa025c" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69207c09403ff349bdfa025c/1763736710014/" data-record-type="12" data-full-url="/schedule/the-simplicity-2-13-25" data-title="The Simplicity + TOUNDS"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--past eventlist-event--multiday">
+
+        <a href="/schedule/owen-and-the-smokes-2-7-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/owen-and-the-smokes-2-7-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Feb</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">7</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Feb 8</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/owen-and-the-smokes-2-7-26" class="eventlist-title-link">Owen &amp; The Smokes</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-02-07">Sat, Feb 7, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-02-07">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-02-07">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-02-08">Sun, Feb 8, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-02-08">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-02-08">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Owen%20%26amp%3B%20The%20Smokes&dates=20260208T020000Z/20260208T070000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/owen-and-the-smokes-2-7-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1761658547334" id="item-6900c6189dca6f5dc9e61189"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-8dedb4e85191d1867cde"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Nikki &amp; The Barn Boys + Winterteeth<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/thesmokesss/" target="_blank">✯&nbsp;Owen &amp; The Smokes</a><br><a href="https://www.instagram.com/nikkiandthebarnboys/" target="_blank">✯&nbsp;Nikki &amp; The Barn Boys</a><br><a href="https://www.instagram.com/winterteethband/" target="_blank">✯&nbsp;Winterteeth</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/owen-and-the-smokes-2-7-26" class="eventlist-button sqs-editable-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="6900c6189dca6f5dc9e61189" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/6900c6189dca6f5dc9e61189/1761658539414/" data-record-type="12" data-full-url="/schedule/owen-and-the-smokes-2-7-26" data-title="Owen &amp;amp; The Smokes"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--past eventlist-event--multiday">
+
+        <a href="/schedule/lightwatch-2-6-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/lightwatch-2-6-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Feb</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">6</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Feb 7</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/lightwatch-2-6-26" class="eventlist-title-link">Lightwatch</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-02-06">Fri, Feb 6, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-02-06">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-02-06">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-02-07">Sat, Feb 7, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-02-07">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-02-07">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Lightwatch&dates=20260207T020000Z/20260207T070000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/lightwatch-2-6-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1763736582026" id="item-69207b77088bed281a48eb6f"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-580de3fb69cfbe62471c"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ The Boonies + Safety Coffin<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/lightwatchofficial/" target="_blank">✯&nbsp;Lightwatch</a><br><a href="https://www.instagram.com/_thebooniesband_/" target="_blank">✯&nbsp;The Boonies</a><br><a href="https://www.instagram.com/safety_coffin/" target="_blank">✯&nbsp;Safety Coffin</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/lightwatch-2-6-26" class="eventlist-button sqs-editable-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="69207b77088bed281a48eb6f" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/69207b77088bed281a48eb6f/1763736573217/" data-record-type="12" data-full-url="/schedule/lightwatch-2-6-26" data-title="Lightwatch"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--past eventlist-event--multiday">
+
+        <a href="/schedule/north-by-north-1-30-25" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/north-by-north-1-30-25" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Jan</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">30</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Jan 31</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/north-by-north-1-30-25" class="eventlist-title-link">North By North</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-01-30">Fri, Jan 30, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-01-30">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-01-30">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-01-31">Sat, Jan 31, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-01-31">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-01-31">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=North%20By%20North&dates=20260131T020000Z/20260131T070000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/north-by-north-1-30-25?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1761658330800" id="item-6900c558a262467a01d2d432"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-e1efa7c8b791c30a9088"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Lilly Hartle + Thoroughfare<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/northbynorthmusic/" target="_blank">✯&nbsp;North By North </a><br><a href="https://www.instagram.com/lilly.hartle/" target="_blank">✯&nbsp;Lilly Hartle</a><br><a href="https://www.instagram.com/thoroughfareofficial/" target="_blank">✯&nbsp;Thoroughfare</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/north-by-north-1-30-25" class="eventlist-button sqs-editable-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="6900c558a262467a01d2d432" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/6900c558a262467a01d2d432/1761658322811/" data-record-type="12" data-full-url="/schedule/north-by-north-1-30-25" data-title="North By North"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--past eventlist-event--multiday">
+
+        <a href="/schedule/weekend-friend-1-24-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/weekend-friend-1-24-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Jan</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">24</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Jan 25</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/weekend-friend-1-24-26" class="eventlist-title-link">Weekend Friend</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-01-24">Sat, Jan 24, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-01-24">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-01-24">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-01-25">Sun, Jan 25, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-01-25">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-01-25">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Weekend%20Friend&dates=20260125T020000Z/20260125T070000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/weekend-friend-1-24-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1761658198757" id="item-6900c4d5cc4f6e1374c93355"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-09f15f7ca3fdddd34ab7"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Oceanic + Camisole<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/weekendfriendmusic/" target="_blank">✯&nbsp;Weekend Friend</a><br><a href="https://www.instagram.com/oceanicofficial/" target="_blank">✯&nbsp;Oceanic</a><br><a href="https://www.instagram.com/camisole.wav/" target="_blank">✯&nbsp;Camisole</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/weekend-friend-1-24-26" class="eventlist-button sqs-editable-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="6900c4d5cc4f6e1374c93355" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/6900c4d5cc4f6e1374c93355/1766081480163/" data-record-type="12" data-full-url="/schedule/weekend-friend-1-24-26" data-title="Weekend Friend"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--past eventlist-event--multiday">
+
+        <a href="/schedule/local-nomad-1-23-25" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/local-nomad-1-23-25" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Jan</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">23</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Jan 24</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/local-nomad-1-23-25" class="eventlist-title-link">Local Nomad</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-01-23">Fri, Jan 23, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-01-23">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-01-23">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-01-24">Sat, Jan 24, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-01-24">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-01-24">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Local%20Nomad&dates=20260124T020000Z/20260124T070000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/local-nomad-1-23-25?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1761658073278" id="item-6900c45599af7e1887b6899b"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-d9fd284deeaca81c1014"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Maraluso + The Fiori<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/iamlocalnomad/" target="_blank">✯&nbsp;Local Nomad</a><br><a href="https://www.instagram.com/maralusomusic/" target="_blank">✯&nbsp;Maraluso</a><br><a href="https://www.instagram.com/thefioriii/" target="_blank">✯&nbsp;The Fiori</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/local-nomad-1-23-25" class="eventlist-button sqs-editable-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="6900c45599af7e1887b6899b" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/6900c45599af7e1887b6899b/1761658065300/" data-record-type="12" data-full-url="/schedule/local-nomad-1-23-25" data-title="Local Nomad"></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+      <article class="eventlist-event eventlist-event--past eventlist-event--multiday">
+
+        <a href="/schedule/current-blue-1-17-26" class="eventlist-column-thumbnail content-fill"></a>
+
+        <a href="/schedule/current-blue-1-17-26" class="eventlist-column-date">
+
+          <div class="eventlist-datetag">
+
+            <div class="eventlist-datetag-inner">
+
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--month">Jan</div>
+              <div class="eventlist-datetag-startdate eventlist-datetag-startdate--day">17</div>
+
+              
+              
+              <div class="eventlist-datetag-enddate">to Jan 18</div>
+
+              
+              
+
+              <div class="eventlist-datetag-status"></div>
+
+            </div>
+
+          </div>
+
+        </a>
+
+        <div class="eventlist-column-info">
+
+          
+
+          <h1 class="eventlist-title"><a href="/schedule/current-blue-1-17-26" class="eventlist-title-link">Slim S.O.U.L.</a></h1>
+
+          <ul class="eventlist-meta event-meta">
+
+            
+            
+
+            <li class="eventlist-meta-item eventlist-meta-date event-meta-item">
+
+              <time class="event-date" datetime="2026-01-17">Sat, Jan 17, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-01-17">9:00 PM</time>
+                <time class="event-time-24hr" datetime="2026-01-17">21:00</time>
+              </span>
+
+              <span class="event-datetime-divider"></span>
+
+              <time class="event-date" datetime="2026-01-18">Sun, Jan 18, 2026</time>
+
+              <span class="eventlist-meta-time">
+                <time class="event-time-12hr" datetime="2026-01-18">2:00 AM</time>
+                <time class="event-time-24hr" datetime="2026-01-18">02:00</time>
+              </span>
+
+            </li>
+
+
+            
+            
+
+            
+              
+            
+
+            <li class="eventlist-meta-item eventlist-meta-export event-meta-item">
+              <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=Slim%20S.O.U.L.&dates=20260118T020000Z/20260118T070000Z" class="eventlist-meta-export-google">Google Calendar</a>
+              <span class="eventlist-meta-export-divider"></span>
+              <a href="/schedule/current-blue-1-17-26?format=ical" class="eventlist-meta-export-ical">ICS</a>
+            </li>
+
+          </ul>
+
+          
+            
+            <div class="eventlist-description"><div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Post Body" data-type="item" data-updated-on="1761657932245" id="item-6900c39f631e710ab46fc9bf"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-8e10fb74a38926438ea1"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <p class="" style="white-space:pre-wrap;">w/ Kaizër + Unheared Ent. + Cervan Campbell<br>Doors: 9pm | $10<br><a href="https://www.instagram.com/slim_s.o.u.l/" target="_blank">✯&nbsp;Slim S.O.U.L.</a><br><a href="https://www.instagram.com/kaizer_iexist/" target="_blank">✯&nbsp;Kaizër</a><br><a href="https://www.instagram.com/unheard.ent/" target="_blank">✯&nbsp;Unheard Ent.</a></p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div></div>
+            
+          
+
+          <a href="/schedule/current-blue-1-17-26" class="eventlist-button sqs-editable-button sqs-button-element--primary">
+            View Event &#8594;
+          </a>
+
+          <div class="eventlist-actions">
+  <span class="sqs-simple-like" data-item-id="6900c39f631e710ab46fc9bf" data-like-count="0">
+    <span class="like-icon"></span>
+    <span class="like-count"></span>
+  </span>
+<span class="squarespace-social-buttons inline-style" data-system-data-id="" data-asset-url="https://static1.squarespace.com/static/5a04b1b8fe54ef9d6db1a38e/5a04b27e24a6946807ae890e/6900c39f631e710ab46fc9bf/1766776508341/" data-record-type="12" data-full-url="/schedule/current-blue-1-17-26" data-title="Slim S.O.U.L."></span></div>
+
+        </div>
+
+        <div class="clear"></div>
+
+      </article>
+
+    
+
+    </div>
+
+  </div>
+
+  <script>
+    // if no thumbnails have been uploaded, but the thumbnails tweak is enabled, manually remove the tweak class.
+    // it just looks nicer.
+    if( document.querySelectorAll('.eventlist--upcoming .eventlist-thumbnail').length === 0 &&
+        document.querySelectorAll('.event-show-past-events .eventlist--past .eventlist-thumbnail').length === 0) {
+      document.querySelector('body').classList.remove('event-thumbnails');
+    }
+  </script>
+              </section>
+            
+          </main>
+
+        </div>
+      </div>
+
+      <footer class="Footer" role="contentinfo" data-controller="FooterBreakpoints">
+
+  <div class="Footer-inner clear">
+
+    <div class="sqs-layout sqs-grid-12 columns-12 Footer-blocks Footer-blocks--top sqs-alternate-block-style-container" data-layout-label="Footer Top Blocks" data-type="block-field" data-updated-on="1515724601303" id="footerBlocksTop"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-sqsp-block="text" id="block-yui_3_17_2_35_1495466395180_4757"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <h3 class="text-align-center"><a href="/schedule">SCHEDULE</a>&nbsp; &nbsp;&nbsp; &nbsp;&nbsp;<a href="/menu">MENU</a>&nbsp; &nbsp; &nbsp;&nbsp;&nbsp;<a href="/gallery">GALLERY</a>&nbsp; &nbsp;&nbsp; &nbsp;&nbsp;<a href="/about">ABOUT</a>&nbsp; &nbsp;&nbsp; &nbsp;&nbsp;<a href="/gear-list">GEAR LIST</a>&nbsp; &nbsp;&nbsp; &nbsp;&nbsp;<a href="/contact">CONTACT</a></h3>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</div></div></div></div></div>
+
+    <div class="Footer-middle">
+      <div class="Footer-business">
+
+        
+
+        
+          
+        
+
+      </div>
+
+      <div class="sqs-layout sqs-grid-12 columns-12 Footer-blocks Footer-blocks--middle sqs-alternate-block-style-container" data-layout-label="Footer Middle Blocks" data-type="block-field" data-updated-on="1771336350648" id="footerBlocksMiddle"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="row sqs-row"><div class="col sqs-col-2 span-2"><div class="sqs-block website-component-block sqs-block-website-component sqs-block-spacer spacer-block sized vsize-1" data-block-css="[&quot;https://definitions.sqspcdn.com/website-component-definition/static-assets/website.components.spacer/ee252eb3-6876-42a2-ac75-8c52de232390_867/website.components.spacer.styles.css&quot;]" data-block-scripts="[&quot;https://definitions.sqspcdn.com/website-component-definition/static-assets/website.components.spacer/ee252eb3-6876-42a2-ac75-8c52de232390_867/website.components.spacer.visitor.js&quot;]" data-block-type="1337" data-definition-name="website.components.spacer" data-website-component-id="yui_3_17_2_2_1511146242432_9651" id="block-yui_3_17_2_2_1511146242432_9651"><div class="sqs-block-content">&nbsp;</div></div></div><div class="col sqs-col-8 span-8"><div class="sqs-block image-block sqs-block-image" data-block-type="5" data-sqsp-block="image-classic" id="block-yui_3_17_2_2_1511146242432_7119"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+        data-sqsp-image-classic-block-layout="inline"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1800px;"
+        >
+          
+        
+        
+
+        
+          <a
+              data-sqsp-image-classic-block-image-link
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/welcome"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div data-sqsp-image-classic-block-image-container class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:20.27777671813965%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                
+                
+                
+                
+                
+                
+                <img data-stretch="false" data-src="https://images.squarespace-cdn.com/content/v1/5a04b1b8fe54ef9d6db1a38e/1511146451257-SWEUBUNORAB2U8M1EH09/The+Royal+American+Illustration" data-image="https://images.squarespace-cdn.com/content/v1/5a04b1b8fe54ef9d6db1a38e/1511146451257-SWEUBUNORAB2U8M1EH09/The+Royal+American+Illustration" data-image-dimensions="1800x365" data-image-focal-point="0.5,0.5" alt="The Royal American Illustration" data-load="false" elementtiming="system-image-block" data-sqsp-image-classic-block-image src="https://images.squarespace-cdn.com/content/v1/5a04b1b8fe54ef9d6db1a38e/1511146451257-SWEUBUNORAB2U8M1EH09/The+Royal+American+Illustration" width="1800" height="365" alt="" sizes="(max-width: 640px) 100vw, (max-width: 767px) 66.66666666666666vw, 66.66666666666666vw" style="display:block;object-fit: cover; width: 100%; height: 100%; object-position: 50% 50%" onload="this.classList.add(&quot;loaded&quot;)" srcset="https://images.squarespace-cdn.com/content/v1/5a04b1b8fe54ef9d6db1a38e/1511146451257-SWEUBUNORAB2U8M1EH09/The+Royal+American+Illustration?format=100w 100w, https://images.squarespace-cdn.com/content/v1/5a04b1b8fe54ef9d6db1a38e/1511146451257-SWEUBUNORAB2U8M1EH09/The+Royal+American+Illustration?format=300w 300w, https://images.squarespace-cdn.com/content/v1/5a04b1b8fe54ef9d6db1a38e/1511146451257-SWEUBUNORAB2U8M1EH09/The+Royal+American+Illustration?format=500w 500w, https://images.squarespace-cdn.com/content/v1/5a04b1b8fe54ef9d6db1a38e/1511146451257-SWEUBUNORAB2U8M1EH09/The+Royal+American+Illustration?format=750w 750w, https://images.squarespace-cdn.com/content/v1/5a04b1b8fe54ef9d6db1a38e/1511146451257-SWEUBUNORAB2U8M1EH09/The+Royal+American+Illustration?format=1000w 1000w, https://images.squarespace-cdn.com/content/v1/5a04b1b8fe54ef9d6db1a38e/1511146451257-SWEUBUNORAB2U8M1EH09/The+Royal+American+Illustration?format=1500w 1500w, https://images.squarespace-cdn.com/content/v1/5a04b1b8fe54ef9d6db1a38e/1511146451257-SWEUBUNORAB2U8M1EH09/The+Royal+American+Illustration?format=2500w 2500w" loading="lazy" decoding="async" data-loader="sqs">
+
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div></div><div class="col sqs-col-2 span-2"><div class="sqs-block website-component-block sqs-block-website-component sqs-block-spacer spacer-block sized vsize-1" data-block-css="[&quot;https://definitions.sqspcdn.com/website-component-definition/static-assets/website.components.spacer/ee252eb3-6876-42a2-ac75-8c52de232390_867/website.components.spacer.styles.css&quot;]" data-block-scripts="[&quot;https://definitions.sqspcdn.com/website-component-definition/static-assets/website.components.spacer/ee252eb3-6876-42a2-ac75-8c52de232390_867/website.components.spacer.visitor.js&quot;]" data-block-type="1337" data-definition-name="website.components.spacer" data-website-component-id="yui_3_17_2_2_1511146242432_8940" id="block-yui_3_17_2_2_1511146242432_8940"><div class="sqs-block-content">&nbsp;</div></div></div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" data-border-radii="&#123;&quot;topLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;topRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomLeft&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;,&quot;bottomRight&quot;:&#123;&quot;unit&quot;:&quot;px&quot;,&quot;value&quot;:0.0&#125;&#125;" data-sqsp-block="text" id="block-yui_3_17_2_2_1511146242432_20190"><div class="sqs-block-content">
+
+<div class="sqs-html-content" data-sqsp-text-block-content>
+  <h3 style="text-align:center;white-space:pre-wrap;">✯ THE ROYAL AMERICAN ✯</h3><p style="text-align:center;white-space:pre-wrap;" class="">Open Daily 11 am - 2 am</p><p style="text-align:center;white-space:pre-wrap;" class="">Kitchen open ‘til 1am every damn day.</p><p style="text-align:center;white-space:pre-wrap;" class=""><a href="https://goo.gl/maps/87QLoKQCN2w" target="_blank">970 Morrison Drive, Charleston, SC</a><br>Phone: <a href="tel:+18438176925" target="_blank">843-817-6925</a>&nbsp;| Email: <a href="mailto:jk@theroyalamerican.com">kirsten@theroyalamerican.com</a><br>Visit our sister properties <a href="https://thebountybar.com/" target="_blank">The Bounty Bar</a> &amp; Grill + Johnny’s Garage</p>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
+</div></div></div></div></div>
+
+      
+    </div>
+
+    <div class="sqs-layout sqs-grid-12 columns-12 Footer-blocks Footer-blocks--bottom sqs-alternate-block-style-container" data-layout-label="Footer Bottom Blocks" data-type="block-field" data-updated-on="1724947291232" id="footerBlocksBottom"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block website-component-block sqs-block-website-component sqs-block-code code-block" data-block-css="[&quot;https://definitions.sqspcdn.com/website-component-definition/static-assets/website.components.code/af9ceeab-bba8-49f2-9ec7-77d5167c6e43_590/website.components.code.styles.css&quot;]" data-block-scripts="[&quot;https://definitions.sqspcdn.com/website-component-definition/static-assets/website.components.code/af9ceeab-bba8-49f2-9ec7-77d5167c6e43_590/website.components.code.visitor.js&quot;]" data-block-type="1337" data-definition-name="website.components.code" data-sqsp-block="code" data-website-component-id="yui_3_17_2_1_1532380926856_4504" id="block-yui_3_17_2_1_1532380926856_4504"><div class="sqs-block-content"><div
+  class="sqs-code-container"
+  
+  
+    data-localized="{&quot;enableSafeModeButton&quot;:&quot;Preview in safe mode&quot;,&quot;enableSafeModeText&quot;:&quot;This block contains embedded scripts. Embedded scripts are disabled while you're logged in and editing your site.&quot;,&quot;enableSafeModeTitle&quot;:&quot;Embedded Scripts&quot;,&quot;exitSafeModeButton&quot;:&quot;Exit safe preview&quot;,&quot;exitSafeModeText&quot;:&quot;Please view the page after logging out for accurate rendering.&quot;,&quot;exitSafeModeTitle&quot;:&quot;Safe Preview&quot;,&quot;globalSafeMode&quot;:&quot;Embedded Code: This block contains embedded code that has been disabled.&quot;,&quot;scriptDisabled&quot;:&quot;Script Disabled&quot;}"
+  
+  
+>
+  
+    <p><a href="http://joshcapeder.com" target="_blank"><font color="270000"><center>Website by Capeder Co</center></font></a></p>
+  
+</div>
+</div></div></div></div></div>
+
+  </div>
+
+</footer>
+
+
+    </div>
+
+    <script src="https://static1.squarespace.com/static/ta/55f0a9b0e4b0f3eb70352f6d/359/scripts/site-bundle.js" type="text/javascript"></script>
+
+    <script data-sqs-type="imageloader-bootstrapper">if(window.ImageLoader) window.ImageLoader.bootstrap({}, document);</script><script>Squarespace.afterBodyLoad(Y);</script>
+
+
+  </body>
+</html>

--- a/tests/Unit/DateTimeParserTest.php
+++ b/tests/Unit/DateTimeParserTest.php
@@ -36,18 +36,44 @@ class DateTimeParserTest extends WP_UnitTestCase {
 		$this->assertEquals( '13:00', $la['time'] );
 	}
 
-	public function test_parse_utc_returns_empty_for_invalid_timezone() {
+	public function test_parse_utc_falls_back_to_site_timezone_for_invalid_timezone() {
+		// Defense-in-depth fix from #254: invalid timezone must NOT silently destroy
+		// the date — it must fall back to the site timezone so a missing venue
+		// timezone cannot cascade into off-by-one duplicates.
 		$result = DateTimeParser::parseUtc( '2026-01-15T18:00:00Z', 'Invalid/Timezone' );
 
-		$this->assertEquals( '', $result['date'] );
-		$this->assertEquals( '', $result['time'] );
-		$this->assertEquals( '', $result['timezone'] );
+		$this->assertNotEmpty( $result['date'], 'parseUtc must not return an empty date when timezone is invalid' );
+		$this->assertNotEmpty( $result['time'] );
+		$this->assertNotEmpty( $result['timezone'], 'parseUtc must report the fallback timezone it used' );
+		$this->assertTrue( DateTimeParser::isValidTimezone( $result['timezone'] ) );
+	}
+
+	public function test_parse_utc_falls_back_to_site_timezone_for_empty_timezone() {
+		// Royal American repro: Squarespace shows at 9pm Eastern land on the next
+		// calendar day in UTC. With an empty timezone, the old code returned empty
+		// and the caller picked a fragile fallback path. With the fix, parseUtc
+		// falls back to the WP site timezone and still produces a stable date.
+		$result = DateTimeParser::parseUtc( '2026-05-16T01:00:00Z', '' );
+
+		$this->assertNotEmpty( $result['date'], 'parseUtc must not silently drop the date when timezone is empty' );
+		$this->assertNotEmpty( $result['timezone'] );
+		$this->assertTrue( DateTimeParser::isValidTimezone( $result['timezone'] ) );
 	}
 
 	public function test_parse_utc_returns_empty_for_empty_datetime() {
 		$result = DateTimeParser::parseUtc( '', 'America/Chicago' );
 
 		$this->assertEquals( '', $result['date'] );
+	}
+
+	public function test_parse_utc_valid_timezone_path_unchanged() {
+		// Regression guard: explicit valid timezone must continue to produce the
+		// exact same output it did before the fallback was introduced.
+		$result = DateTimeParser::parseUtc( '2026-05-16T01:00:00Z', 'America/New_York' );
+
+		$this->assertEquals( '2026-05-15', $result['date'] );
+		$this->assertEquals( '21:00', $result['time'] );
+		$this->assertEquals( 'America/New_York', $result['timezone'] );
 	}
 
 	public function test_parse_local_preserves_datetime() {

--- a/tests/Unit/PageVenueExtractorTest.php
+++ b/tests/Unit/PageVenueExtractorTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * PageVenueExtractor Tests
+ *
+ * Regression coverage for the Squarespace timezone regex fix (#254).
+ *
+ * @package DataMachineEvents\Tests\Unit
+ */
+
+namespace DataMachineEvents\Tests\Unit;
+
+use WP_UnitTestCase;
+use DataMachineEvents\Steps\EventImport\Handlers\WebScraper\PageVenueExtractor;
+
+class PageVenueExtractorTest extends WP_UnitTestCase {
+
+	/**
+	 * Minimal HTML mimicking Squarespace's nested SQUARESPACE_CONTEXT JSON.
+	 *
+	 * The pre-#254 regex used `[^}]*` which cannot cross any `}` boundary, so
+	 * it could never match a real Squarespace page (whose context JSON always
+	 * has multiple nested objects before `website.timeZone`). This fixture
+	 * reproduces that nested shape with the absolute minimum nesting required
+	 * to trigger the bug.
+	 */
+	public function test_extractTimezone_matches_nested_squarespace_context() {
+		$html = '<html><head><script>'
+			. 'Static.SQUARESPACE_CONTEXT = {'
+			. '"betaFeatureFlags":{"foo":true,"bar":1},'
+			. '"rollups":{"x":{"y":1}},'
+			. '"website":{"timeZone":"America/New_York","other":"x"}'
+			. '};'
+			. '</script></head><body></body></html>';
+
+		$this->assertEquals(
+			'America/New_York',
+			PageVenueExtractor::extractTimezone( $html ),
+			'Squarespace context with nested objects before website.timeZone must still match.'
+		);
+	}
+
+	public function test_extractTimezone_matches_when_timezone_is_first_key() {
+		// Simple shape (no nesting before timeZone) — should still match.
+		$html = '<script>Static.SQUARESPACE_CONTEXT = {"website":{"timeZone":"America/Chicago"}};</script>';
+
+		$this->assertEquals( 'America/Chicago', PageVenueExtractor::extractTimezone( $html ) );
+	}
+
+	public function test_extractTimezone_falls_back_to_generic_timezone_property() {
+		// Non-Squarespace platforms expose a generic "timezone" JSON property —
+		// the second regex branch must still hit when there's no SQUARESPACE_CONTEXT.
+		$html = '<script>var config = {"timezone":"America/Denver"};</script>';
+
+		$this->assertEquals( 'America/Denver', PageVenueExtractor::extractTimezone( $html ) );
+	}
+
+	public function test_extractTimezone_falls_back_to_meta_tag() {
+		$html = '<html><head><meta name="timezone" content="Europe/London"></head></html>';
+
+		$this->assertEquals( 'Europe/London', PageVenueExtractor::extractTimezone( $html ) );
+	}
+
+	public function test_extractTimezone_returns_empty_when_nothing_found() {
+		$html = '<html><body>no timezone here</body></html>';
+
+		$this->assertEquals( '', PageVenueExtractor::extractTimezone( $html ) );
+	}
+
+	public function test_extractTimezone_matches_royal_american_fixture() {
+		// Snapshot of https://www.theroyalamerican.com/schedule (Squarespace 7.x)
+		// captured during the #254 investigation. The full live HTML reproduces
+		// the exact failure mode of the pre-fix regex — if this stops matching,
+		// the regex has regressed.
+		$fixture = __DIR__ . '/../Fixtures/squarespace-royal-american.html';
+
+		if ( ! file_exists( $fixture ) ) {
+			$this->markTestSkipped( 'Royal American fixture not present (optional snapshot).' );
+		}
+
+		$html = file_get_contents( $fixture );
+		$this->assertEquals( 'America/New_York', PageVenueExtractor::extractTimezone( $html ) );
+	}
+}


### PR DESCRIPTION
Fixes #254.

## Summary

- **One-character-class regex fix** in `PageVenueExtractor::extractTimezone()`: replace `\{[^}]*"timeZone"` → `\{.*?"timeZone"`. The old `[^}]*` could not cross any `}` boundary, so it never matched real Squarespace pages whose context JSON nests objects (`betaFeatureFlags`, `rollups`, `merchandisingSettings`, `userAccountsSettings`, …) before `website.timeZone`.
- **Defense in depth** in `DateTimeParser::parseUtc()`: an empty/invalid `$timezone` no longer silently returns an empty result. It falls back to the WP site timezone (`wp_timezone()`) and emits a `datamachine_log` warning. This prevents the next upstream extractor bug from cascading into off-by-one duplicates.
- New unit tests in `tests/Unit/PageVenueExtractorTest.php` covering nested context JSON, the simple shape, the generic `"timezone"` fallback, the meta-tag fallback, and a Royal American snapshot fixture.
- Updated `tests/Unit/DateTimeParserTest.php` to assert the new fallback contract (was asserting the silent-empty behavior that **caused** #254).
- Squarespace JSON-LD prefer-path (#254 fix direction step 4) deliberately **skipped** — `SquarespaceExtractor` processes listing JSON, not single-event pages, so the path isn't reachable. Left as out-of-scope per the issue's verification instruction.

## Before / after regex

```diff
- '/Static\.SQUARESPACE_CONTEXT\s*=\s*\{[^}]*"timeZone"\s*:\s*"([^"]+)"/s'
+ '/Static\.SQUARESPACE_CONTEXT\s*=\s*\{.*?"timeZone"\s*:\s*"([^"]+)"/s'
```

Verified against the live Royal American page (saved as `tests/Fixtures/squarespace-royal-american.html`):

```
$ curl -sL https://www.theroyalamerican.com/schedule -A 'Mozilla/5.0' \
    | php -r '$h=stream_get_contents(STDIN);
              echo preg_match("/Static\\.SQUARESPACE_CONTEXT\\s*=\\s*\\{[^}]*\"timeZone\"\\s*:\\s*\"([^\"]+)\"/s", $h, $m) ? "OLD: $m[1]\n" : "OLD: NO MATCH\n";
              echo preg_match("/Static\\.SQUARESPACE_CONTEXT\\s*=\\s*\\{.*?\"timeZone\"\\s*:\\s*\"([^\"]+)\"/s", $h, $m) ? "NEW: $m[1]\n" : "NEW: NO MATCH\n";'
OLD: NO MATCH
NEW: America/New_York
```

## Why the calendar dupes stop accumulating

Once the timezone resolves correctly, `parseSquarespaceTimestamp(1778893200776, "America/New_York")` returns `2026-05-15 21:00` instead of falling through to a fragile fallback that produced a different date on each run. The Royal American repro from #254:

| Title | Post A date | Post B date | URL slug says | Real date |
|---|---|---|---|---|
| She Returns From War | 2026-01-17 | 2026-01-16 | `…-1-16-26` | 2026-01-16 |
| C. Shreve The Professor | 2026-02-20 | 2026-02-21 | `…-2-21-26` | 2026-02-21 |
| Never Really Over | 2026-03-06 | 2026-03-07 | `…-3-7-26` | 2026-03-07 |
| Daddy's Mantra Tour | 2026-03-13 | 2026-03-14 | `…-3-13-26` | 2026-03-13 |
| Recess Party + Winterteeth | 2026-03-20 | 2026-03-21 | (no slug) | one of two |

After this lands, every Squarespace-on-Eastern venue stops producing new off-by-one dupes on each scrape. Network-wide, ~2,245 existing upcoming-event dupes (~6.8% of the calendar) will stop growing.

## Test plan

New / updated tests:

1. `PageVenueExtractorTest::test_extractTimezone_matches_nested_squarespace_context` — minimal nested fixture that the old regex provably cannot match.
2. `PageVenueExtractorTest::test_extractTimezone_matches_when_timezone_is_first_key` — simple SQS shape (regression guard).
3. `PageVenueExtractorTest::test_extractTimezone_falls_back_to_generic_timezone_property` — non-Squarespace JSON branch still works.
4. `PageVenueExtractorTest::test_extractTimezone_falls_back_to_meta_tag` — meta-tag branch still works.
5. `PageVenueExtractorTest::test_extractTimezone_returns_empty_when_nothing_found` — clean miss path.
6. `PageVenueExtractorTest::test_extractTimezone_matches_royal_american_fixture` — full live HTML snapshot from `https://www.theroyalamerican.com/schedule`.
7. `DateTimeParserTest::test_parse_utc_falls_back_to_site_timezone_for_invalid_timezone` — new contract.
8. `DateTimeParserTest::test_parse_utc_falls_back_to_site_timezone_for_empty_timezone` — new contract, repro for the #254 cascade.
9. `DateTimeParserTest::test_parse_utc_valid_timezone_path_unchanged` — regression guard for the happy path.

<callout accent="#f59e0b">
## PHPUnit harness has a pre-existing bootstrap failure

`homeboy test` on this repo currently fails before any plugin test runs (same blocker reported in #253):

```
BOOTSTRAP FAILURE: load_deps:Error: Class "WP_Agent_Memory_Layer" not found
  at /wordpress/wp-content/plugins/data-machine/inc/Engine/AI/MemoryFileRegistry.php:593
```

This is a DM-core / playground bootstrap problem unrelated to this change. The new tests are syntactically valid (`php -l` passes on all four touched PHP files) and the regex assertions were verified independently against:

- the live Royal American HTML (saved as the test fixture)
- the minimal nested fixture from the new unit test

`homeboy audit --path .` reports **13 outliers, alignment score 0.877** — identical to the baseline on `main`, so no new architectural drift was introduced.
</callout>

## Cleanup (post-deploy, not part of this PR)

Run `wp data-machine-events check clean-duplicates --scope=all --yes` after this lands so the existing ~2,245 off-by-one dupes get collapsed once a fresh scrape rewrites the canonical posts.

## Constraints honored

- No version bump, no `CHANGELOG.md` edits, no release, no deploy.
- Conventional commit (`fix:`) subject = 65 chars; #254 referenced in body.
- Worktree-only: edits live at `/var/lib/datamachine/workspace/data-machine-events@fix-squarespace-timezone-regex`; `/var/www/extrachill.com/wp-content/plugins/data-machine-events/` untouched.
- Did NOT touch the AI Vision fallback (out of scope per #254).
- Did NOT attempt #198 / #199 / #219 (separate issues).