### PR TITLE
feat(extractors): Bandzoogle handler for indie venues using Bandzoogle CMS

### DIFF
--- a/inc/Steps/EventImport/Handlers/WebScraper/Extractors/BandzoogleExtractor.php
+++ b/inc/Steps/EventImport/Handlers/WebScraper/Extractors/BandzoogleExtractor.php
@@ -1,17 +1,49 @@
 <?php
 /**
-/**
- * Bandzoogle extractor.
+ * Bandzoogle CMS extractor.
  *
- * Extracts event data from Bandzoogle calendar sites by crawling month pages
- * and fetching individual event detail popups. Maintains legacy regex stability.
+ * Bandzoogle is a self-serve website builder popular with small indie venues
+ * and DIY rooms. Calendars live at venue-specific paths (e.g. /calendar,
+ * /gigs, /shows) and the markup is platform-specific.
+ *
+ * The current Bandzoogle "anthem" generation of themes renders an event
+ * list using:
+ *
+ *   <div class="event-detail" data-event-id="..." data-occurrence-id="...">
+ *     <div class="event-image"><a><img src="..." /></a></div>
+ *     <div class="event-description">
+ *       <h2 class="event-info event-title"><a href="...">Title</a></h2>
+ *       <p class="event-info event-datetime">
+ *         <time class="from">
+ *           <span class="date">Wednesday, May 13</span> @ <span class="time">6:00PM</span>
+ *         </time>
+ *       </p>
+ *       <p class="event-info event-location"><a href="...maps...">Sub-venue</a></p>
+ *       <div class="event-info event-notes"><p>...</p></div>
+ *       <div class="event-info buying-options">...share/ticket buttons...</div>
+ *     </div>
+ *   </div>
+ *
+ * The calendar's month/year context lives separately in
+ * `<span class="month-name">May 2026</span>` near the top of the calendar
+ * feature. The individual `event-datetime` markup intentionally omits the
+ * year, so we resolve the year from that header (with a sane fallback).
+ *
+ * Detection: Bandzoogle ships everything from `bndzgl.com` (app assets) and
+ * `zoogletools.com` (image CDN), plus a `data-event-id` attribute on each
+ * event card. Any one of those is enough to call it Bandzoogle.
+ *
+ * Note: the original issue (#261) described an older Bandzoogle theme using
+ * `.gig-info`, `.gig-artist`, etc. We keep detection broad enough to catch
+ * that legacy markup too, but the parser targets the current `event-detail`
+ * shape observed on real production sites (Elephant Room, Austin TX).
  *
  * @package DataMachineEvents\Steps\EventImport\Handlers\WebScraper\Extractors
  */
 
 namespace DataMachineEvents\Steps\EventImport\Handlers\WebScraper\Extractors;
 
-use DataMachine\Core\HttpClient;
+use DataMachineEvents\Steps\EventImport\Handlers\WebScraper\PageVenueExtractor;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -19,68 +51,59 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class BandzoogleExtractor extends BaseExtractor {
 
-	const MAX_PAGES = 12; // Limit pagination to 1 year forward
-
+	/**
+	 * Detect Bandzoogle.
+	 *
+	 * Any of these is a strong positive signal:
+	 *   - asset host `bndzgl.com`
+	 *   - image CDN `zoogletools.com`
+	 *   - `bandzoogle.com` reference (footer credit / "powered by")
+	 *   - `data-event-id=` paired with `event-detail` class
+	 *   - legacy `.gig-info` / `.gigs` / `.bandzoogle-` class names
+	 */
 	public function canExtract( string $html ): bool {
-		// Bandzoogle sites often have these characteristic identifiers
-		return ( strpos( $html, 'class="month-name"' ) !== false && strpos( $html, '/go/calendar/' ) !== false )
-			|| ( strpos( $html, 'class="event-title"' ) !== false && strpos( $html, 'class="event-notes"' ) !== false )
-			|| strpos( $html, 'bandzoogle.com' ) !== false;
+		if ( '' === $html ) {
+			return false;
+		}
+
+		$markers = array(
+			'bndzgl.com',
+			'zoogletools.com',
+			'bandzoogle.com',
+			'class="bandzoogle-',
+			'class="gig-info"',
+			'class="gigs"',
+		);
+
+		foreach ( $markers as $marker ) {
+			if ( false !== strpos( $html, $marker ) ) {
+				return true;
+			}
+		}
+
+		// data-event-id + event-detail is unique to Bandzoogle calendars.
+		if ( false !== strpos( $html, 'data-event-id=' ) && false !== strpos( $html, 'event-detail' ) ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	public function extract( string $html, string $source_url ): array {
-		$all_events  = array();
-		$current_url = $source_url;
-		$visited     = array();
-		$page_count  = 1;
+		$page_venue = PageVenueExtractor::extract( $html, $source_url );
 
-		// Start with the initial HTML provided
-		$current_html = $html;
+		// Resolve year from the calendar header (`May 2026`). Falls back to
+		// the current year, then to inferring from month/day.
+		$calendar_year = $this->extractCalendarYear( $html );
 
-		while ( $page_count <= self::MAX_PAGES ) {
-			$url_hash = md5( $current_url );
-			if ( isset( $visited[ $url_hash ] ) ) {
-				break;
-			}
-			$visited[ $url_hash ] = true;
+		$events = $this->extractEventDetailBlocks( $html, $source_url, $page_venue, $calendar_year );
 
-			// 1. Get month context (Year/Month) for date resolution
-			$context = $this->parseMonthContext( $current_html );
-			if ( empty( $context ) ) {
-				$context = $this->parseMonthContextFromUrl( $current_url );
-			}
-
-			// 2. Extract individual occurrence URLs (popups)
-			$occurrence_urls = $this->extractOccurrenceUrls( $current_html, $current_url );
-
-			foreach ( $occurrence_urls as $occurrence_url ) {
-				$detail_html = $this->fetchHtml( $occurrence_url );
-				if ( empty( $detail_html ) ) {
-					continue;
-				}
-
-				$event = $this->parseOccurrenceHtml( $detail_html, $occurrence_url, $context );
-				if ( ! empty( $event['title'] ) && ! empty( $event['startDate'] ) ) {
-					$all_events[] = $event;
-				}
-			}
-
-			// 3. Find next month URL
-			$next_url = $this->findNextMonthUrl( $current_html, $current_url );
-			if ( empty( $next_url ) ) {
-				break;
-			}
-
-			$current_url  = $next_url;
-			$current_html = $this->fetchHtml( $current_url );
-			if ( empty( $current_html ) ) {
-				break;
-			}
-
-			++$page_count;
+		if ( empty( $events ) ) {
+			// Legacy `.gig-info` markup fallback.
+			$events = $this->extractGigInfoBlocks( $html, $source_url, $page_venue );
 		}
 
-		return $all_events;
+		return $events;
 	}
 
 	public function getMethod(): string {
@@ -88,195 +111,416 @@ class BandzoogleExtractor extends BaseExtractor {
 	}
 
 	/**
-	 * Parse month/year from the calendar header.
+	 * Parse the calendar header for a 4-digit year.
+	 *
+	 * Bandzoogle renders the current month as:
+	 *   <span class="month-name">May 2026</span>
+	 *
+	 * Some themes use slightly different wrappers, so we accept any
+	 * `month-name` span. If absent, returns 0 (caller falls back to
+	 * BaseExtractor::inferDateFromMonthDay).
+	 *
+	 * @return int Year (e.g. 2026) or 0 when unknown.
 	 */
-	private function parseMonthContext( string $html ): ?array {
-		if ( ! preg_match( '#<span[^>]*class=["\']month-name["\'][^>]*>\s*([^<]+)\s*</span>#i', $html, $m ) ) {
-			return null;
+	private function extractCalendarYear( string $html ): int {
+		if ( preg_match( '/<span[^>]*class="[^"]*month-name[^"]*"[^>]*>\s*([A-Za-z]+)\s+(\d{4})\s*<\/span>/i', $html, $m ) ) {
+			return (int) $m[2];
 		}
 
-		$label = trim( html_entity_decode( $m[1], ENT_QUOTES | ENT_HTML5 ) );
-		if ( ! preg_match( '/^([A-Za-z]+)\s+(\d{4})$/', $label, $mm ) ) {
-			return null;
+		// Fallback: pagination links carry `?month=N&year=YYYY`. The "next" link
+		// always points one month ahead of the current view; subtracting 1 from
+		// that month would require date math, so we just use the year as-is
+		// because the year flips so rarely that this is good enough.
+		if ( preg_match( '/[?&]year=(\d{4})/', $html, $m ) ) {
+			return (int) $m[1];
 		}
 
-		$month_num = (int) date( 'n', strtotime( $mm[1] . ' 1' ) );
-		$year      = (int) $mm[2];
-
-		return ( $month_num > 0 && $year > 0 ) ? array(
-			'year'  => $year,
-			'month' => $month_num,
-		) : null;
+		return 0;
 	}
 
 	/**
-	 * Parse month/year from the URL if not found in HTML.
+	 * Extract events from the modern `event-detail` list view.
+	 *
+	 * @param string $html       Full page HTML.
+	 * @param string $source_url Source URL for resolving relative links.
+	 * @param array  $page_venue Venue data extracted from page context.
+	 * @param int    $calendar_year Year resolved from calendar header, or 0.
+	 * @return array Normalized event records.
 	 */
-	private function parseMonthContextFromUrl( string $url ): ?array {
-		$path = (string) parse_url( $url, PHP_URL_PATH );
-		if ( preg_match( '#/go/calendar/\d+/(\d{4})/(\d{1,2})#', $path, $m ) ) {
-			return array(
-				'year'  => (int) $m[1],
-				'month' => (int) $m[2],
-			);
+	private function extractEventDetailBlocks( string $html, string $source_url, array $page_venue, int $calendar_year ): array {
+		// Capture each <div class="event-detail" data-event-id="...">...</div> block.
+		// We anchor on the opening tag and consume until the matching closing div by
+		// using a depth-aware split: the next `event-detail` opener (or EOF) bounds it.
+		if ( ! preg_match_all(
+			'/<div\s+class="event-detail"[^>]*data-event-id="(\d+)"[^>]*data-occurrence-id="(\d+)"[^>]*>(.*?)(?=<div\s+class="event-detail"\b|<div class="event-clear">|<\/article>\s*<\/div>\s*<\/section>|<\/section>\s*<\/div>\s*<footer)/si',
+			$html,
+			$matches,
+			PREG_SET_ORDER
+		) ) {
+			return array();
 		}
-		return null;
-	}
 
-	/**
-	 * Extract event detail URLs from the calendar grid.
-	 */
-	private function extractOccurrenceUrls( string $html, string $current_url ): array {
-		preg_match_all( '#href=["\'](/go/events/\d+\?[^"\']*occurrence_id=\d+[^"\']*)["\']#i', $html, $matches );
+		$events = array();
 
-		$urls   = array();
-		$parsed = parse_url( $current_url );
-		$host   = $parsed['host'] ?? '';
-		$scheme = $parsed['scheme'] ?? 'https';
+		foreach ( $matches as $match ) {
+			$event_id      = $match[1];
+			$occurrence_id = $match[2];
+			$inner         = $match[3];
 
-		foreach ( ( $matches[1] ?? array() ) as $rel ) {
-			$rel = html_entity_decode( $rel, ENT_QUOTES | ENT_HTML5 );
-			if ( ! str_contains( $rel, 'popup=1' ) ) {
-				$rel .= ( str_contains( $rel, '?' ) ? '&' : '?' ) . 'popup=1';
+			$event = $this->parseEventDetailBlock( $inner, $source_url, $page_venue, $calendar_year, $event_id, $occurrence_id );
+			if ( ! empty( $event['title'] ) && ! empty( $event['startDate'] ) ) {
+				$events[] = $event;
 			}
-			$urls[] = $scheme . '://' . $host . $rel;
 		}
 
-		return array_values( array_unique( $urls ) );
+		return $events;
 	}
 
 	/**
-	 * Find the link to the next month's calendar.
+	 * Parse a single `.event-detail` block.
 	 */
-	private function findNextMonthUrl( string $html, string $current_url ): string {
-		if ( ! preg_match( '#<a[^>]*class=["\'][^"\']*\bnext\b[^"\']*["\'][^>]*href=["\']([^"\']+)["\']#i', $html, $m ) ) {
-			return '';
+	private function parseEventDetailBlock( string $html, string $source_url, array $page_venue, int $calendar_year, string $event_id, string $occurrence_id ): array {
+		$event = array(
+			'title'         => '',
+			'description'   => '',
+			'startDate'     => '',
+			'startTime'     => '',
+			'endDate'       => '',
+			'endTime'       => '',
+			'venue'         => $page_venue['venue'] ?? '',
+			'venueAddress'  => $page_venue['venueAddress'] ?? '',
+			'venueCity'     => $page_venue['venueCity'] ?? '',
+			'venueState'    => $page_venue['venueState'] ?? '',
+			'venueZip'      => $page_venue['venueZip'] ?? '',
+			'venueCountry'  => $page_venue['venueCountry'] ?? 'US',
+			'venueTimezone' => $page_venue['venueTimezone'] ?? '',
+			'ticketUrl'     => '',
+			'imageUrl'      => '',
+			'source_url'    => '',
+			'price'         => '',
+		);
+
+		// Title + event detail page URL.
+		if ( preg_match( '/<h2[^>]*class="[^"]*event-title[^"]*"[^>]*>\s*<a\s+href="([^"]+)"[^>]*>(.*?)<\/a>\s*<\/h2>/is', $html, $m ) ) {
+			$event['source_url'] = esc_url_raw( html_entity_decode( $m[1], ENT_QUOTES, 'UTF-8' ) );
+			$event['title']      = $this->sanitizeText( html_entity_decode( wp_strip_all_tags( $m[2] ), ENT_QUOTES, 'UTF-8' ) );
 		}
 
-		$href = html_entity_decode( $m[1], ENT_QUOTES | ENT_HTML5 );
-		if ( empty( $href ) ) {
-			return '';
+		// Datetime: parse "Wednesday, May 13" + "6:00PM" inside event-datetime.
+		if ( preg_match( '/<p[^>]*class="[^"]*event-datetime[^"]*"[^>]*>(.*?)<\/p>/is', $html, $dt_match ) ) {
+			$this->parseDatetimeFragment( $event, $dt_match[1], $calendar_year );
 		}
 
-		if ( strpos( $href, '//' ) === 0 ) {
-			return 'https:' . $href;
-		}
-		if ( preg_match( '#^https?://#i', $href ) ) {
-			return $href;
-		}
-
-		$parsed = parse_url( $current_url );
-		$host   = $parsed['host'] ?? '';
-		$scheme = $parsed['scheme'] ?? 'https';
-
-		if ( empty( $host ) ) {
-			return '';
-		}
-		if ( '/' !== $href[0] ) {
-			$href = '/' . $href;
+		// Sub-venue / room (e.g. "🐘6pm" at Elephant Room). Only override the
+		// venue NAME — keep page-level address. Many Bandzoogle venues do not
+		// expose per-event addresses.
+		if ( preg_match( '/<p[^>]*class="[^"]*event-location[^"]*"[^>]*>(.*?)<\/p>/is', $html, $loc_match ) ) {
+			$loc_text = trim( html_entity_decode( wp_strip_all_tags( $loc_match[1] ), ENT_QUOTES, 'UTF-8' ) );
+			if ( '' !== $loc_text && empty( $event['venue'] ) ) {
+				$event['venue'] = $this->sanitizeText( $loc_text );
+			}
 		}
 
-		return $scheme . '://' . $host . $href;
+		// Description from event-notes block.
+		if ( preg_match( '/<div[^>]*class="[^"]*event-notes[^"]*"[^>]*>(.*?)<\/div>/is', $html, $notes_match ) ) {
+			$event['description'] = $this->cleanHtml( $notes_match[1] );
+		}
+
+		// Image — prefer the social-sized event-image, fall back to any <img>.
+		if ( preg_match( '/<div[^>]*class="[^"]*event-image[^"]*"[^>]*>.*?<img[^>]+src="([^"]+)"/is', $html, $img_match ) ) {
+			$event['imageUrl'] = esc_url_raw( $this->resolveUrl( html_entity_decode( $img_match[1], ENT_QUOTES, 'UTF-8' ), $source_url ) );
+		}
+
+		// Ticket URL — Bandzoogle's buying-options block contains an external
+		// purchase link when the venue sells tickets through the site. Look
+		// for any non-share, non-map external link inside it.
+		$event['ticketUrl'] = $this->findTicketUrl( $html, $source_url );
+
+		// As a last resort, point ticketUrl at the event detail page so
+		// downstream pipelines always have something to link to.
+		if ( '' === $event['ticketUrl'] && '' !== $event['source_url'] ) {
+			$event['ticketUrl'] = $event['source_url'];
+		}
+
+		return $event;
 	}
 
 	/**
-	 * Parse the individual event popup HTML.
+	 * Pull date + time out of the `.event-datetime` paragraph.
+	 *
+	 * Bandzoogle prints two variants side-by-side (long + short). We parse
+	 * the first one we find. Format examples:
+	 *   "Wednesday, May 13 @ 6:00PM"
+	 *   "Wed, May 13 @ 6:00PM"
 	 */
-	private function parseOccurrenceHtml( string $html, string $occurrence_url, ?array $context ): array {
-		$title       = '';
-		$source_url  = $occurrence_url;
-		$description = '';
-		$image_url   = '';
-		$date_text   = '';
-		$time_text   = '';
+	private function parseDatetimeFragment( array &$event, string $fragment, int $calendar_year ): void {
+		// Pull all `<time>` elements; the first `class="from"` is start, second is end (if present).
+		if ( preg_match_all( '/<time[^>]*class="([^"]*)"[^>]*>(.*?)<\/time>/is', $fragment, $time_matches, PREG_SET_ORDER ) ) {
+			$start_set = false;
+			foreach ( $time_matches as $tm ) {
+				$class = $tm[1];
+				$inner = $tm[2];
 
-		// Title and Source URL
-		if ( preg_match( '#<h2[^>]*class=["\'][^"\']*\bevent-title\b[^"\']*["\'][^>]*>\s*<a[^>]*href=["\']([^"\']+)["\'][^>]*>(.*?)</a>#is', $html, $m ) ) {
-			$source_url = html_entity_decode( $m[1], ENT_QUOTES | ENT_HTML5 );
-			$title      = trim( wp_strip_all_tags( html_entity_decode( $m[2], ENT_QUOTES | ENT_HTML5 ) ) );
-		} elseif ( preg_match( '#<h2[^>]*class=["\'][^"\']*\bevent-title\b[^"\']*["\'][^>]*>(.*?)</h2>#is', $html, $m ) ) {
-			$title = trim( wp_strip_all_tags( html_entity_decode( $m[1], ENT_QUOTES | ENT_HTML5 ) ) );
+				$is_start = ! $start_set && ( false !== strpos( $class, 'from' ) || ! $start_set );
+				$is_end   = $start_set && false !== strpos( $class, 'to' );
+
+				$parsed = $this->parseTimeBlock( $inner, $calendar_year );
+
+				if ( $is_start && ! empty( $parsed['date'] ) ) {
+					$event['startDate'] = $parsed['date'];
+					$event['startTime'] = $parsed['time'];
+					$start_set          = true;
+				} elseif ( $is_end && ! empty( $parsed['date'] ) ) {
+					$event['endDate'] = $parsed['date'];
+					$event['endTime'] = $parsed['time'];
+				}
+			}
 		}
 
-		// Date and Time
-		if ( preg_match( '#<time[^>]*class=["\']from["\'][^>]*>.*?<span[^>]*class=["\'][^"\']*\bdate\b[^"\']*["\'][^>]*>(.*?)</span>\s*@\s*<span[^>]*class=["\'][^"\']*\btime\b[^"\']*["\'][^>]*>(.*?)</span>#is', $html, $m ) ) {
-			$date_text = trim( wp_strip_all_tags( html_entity_decode( $m[1], ENT_QUOTES | ENT_HTML5 ) ) );
-			$time_text = trim( wp_strip_all_tags( html_entity_decode( $m[2], ENT_QUOTES | ENT_HTML5 ) ) );
+		// Some Bandzoogle themes omit the inner spans and inline the text.
+		// Fall back to scraping the raw fragment if we still have nothing.
+		if ( '' === $event['startDate'] ) {
+			$parsed = $this->parseTimeBlock( $fragment, $calendar_year );
+			if ( ! empty( $parsed['date'] ) ) {
+				$event['startDate'] = $parsed['date'];
+				$event['startTime'] = $parsed['time'];
+			}
+		}
+	}
+
+	/**
+	 * Parse a single time block's inner HTML (e.g. the contents of a `<time>` tag)
+	 * to a date + time tuple.
+	 *
+	 * @return array{date: string, time: string}
+	 */
+	private function parseTimeBlock( string $html, int $calendar_year ): array {
+		$out = array(
+			'date' => '',
+			'time' => '',
+		);
+
+		// Date span: "Wednesday, May 13" or "Wed, May 13".
+		$date_text = '';
+		if ( preg_match( '/<span[^>]*class="date"[^>]*>(.*?)<\/span>/is', $html, $m ) ) {
+			$date_text = trim( wp_strip_all_tags( $m[1] ) );
 		} else {
-			if ( preg_match( '#<span[^>]*class=["\'][^"\']*\bdate\b[^"\']*["\'][^>]*>(.*?)</span>#is', $html, $m ) ) {
-				$date_text = trim( wp_strip_all_tags( html_entity_decode( $m[1], ENT_QUOTES | ENT_HTML5 ) ) );
-			}
-			if ( preg_match( '#<span[^>]*class=["\'][^"\']*\btime\b[^"\']*["\'][^>]*>(.*?)</span>#is', $html, $m ) ) {
-				$time_text = trim( wp_strip_all_tags( html_entity_decode( $m[1], ENT_QUOTES | ENT_HTML5 ) ) );
+			$date_text = trim( wp_strip_all_tags( $html ) );
+		}
+
+		// Time span: "6:00PM".
+		$time_text = '';
+		if ( preg_match( '/<span[^>]*class="time"[^>]*>(.*?)<\/span>/is', $html, $m ) ) {
+			$time_text = trim( wp_strip_all_tags( $m[1] ) );
+		}
+
+		// Extract month + day from date_text. Day-of-week prefix is optional.
+		$months = '(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:t)?(?:ember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)';
+		if ( preg_match( '/(' . $months . ')\s+(\d{1,2})/i', $date_text, $dm ) ) {
+			$month_name = $dm[1];
+			$day        = (int) $dm[2];
+
+			if ( $calendar_year > 0 ) {
+				try {
+					$dt           = new \DateTime( sprintf( '%s %d %d', $month_name, $day, $calendar_year ) );
+					$out['date']  = $dt->format( 'Y-m-d' );
+				} catch ( \Exception $e ) {
+					$out['date'] = '';
+				}
+			} else {
+				$out['date'] = $this->inferDateFromMonthDay( $month_name, (string) $day );
 			}
 		}
 
-		// Description
-		if ( preg_match( '#<div[^>]*class=["\'][^"\']*\bevent-notes\b[^"\']*["\'][^>]*>(.*?)</div>#is', $html, $m ) ) {
-			$description = wp_kses_post( $m[1] );
+		if ( '' !== $time_text ) {
+			$out['time'] = $this->parseTimeString( $time_text );
 		}
 
-		// Image
-		if ( preg_match( '#<div[^>]*class=["\'][^"\']*\bevent-image\b[^"\']*["\'][^>]*>.*?<img[^>]*src=["\']([^"\']+)["\']#is', $html, $m ) ) {
-			$image_url = html_entity_decode( $m[1], ENT_QUOTES | ENT_HTML5 );
-			if ( strpos( $image_url, '//' ) === 0 ) {
-				$image_url = 'https:' . $image_url;
-			}
-		}
-
-		$start_date = $this->resolveDate( $date_text, $context );
-		$start_time = $this->parseTimeString( $time_text );
-
-		return array(
-			'title'       => sanitize_text_field( $title ),
-			'description' => $description,
-			'startDate'   => $start_date,
-			'endDate'     => $start_date,
-			'startTime'   => $start_time,
-			'ticketUrl'   => esc_url_raw( $source_url ),
-			'imageUrl'    => esc_url_raw( $image_url ),
-			'eventType'   => 'Event',
-		);
+		return $out;
 	}
 
-	private function resolveDate( string $date_text, ?array $context ): string {
-		if ( empty( $date_text ) || empty( $context ) ) {
+	/**
+	 * Find a ticket purchase URL inside an event-detail block.
+	 *
+	 * Bandzoogle's buying-options div wraps a share dialog (junk) and an
+	 * optional external ticket link. We accept any external URL whose host
+	 * differs from the source URL's host and doesn't smell like a share /
+	 * social link. As a fallback, well-known ticket vendor domains win
+	 * regardless of position.
+	 */
+	private function findTicketUrl( string $html, string $source_url ): string {
+		$ticket_domains = array(
+			'eventbrite',
+			'tixr',
+			'etix',
+			'dice.fm',
+			'ticketmaster',
+			'seetickets',
+			'ticketweb',
+			'aftontickets',
+			'prekindle',
+			'showclix',
+			'opentable',
+			'resy',
+			'tock',
+			'venuepilot',
+			'freshtix',
+			'showare',
+			'wl.seetickets',
+		);
+
+		if ( ! preg_match_all( '/<a[^>]+href="([^"]+)"[^>]*>/i', $html, $links ) ) {
 			return '';
 		}
 
-		if ( ! preg_match( '/([A-Za-z]+)\s+(\d{1,2})$/', $date_text, $m ) ) {
-			return '';
+		$source_host = wp_parse_url( $source_url, PHP_URL_HOST );
+
+		// Pass 1: known ticket vendor domains.
+		foreach ( $links[1] as $href ) {
+			$href_decoded = html_entity_decode( $href, ENT_QUOTES, 'UTF-8' );
+			foreach ( $ticket_domains as $domain ) {
+				if ( false !== stripos( $href_decoded, $domain ) ) {
+					return esc_url_raw( $href_decoded );
+				}
+			}
 		}
 
-		$month_name = $m[1];
-		$day        = (int) $m[2];
-		$month      = (int) date( 'n', strtotime( $month_name . ' 1' ) );
-		if ( $month <= 0 || $day <= 0 ) {
-			return '';
+		// Pass 2: any external link that isn't share/social/maps/javascript.
+		$blocklist = array( 'facebook.com', 'twitter.com', 'instagram.com', 'threads.net', 'google.com/maps', 'mailto:', 'javascript:', '#', 'pinterest', 'bandzoogle.com', 'bndzgl.com', 'zoogletools.com' );
+
+		foreach ( $links[1] as $href ) {
+			$href_decoded = html_entity_decode( $href, ENT_QUOTES, 'UTF-8' );
+
+			foreach ( $blocklist as $bad ) {
+				if ( false !== stripos( $href_decoded, $bad ) ) {
+					continue 2;
+				}
+			}
+
+			if ( ! preg_match( '#^https?://#i', $href_decoded ) ) {
+				continue;
+			}
+
+			$link_host = wp_parse_url( $href_decoded, PHP_URL_HOST );
+			if ( $link_host && $source_host && $link_host !== $source_host ) {
+				return esc_url_raw( $href_decoded );
+			}
 		}
 
-		$year          = (int) $context['year'];
-		$context_month = (int) $context['month'];
-
-		// Handle year rollover (e.g. looking at January from December view or vice-versa)
-		if ( 12 === $month && 1 === $context_month ) {
-			$year -= 1;
-		} elseif ( 1 === $month && 12 === $context_month ) {
-			$year += 1;
-		}
-
-		return sprintf( '%04d-%02d-%02d', $year, $month, $day );
+		return '';
 	}
 
-	private function fetchHtml( string $url ): string {
-		$result = HttpClient::get(
-			$url,
-			array(
-				'timeout'      => 30,
-				'browser_mode' => true,
-				'context'      => 'Bandzoogle Extractor',
-			)
+	/**
+	 * Legacy `.gig-info` parser.
+	 *
+	 * Older Bandzoogle themes (and the markup originally described in #261)
+	 * use `<div class="gig-info">` blocks. We don't currently have a
+	 * production sample for this shape, but the parser is straightforward
+	 * and cheap to ship for forward compatibility.
+	 *
+	 * @return array
+	 */
+	private function extractGigInfoBlocks( string $html, string $source_url, array $page_venue ): array {
+		if ( false === strpos( $html, 'gig-info' ) ) {
+			return array();
+		}
+
+		if ( ! preg_match_all(
+			'/<div[^>]*class="[^"]*gig-info[^"]*"[^>]*>(.*?)(?=<div[^>]*class="[^"]*gig-info[^"]*"|<\/section>|<\/div>\s*<\/div>\s*<\/div>)/si',
+			$html,
+			$matches
+		) ) {
+			return array();
+		}
+
+		$events = array();
+		foreach ( $matches[1] as $inner ) {
+			$event = $this->parseGigInfoBlock( $inner, $source_url, $page_venue );
+			if ( ! empty( $event['title'] ) && ! empty( $event['startDate'] ) ) {
+				$events[] = $event;
+			}
+		}
+
+		return $events;
+	}
+
+	/**
+	 * Parse a single `.gig-info` legacy block.
+	 */
+	private function parseGigInfoBlock( string $html, string $source_url, array $page_venue ): array {
+		$event = array(
+			'title'         => '',
+			'description'   => '',
+			'startDate'     => '',
+			'startTime'     => '',
+			'endDate'       => '',
+			'endTime'       => '',
+			'venue'         => $page_venue['venue'] ?? '',
+			'venueAddress'  => $page_venue['venueAddress'] ?? '',
+			'venueCity'     => $page_venue['venueCity'] ?? '',
+			'venueState'    => $page_venue['venueState'] ?? '',
+			'venueZip'      => $page_venue['venueZip'] ?? '',
+			'venueCountry'  => $page_venue['venueCountry'] ?? 'US',
+			'venueTimezone' => $page_venue['venueTimezone'] ?? '',
+			'ticketUrl'     => '',
+			'imageUrl'      => '',
+			'source_url'    => '',
+			'price'         => '',
 		);
-		return ( $result['success'] && 200 === $result['status_code'] ) ? $result['data'] : '';
+
+		// time[datetime] -> ISO 8601.
+		if ( preg_match( '/<time[^>]+datetime="([^"]+)"/i', $html, $m ) ) {
+			$parsed             = $this->parseIsoDatetime( $m[1] );
+			$event['startDate'] = $parsed['date'];
+			$event['startTime'] = $parsed['time'];
+			if ( ! empty( $parsed['timezone'] ) ) {
+				$event['venueTimezone'] = $parsed['timezone'];
+			}
+		} elseif ( preg_match( '/<time[^>]*>(.*?)<\/time>/is', $html, $m ) ) {
+			// Fall back to time element text.
+			$text   = trim( wp_strip_all_tags( $m[1] ) );
+			$parsed = $this->parseDatetime( $text, $page_venue['venueTimezone'] ?? '' );
+			if ( ! empty( $parsed['date'] ) ) {
+				$event['startDate'] = $parsed['date'];
+				$event['startTime'] = $parsed['time'];
+			}
+		}
+
+		// Title: .gig-artist or .gig-title.
+		foreach ( array( 'gig-artist', 'gig-title' ) as $title_class ) {
+			if ( preg_match( '/<[a-z0-9]+[^>]*class="[^"]*' . preg_quote( $title_class, '/' ) . '[^"]*"[^>]*>(.*?)<\/[a-z0-9]+>/is', $html, $m ) ) {
+				$event['title'] = $this->sanitizeText( html_entity_decode( wp_strip_all_tags( $m[1] ), ENT_QUOTES, 'UTF-8' ) );
+				if ( ! empty( $event['title'] ) ) {
+					break;
+				}
+			}
+		}
+
+		// Venue override.
+		if ( preg_match( '/<[a-z0-9]+[^>]*class="[^"]*gig-venue[^"]*"[^>]*>(.*?)<\/[a-z0-9]+>/is', $html, $m ) ) {
+			$venue_text = $this->sanitizeText( html_entity_decode( wp_strip_all_tags( $m[1] ), ENT_QUOTES, 'UTF-8' ) );
+			if ( '' !== $venue_text ) {
+				$event['venue'] = $venue_text;
+			}
+		}
+
+		// Ticket URL: .gig-tickets a[href].
+		if ( preg_match( '/<[a-z0-9]+[^>]*class="[^"]*gig-tickets[^"]*"[^>]*>.*?<a[^>]+href="([^"]+)"/is', $html, $m ) ) {
+			$event['ticketUrl'] = esc_url_raw( $this->resolveUrl( html_entity_decode( $m[1], ENT_QUOTES, 'UTF-8' ), $source_url ) );
+		}
+
+		// Image: poster img or first img inside the gig block.
+		if ( preg_match( '/<[a-z0-9]+[^>]*class="[^"]*gig-poster[^"]*"[^>]*>.*?<img[^>]+src="([^"]+)"/is', $html, $m ) ) {
+			$event['imageUrl'] = esc_url_raw( $this->resolveUrl( html_entity_decode( $m[1], ENT_QUOTES, 'UTF-8' ), $source_url ) );
+		} elseif ( preg_match( '/<img[^>]+src="([^"]+)"/i', $html, $m ) ) {
+			$event['imageUrl'] = esc_url_raw( $this->resolveUrl( html_entity_decode( $m[1], ENT_QUOTES, 'UTF-8' ), $source_url ) );
+		}
+
+		// Description.
+		if ( preg_match( '/<[a-z0-9]+[^>]*class="[^"]*gig-description[^"]*"[^>]*>(.*?)<\/[a-z0-9]+>/is', $html, $m ) ) {
+			$event['description'] = $this->cleanHtml( $m[1] );
+		}
+
+		return $event;
 	}
 }

--- a/tests/Fixtures/bandzoogle-elephant-room.html
+++ b/tests/Fixtures/bandzoogle-elephant-room.html
@@ -1,0 +1,5389 @@
+<!DOCTYPE html>
+<html id="scoped-css" class="not-logged-in no-js locale-en no-commerce" data-controller="" data-action="">
+  <head prefix="fb: http://www.facebook.com/2008/fbml og: http://opengraphprotocol.org/schema/">
+    <meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<title>Elephant Room - Calendar</title>
+
+
+
+    
+
+    <link rel="icon" type="image/png" href="//images.zoogletools.com/s:bzglfiles/u/523260/c4212c669d575e24803934bcf7a90c76227caf46/original/elephant-room-martini.png/!!/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.png" sizes="any" />
+
+
+<meta name="viewport" content="width=device-width">
+
+
+<link rel="stylesheet" href="//assets-app-production-pubnet.bndzgl.com/assets/usersite/application-3c44a462f1fc0faae6a5750ee822dd6795b5ec932d3890d1b332f898f1b8acc5.css" media="screen" data-turbo-track="reload" />
+
+    <script src="//assets-app-production-pubnet.bndzgl.com/assets/usersite/themes/anthem-cba8a334f3a1e8f9528137de3d20c3a79ec6795ee0e6ac3f76d479db7c2bb19d.js" type="module" async="async" data-turbo-track="reload"></script>
+  <link rel="stylesheet" href="//assets-app-production-pubnet.bndzgl.com/assets/usersite/themes/anthem-90497d8ad4f3807c03883e33eecdd9044c02afa2d307f7e892661399b3fdc234.css" media="screen" data-turbo-track="reload" />
+  
+  <style type="text/css" class="theme-config-properties">
+    @import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Open+Sans&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@700&display=swap');
+@font-face { font-family: "Aboreto"; src: url('//assets-production.bndzgl.com/assets/09a6dc31-890b-43f7-b61d-8377032391be/aboreto-regular.woff2') format('woff2'), url('//assets-production.bndzgl.com/assets/09a6dc31-890b-43f7-b61d-8377032391be/aboreto-regular.woff') format('woff'), url('//assets-production.bndzgl.com/assets/09a6dc31-890b-43f7-b61d-8377032391be/aboreto-regular.ttf') format('truetype'); font-style: normal; font-weight: 400; }
+@font-face { font-family: "Cinzel Decorative"; src: url('//assets-production.bndzgl.com/assets/b2fc7a36-b169-49e3-8829-b351a95f4ae3/cinzeldecorative-regular.woff2') format('woff2'), url('//assets-production.bndzgl.com/assets/b2fc7a36-b169-49e3-8829-b351a95f4ae3/cinzeldecorative-regular.woff') format('woff'), url('//assets-production.bndzgl.com/assets/b2fc7a36-b169-49e3-8829-b351a95f4ae3/cinzeldecorative-regular.ttf') format('truetype'); font-style: normal; font-weight: 400; }
+@font-face { font-family: "Bungee"; src: url('//assets-production.bndzgl.com/assets/4285169f-4348-4102-a7d4-b62cbaf9dc3f/bungee-regular.woff2') format('woff2'), url('//assets-production.bndzgl.com/assets/4285169f-4348-4102-a7d4-b62cbaf9dc3f/bungee-regular.woff') format('woff'), url('//assets-production.bndzgl.com/assets/4285169f-4348-4102-a7d4-b62cbaf9dc3f/bungee-regular.ttf') format('truetype'); font-style: normal; font-weight: 400; }
+:root {
+  --theme-config-version: "theme_configs/1123412-20260425051404000000";
+  --theme-frame-border-start-rgba: hsl(0, 0%, 0%);
+--theme-frame-border-start-color: hsl(0, 0%, 0%);
+--theme-frame-border-start-rgba-hsl: 0, 0%, 0%;
+--theme-frame-border-start-rgba-h: 0;
+--theme-frame-border-start-rgba-s: 0;
+--theme-frame-border-start-rgba-l: 0;
+--theme-frame-border-start-rgba-a: 1.0;
+--theme-frame-background-start-rgba: hsl(0, 0%, 0%);
+--theme-frame-background-start-color: hsl(0, 0%, 0%);
+--theme-frame-background-start-rgba-hsl: 0, 0%, 0%;
+--theme-frame-background-start-rgba-h: 0;
+--theme-frame-background-start-rgba-s: 0;
+--theme-frame-background-start-rgba-l: 0;
+--theme-frame-background-start-rgba-a: 1.0;
+--theme-frame-border-end-rgba: hsl(0, 0%, 0%);
+--theme-frame-border-end-color: hsl(0, 0%, 0%);
+--theme-frame-border-end-rgba-hsl: 0, 0%, 0%;
+--theme-frame-border-end-rgba-h: 0;
+--theme-frame-border-end-rgba-s: 0;
+--theme-frame-border-end-rgba-l: 0;
+--theme-frame-border-end-rgba-a: 1.0;
+--theme-frame-background-end-rgba: hsl(0, 0%, 0%);
+--theme-frame-background-end-color: hsl(0, 0%, 0%);
+--theme-frame-background-end-rgba-hsl: 0, 0%, 0%;
+--theme-frame-background-end-rgba-h: 0;
+--theme-frame-background-end-rgba-s: 0;
+--theme-frame-background-end-rgba-l: 0;
+--theme-frame-background-end-rgba-a: 1.0;
+--text-color: hsl(0, 16%, 85%);
+--text-color-hsl: 0, 16%, 85%;
+--text-color-h: 0;
+--text-color-s: 16;
+--text-color-l: 85;
+--text-color-a: 1.0;
+--link-color: hsl(0, 0%, 100%);
+--link-color-hsl: 0, 0%, 100%;
+--link-color-h: 0;
+--link-color-s: 0;
+--link-color-l: 100;
+--link-color-a: 1.0;
+--feature-title-color: hsl(0, 0%, 100%);
+--feature-title-color-hsl: 0, 0%, 100%;
+--feature-title-color-h: 0;
+--feature-title-color-s: 0;
+--feature-title-color-l: 100;
+--feature-title-color-a: 1.0;
+--nav-link-color: hsl(69, 19%, 85%);
+--nav-link-color-hsl: 69, 19%, 85%;
+--nav-link-color-h: 69;
+--nav-link-color-s: 19;
+--nav-link-color-l: 85;
+--nav-link-color-a: 1.0;
+--nav-link-rollover-color: hsl(0, 0%, 0%);
+--nav-link-rollover-color-hsl: 0, 0%, 0%;
+--nav-link-rollover-color-h: 0;
+--nav-link-rollover-color-s: 0;
+--nav-link-rollover-color-l: 0;
+--nav-link-rollover-color-a: 1.0;
+--sub-menu-background-color: hsl(0, 0%, 0%);
+--sub-menu-background-color-hsl: 0, 0%, 0%;
+--sub-menu-background-color-h: 0;
+--sub-menu-background-color-s: 0;
+--sub-menu-background-color-l: 0;
+--sub-menu-background-color-a: 1.0;
+--sub-menu-link-color: hsl(0, 0%, 100%);
+--sub-menu-link-color-hsl: 0, 0%, 100%;
+--sub-menu-link-color-h: 0;
+--sub-menu-link-color-s: 0;
+--sub-menu-link-color-l: 100;
+--sub-menu-link-color-a: 1.0;
+--page-title-color: hsl(0, 0%, 100%);
+--page-title-color-hsl: 0, 0%, 100%;
+--page-title-color-h: 0;
+--page-title-color-s: 0;
+--page-title-color-l: 100;
+--page-title-color-a: 1.0;
+--swmp-use-custom-colors-boolean: false;
+--swmp-background-color: hsl(0, 0%, 0%);
+--swmp-background-color-hsl: 0, 0%, 0%;
+--swmp-background-color-h: 0;
+--swmp-background-color-s: 0;
+--swmp-background-color-l: 0;
+--swmp-background-color-a: 1.0;
+--swmp-text-color-enum: white;
+--page-title-type-enum: text;
+--page-title-logo-background-image: url("//images.zoogletools.com/s:bzglfiles/u/523260/c38cd2f1df2565b56740e72901257dc9b2a522ba/original/elephant-neon-glass.png/!!/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.png");
+--page-title-string: "Elephant Room";
+--page-title-logo-size-number: 50%;
+--page-title-logo-size-number-unitless: 50;
+--site-wide-my-sites-align-enum: left;
+--site-wide-my-sites-size-number: 1.25rem;
+--site-wide-my-sites-size-number-unitless: 1.25;
+--site-wide-my-sites-rgba: hsl(0, 0%, 0%);
+--site-wide-my-sites-color: hsl(0, 0%, 0%);
+--site-wide-my-sites-rgba-hsl: 0, 0%, 0%;
+--site-wide-my-sites-rgba-h: 0;
+--site-wide-my-sites-rgba-s: 0;
+--site-wide-my-sites-rgba-l: 0;
+--site-wide-my-sites-rgba-a: 1.0;
+--site-wide-my-sites-hover-rgba: hsl(0, 0%, 0%);
+--site-wide-my-sites-hover-color: hsl(0, 0%, 0%);
+--site-wide-my-sites-hover-rgba-hsl: 0, 0%, 0%;
+--site-wide-my-sites-hover-rgba-h: 0;
+--site-wide-my-sites-hover-rgba-s: 0;
+--site-wide-my-sites-hover-rgba-l: 0;
+--site-wide-my-sites-hover-rgba-a: 1.0;
+--page-background-color: hsl(0, 3%, 6%);
+--page-background-color-hsl: 0, 3%, 6%;
+--page-background-color-h: 0;
+--page-background-color-s: 3;
+--page-background-color-l: 6;
+--page-background-color-a: 1.0;
+--mobile-nav-link-color: hsl(0, 0%, 100%);
+--mobile-nav-link-color-hsl: 0, 0%, 100%;
+--mobile-nav-link-color-h: 0;
+--mobile-nav-link-color-s: 0;
+--mobile-nav-link-color-l: 100;
+--mobile-nav-link-color-a: 1.0;
+--mobile-nav-background-color: hsl(0, 9%, 11%);
+--mobile-nav-background-color-hsl: 0, 9%, 11%;
+--mobile-nav-background-color-h: 0;
+--mobile-nav-background-color-s: 9;
+--mobile-nav-background-color-l: 11;
+--mobile-nav-background-color-a: 1.0;
+--cta-header-heading-rgba: hsl(0, 0%, 100%);
+--cta-header-heading-color: hsl(0, 0%, 100%);
+--cta-header-heading-rgba-hsl: 0, 0%, 100%;
+--cta-header-heading-rgba-h: 0;
+--cta-header-heading-rgba-s: 0;
+--cta-header-heading-rgba-l: 100;
+--cta-header-heading-rgba-a: 1.0;
+--cta-header-subheading-rgba: hsl(0, 0%, 100%);
+--cta-header-subheading-color: hsl(0, 0%, 100%);
+--cta-header-subheading-rgba-hsl: 0, 0%, 100%;
+--cta-header-subheading-rgba-h: 0;
+--cta-header-subheading-rgba-s: 0;
+--cta-header-subheading-rgba-l: 100;
+--cta-header-subheading-rgba-a: 1.0;
+--cta-header-button-rgba: hsl(191, 49%, 78%);
+--cta-header-button-color: hsl(191, 49%, 78%);
+--cta-header-button-rgba-hsl: 191, 49%, 78%;
+--cta-header-button-rgba-h: 191;
+--cta-header-button-rgba-s: 49;
+--cta-header-button-rgba-l: 78;
+--cta-header-button-rgba-a: 1.0;
+--cta-header-button-hover-rgba: hsl(191, 49%, 78%);
+--cta-header-button-hover-color: hsl(191, 49%, 78%);
+--cta-header-button-hover-rgba-hsl: 191, 49%, 78%;
+--cta-header-button-hover-rgba-h: 191;
+--cta-header-button-hover-rgba-s: 49;
+--cta-header-button-hover-rgba-l: 78;
+--cta-header-button-hover-rgba-a: 1.0;
+--cta-header-align-enum: left;
+--cta-header-position-enum: middle;
+--button-color: hsl(0, 0%, 0%);
+--button-color-hsl: 0, 0%, 0%;
+--button-color-h: 0;
+--button-color-s: 0;
+--button-color-l: 0;
+--button-color-a: 1.0;
+--button-hover-color: hsl(0, 0%, 0%);
+--button-hover-color-hsl: 0, 0%, 0%;
+--button-hover-color-h: 0;
+--button-hover-color-s: 0;
+--button-hover-color-l: 0;
+--button-hover-color-a: 1.0;
+--button-shape-enum: square;
+--button-style-enum: solid;
+--image-filter-enum: none;
+--image-filter-custom-rgba: hsla(0, 0%, 12%, 0.3);
+--image-filter-custom-color: hsla(0, 0%, 12%, 0.3);
+--image-filter-custom-rgba-hsl: 0, 0%, 12%;
+--image-filter-custom-rgba-h: 0;
+--image-filter-custom-rgba-s: 0;
+--image-filter-custom-rgba-l: 12;
+--image-filter-custom-rgba-a: 0.3;
+--image-filter-custom-mode-enum: multiply;
+--heading-color: hsl(0, 0%, 100%);
+--heading-color-hsl: 0, 0%, 100%;
+--heading-color-h: 0;
+--heading-color-s: 0;
+--heading-color-l: 100;
+--heading-color-a: 1.0;
+--cta-header-border-rgba: hsla(0, 0%, 86%, 0.1);
+--cta-header-border-color: hsla(0, 0%, 86%, 0.1);
+--cta-header-border-rgba-hsl: 0, 0%, 86%;
+--cta-header-border-rgba-h: 0;
+--cta-header-border-rgba-s: 0;
+--cta-header-border-rgba-l: 86;
+--cta-header-border-rgba-a: 0.1;
+--cta-header-border-width-number: 0px;
+--cta-header-border-width-number-unitless: 0;
+--cta-header-background-rgba: hsla(0, 0%, 100%, 0.0);
+--cta-header-background-color: hsla(0, 0%, 100%, 0.0);
+--cta-header-background-rgba-hsl: 0, 0%, 100%;
+--cta-header-background-rgba-h: 0;
+--cta-header-background-rgba-s: 0;
+--cta-header-background-rgba-l: 100;
+--cta-header-background-rgba-a: 0.0;
+--page-title-typeface-style: "regular";
+--page-title-typeface-style-stylesheet: "//assets-production.bndzgl.com/assets/09a6dc31-890b-43f7-b61d-8377032391be/stylesheet.css#Aboreto-regular";
+--page-title-typeface-style-stack: 'Aboreto', cursive;
+--page-title-typeface-style-font-weight: 400;
+--page-title-typeface-style-font-style: normal;
+--page-title-typeface-size-number: 30px;
+--page-title-typeface-size-number-unitless: 30;
+--page-title-uppercase-boolean: false;
+--heading-typeface-style: "semibold";
+--heading-typeface-style-stylesheet: "https://fonts.googleapis.com/css2?family=Open+Sans:wght@600&display=swap";
+--heading-typeface-style-stack: 'Open Sans', sans-serif;
+--heading-typeface-style-font-weight: 600;
+--heading-typeface-style-font-style: normal;
+--heading-typeface-size-number: 21px;
+--heading-typeface-size-number-unitless: 21;
+--heading-uppercase-boolean: true;
+--content-typeface-style: "regular";
+--content-typeface-style-stylesheet: "https://fonts.googleapis.com/css2?family=Open+Sans&display=swap";
+--content-typeface-style-stack: 'Open Sans', sans-serif;
+--content-typeface-style-font-weight: 400;
+--content-typeface-style-font-style: normal;
+--content-typeface-size-number: 14px;
+--content-typeface-size-number-unitless: 14;
+--content-lineheight-number: 1.6;
+--content-lineheight-number-unitless: 1.6;
+--content-uppercase-boolean: false;
+--feature-title-typeface-style: "regular";
+--feature-title-typeface-style-stylesheet: "//assets-production.bndzgl.com/assets/b2fc7a36-b169-49e3-8829-b351a95f4ae3/stylesheet.css#Cinzel Decorative-regular";
+--feature-title-typeface-style-stack: 'Cinzel Decorative', serif;
+--feature-title-typeface-style-font-weight: 400;
+--feature-title-typeface-style-font-style: normal;
+--feature-title-typeface-size-number: 21px;
+--feature-title-typeface-size-number-unitless: 21;
+--feature-title-uppercase-boolean: false;
+--menu-item-typeface-style: "regular";
+--menu-item-typeface-style-stylesheet: "https://fonts.googleapis.com/css2?family=Open+Sans&display=swap";
+--menu-item-typeface-style-stack: 'Open Sans', sans-serif;
+--menu-item-typeface-style-font-weight: 400;
+--menu-item-typeface-style-font-style: normal;
+--menu-item-typeface-size-number: 17px;
+--menu-item-typeface-size-number-unitless: 17;
+--menu-item-uppercase-boolean: false;
+--feature-title-letterspacing-number: 0em;
+--feature-title-letterspacing-number-unitless: 0;
+--page-title-letterspacing-number: 0em;
+--page-title-letterspacing-number-unitless: 0;
+--cta-header-heading-typeface-style: "regular";
+--cta-header-heading-typeface-style-stylesheet: "//assets-production.bndzgl.com/assets/4285169f-4348-4102-a7d4-b62cbaf9dc3f/stylesheet.css#Bungee-regular";
+--cta-header-heading-typeface-style-stack: 'Bungee', cursive;
+--cta-header-heading-typeface-style-font-weight: 400;
+--cta-header-heading-typeface-style-font-style: normal;
+--cta-header-heading-letterspacing-number: 0em;
+--cta-header-heading-letterspacing-number-unitless: 0;
+--cta-header-heading-uppercase-boolean: true;
+--cta-header-subheading-typeface-style: "semibold";
+--cta-header-subheading-typeface-style-stylesheet: "https://fonts.googleapis.com/css2?family=Open+Sans:wght@600&display=swap";
+--cta-header-subheading-typeface-style-stack: 'Open Sans', sans-serif;
+--cta-header-subheading-typeface-style-font-weight: 600;
+--cta-header-subheading-typeface-style-font-style: normal;
+--cta-header-subheading-letterspacing-number: 0.1em;
+--cta-header-subheading-letterspacing-number-unitless: 0.1;
+--cta-header-subheading-uppercase-boolean: false;
+--secondary-heading-typeface-style: "semibold";
+--secondary-heading-typeface-style-stylesheet: "https://fonts.googleapis.com/css2?family=Open+Sans:wght@600&display=swap";
+--secondary-heading-typeface-style-stack: 'Open Sans', sans-serif;
+--secondary-heading-typeface-style-font-weight: 600;
+--secondary-heading-typeface-style-font-style: normal;
+--secondary-heading-typeface-size-number: 16px;
+--secondary-heading-typeface-size-number-unitless: 16;
+--secondary-heading-uppercase-boolean: true;
+--secondary-heading-color: hsl(0, 0%, 100%);
+--secondary-heading-color-hsl: 0, 0%, 100%;
+--secondary-heading-color-h: 0;
+--secondary-heading-color-s: 0;
+--secondary-heading-color-l: 100;
+--secondary-heading-color-a: 1.0;
+--heading-lineheight-number: 1.4;
+--heading-lineheight-number-unitless: 1.4;
+--secondary-heading-lineheight-number: 1.5;
+--secondary-heading-lineheight-number-unitless: 1.5;
+--feature-title-lineheight-number: 1.3;
+--feature-title-lineheight-number-unitless: 1.3;
+--content-link-style-enum: none;
+--cta-header-button-shape-enum: square;
+--cta-header-button-style-enum: outline;
+--cta-header-description-rgba: hsl(0, 0%, 100%);
+--cta-header-description-color: hsl(0, 0%, 100%);
+--cta-header-description-rgba-hsl: 0, 0%, 100%;
+--cta-header-description-rgba-h: 0;
+--cta-header-description-rgba-s: 0;
+--cta-header-description-rgba-l: 100;
+--cta-header-description-rgba-a: 1.0;
+--cta-header-heading-typeface-size-number: 52px;
+--cta-header-heading-typeface-size-number-unitless: 52;
+--cta-header-heading-lineheight-number: 1.1;
+--cta-header-heading-lineheight-number-unitless: 1.1;
+--cta-header-subheading-typeface-size-number: 18px;
+--cta-header-subheading-typeface-size-number-unitless: 18;
+--cta-header-subheading-lineheight-number: 1.1;
+--cta-header-subheading-lineheight-number-unitless: 1.1;
+--cta-header-description-typeface-style: "bold";
+--cta-header-description-typeface-style-stylesheet: "https://fonts.googleapis.com/css2?family=Open+Sans:wght@700&display=swap";
+--cta-header-description-typeface-style-stack: 'Open Sans', sans-serif;
+--cta-header-description-typeface-style-font-weight: 700;
+--cta-header-description-typeface-style-font-style: normal;
+--cta-header-description-letterspacing-number: 0em;
+--cta-header-description-letterspacing-number-unitless: 0;
+--cta-header-description-uppercase-boolean: true;
+--cta-header-description-typeface-size-number: 14px;
+--cta-header-description-typeface-size-number-unitless: 14;
+--cta-header-description-lineheight-number: 1.1;
+--cta-header-description-lineheight-number-unitless: 1.1;
+--use-device-dependent-logo-sizes-boolean: false;
+--tablet-logo-size-number: 50%;
+--tablet-logo-size-number-unitless: 50;
+--mobile-logo-size-number: 50%;
+--mobile-logo-size-number-unitless: 50;
+--use-device-dependent-title-sizes-boolean: false;
+--tablet-page-title-typeface-size-number: 36px;
+--tablet-page-title-typeface-size-number-unitless: 36;
+--mobile-page-title-typeface-size-number: 24px;
+--mobile-page-title-typeface-size-number-unitless: 24;
+--page-title-letterspacing-mobile-boolean: false;
+--section-background-color: hsl(0, 3%, 6%);
+--_section-background-color: hsl(0, 3%, 6%);
+--section-background-color-hsl: 0, 3%, 6%;
+--_section-background-color-hsl: 0, 3%, 6%;
+--section-background-color-h: 0;
+--_section-background-color-h: 0;
+--section-background-color-s: 3;
+--_section-background-color-s: 3;
+--section-background-color-l: 6;
+--_section-background-color-l: 6;
+--section-background-color-a: 1.0;
+--_section-background-color-a: 1.0;
+}
+
+.style-section-style-1,.style-section-style-2 .complementary-section-style {
+  --background-color-hsl: 0, 7%, 3%;
+--background-color-h: 0;
+--background-color-s: 7;
+--background-color-l: 3;
+--background-color-a: 1.0;
+--text-color: hsl(0, 0%, 100%);
+--text-color-hsl: 0, 0%, 100%;
+--text-color-h: 0;
+--text-color-s: 0;
+--text-color-l: 100;
+--text-color-a: 1.0;
+--link-color: hsl(0, 0%, 85%);
+--link-color-hsl: 0, 0%, 85%;
+--link-color-h: 0;
+--link-color-s: 0;
+--link-color-l: 85;
+--link-color-a: 1.0;
+--feature-title-color: hsl(0, 0%, 100%);
+--feature-title-color-hsl: 0, 0%, 100%;
+--feature-title-color-h: 0;
+--feature-title-color-s: 0;
+--feature-title-color-l: 100;
+--feature-title-color-a: 1.0;
+--heading-color: hsl(0, 0%, 100%);
+--heading-color-hsl: 0, 0%, 100%;
+--heading-color-h: 0;
+--heading-color-s: 0;
+--heading-color-l: 100;
+--heading-color-a: 1.0;
+--button-color: hsl(0, 0%, 0%);
+--button-color-hsl: 0, 0%, 0%;
+--button-color-h: 0;
+--button-color-s: 0;
+--button-color-l: 0;
+--button-color-a: 1.0;
+--button-hover-color: hsl(0, 0%, 100%);
+--button-hover-color-hsl: 0, 0%, 100%;
+--button-hover-color-h: 0;
+--button-hover-color-s: 0;
+--button-hover-color-l: 100;
+--button-hover-color-a: 1.0;
+--secondary-heading-color: hsl(0, 0%, 100%);
+--secondary-heading-color-hsl: 0, 0%, 100%;
+--secondary-heading-color-h: 0;
+--secondary-heading-color-s: 0;
+--secondary-heading-color-l: 100;
+--secondary-heading-color-a: 1.0;
+--section-background-color: hsl(0, 7%, 3%);
+--_section-background-color: hsl(0, 7%, 3%);
+--section-background-color-hsl: 0, 7%, 3%;
+--_section-background-color-hsl: 0, 7%, 3%;
+--section-background-color-h: 0;
+--_section-background-color-h: 0;
+--section-background-color-s: 7;
+--_section-background-color-s: 7;
+--section-background-color-l: 3;
+--_section-background-color-l: 3;
+--section-background-color-a: 1.0;
+--_section-background-color-a: 1.0;
+  --_background-color: hsl(0, 7%, 3%);
+--_background-color-hsl: 0, 7%, 3%;
+--_background-color-h: 0;
+--_background-color-s: 7;
+--_background-color-l: 3;
+--_background-color-a: 1.0;
+}
+
+
+.style-section-style-2,.style-section-style-1 .complementary-section-style,.default-section-style .complementary-section-style {
+  --background-color-hsl: 240, 5%, 4%;
+--background-color-h: 240;
+--background-color-s: 5;
+--background-color-l: 4;
+--background-color-a: 1.0;
+--text-color: hsl(0, 0%, 100%);
+--text-color-hsl: 0, 0%, 100%;
+--text-color-h: 0;
+--text-color-s: 0;
+--text-color-l: 100;
+--text-color-a: 1.0;
+--link-color: hsl(0, 0%, 100%);
+--link-color-hsl: 0, 0%, 100%;
+--link-color-h: 0;
+--link-color-s: 0;
+--link-color-l: 100;
+--link-color-a: 1.0;
+--feature-title-color: hsl(0, 0%, 100%);
+--feature-title-color-hsl: 0, 0%, 100%;
+--feature-title-color-h: 0;
+--feature-title-color-s: 0;
+--feature-title-color-l: 100;
+--feature-title-color-a: 1.0;
+--heading-color: hsl(0, 0%, 100%);
+--heading-color-hsl: 0, 0%, 100%;
+--heading-color-h: 0;
+--heading-color-s: 0;
+--heading-color-l: 100;
+--heading-color-a: 1.0;
+--button-color: hsl(0, 0%, 0%);
+--button-color-hsl: 0, 0%, 0%;
+--button-color-h: 0;
+--button-color-s: 0;
+--button-color-l: 0;
+--button-color-a: 1.0;
+--button-hover-color: hsl(0, 0%, 100%);
+--button-hover-color-hsl: 0, 0%, 100%;
+--button-hover-color-h: 0;
+--button-hover-color-s: 0;
+--button-hover-color-l: 100;
+--button-hover-color-a: 1.0;
+--secondary-heading-color: hsl(0, 0%, 100%);
+--secondary-heading-color-hsl: 0, 0%, 100%;
+--secondary-heading-color-h: 0;
+--secondary-heading-color-s: 0;
+--secondary-heading-color-l: 100;
+--secondary-heading-color-a: 1.0;
+--section-background-color: hsl(240, 5%, 4%);
+--_section-background-color: hsl(240, 5%, 4%);
+--section-background-color-hsl: 240, 5%, 4%;
+--_section-background-color-hsl: 240, 5%, 4%;
+--section-background-color-h: 240;
+--_section-background-color-h: 240;
+--section-background-color-s: 5;
+--_section-background-color-s: 5;
+--section-background-color-l: 4;
+--_section-background-color-l: 4;
+--section-background-color-a: 1.0;
+--_section-background-color-a: 1.0;
+  --_background-color: hsl(240, 5%, 4%);
+--_background-color-hsl: 240, 5%, 4%;
+--_background-color-h: 240;
+--_background-color-s: 5;
+--_background-color-l: 4;
+--_background-color-a: 1.0;
+}
+
+
+
+
+  </style>
+
+
+
+
+
+<link rel="stylesheet" href="//assets-app-production-pubnet.bndzgl.com/assets/usersite_print-b71ab680fe1fa86be1153b0da4ccb898bd3971ddb341910c16fbca8228daac75.css" media="print" data-turbo-track="reload" />
+
+<script type="application/ld+json">{"@context":"http:\/\/schema.org","@type":"WebSite","name":"Elephant Room","url":"https:\/\/elephantroom.com\/","sameAs":["https:\/\/www.facebook.com\/Elephant-Room-288488406823","https:\/\/www.instagram.com\/explore\/locations\/49310\/elephant-room\/","https:\/\/twitter.com\/@elephantroomATX"]}</script>
+
+
+  <script src="//assets-app-production-pubnet.bndzgl.com/assets/usersite/application-e9ae2fa9a6e2933d4ef926a1377fc9cd2927aab233caf548413588e1d72e8941.js" data-turbo-track="reload"></script>
+<script src="//assets-app-production-pubnet.bndzgl.com/assets/usersite-d40b80d42e228ab21157a2fed454ded51c5f773d8465afef9854479817ccbb43.js" defer="defer" type="module" data-turbo-track="reload"></script>
+<link rel="stylesheet" href="//assets-app-production-pubnet.bndzgl.com/assets/usersite-d94f5be6abab9a957c53aece05b4c45c98bcc10db450c4e1cf73d87d27003ab5.css" async="async" media="screen" data-turbo-track="reload" />
+
+
+  <script type="text/javascript">
+    themeJsManager.registerTheme(179, $.extend({}, themeJsManager.blankJs, // DUPLICATE JS USED BY ALMA
+{
+	_throttle: function(func, limit, context) {
+		var wait = false;
+		return function () {
+			if (!wait) {
+				func.call(context);
+				wait = true;
+				setTimeout(function () {
+					wait = false;
+					func.call(context);
+				}, limit);
+			}
+		}
+	},
+
+	_checkForDesktopNav: function() {
+		var nav = this.$frame.find('.title-nav-container .nav-bar');
+		var checkForDesktopNav = $.trim(nav.html()) == '';
+
+		return checkForDesktopNav;
+	},
+
+	_checkPageTitleEnum: function() {
+		// if member toggles between text,logo and none, when logo is selected reruns functions to prevent overlap with CTA
+		this.logoEnumSelected = this.$container[0].dataset.themePageTitleTypeEnum === 'logo';
+		this.textEnumSelected = this.$container[0].dataset.themePageTitleTypeEnum === 'text';
+
+		if (this.logoEnumSelected || this.textEnumSelected) {
+			this._onFrameTopResize();
+			this._setupFrameTopPosition();
+		}
+	},
+
+	_setupLogoConfigObservers: function() {
+		this.pageTitleEnumObserver = new MutationObserver(this._onLogoEnumMutation.bind(this));
+		this.frameTopHeightObserver = new ResizeObserver(this._onFrameTopResize.bind(this));
+
+		this.pageTitleEnumObserver.observe(this.$container[0], { attributes: true, attributeFilter: ['data-theme-page-title-type-enum'] });
+	},
+
+	_onLogoEnumMutation: function() {
+		this._checkPageTitleEnum();
+	},
+
+	_onFrameTopResize: function(entries) {
+		if (!entries || this.frameTop === undefined) { return; }
+
+		// positions the 'frame-top' div based on size of logo
+		let frameTopHeight;
+		if (entries) {
+			const entry = entries[0];
+			frameTopHeight = entry.contentRect.height;
+		} else {
+			frameTopHeight = this.frameTop.offsetHeight;
+		}
+		this.desktopMobileNav.style.top = `${frameTopHeight}px`;
+		this.frame.style.top = `${frameTopHeight}px`;
+		this.frameTop.style.top = `-${frameTopHeight}px`;
+		this.frameRight.style.top = `-${frameTopHeight}px`;
+		this.frameLeft.style.top = `-${frameTopHeight}px`;
+	},
+
+	_setupFrameTopPosition: function() {
+		if (this.frameTopHeightObserver && this.frameTop) {
+			if (!this.frameTopObserved) {
+				this.frameTopHeightObserver.observe(this.frameTop);
+				this.frameTopObserved = true;
+			}
+		} else {
+			this._undoFrameTopPosition();
+		}
+	},
+
+	_toggleHideNavigationClass: function() {
+		this.$container.toggleClass('hide-nav', this._checkForDesktopNav());
+	},
+
+	_scrollCheck: function() {
+		var windowScroll = this.$window.scrollTop();
+		var containerScroll = this.$container.scrollTop();
+
+		if (windowScroll > 0 || containerScroll > windowScroll) {
+			this.$frame.addClass('scrolled')
+		} else {
+			this.$frame.removeClass('scrolled')
+		}
+	},
+
+	_setupScrollCheck: function() {
+		this.scrollListenerFn = this._throttle(this._scrollCheck, 50, this);
+		this.$window.on('scroll.anthemScrollCheck', this.scrollListenerFn);
+		this.$container.on('scroll.anthemScrollCheck', this.scrollListenerFn);
+	},
+
+	_removeScrollCheck: function() {
+		this.$window.off('scroll.anthemScrollCheck', this.scrollListenerFn);
+		this.$container.off('scroll.anthemScrollCheck', this.scrollListenerFn);
+	},
+
+	_undoFrameTopPosition: function () {
+		if (this.frameTopHeightObserver){
+			this.frameTopHeightObserver.disconnect();
+			this.frameTopObserved = false;
+			// remove styles that were added by the observer
+			if(this.frame) { this.frame.style = ''; }
+			if(this.frameTop) { this.frameTop.style = ''; }
+		}
+	},
+
+	setup: function () {
+		this.$window = $(window);
+		this.$frame = $('#frame');
+		this.windowHeight = this.$window.height();
+		this.$container = $('#usersite-container');
+		this.pageRoot = document.getElementById('page-root');
+		this.desktopMobileNav = document.querySelector('body.desktop-hamburger-nav #usersite-container #main-nav.mobile ul.mobile');
+		this.frame = this.$frame[0];
+		this.frameTop = document.getElementById('frame-top');
+		this.frameRight = document.getElementById('frame-right');
+		this.frameLeft = document.getElementById('frame-left');
+		this.ctaContainerParent = document.querySelector('#default-page-header .zoogle-feature');
+
+		if (this.$container.length === 0) {
+			return;
+		}
+
+		this._setupScrollCheck();
+		this._toggleHideNavigationClass();
+		this._setupLogoConfigObservers();
+		this._checkPageTitleEnum();
+	},
+
+	tearDown: function () {
+		this._removeScrollCheck();
+		this._undoFrameTopPosition();
+	},
+
+	plugins: {
+		navTitleNextToFlexbox: {},
+		navDesktopHamburger: {}
+	}
+}
+));
+  </script>
+
+
+
+
+
+
+<meta name="csrf-param" content="authenticity_token" />
+<meta name="csrf-token" content="IpyR4k0VILdnVWz4awEKENmv1xz4AzAWgJpF7Z1JDoxKAc6fVxhXp3Ib1Z8bP-5QA3caoM1rNfNak_MgkhUtNQ" />
+<meta name="title" content="Elephant Room - Calendar">
+<meta property="og:title" content="Elephant Room - Calendar">
+<meta name="twitter:title" content="Elephant Room - Calendar">
+<meta name="description" content="Calendar. Elephant Room, a venue from Austin">
+<meta property="og:description" content="Calendar. Elephant Room, a venue from Austin">
+<meta name="twitter:description" content="Calendar. Elephant Room, a venue from Austin">
+<meta name="url" content="https://elephantroom.com/calendar">
+<meta property="og:url" content="https://elephantroom.com/calendar">
+<meta name="twitter:card" content="summary">
+
+<meta name="turbo-prefetch" content="false">
+<meta name="turbo-refresh-method" content="morph">
+
+
+<link rel="canonical" href="https://elephantroom.com/calendar">
+
+
+  <style class="page-styles">
+    .website-page-calendar {
+      --first-row-background-color: hsl(0, 7%, 3%);
+    }
+  </style>
+
+
+
+
+
+
+
+
+<meta name="remix-stylesheet" content="//assets-app-production-pubnet.bndzgl.com/assets/remix-9f73f71677241d54de0d94403b199902f9e68b37a3c0f4c615a94a5ec50268c1.css">
+
+
+
+
+</head>
+  <body class="theme-anthem theme-anthem-a m-style-theme-config-1123412 bz has-swms not-intro-page" data-slug="calendar" data-turbo="true" data-controller="live-chat no-pjax" data-editor--editor-state-target="usersite" data-variant="a">
+    
+
+
+    
+
+      
+<div class="usersite-container-wrap">
+  <div id="usersite-container-inner-wrap">
+    <div id="usersite-container" data-theme-swmp-use-custom-colors-boolean="0" data-theme-swmp-text-color-enum="white" data-theme-page-title-type-enum="text" data-theme-site-wide-my-sites-align-enum="left" data-theme-cta-header-align-enum="left" data-theme-cta-header-position-enum="middle" data-theme-button-shape-enum="square" data-theme-button-style-enum="solid" data-theme-image-filter-enum="none" data-theme-image-filter-custom-mode-enum="multiply" data-theme-cta-header-border-width-number-borderless-boolean="1" data-theme-cta-header-background-rgba-alpha-zero-boolean="1" data-theme-page-title-uppercase-boolean="0" data-theme-heading-uppercase-boolean="1" data-theme-content-uppercase-boolean="0" data-theme-feature-title-uppercase-boolean="0" data-theme-menu-item-uppercase-boolean="0" data-theme-cta-header-heading-uppercase-boolean="1" data-theme-cta-header-subheading-uppercase-boolean="0" data-theme-secondary-heading-uppercase-boolean="1" data-theme-content-link-style-enum="none" data-theme-cta-header-button-shape-enum="square" data-theme-cta-header-button-style-enum="outline" data-theme-cta-header-description-uppercase-boolean="1" data-theme-use-device-dependent-logo-sizes-boolean="0" data-theme-use-device-dependent-title-sizes-boolean="0" data-theme-page-title-letterspacing-mobile-boolean="0" data-theme-variant-key="a" data-controller="content-width">
+      <nav id="main-nav" class="mobile" data-action="turbo:load@document-&gt;selected-page#mark" data-controller="selected-page"><ul class="mobile list top menu-length-2"><li class="has-submenu top"><div><a class="top" href="/home">Home</a></div><ul><li class="subpage"><div><a class="" href="/pubcast">PUBcast</a></div></li><li class="subpage"><div><a class="" target="_external" href="/gift-card">Gift card</a></div></li><li class="subpage"><div><a class="" target="_external" href="/store">Store</a></div></li></ul></li><li class="top selected"><div><a class="top" href="/calendar">Calendar</a></div></li></ul><ul class="my-sites"><li class="facebook">  <a class="icon facebook" rel="noopener" target="_blank" title="https://www.facebook.com/Elephant-Room-288488406823" href="https://www.facebook.com/Elephant-Room-288488406823"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 18" class="icon"><path fill-rule="evenodd" d="M1.907 18V8.999H0V5.897h1.907V4.035C1.907 1.505 2.984 0 6.044 0h2.547v3.103H7c-1.191 0-1.27.433-1.27 1.242l-.005 1.552h2.885L8.27 9H5.724V18H1.907z"></path></svg></a>
+</li> <li class="instagram">  <a class="icon instagram" rel="noopener" target="_blank" title="https://www.instagram.com/explore/locations/49310/elephant-room/" href="https://www.instagram.com/explore/locations/49310/elephant-room/"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon"><path fill-rule="evenodd" d="M6.955 1.628l2.582-.006c1.916.001 2.227.012 3.1.052.877.04 1.354.187 1.67.31.421.163.72.358 1.036.673.27.27.452.529.6.862l.073.173c.113.29.246.715.298 1.46l.03.627c.012.29.02.553.025.917l.01 2.842c-.002 1.915-.013 2.226-.053 3.099-.037.804-.163 1.272-.279 1.588l-.031.083c-.163.42-.358.72-.673 1.035-.315.315-.615.51-1.035.673-.29.113-.715.246-1.46.298l-1.21.05c-.344.007-.761.011-1.428.013l-3.255-.005a37.01 37.01 0 01-1.592-.046c-.877-.04-1.354-.187-1.67-.31a2.788 2.788 0 01-1.036-.673 2.788 2.788 0 01-.673-1.035c-.113-.29-.246-.715-.298-1.46l-.05-1.21a71.292 71.292 0 01-.013-1.428l.005-3.255c.006-.692.02-1.022.046-1.592.04-.877.187-1.354.31-1.67.163-.421.358-.72.673-1.036.315-.315.615-.51 1.035-.673.29-.113.715-.246 1.46-.298l.627-.03c.355-.015.668-.023 1.176-.028zM6.97.006h4.06c.747.007 1.09.021 1.68.048.959.044 1.613.196 2.185.419.592.23 1.094.537 1.594 1.038.5.5.808 1.002 1.038 1.594.198.509.34 1.082.4 1.876l.035.68c.026.62.036 1.093.038 2.574l-.005 2.658c-.006.844-.02 1.192-.05 1.818-.043.958-.195 1.612-.418 2.184a4.412 4.412 0 01-1.038 1.594c-.5.5-1.002.809-1.594 1.039-.509.197-1.082.34-1.876.4l-.795.039c-.53.021-1.003.03-2.193.032l-2.924-.004a39.115 39.115 0 01-1.818-.05c-.958-.043-1.612-.195-2.184-.417a4.412 4.412 0 01-1.594-1.039c-.5-.5-.809-1.002-1.039-1.594-.197-.509-.34-1.082-.4-1.876l-.042-.876C.009 11.575 0 11.027 0 9.527L.006 6.97c.007-.747.021-1.09.048-1.68.044-.959.196-1.613.418-2.185A4.412 4.412 0 011.511 1.51c.5-.5 1.002-.808 1.594-1.038.509-.198 1.082-.34 1.876-.4L5.857.03C6.177.018 6.49.01 6.97.006zm2.048 4.387a4.625 4.625 0 100 9.25 4.625 4.625 0 000-9.25zm0 1.623a3.002 3.002 0 110 6.004 3.002 3.002 0 010-6.004zm4.768-2.909a1.071 1.071 0 100 2.143 1.071 1.071 0 000-2.143z"></path></svg></a>
+</li> <li class="twitter">  <a class="icon twitter" rel="noopener" target="_blank" title="https://twitter.com/@elephantroomATX" href="https://twitter.com/@elephantroomATX"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 16" class="icon"><path fill-rule="evenodd" d="M15.88 2.44A3.866 3.866 0 0017.502.284a7.162 7.162 0 01-2.345.945A3.595 3.595 0 0012.462 0C10.422 0 8.77 1.744 8.77 3.894c0 .306.03.603.094.887C5.796 4.62 3.076 3.07 1.253.712a4.05 4.05 0 00-.5 1.959c0 1.35.652 2.543 1.643 3.243a3.56 3.56 0 01-1.673-.487v.048c0 1.887 1.272 3.462 2.963 3.818-.31.092-.636.137-.974.137-.238 0-.47-.023-.694-.069.47 1.547 1.833 2.675 3.45 2.705A7.17 7.17 0 010 13.679a10.07 10.07 0 005.66 1.75c6.794 0 10.507-5.935 10.507-11.082 0-.17-.002-.338-.01-.504A7.72 7.72 0 0018 1.826c-.662.31-1.375.52-2.12.613z"></path></svg></a>
+</li></ul></nav>
+
+
+<div id="frame">
+  <div id="frame-top">
+    
+      <div class="title-nav-container">
+        <div id="title-wrap" class="title-wrap" data-apply-textfit="false">
+          <h1 id="page-title" class="page-title display-type-text text-fit"><a href="/home"><span class="outer" data-max-font-size="30"><span class="inner" id="page-title-string">Elephant Room</span></span></a></h1>
+        </div>
+
+        <div class="nav-bar">
+              <span id="toggle-mobile-menu" class="toggle-mobile-menu"><a href="javascript:"><i class="icon-hamburger"></i></a></span><nav id="main-nav" class="non-mobile" data-action="turbo:load@document-&gt;selected-page#mark" data-controller="selected-page"><ul class="horizontal list top menu-length-2"><li class="has-submenu top"><div><a class="top" href="/home">Home</a></div><ul><li class="subpage"><div><a class="" href="/pubcast">PUBcast</a></div></li><li class="subpage"><div><a class="" target="_external" href="/gift-card">Gift card</a></div></li><li class="subpage"><div><a class="" target="_external" href="/store">Store</a></div></li></ul></li><li class="top selected"><div><a class="top" href="/calendar">Calendar</a></div></li></ul></nav>
+
+        </div>
+      </div>
+    
+  </div>
+
+  <div id="frame-left"></div>
+  <div id="frame-right"></div>
+
+  <div id="frame-bottom" data-editor--fixed-elements-to-clip-path-target="element">
+    
+      <div class="site-wrap">
+        <aside class="side-bar" id="sticky-side-bar" data-turbo-permanent>
+          
+        </aside>
+
+        <aside class="side-bar">
+          
+<div id="site-wide-header" class="site-wide-feature-area"><moda-sections class="zoogle-content" data-arrangement-id="4721636" data-controller="content-width"><moda-section class="moda m-section m-shape m-masked m-style-feature-row-12716066 zoogle-columns zoogle-columns-1 zoogle-columns-100 default-section-style padding-none title-alignment-left block block-row layout_full" data-row-id="12716066" id="feature_row_12716066" variant="1">
+  
+  
+
+  
+
+  <div class="zoogle-columns-inner site-wrap">
+    
+
+
+    
+    <div class="zoogle-column zoogle-column-1-of-1 col_1_of_1 layout_full" data-column-id="15041355" id="feature_column_15041355">
+  
+  <div class="zoogle-feature block layout_full" data-block-id="15443210" id="feature_block_15443210"><section class="feature my_site_feature" data-feature-id="903945" data-controller="content-width" data-content-width-name="feature" id="my_site_feature_903945">  <ul class="my_sites -align-center my_sites_font_face my_sites_count_3 my_sites_shape_icon site_wide_my_sites" style="--my-sites-feature-size: 20px; --my-sites-feature-background-color: hsla(0,0%,0%,1);">
+      <li class="facebook">
+          <a class="icon facebook" rel="noopener" target="_blank" title="https://www.facebook.com/Elephant-Room-288488406823" data-stat-action="Click" data-event-category="My sites" href="https://www.facebook.com/Elephant-Room-288488406823"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 18" class="icon"><path fill-rule="evenodd" d="M1.907 18V8.999H0V5.897h1.907V4.035C1.907 1.505 2.984 0 6.044 0h2.547v3.103H7c-1.191 0-1.27.433-1.27 1.242l-.005 1.552h2.885L8.27 9H5.724V18H1.907z"></path></svg></a>
+
+</li>      <li class="instagram">
+          <a class="icon instagram" rel="noopener" target="_blank" title="https://www.instagram.com/explore/locations/49310/elephant-room/" data-stat-action="Click" data-event-category="My sites" href="https://www.instagram.com/explore/locations/49310/elephant-room/"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon"><path fill-rule="evenodd" d="M6.955 1.628l2.582-.006c1.916.001 2.227.012 3.1.052.877.04 1.354.187 1.67.31.421.163.72.358 1.036.673.27.27.452.529.6.862l.073.173c.113.29.246.715.298 1.46l.03.627c.012.29.02.553.025.917l.01 2.842c-.002 1.915-.013 2.226-.053 3.099-.037.804-.163 1.272-.279 1.588l-.031.083c-.163.42-.358.72-.673 1.035-.315.315-.615.51-1.035.673-.29.113-.715.246-1.46.298l-1.21.05c-.344.007-.761.011-1.428.013l-3.255-.005a37.01 37.01 0 01-1.592-.046c-.877-.04-1.354-.187-1.67-.31a2.788 2.788 0 01-1.036-.673 2.788 2.788 0 01-.673-1.035c-.113-.29-.246-.715-.298-1.46l-.05-1.21a71.292 71.292 0 01-.013-1.428l.005-3.255c.006-.692.02-1.022.046-1.592.04-.877.187-1.354.31-1.67.163-.421.358-.72.673-1.036.315-.315.615-.51 1.035-.673.29-.113.715-.246 1.46-.298l.627-.03c.355-.015.668-.023 1.176-.028zM6.97.006h4.06c.747.007 1.09.021 1.68.048.959.044 1.613.196 2.185.419.592.23 1.094.537 1.594 1.038.5.5.808 1.002 1.038 1.594.198.509.34 1.082.4 1.876l.035.68c.026.62.036 1.093.038 2.574l-.005 2.658c-.006.844-.02 1.192-.05 1.818-.043.958-.195 1.612-.418 2.184a4.412 4.412 0 01-1.038 1.594c-.5.5-1.002.809-1.594 1.039-.509.197-1.082.34-1.876.4l-.795.039c-.53.021-1.003.03-2.193.032l-2.924-.004a39.115 39.115 0 01-1.818-.05c-.958-.043-1.612-.195-2.184-.417a4.412 4.412 0 01-1.594-1.039c-.5-.5-.809-1.002-1.039-1.594-.197-.509-.34-1.082-.4-1.876l-.042-.876C.009 11.575 0 11.027 0 9.527L.006 6.97c.007-.747.021-1.09.048-1.68.044-.959.196-1.613.418-2.185A4.412 4.412 0 011.511 1.51c.5-.5 1.002-.808 1.594-1.038.509-.198 1.082-.34 1.876-.4L5.857.03C6.177.018 6.49.01 6.97.006zm2.048 4.387a4.625 4.625 0 100 9.25 4.625 4.625 0 000-9.25zm0 1.623a3.002 3.002 0 110 6.004 3.002 3.002 0 010-6.004zm4.768-2.909a1.071 1.071 0 100 2.143 1.071 1.071 0 000-2.143z"></path></svg></a>
+
+</li>      <li class="twitter">
+          <a class="icon twitter" rel="noopener" target="_blank" title="https://twitter.com/@elephantroomATX" data-stat-action="Click" data-event-category="My sites" href="https://twitter.com/@elephantroomATX"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 16" class="icon"><path fill-rule="evenodd" d="M15.88 2.44A3.866 3.866 0 0017.502.284a7.162 7.162 0 01-2.345.945A3.595 3.595 0 0012.462 0C10.422 0 8.77 1.744 8.77 3.894c0 .306.03.603.094.887C5.796 4.62 3.076 3.07 1.253.712a4.05 4.05 0 00-.5 1.959c0 1.35.652 2.543 1.643 3.243a3.56 3.56 0 01-1.673-.487v.048c0 1.887 1.272 3.462 2.963 3.818-.31.092-.636.137-.974.137-.238 0-.47-.023-.694-.069.47 1.547 1.833 2.675 3.45 2.705A7.17 7.17 0 010 13.679a10.07 10.07 0 005.66 1.75c6.794 0 10.507-5.935 10.507-11.082 0-.17-.002-.338-.01-.504A7.72 7.72 0 0018 1.826c-.662.31-1.375.52-2.12.613z"></path></svg></a>
+
+</li></ul></section></div>
+</div>
+</div>
+</moda-section></moda-sections></div>
+
+
+        </aside>
+      </div>
+    
+  </div>
+</div>
+
+<div data-pjax-container>
+  
+        
+  <div id="page-root" class="inner-page display-type-text website-page-calendar has-swms has-section-styles" data-page-id="3839194" data-slug="calendar" data-chromeless="false">
+    <div id="container">
+	
+		<!-- this element is only here to fix an IE11 flexbox bug. see css for details. -->
+		<div class="ie-flexbox-fix-wrapper">
+			<div class="cta-header-container">
+				
+			</div>
+			<header id="page-header">
+				<div id="page_media_container" class="page-media-wrapper">
+      <media-background-container class="moda m-page-media m-media m-bordered m-cut-corner m-clipped m-shape m-masked page-photos page-media-container" interval="medium" speed="medium" transition="fade" style="--media-background-color: #000000">
+  <media-background crop-rect="{&quot;x&quot;:0,&quot;y&quot;:0,&quot;w&quot;:660,&quot;h&quot;:441}" focal-point="{&quot;x&quot;:330,&quot;y&quot;:220}" original-width="660" original-height="441" mode="contained" class="page-photo" image-align="center" image-justify="center" vignette="none" background-style="color" opacity="100">
+  <picture>
+      <source media="(max-width: 600px)" srcset="//images.zoogletools.com/s:bzglfiles/u/523260/5ac11b759db337706a5ffa42b329cd0379a8bb63/original/elephant-room-dave-creaney-american-statesman.jpeg/!!/b%3AW1sicmVzaXplIiwxMjAwXSxbIm1heCJdLFsid2UiXV0%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg 1x, //images.zoogletools.com/s:bzglfiles/u/523260/5ac11b759db337706a5ffa42b329cd0379a8bb63/original/elephant-room-dave-creaney-american-statesman.jpeg/!!/b%3AW1sicmVzaXplIiwxODAwXSxbIm1heCJdLFsid2UiXV0%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg 2x">
+      <source media="(min-width: 601px)" srcset="//images.zoogletools.com/s:bzglfiles/u/523260/5ac11b759db337706a5ffa42b329cd0379a8bb63/original/elephant-room-dave-creaney-american-statesman.jpeg/!!/b%3AW1sicmVzaXplIiwxODAwXSxbIm1heCJdLFsid2UiXV0%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg 1x, //images.zoogletools.com/s:bzglfiles/u/523260/5ac11b759db337706a5ffa42b329cd0379a8bb63/original/elephant-room-dave-creaney-american-statesman.jpeg/!!/b%3AW1sicmVzaXplIiwzMjAwXSxbIm1heCJdLFsid2UiXV0%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg 2x">
+
+    <img src="//images.zoogletools.com/s:bzglfiles/u/523260/5ac11b759db337706a5ffa42b329cd0379a8bb63/original/elephant-room-dave-creaney-american-statesman.jpeg/!!/b%3AW1sicmVzaXplIiwxODAwXSxbIm1heCJdLFsid2UiXV0%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg">
+  </picture>
+</media-background>
+
+</media-background-container>
+
+</div>
+			</header>
+		</div>
+	
+
+	<div id="content-wrap">
+		<div id="content">
+			<!-- temporary: so site_wide_my_sites show up in pages tab of controlpanel -->
+			<div style="display: none">
+<div id="site-wide-header" class="site-wide-feature-area"><moda-sections class="zoogle-content" data-arrangement-id="4721636" data-controller="content-width"><moda-section class="moda m-section m-shape m-masked m-style-feature-row-12716066 zoogle-columns zoogle-columns-1 zoogle-columns-100 default-section-style padding-none title-alignment-left block block-row layout_full" data-row-id="12716066" id="feature_row_12716066" variant="1">
+  
+  
+
+  
+
+  <div class="zoogle-columns-inner site-wrap">
+    
+
+
+    
+    <div class="zoogle-column zoogle-column-1-of-1 col_1_of_1 layout_full" data-column-id="15041355" id="feature_column_15041355">
+  
+  <div class="zoogle-feature block layout_full" data-block-id="15443210" id="feature_block_15443210"><section class="feature my_site_feature" data-feature-id="903945" data-controller="content-width" data-content-width-name="feature" id="my_site_feature_903945">  <ul class="my_sites -align-center my_sites_font_face my_sites_count_3 my_sites_shape_icon site_wide_my_sites" style="--my-sites-feature-size: 20px; --my-sites-feature-background-color: hsla(0,0%,0%,1);">
+      <li class="facebook">
+          <a class="icon facebook" rel="noopener" target="_blank" title="https://www.facebook.com/Elephant-Room-288488406823" data-stat-action="Click" data-event-category="My sites" href="https://www.facebook.com/Elephant-Room-288488406823"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 18" class="icon"><path fill-rule="evenodd" d="M1.907 18V8.999H0V5.897h1.907V4.035C1.907 1.505 2.984 0 6.044 0h2.547v3.103H7c-1.191 0-1.27.433-1.27 1.242l-.005 1.552h2.885L8.27 9H5.724V18H1.907z"></path></svg></a>
+
+</li>      <li class="instagram">
+          <a class="icon instagram" rel="noopener" target="_blank" title="https://www.instagram.com/explore/locations/49310/elephant-room/" data-stat-action="Click" data-event-category="My sites" href="https://www.instagram.com/explore/locations/49310/elephant-room/"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon"><path fill-rule="evenodd" d="M6.955 1.628l2.582-.006c1.916.001 2.227.012 3.1.052.877.04 1.354.187 1.67.31.421.163.72.358 1.036.673.27.27.452.529.6.862l.073.173c.113.29.246.715.298 1.46l.03.627c.012.29.02.553.025.917l.01 2.842c-.002 1.915-.013 2.226-.053 3.099-.037.804-.163 1.272-.279 1.588l-.031.083c-.163.42-.358.72-.673 1.035-.315.315-.615.51-1.035.673-.29.113-.715.246-1.46.298l-1.21.05c-.344.007-.761.011-1.428.013l-3.255-.005a37.01 37.01 0 01-1.592-.046c-.877-.04-1.354-.187-1.67-.31a2.788 2.788 0 01-1.036-.673 2.788 2.788 0 01-.673-1.035c-.113-.29-.246-.715-.298-1.46l-.05-1.21a71.292 71.292 0 01-.013-1.428l.005-3.255c.006-.692.02-1.022.046-1.592.04-.877.187-1.354.31-1.67.163-.421.358-.72.673-1.036.315-.315.615-.51 1.035-.673.29-.113.715-.246 1.46-.298l.627-.03c.355-.015.668-.023 1.176-.028zM6.97.006h4.06c.747.007 1.09.021 1.68.048.959.044 1.613.196 2.185.419.592.23 1.094.537 1.594 1.038.5.5.808 1.002 1.038 1.594.198.509.34 1.082.4 1.876l.035.68c.026.62.036 1.093.038 2.574l-.005 2.658c-.006.844-.02 1.192-.05 1.818-.043.958-.195 1.612-.418 2.184a4.412 4.412 0 01-1.038 1.594c-.5.5-1.002.809-1.594 1.039-.509.197-1.082.34-1.876.4l-.795.039c-.53.021-1.003.03-2.193.032l-2.924-.004a39.115 39.115 0 01-1.818-.05c-.958-.043-1.612-.195-2.184-.417a4.412 4.412 0 01-1.594-1.039c-.5-.5-.809-1.002-1.039-1.594-.197-.509-.34-1.082-.4-1.876l-.042-.876C.009 11.575 0 11.027 0 9.527L.006 6.97c.007-.747.021-1.09.048-1.68.044-.959.196-1.613.418-2.185A4.412 4.412 0 011.511 1.51c.5-.5 1.002-.808 1.594-1.038.509-.198 1.082-.34 1.876-.4L5.857.03C6.177.018 6.49.01 6.97.006zm2.048 4.387a4.625 4.625 0 100 9.25 4.625 4.625 0 000-9.25zm0 1.623a3.002 3.002 0 110 6.004 3.002 3.002 0 010-6.004zm4.768-2.909a1.071 1.071 0 100 2.143 1.071 1.071 0 000-2.143z"></path></svg></a>
+
+</li>      <li class="twitter">
+          <a class="icon twitter" rel="noopener" target="_blank" title="https://twitter.com/@elephantroomATX" data-stat-action="Click" data-event-category="My sites" href="https://twitter.com/@elephantroomATX"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 16" class="icon"><path fill-rule="evenodd" d="M15.88 2.44A3.866 3.866 0 0017.502.284a7.162 7.162 0 01-2.345.945A3.595 3.595 0 0012.462 0C10.422 0 8.77 1.744 8.77 3.894c0 .306.03.603.094.887C5.796 4.62 3.076 3.07 1.253.712a4.05 4.05 0 00-.5 1.959c0 1.35.652 2.543 1.643 3.243a3.56 3.56 0 01-1.673-.487v.048c0 1.887 1.272 3.462 2.963 3.818-.31.092-.636.137-.974.137-.238 0-.47-.023-.694-.069.47 1.547 1.833 2.675 3.45 2.705A7.17 7.17 0 010 13.679a10.07 10.07 0 005.66 1.75c6.794 0 10.507-5.935 10.507-11.082 0-.17-.002-.338-.01-.504A7.72 7.72 0 0018 1.826c-.662.31-1.375.52-2.12.613z"></path></svg></a>
+
+</li></ul></section></div>
+</div>
+</div>
+</moda-section></moda-sections></div>
+
+</div>
+
+			<div class="zoogle_flash">
+</div>
+
+<div id="cart-badge" class="cart-badge style-section-style-1 -empty-on-load" data-controller="cart--badge-loader cart--badge" data-action="cart--badge-loader:load-&gt;cart--badge-loader#injectBadge cart--cart:updated@window-&gt;cart--badge#onCartUpdate cart--cart:display@window-&gt;cart--badge#displayCart" data-cart--badge-loader-url-value="/api/cart/badge" data-turbo-permanent=""></div>
+
+
+  <div id="page-content-wrap"><moda-sections class="zoogle-content" data-arrangement-id="4730016" data-controller="content-width"><moda-section class="moda m-section m-shape m-masked m-style-feature-row-20004087 zoogle-columns zoogle-columns-1 zoogle-columns-100 style-section-style-1 padding-small title-alignment-left block block-row layout_full zoogle-columns-first" data-row-id="20004087" id="feature_row_20004087" variant="2">
+  
+  
+
+  
+
+  <div class="zoogle-columns-inner site-wrap">
+    
+
+
+    
+    <div class="zoogle-column zoogle-column-1-of-1 col_1_of_1 layout_full" data-column-id="23539474" id="feature_column_23539474">
+  
+  <div class="zoogle-feature block layout_full" data-block-id="29026218" id="feature_block_29026218"><section class="feature calendar_feature" data-feature-id="1319444" data-controller="content-width" data-content-width-name="feature" id="calendar_feature_1319444"><div class="calendar-wrap">
+  
+<div id="calendar">
+  <div class="month current">
+    <header>
+      <h2>
+          <a class="prev border-accent-dark pdf__hide" title="Previous month" data-turbo-stream="true" href="/calendar/features/load/calendar_feature_1319444?month=4&amp;year=2026">
+          <i class="icon-chevron-sign-left"></i>
+</a>        <span class="month-name">
+          May 2026
+        </span>
+          <a class="next border-accent-dark pdf__hide" title="Next month" data-turbo-stream="true" href="/calendar/features/load/calendar_feature_1319444?month=6&amp;year=2026">
+          <i class="icon-chevron-sign-right"></i>
+</a>      </h2>
+    </header>
+
+    <table class="calendar"><thead><tr><th>Sunday</th><th>Monday</th><th>Tuesday</th><th>Wednesday</th><th>Thursday</th><th>Friday</th><th>Saturday</th></tr></thead><tbody class="border-accent"><tr><td class="border-accent text-secondary other-month text-tertiary">
+      
+<div>
+  <div class="day">26</div>
+</div>
+</td><td class="border-accent text-secondary other-month text-tertiary">
+      
+<div>
+  <div class="day">27</div>
+</div>
+</td><td class="border-accent text-secondary other-month text-tertiary">
+      
+<div>
+  <div class="day">28</div>
+</div>
+</td><td class="border-accent text-secondary other-month text-tertiary">
+      
+<div>
+  <div class="day">29</div>
+</div>
+</td><td class="border-accent text-secondary other-month text-tertiary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">30</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/6031397?feature_id=1319444&amp;occurrence_id=719668915&amp;popup=1">
+  <span class="event-name alt-font">International Jazz Day!</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/6031397?feature_id=1319444&amp;occurrence_id=719668915&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/d845f826d138f4a641320850a809af5cb1aeb630/original/intl-jazz-day.png/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.png" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/6031397?feature_id=1319444&amp;occurrence_id=719668915&amp;popup=1">International Jazz Day!</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/6031397?feature_id=1319444&amp;occurrence_id=719668915&amp;popup=1">
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/6031397?feature_id=1319444&amp;occurrence_id=719668915&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td><td class="border-accent text-secondary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">1</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/5600228?feature_id=1319444&amp;occurrence_id=759226888&amp;popup=1">
+  <span class="event-name alt-font">Shane Pitsch &amp; the Dirty Six</span>
+    <br>
+    <span>🐘6pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/5600228?feature_id=1319444&amp;occurrence_id=759226888&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/0bdf88f7cabd823cd590458758eb68da7f23d201/original/434361352-8071872009507785-3789974501505665645-n.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5600228?feature_id=1319444&amp;occurrence_id=759226888&amp;popup=1">Shane Pitsch &amp; the Dirty Six</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5600228?feature_id=1319444&amp;occurrence_id=759226888&amp;popup=1">
+        <span>🐘6pm</span>
+        <span class="time"><span class="icon-clock"></span>6:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5600228?feature_id=1319444&amp;occurrence_id=759226888&amp;popup=1"></a>
+</div>
+
+</li>        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4184677?feature_id=1319444&amp;occurrence_id=763189025&amp;popup=1">
+  <span class="event-name alt-font">Dr. James Polk&#39;s CENTERPEACE</span>
+    <br>
+    <span>🐘9pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4184677?feature_id=1319444&amp;occurrence_id=763189025&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/d3aa41d959bde750d39ce6054097d3054a647d7b/original/dr-james-polk.jpeg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4184677?feature_id=1319444&amp;occurrence_id=763189025&amp;popup=1">Dr. James Polk&#39;s CENTERPEACE</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4184677?feature_id=1319444&amp;occurrence_id=763189025&amp;popup=1">
+        <span>🐘9pm</span>
+        <span class="time"><span class="icon-clock"></span>9:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4184677?feature_id=1319444&amp;occurrence_id=763189025&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td><td class="border-accent text-secondary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">2</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4178838?feature_id=1319444&amp;occurrence_id=762545885&amp;popup=1">
+  <span class="event-name alt-font">Michael Malone NUJAZZSWING</span>
+    <br>
+    <span>🐘9pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4178838?feature_id=1319444&amp;occurrence_id=762545885&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/64c0a5571f7ab4bb3fbed88b9516befc3af0dbc4/original/mike-malone.jpeg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4178838?feature_id=1319444&amp;occurrence_id=762545885&amp;popup=1">Michael Malone NUJAZZSWING</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4178838?feature_id=1319444&amp;occurrence_id=762545885&amp;popup=1">
+        <span>🐘9pm</span>
+        <span class="time"><span class="icon-clock"></span>9:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4178838?feature_id=1319444&amp;occurrence_id=762545885&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td></tr><tr><td class="border-accent text-secondary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">3</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4660627?feature_id=1319444&amp;occurrence_id=762545838&amp;popup=1">
+  <span class="event-name alt-font">Bree Romeo Quartet</span>
+    <br>
+    <span>🐘8pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4660627?feature_id=1319444&amp;occurrence_id=762545838&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/11a70c2720792a646e4a2fa1a5e0888a56238c17/original/bree-remeo.jpeg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4660627?feature_id=1319444&amp;occurrence_id=762545838&amp;popup=1">Bree Romeo Quartet</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4660627?feature_id=1319444&amp;occurrence_id=762545838&amp;popup=1">
+        <span>🐘8pm</span>
+        <span class="time"><span class="icon-clock"></span>8:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4660627?feature_id=1319444&amp;occurrence_id=762545838&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td><td class="border-accent text-secondary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">4</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4486785?feature_id=1319444&amp;occurrence_id=759226771&amp;popup=1">
+  <span class="event-name alt-font">Jon Blondell &amp; Friends</span>
+    <br>
+    <span>🐘6pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4486785?feature_id=1319444&amp;occurrence_id=759226771&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/35475bbd9869e181c8519f3c48f348bcd64ef17e/original/jon-blondell-w-bass.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4486785?feature_id=1319444&amp;occurrence_id=759226771&amp;popup=1">Jon Blondell &amp; Friends</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4486785?feature_id=1319444&amp;occurrence_id=759226771&amp;popup=1">
+        <span>🐘6pm</span>
+        <span class="time"><span class="icon-clock"></span>6:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4486785?feature_id=1319444&amp;occurrence_id=759226771&amp;popup=1"></a>
+</div>
+
+</li>        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4821425?feature_id=1319444&amp;occurrence_id=763314808&amp;popup=1">
+  <span class="event-name alt-font">Jazz Jam hosted by: Kris Kimura </span>
+    <br>
+    <span>🐘9pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4821425?feature_id=1319444&amp;occurrence_id=763314808&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/5942d5a87b4de96ddf5c2daef179550a8ef1b421/original/kris-kimura.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4821425?feature_id=1319444&amp;occurrence_id=763314808&amp;popup=1">Jazz Jam hosted by: Kris Kimura </a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4821425?feature_id=1319444&amp;occurrence_id=763314808&amp;popup=1">
+        <span>🐘9pm</span>
+        <span class="time"><span class="icon-clock"></span>9:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4821425?feature_id=1319444&amp;occurrence_id=763314808&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td><td class="border-accent text-secondary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">5</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/6206846?feature_id=1319444&amp;occurrence_id=763315460&amp;popup=1">
+  <span class="event-name alt-font">Drew Simpson Trio</span>
+    <br>
+    <span>🐘6pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/6206846?feature_id=1319444&amp;occurrence_id=763315460&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/0f3a4a284fa737a452ecb8e169729cf1c1de03a8/original/drew-simpson.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/6206846?feature_id=1319444&amp;occurrence_id=763315460&amp;popup=1">Drew Simpson Trio</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/6206846?feature_id=1319444&amp;occurrence_id=763315460&amp;popup=1">
+        <span>🐘6pm</span>
+        <span class="time"><span class="icon-clock"></span>6:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/6206846?feature_id=1319444&amp;occurrence_id=763315460&amp;popup=1"></a>
+</div>
+
+</li>        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4178827?feature_id=1319444&amp;occurrence_id=762545840&amp;popup=1">
+  <span class="event-name alt-font">BLONDELL !</span>
+    <br>
+    <span>🐘9pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4178827?feature_id=1319444&amp;occurrence_id=762545840&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/ede0bb2af0437565ac3caec3c61ebddbb4b15049/original/blondell-w-bass.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4178827?feature_id=1319444&amp;occurrence_id=762545840&amp;popup=1">BLONDELL !</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4178827?feature_id=1319444&amp;occurrence_id=762545840&amp;popup=1">
+        <span>🐘9pm</span>
+        <span class="time"><span class="icon-clock"></span>9:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4178827?feature_id=1319444&amp;occurrence_id=762545840&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td><td class="border-accent text-secondary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">6</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4490173?feature_id=1319444&amp;occurrence_id=763701782&amp;popup=1">
+  <span class="event-name alt-font">Violet Crown Jazz Revue with Liz Morphis</span>
+    <br>
+    <span>🐘6pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4490173?feature_id=1319444&amp;occurrence_id=763701782&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/059f2500d5c0f6c6dda6e5e988627048524a1537/original/liz-morphis-thumbnail.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4490173?feature_id=1319444&amp;occurrence_id=763701782&amp;popup=1">Violet Crown Jazz Revue with Liz Morphis</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4490173?feature_id=1319444&amp;occurrence_id=763701782&amp;popup=1">
+        <span>🐘6pm</span>
+        <span class="time"><span class="icon-clock"></span>6:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4490173?feature_id=1319444&amp;occurrence_id=763701782&amp;popup=1"></a>
+</div>
+
+</li>        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4184675?feature_id=1319444&amp;occurrence_id=762545828&amp;popup=1">
+  <span class="event-name alt-font">John Mills  TIMES TEN</span>
+    <br>
+    <span>🐘9pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4184675?feature_id=1319444&amp;occurrence_id=762545828&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/12de7073dd67181fe8080f0a4152afab9b5b5a35/original/john-mills-ut-music2-1-07.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4184675?feature_id=1319444&amp;occurrence_id=762545828&amp;popup=1">John Mills  TIMES TEN</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4184675?feature_id=1319444&amp;occurrence_id=762545828&amp;popup=1">
+        <span>🐘9pm</span>
+        <span class="time"><span class="icon-clock"></span>9:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4184675?feature_id=1319444&amp;occurrence_id=762545828&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td><td class="border-accent text-secondary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">7</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4558295?feature_id=1319444&amp;occurrence_id=763189015&amp;popup=1">
+  <span class="event-name alt-font">Sarah Sharp Quintet</span>
+    <br>
+    <span>🐘6pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4558295?feature_id=1319444&amp;occurrence_id=763189015&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/d4c8a75373e01ff7aee47194935554f0e3df7688/original/sarah-sharp.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4558295?feature_id=1319444&amp;occurrence_id=763189015&amp;popup=1">Sarah Sharp Quintet</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4558295?feature_id=1319444&amp;occurrence_id=763189015&amp;popup=1">
+        <span>🐘6pm</span>
+        <span class="time"><span class="icon-clock"></span>6:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4558295?feature_id=1319444&amp;occurrence_id=763189015&amp;popup=1"></a>
+</div>
+
+</li>        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4766592?feature_id=1319444&amp;occurrence_id=762545988&amp;popup=1">
+  <span class="event-name alt-font">Waxahachie Horns</span>
+    <br>
+    <span>🐘9pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4766592?feature_id=1319444&amp;occurrence_id=762545988&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/84696549c7640ee132dbbe10cc8fb06fad0374f3/original/waxhorns.jpeg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4766592?feature_id=1319444&amp;occurrence_id=762545988&amp;popup=1">Waxahachie Horns</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4766592?feature_id=1319444&amp;occurrence_id=762545988&amp;popup=1">
+        <span>🐘9pm</span>
+        <span class="time"><span class="icon-clock"></span>9:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4766592?feature_id=1319444&amp;occurrence_id=762545988&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td><td class="border-accent text-secondary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">8</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/6004746?feature_id=1319444&amp;occurrence_id=762545870&amp;popup=1">
+  <span class="event-name alt-font">The Brew</span>
+    <br>
+    <span>🐘6pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/6004746?feature_id=1319444&amp;occurrence_id=762545870&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/fdf3ba62fd53721321714ef304fcd8a7ecefb652/original/screenshot-2025-03-17-at-8-33-07-am.png/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.png" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/6004746?feature_id=1319444&amp;occurrence_id=762545870&amp;popup=1">The Brew</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/6004746?feature_id=1319444&amp;occurrence_id=762545870&amp;popup=1">
+        <span>🐘6pm</span>
+        <span class="time"><span class="icon-clock"></span>6:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/6004746?feature_id=1319444&amp;occurrence_id=762545870&amp;popup=1"></a>
+</div>
+
+</li>        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4178814?feature_id=1319444&amp;occurrence_id=762545876&amp;popup=1">
+  <span class="event-name alt-font">Elias Haslanger Quintet</span>
+    <br>
+    <span>🐘9pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4178814?feature_id=1319444&amp;occurrence_id=762545876&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/6ea4ee5507d38eefe16af0ecca19dcfaac7b1e3e/original/th.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4178814?feature_id=1319444&amp;occurrence_id=762545876&amp;popup=1">Elias Haslanger Quintet</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4178814?feature_id=1319444&amp;occurrence_id=762545876&amp;popup=1">
+        <span>🐘9pm</span>
+        <span class="time"><span class="icon-clock"></span>9:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4178814?feature_id=1319444&amp;occurrence_id=762545876&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td><td class="border-accent text-secondary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">9</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4490297?feature_id=1319444&amp;occurrence_id=762546035&amp;popup=1">
+  <span class="event-name alt-font">J Serrato Quintet</span>
+    <br>
+    <span>🐘9pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4490297?feature_id=1319444&amp;occurrence_id=762546035&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/c5b6924dca83f206b93da121d9e120ca37cbf528/original/page1image256.png/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.png" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4490297?feature_id=1319444&amp;occurrence_id=762546035&amp;popup=1">J Serrato Quintet</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4490297?feature_id=1319444&amp;occurrence_id=762546035&amp;popup=1">
+        <span>🐘9pm</span>
+        <span class="time"><span class="icon-clock"></span>9:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4490297?feature_id=1319444&amp;occurrence_id=762546035&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td></tr><tr><td class="border-accent text-secondary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">10</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/5686421?feature_id=1319444&amp;occurrence_id=759226914&amp;popup=1">
+  <span class="event-name alt-font">Kevin Hrabak Group</span>
+    <br>
+    <span>🐘8pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/5686421?feature_id=1319444&amp;occurrence_id=759226914&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/f8babcb98f996672c4cb87a043bfa9105adfcbfe/original/kevin-blue-suit.png/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.png" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5686421?feature_id=1319444&amp;occurrence_id=759226914&amp;popup=1">Kevin Hrabak Group</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5686421?feature_id=1319444&amp;occurrence_id=759226914&amp;popup=1">
+        <span>🐘8pm</span>
+        <span class="time"><span class="icon-clock"></span>8:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5686421?feature_id=1319444&amp;occurrence_id=759226914&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td><td class="border-accent text-secondary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">11</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4486785?feature_id=1319444&amp;occurrence_id=759226772&amp;popup=1">
+  <span class="event-name alt-font">Jon Blondell &amp; Friends</span>
+    <br>
+    <span>🐘6pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4486785?feature_id=1319444&amp;occurrence_id=759226772&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/35475bbd9869e181c8519f3c48f348bcd64ef17e/original/jon-blondell-w-bass.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4486785?feature_id=1319444&amp;occurrence_id=759226772&amp;popup=1">Jon Blondell &amp; Friends</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4486785?feature_id=1319444&amp;occurrence_id=759226772&amp;popup=1">
+        <span>🐘6pm</span>
+        <span class="time"><span class="icon-clock"></span>6:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4486785?feature_id=1319444&amp;occurrence_id=759226772&amp;popup=1"></a>
+</div>
+
+</li>        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4489016?feature_id=1319444&amp;occurrence_id=762545912&amp;popup=1">
+  <span class="event-name alt-font">Michael Mordecai Jazz Jam</span>
+    <br>
+    <span>🐘9pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4489016?feature_id=1319444&amp;occurrence_id=762545912&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/1075b1c93f99c59916fac0aa596ef3f936d4b6dc/original/michael-trombone-bell.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4489016?feature_id=1319444&amp;occurrence_id=762545912&amp;popup=1">Michael Mordecai Jazz Jam</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4489016?feature_id=1319444&amp;occurrence_id=762545912&amp;popup=1">
+        <span>🐘9pm</span>
+        <span class="time"><span class="icon-clock"></span>9:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4489016?feature_id=1319444&amp;occurrence_id=762545912&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td><td class="border-accent text-secondary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">12</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4315535?feature_id=1319444&amp;occurrence_id=763189022&amp;popup=1">
+  <span class="event-name alt-font">Mitch Watkins Trio</span>
+    <br>
+    <span>🐘6pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4315535?feature_id=1319444&amp;occurrence_id=763189022&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/96ac109ed301bc8b4d0400b31ecd30f84506e12b/original/mitchwatkins.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4315535?feature_id=1319444&amp;occurrence_id=763189022&amp;popup=1">Mitch Watkins Trio</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4315535?feature_id=1319444&amp;occurrence_id=763189022&amp;popup=1">
+        <span>🐘6pm</span>
+        <span class="time"><span class="icon-clock"></span>6:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4315535?feature_id=1319444&amp;occurrence_id=763189022&amp;popup=1"></a>
+</div>
+
+</li>        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4490206?feature_id=1319444&amp;occurrence_id=762545973&amp;popup=1">
+  <span class="event-name alt-font">Boss Street Brass Band</span>
+    <br>
+    <span>🐘9pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4490206?feature_id=1319444&amp;occurrence_id=762545973&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/e814a24740b2b1fc856ae3904ca740bcdcc13824/original/boss-street-brass-band.png/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.png" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4490206?feature_id=1319444&amp;occurrence_id=762545973&amp;popup=1">Boss Street Brass Band</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4490206?feature_id=1319444&amp;occurrence_id=762545973&amp;popup=1">
+        <span>🐘9pm</span>
+        <span class="time"><span class="icon-clock"></span>9:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4490206?feature_id=1319444&amp;occurrence_id=762545973&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td><td class="border-accent text-secondary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">13</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/5871478?feature_id=1319444&amp;occurrence_id=762545969&amp;popup=1">
+  <span class="event-name alt-font">Stephen Summer Trio</span>
+    <br>
+    <span>🐘6pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/5871478?feature_id=1319444&amp;occurrence_id=762545969&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/face1db3290e1d28217a29ec0adac450f66dd92f/original/image0.jpeg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5871478?feature_id=1319444&amp;occurrence_id=762545969&amp;popup=1">Stephen Summer Trio</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5871478?feature_id=1319444&amp;occurrence_id=762545969&amp;popup=1">
+        <span>🐘6pm</span>
+        <span class="time"><span class="icon-clock"></span>6:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5871478?feature_id=1319444&amp;occurrence_id=762545969&amp;popup=1"></a>
+</div>
+
+</li>        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4335451?feature_id=1319444&amp;occurrence_id=762545862&amp;popup=1">
+  <span class="event-name alt-font">BAKER&#39;s DOZEN led by Freddie Mendoza</span>
+    <br>
+    <span>🐘9pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4335451?feature_id=1319444&amp;occurrence_id=762545862&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/524e9899f5808648da94570f25c58624417b3e56/original/images-1.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4335451?feature_id=1319444&amp;occurrence_id=762545862&amp;popup=1">BAKER&#39;s DOZEN led by Freddie Mendoza</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4335451?feature_id=1319444&amp;occurrence_id=762545862&amp;popup=1">
+        <span>🐘9pm</span>
+        <span class="time"><span class="icon-clock"></span>9:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4335451?feature_id=1319444&amp;occurrence_id=762545862&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td><td class="border-accent text-secondary bg-accent-slight">
+      
+<div class="with-events">
+  <div class="day bg-highlight">14</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4558295?feature_id=1319444&amp;occurrence_id=763189016&amp;popup=1">
+  <span class="event-name alt-font">Sarah Sharp Quintet</span>
+    <br>
+    <span>🐘6pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4558295?feature_id=1319444&amp;occurrence_id=763189016&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/d4c8a75373e01ff7aee47194935554f0e3df7688/original/sarah-sharp.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4558295?feature_id=1319444&amp;occurrence_id=763189016&amp;popup=1">Sarah Sharp Quintet</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4558295?feature_id=1319444&amp;occurrence_id=763189016&amp;popup=1">
+        <span>🐘6pm</span>
+        <span class="time"><span class="icon-clock"></span>6:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4558295?feature_id=1319444&amp;occurrence_id=763189016&amp;popup=1"></a>
+</div>
+
+</li>        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/5646964?feature_id=1319444&amp;occurrence_id=762288846&amp;popup=1">
+  <span class="event-name alt-font">Brian Bettger&#39;s Texas Cool Quintet</span>
+    <br>
+    <span>🐘9pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/5646964?feature_id=1319444&amp;occurrence_id=762288846&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/72a94664fa6eeefb60bcc4ad7647a559f10711ae/original/brian-bettger.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5646964?feature_id=1319444&amp;occurrence_id=762288846&amp;popup=1">Brian Bettger&#39;s Texas Cool Quintet</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5646964?feature_id=1319444&amp;occurrence_id=762288846&amp;popup=1">
+        <span>🐘9pm</span>
+        <span class="time"><span class="icon-clock"></span>9:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5646964?feature_id=1319444&amp;occurrence_id=762288846&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td><td class="border-accent text-secondary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">15</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/6082513?feature_id=1319444&amp;occurrence_id=763314679&amp;popup=1">
+  <span class="event-name alt-font">Dave Scher Group</span>
+    <br>
+    <span>🐘6pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/6082513?feature_id=1319444&amp;occurrence_id=763314679&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/222ce8f99b3cfa41c6163151c8de96090155cf97/original/bioguitarsm.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/6082513?feature_id=1319444&amp;occurrence_id=763314679&amp;popup=1">Dave Scher Group</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/6082513?feature_id=1319444&amp;occurrence_id=763314679&amp;popup=1">
+        <span>🐘6pm</span>
+        <span class="time"><span class="icon-clock"></span>6:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/6082513?feature_id=1319444&amp;occurrence_id=763314679&amp;popup=1"></a>
+</div>
+
+</li>        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/5925515?feature_id=1319444&amp;occurrence_id=762545908&amp;popup=1">
+  <span class="event-name alt-font">Red Young TENOR MADNESS</span>
+    <br>
+    <span>🐘9pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/5925515?feature_id=1319444&amp;occurrence_id=762545908&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/cd838d14a33c26c0474afb3bcd81261077b673eb/original/red-mkb-crop-1-300.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5925515?feature_id=1319444&amp;occurrence_id=762545908&amp;popup=1">Red Young TENOR MADNESS</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5925515?feature_id=1319444&amp;occurrence_id=762545908&amp;popup=1">
+        <span>🐘9pm</span>
+        <span class="time"><span class="icon-clock"></span>9:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5925515?feature_id=1319444&amp;occurrence_id=762545908&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td><td class="border-accent text-secondary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">16</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4558265?feature_id=1319444&amp;occurrence_id=762545998&amp;popup=1">
+  <span class="event-name alt-font">Jerry Espinoza Quintet</span>
+    <br>
+    <span>🐘9pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4558265?feature_id=1319444&amp;occurrence_id=762545998&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/765f02e20b79fe17806d4e9eaf3b9acd0eb9fd21/original/jerry-espinoza.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4558265?feature_id=1319444&amp;occurrence_id=762545998&amp;popup=1">Jerry Espinoza Quintet</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4558265?feature_id=1319444&amp;occurrence_id=762545998&amp;popup=1">
+        <span>🐘9pm</span>
+        <span class="time"><span class="icon-clock"></span>9:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4558265?feature_id=1319444&amp;occurrence_id=762545998&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td></tr><tr><td class="border-accent text-secondary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">17</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/6505037?feature_id=1319444&amp;occurrence_id=757033091&amp;popup=1">
+  <span class="event-name alt-font">Luke Allen Quartet</span>
+    <br>
+    <span>🐘8pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/6505037?feature_id=1319444&amp;occurrence_id=757033091&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/e5cb77f23699b2b9749bbda0e44e374d30b324a3/original/d677ad31-ad85-4d1e-ac71-bece01a4909b-img-0603.jpeg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/6505037?feature_id=1319444&amp;occurrence_id=757033091&amp;popup=1">Luke Allen Quartet</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/6505037?feature_id=1319444&amp;occurrence_id=757033091&amp;popup=1">
+        <span>🐘8pm</span>
+        <span class="time"><span class="icon-clock"></span>8:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/6505037?feature_id=1319444&amp;occurrence_id=757033091&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td><td class="border-accent text-secondary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">18</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4489021?feature_id=1319444&amp;occurrence_id=756908011&amp;popup=1">
+  <span class="event-name alt-font">Austin Jazz Band</span>
+    <br>
+    <span>🐘7pm Show</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4489021?feature_id=1319444&amp;occurrence_id=756908011&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/16e3711f5210635ea9ab2d02c56dd2d4d0dbf1c1/original/austinjazzband.png/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.png" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4489021?feature_id=1319444&amp;occurrence_id=756908011&amp;popup=1">Austin Jazz Band</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4489021?feature_id=1319444&amp;occurrence_id=756908011&amp;popup=1">
+        <span>🐘7pm Show</span>
+        <span class="time"><span class="icon-clock"></span>7:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4489021?feature_id=1319444&amp;occurrence_id=756908011&amp;popup=1"></a>
+</div>
+
+</li>        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4489016?feature_id=1319444&amp;occurrence_id=762545913&amp;popup=1">
+  <span class="event-name alt-font">Michael Mordecai Jazz Jam</span>
+    <br>
+    <span>🐘9pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4489016?feature_id=1319444&amp;occurrence_id=762545913&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/1075b1c93f99c59916fac0aa596ef3f936d4b6dc/original/michael-trombone-bell.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4489016?feature_id=1319444&amp;occurrence_id=762545913&amp;popup=1">Michael Mordecai Jazz Jam</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4489016?feature_id=1319444&amp;occurrence_id=762545913&amp;popup=1">
+        <span>🐘9pm</span>
+        <span class="time"><span class="icon-clock"></span>9:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4489016?feature_id=1319444&amp;occurrence_id=762545913&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td><td class="border-accent text-secondary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">19</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4315535?feature_id=1319444&amp;occurrence_id=763189023&amp;popup=1">
+  <span class="event-name alt-font">Mitch Watkins Trio</span>
+    <br>
+    <span>🐘6pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4315535?feature_id=1319444&amp;occurrence_id=763189023&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/96ac109ed301bc8b4d0400b31ecd30f84506e12b/original/mitchwatkins.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4315535?feature_id=1319444&amp;occurrence_id=763189023&amp;popup=1">Mitch Watkins Trio</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4315535?feature_id=1319444&amp;occurrence_id=763189023&amp;popup=1">
+        <span>🐘6pm</span>
+        <span class="time"><span class="icon-clock"></span>6:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4315535?feature_id=1319444&amp;occurrence_id=763189023&amp;popup=1"></a>
+</div>
+
+</li>        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4912306?feature_id=1319444&amp;occurrence_id=763189033&amp;popup=1">
+  <span class="event-name alt-font">Zack Varner Quintet</span>
+    <br>
+    <span>🐘 9pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4912306?feature_id=1319444&amp;occurrence_id=763189033&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/8a42a9e2a898cdc1cd1af240f36e18d4b34ac592/original/zack-varner.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4912306?feature_id=1319444&amp;occurrence_id=763189033&amp;popup=1">Zack Varner Quintet</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4912306?feature_id=1319444&amp;occurrence_id=763189033&amp;popup=1">
+        <span>🐘 9pm</span>
+        <span class="time"><span class="icon-clock"></span>9:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4912306?feature_id=1319444&amp;occurrence_id=763189033&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td><td class="border-accent text-secondary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">20</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4490173?feature_id=1319444&amp;occurrence_id=763701783&amp;popup=1">
+  <span class="event-name alt-font">Violet Crown Jazz Revue with Liz Morphis</span>
+    <br>
+    <span>🐘6pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4490173?feature_id=1319444&amp;occurrence_id=763701783&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/059f2500d5c0f6c6dda6e5e988627048524a1537/original/liz-morphis-thumbnail.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4490173?feature_id=1319444&amp;occurrence_id=763701783&amp;popup=1">Violet Crown Jazz Revue with Liz Morphis</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4490173?feature_id=1319444&amp;occurrence_id=763701783&amp;popup=1">
+        <span>🐘6pm</span>
+        <span class="time"><span class="icon-clock"></span>6:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4490173?feature_id=1319444&amp;occurrence_id=763701783&amp;popup=1"></a>
+</div>
+
+</li>        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/5800473?feature_id=1319444&amp;occurrence_id=762545888&amp;popup=1">
+  <span class="event-name alt-font">Monster Big Band</span>
+    <br>
+    <span>🐘9pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/5800473?feature_id=1319444&amp;occurrence_id=762545888&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/130dba579a79ddd969cb68e9fc639f3a47bb191b/original/view-recent-photos.png/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.png" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5800473?feature_id=1319444&amp;occurrence_id=762545888&amp;popup=1">Monster Big Band</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5800473?feature_id=1319444&amp;occurrence_id=762545888&amp;popup=1">
+        <span>🐘9pm</span>
+        <span class="time"><span class="icon-clock"></span>9:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5800473?feature_id=1319444&amp;occurrence_id=762545888&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td><td class="border-accent text-secondary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">21</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4558295?feature_id=1319444&amp;occurrence_id=763189017&amp;popup=1">
+  <span class="event-name alt-font">Sarah Sharp Quintet</span>
+    <br>
+    <span>🐘6pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4558295?feature_id=1319444&amp;occurrence_id=763189017&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/d4c8a75373e01ff7aee47194935554f0e3df7688/original/sarah-sharp.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4558295?feature_id=1319444&amp;occurrence_id=763189017&amp;popup=1">Sarah Sharp Quintet</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4558295?feature_id=1319444&amp;occurrence_id=763189017&amp;popup=1">
+        <span>🐘6pm</span>
+        <span class="time"><span class="icon-clock"></span>6:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4558295?feature_id=1319444&amp;occurrence_id=763189017&amp;popup=1"></a>
+</div>
+
+</li>        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4315520?feature_id=1319444&amp;occurrence_id=759226940&amp;popup=1">
+  <span class="event-name alt-font">Tony Bray Quintet</span>
+    <br>
+    <span>🐘9pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4315520?feature_id=1319444&amp;occurrence_id=759226940&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/2be86a757b2338f450cb20ea5229da1fff494de1/original/tony-bray.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4315520?feature_id=1319444&amp;occurrence_id=759226940&amp;popup=1">Tony Bray Quintet</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4315520?feature_id=1319444&amp;occurrence_id=759226940&amp;popup=1">
+        <span>🐘9pm</span>
+        <span class="time"><span class="icon-clock"></span>9:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4315520?feature_id=1319444&amp;occurrence_id=759226940&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td><td class="border-accent text-secondary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">22</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/6397039?feature_id=1319444&amp;occurrence_id=763314683&amp;popup=1">
+  <span class="event-name alt-font">Jazz Pharaohs</span>
+    <br>
+    <span>🐘6pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/6397039?feature_id=1319444&amp;occurrence_id=763314683&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/63fad7585bcb441eaa2481836956ec36dc564854/original/mendoza-freddie.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/6397039?feature_id=1319444&amp;occurrence_id=763314683&amp;popup=1">Jazz Pharaohs</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/6397039?feature_id=1319444&amp;occurrence_id=763314683&amp;popup=1">
+        <span>🐘6pm</span>
+        <span class="time"><span class="icon-clock"></span>6:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/6397039?feature_id=1319444&amp;occurrence_id=763314683&amp;popup=1"></a>
+</div>
+
+</li>        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/5378796?feature_id=1319444&amp;occurrence_id=763189035&amp;popup=1">
+  <span class="event-name alt-font">Melissa Raquel Quartet featuring Andre Hayward</span>
+    <br>
+    <span>🐘8pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/5378796?feature_id=1319444&amp;occurrence_id=763189035&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/f32900ec4aabc51851231d36f24859f714fd7796/original/images-1.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5378796?feature_id=1319444&amp;occurrence_id=763189035&amp;popup=1">Melissa Raquel Quartet featuring Andre Hayward</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5378796?feature_id=1319444&amp;occurrence_id=763189035&amp;popup=1">
+        <span>🐘8pm</span>
+        <span class="time"><span class="icon-clock"></span>9:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5378796?feature_id=1319444&amp;occurrence_id=763189035&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td><td class="border-accent text-secondary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">23</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4933190?feature_id=1319444&amp;occurrence_id=762546051&amp;popup=1">
+  <span class="event-name alt-font">Ryan D Howard Organic Combo</span>
+    <br>
+    <span>🐘</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4933190?feature_id=1319444&amp;occurrence_id=762546051&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/fdcdc67c4ce7f17ba44e06460968051142b6f8ba/original/ryan-howard.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4933190?feature_id=1319444&amp;occurrence_id=762546051&amp;popup=1">Ryan D Howard Organic Combo</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4933190?feature_id=1319444&amp;occurrence_id=762546051&amp;popup=1">
+        <span>🐘</span>
+        <span class="time"><span class="icon-clock"></span>6:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4933190?feature_id=1319444&amp;occurrence_id=762546051&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td></tr><tr><td class="border-accent text-secondary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">24</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4558108?feature_id=1319444&amp;occurrence_id=762546025&amp;popup=1">
+  <span class="event-name alt-font">Jackie Myers Trio</span>
+    <br>
+    <span>🐘8pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4558108?feature_id=1319444&amp;occurrence_id=762546025&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/5b1137f1cdb7cbd5681009077670032809c1d7e3/original/images.jpeg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4558108?feature_id=1319444&amp;occurrence_id=762546025&amp;popup=1">Jackie Myers Trio</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4558108?feature_id=1319444&amp;occurrence_id=762546025&amp;popup=1">
+        <span>🐘8pm</span>
+        <span class="time"><span class="icon-clock"></span>8:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4558108?feature_id=1319444&amp;occurrence_id=762546025&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td><td class="border-accent text-secondary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">25</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/5086588?feature_id=1319444&amp;occurrence_id=722849368&amp;popup=1">
+  <span class="event-name alt-font">The club will open at 8pm in observance of MEMORIAL DAY</span>
+    <br>
+    <span>🐘8pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/5086588?feature_id=1319444&amp;occurrence_id=722849368&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/0e15c801fbef65ee3f29dd336794fb4849059a6e/original/images.jpeg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5086588?feature_id=1319444&amp;occurrence_id=722849368&amp;popup=1">The club will open at 8pm in observance of MEMORIAL DAY</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5086588?feature_id=1319444&amp;occurrence_id=722849368&amp;popup=1">
+        <span>🐘8pm</span>
+        <span class="time"><span class="icon-clock"></span>8:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5086588?feature_id=1319444&amp;occurrence_id=722849368&amp;popup=1"></a>
+</div>
+
+</li>        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4489016?feature_id=1319444&amp;occurrence_id=762545914&amp;popup=1">
+  <span class="event-name alt-font">Michael Mordecai Jazz Jam</span>
+    <br>
+    <span>🐘9pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4489016?feature_id=1319444&amp;occurrence_id=762545914&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/1075b1c93f99c59916fac0aa596ef3f936d4b6dc/original/michael-trombone-bell.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4489016?feature_id=1319444&amp;occurrence_id=762545914&amp;popup=1">Michael Mordecai Jazz Jam</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4489016?feature_id=1319444&amp;occurrence_id=762545914&amp;popup=1">
+        <span>🐘9pm</span>
+        <span class="time"><span class="icon-clock"></span>9:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4489016?feature_id=1319444&amp;occurrence_id=762545914&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td><td class="border-accent text-secondary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">26</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/5863917?feature_id=1319444&amp;occurrence_id=763189005&amp;popup=1">
+  <span class="event-name alt-font">Mark Scott III </span>
+    <br>
+    <span>🐘6pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/5863917?feature_id=1319444&amp;occurrence_id=763189005&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/57e69adeccbd48c8b337f8c5713095ff459ce7e1/original/mark-scott-iii.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5863917?feature_id=1319444&amp;occurrence_id=763189005&amp;popup=1">Mark Scott III </a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5863917?feature_id=1319444&amp;occurrence_id=763189005&amp;popup=1">
+        <span>🐘6pm</span>
+        <span class="time"><span class="icon-clock"></span>6:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5863917?feature_id=1319444&amp;occurrence_id=763189005&amp;popup=1"></a>
+</div>
+
+</li>        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4426955?feature_id=1319444&amp;occurrence_id=763189034&amp;popup=1">
+  <span class="event-name alt-font">Alex Coke Quintet</span>
+    <br>
+    <span>🐘9pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4426955?feature_id=1319444&amp;occurrence_id=763189034&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/f418fab61335f6bef656529c3ca0ad4f35898cf8/original/alex-coke.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4426955?feature_id=1319444&amp;occurrence_id=763189034&amp;popup=1">Alex Coke Quintet</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4426955?feature_id=1319444&amp;occurrence_id=763189034&amp;popup=1">
+        <span>🐘9pm</span>
+        <span class="time"><span class="icon-clock"></span>9:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4426955?feature_id=1319444&amp;occurrence_id=763189034&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td><td class="border-accent text-secondary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">27</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/6459189?feature_id=1319444&amp;occurrence_id=763189004&amp;popup=1">
+  <span class="event-name alt-font">Bruce Robison Mosey Piano Trio</span>
+    <br>
+    <span>🐘6pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/6459189?feature_id=1319444&amp;occurrence_id=763189004&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/aab6cdc765c6efc16e4105d895358294e6bed15a/original/img-2636.jpeg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/6459189?feature_id=1319444&amp;occurrence_id=763189004&amp;popup=1">Bruce Robison Mosey Piano Trio</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/6459189?feature_id=1319444&amp;occurrence_id=763189004&amp;popup=1">
+        <span>🐘6pm</span>
+        <span class="time"><span class="icon-clock"></span>6:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/6459189?feature_id=1319444&amp;occurrence_id=763189004&amp;popup=1"></a>
+</div>
+
+</li>        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4660622?feature_id=1319444&amp;occurrence_id=762545919&amp;popup=1">
+  <span class="event-name alt-font">NOW Jazz Orchestra</span>
+    <br>
+    <span>🐘9pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4660622?feature_id=1319444&amp;occurrence_id=762545919&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/eca3b102bace99c40733c417a72dceb90390055a/original/now-jazz-orchestra.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4660622?feature_id=1319444&amp;occurrence_id=762545919&amp;popup=1">NOW Jazz Orchestra</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4660622?feature_id=1319444&amp;occurrence_id=762545919&amp;popup=1">
+        <span>🐘9pm</span>
+        <span class="time"><span class="icon-clock"></span>9:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4660622?feature_id=1319444&amp;occurrence_id=762545919&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td><td class="border-accent text-secondary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">28</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4558295?feature_id=1319444&amp;occurrence_id=763189018&amp;popup=1">
+  <span class="event-name alt-font">Sarah Sharp Quintet</span>
+    <br>
+    <span>🐘6pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4558295?feature_id=1319444&amp;occurrence_id=763189018&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/d4c8a75373e01ff7aee47194935554f0e3df7688/original/sarah-sharp.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4558295?feature_id=1319444&amp;occurrence_id=763189018&amp;popup=1">Sarah Sharp Quintet</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4558295?feature_id=1319444&amp;occurrence_id=763189018&amp;popup=1">
+        <span>🐘6pm</span>
+        <span class="time"><span class="icon-clock"></span>6:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4558295?feature_id=1319444&amp;occurrence_id=763189018&amp;popup=1"></a>
+</div>
+
+</li>        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/5768764?feature_id=1319444&amp;occurrence_id=759226920&amp;popup=1">
+  <span class="event-name alt-font">Marco Antonio Santos Quartet</span>
+    <br>
+    <span>🐘9pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/5768764?feature_id=1319444&amp;occurrence_id=759226920&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/152231473133df910486409525963d3e4cdf650b/original/marco-antonio-santos-headshot-zoom.jpeg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5768764?feature_id=1319444&amp;occurrence_id=759226920&amp;popup=1">Marco Antonio Santos Quartet</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5768764?feature_id=1319444&amp;occurrence_id=759226920&amp;popup=1">
+        <span>🐘9pm</span>
+        <span class="time"><span class="icon-clock"></span>9:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5768764?feature_id=1319444&amp;occurrence_id=759226920&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td><td class="border-accent text-secondary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">29</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4799506?feature_id=1319444&amp;occurrence_id=762545945&amp;popup=1">
+  <span class="event-name alt-font">King Daddy &amp; the Flat Five</span>
+    <br>
+    <span>🐘6pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4799506?feature_id=1319444&amp;occurrence_id=762545945&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/f8c69b2f134e86ee027c94be535edc3ea75cc7fe/original/aaron-frescas-2022.jpeg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4799506?feature_id=1319444&amp;occurrence_id=762545945&amp;popup=1">King Daddy &amp; the Flat Five</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4799506?feature_id=1319444&amp;occurrence_id=762545945&amp;popup=1">
+        <span>🐘6pm</span>
+        <span class="time"><span class="icon-clock"></span>6:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4799506?feature_id=1319444&amp;occurrence_id=762545945&amp;popup=1"></a>
+</div>
+
+</li>        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/5135027?feature_id=1319444&amp;occurrence_id=759226971&amp;popup=1">
+  <span class="event-name alt-font">Extreme Heat</span>
+    <br>
+    <span>🐘9pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/5135027?feature_id=1319444&amp;occurrence_id=759226971&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/bfbc7061ccb8b87410db32cafc5134ee6d33f813/original/ehandnile.png/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.png" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5135027?feature_id=1319444&amp;occurrence_id=759226971&amp;popup=1">Extreme Heat</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5135027?feature_id=1319444&amp;occurrence_id=759226971&amp;popup=1">
+        <span>🐘9pm</span>
+        <span class="time"><span class="icon-clock"></span>9:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5135027?feature_id=1319444&amp;occurrence_id=759226971&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td><td class="border-accent text-secondary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">30</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4163743?feature_id=1319444&amp;occurrence_id=763314687&amp;popup=1">
+  <span class="event-name alt-font">The Brew</span>
+    <br>
+    <span>🐘9pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4163743?feature_id=1319444&amp;occurrence_id=763314687&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/d2bbd862b3f6726bc9e6baeede29dfeb2f0262fd/original/the-brew.png/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.png" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4163743?feature_id=1319444&amp;occurrence_id=763314687&amp;popup=1">The Brew</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4163743?feature_id=1319444&amp;occurrence_id=763314687&amp;popup=1">
+        <span>🐘9pm</span>
+        <span class="time"><span class="icon-clock"></span>9:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4163743?feature_id=1319444&amp;occurrence_id=763314687&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td></tr><tr><td class="border-accent text-secondary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">31</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/6341232?feature_id=1319444&amp;occurrence_id=758334550&amp;popup=1">
+  <span class="event-name alt-font">Jerry Z Trio</span>
+    <br>
+    <span>🐘8pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/6341232?feature_id=1319444&amp;occurrence_id=758334550&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/da5cbf5b4666b1ed49b5a79be20f66d360ab581a/original/jerry-z.png/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.png" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/6341232?feature_id=1319444&amp;occurrence_id=758334550&amp;popup=1">Jerry Z Trio</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/6341232?feature_id=1319444&amp;occurrence_id=758334550&amp;popup=1">
+        <span>🐘8pm</span>
+        <span class="time"><span class="icon-clock"></span>8:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/6341232?feature_id=1319444&amp;occurrence_id=758334550&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td><td class="border-accent text-secondary other-month text-tertiary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">1</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/6082492?feature_id=1319444&amp;occurrence_id=763314816&amp;popup=1">
+  <span class="event-name alt-font">Jon Blondell &amp; Friends</span>
+    <br>
+    <span>🐘6pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/6082492?feature_id=1319444&amp;occurrence_id=763314816&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/eba643d90ac7f02164da8f6d084e6c0b67d248e4/original/screenshot-2025-05-07-at-4-04-55-am.png/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.png" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/6082492?feature_id=1319444&amp;occurrence_id=763314816&amp;popup=1">Jon Blondell &amp; Friends</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/6082492?feature_id=1319444&amp;occurrence_id=763314816&amp;popup=1">
+        <span>🐘6pm</span>
+        <span class="time"><span class="icon-clock"></span>6:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/6082492?feature_id=1319444&amp;occurrence_id=763314816&amp;popup=1"></a>
+</div>
+
+</li>        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4821425?feature_id=1319444&amp;occurrence_id=763314809&amp;popup=1">
+  <span class="event-name alt-font">Jazz Jam hosted by: Kris Kimura </span>
+    <br>
+    <span>🐘9pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4821425?feature_id=1319444&amp;occurrence_id=763314809&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/5942d5a87b4de96ddf5c2daef179550a8ef1b421/original/kris-kimura.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4821425?feature_id=1319444&amp;occurrence_id=763314809&amp;popup=1">Jazz Jam hosted by: Kris Kimura </a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4821425?feature_id=1319444&amp;occurrence_id=763314809&amp;popup=1">
+        <span>🐘9pm</span>
+        <span class="time"><span class="icon-clock"></span>9:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4821425?feature_id=1319444&amp;occurrence_id=763314809&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td><td class="border-accent text-secondary other-month text-tertiary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">2</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/5851749?feature_id=1319444&amp;occurrence_id=763314700&amp;popup=1">
+  <span class="event-name alt-font">Mitch Watkins Trio</span>
+    <br>
+    <span>🐘6pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/5851749?feature_id=1319444&amp;occurrence_id=763314700&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/4093be938c657d32fd6bba32496bdb8f7a3cfb9a/original/mitch-watkins.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5851749?feature_id=1319444&amp;occurrence_id=763314700&amp;popup=1">Mitch Watkins Trio</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5851749?feature_id=1319444&amp;occurrence_id=763314700&amp;popup=1">
+        <span>🐘6pm</span>
+        <span class="time"><span class="icon-clock"></span>6:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/5851749?feature_id=1319444&amp;occurrence_id=763314700&amp;popup=1"></a>
+</div>
+
+</li>        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4178827?feature_id=1319444&amp;occurrence_id=762545841&amp;popup=1">
+  <span class="event-name alt-font">BLONDELL !</span>
+    <br>
+    <span>🐘9pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4178827?feature_id=1319444&amp;occurrence_id=762545841&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/ede0bb2af0437565ac3caec3c61ebddbb4b15049/original/blondell-w-bass.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4178827?feature_id=1319444&amp;occurrence_id=762545841&amp;popup=1">BLONDELL !</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4178827?feature_id=1319444&amp;occurrence_id=762545841&amp;popup=1">
+        <span>🐘9pm</span>
+        <span class="time"><span class="icon-clock"></span>9:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4178827?feature_id=1319444&amp;occurrence_id=762545841&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td><td class="border-accent text-secondary other-month text-tertiary">
+      
+<div>
+  <div class="day">3</div>
+</div>
+</td><td class="border-accent text-secondary other-month text-tertiary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">4</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4558295?feature_id=1319444&amp;occurrence_id=763189019&amp;popup=1">
+  <span class="event-name alt-font">Sarah Sharp Quintet</span>
+    <br>
+    <span>🐘6pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4558295?feature_id=1319444&amp;occurrence_id=763189019&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/d4c8a75373e01ff7aee47194935554f0e3df7688/original/sarah-sharp.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4558295?feature_id=1319444&amp;occurrence_id=763189019&amp;popup=1">Sarah Sharp Quintet</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4558295?feature_id=1319444&amp;occurrence_id=763189019&amp;popup=1">
+        <span>🐘6pm</span>
+        <span class="time"><span class="icon-clock"></span>6:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4558295?feature_id=1319444&amp;occurrence_id=763189019&amp;popup=1"></a>
+</div>
+
+</li>        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4429223?feature_id=1319444&amp;occurrence_id=762545917&amp;popup=1">
+  <span class="event-name alt-font">Matt Maldonado Quintet</span>
+    <br>
+    <span>🐘9pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4429223?feature_id=1319444&amp;occurrence_id=762545917&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/3069180ae8d967b5907aef1271bf81ca5ba15cdc/original/matt-maldonado.png/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.png" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4429223?feature_id=1319444&amp;occurrence_id=762545917&amp;popup=1">Matt Maldonado Quintet</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4429223?feature_id=1319444&amp;occurrence_id=762545917&amp;popup=1">
+        <span>🐘9pm</span>
+        <span class="time"><span class="icon-clock"></span>9:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4429223?feature_id=1319444&amp;occurrence_id=762545917&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td><td class="border-accent text-secondary other-month text-tertiary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">5</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4184677?feature_id=1319444&amp;occurrence_id=763189026&amp;popup=1">
+  <span class="event-name alt-font">Dr. James Polk&#39;s CENTERPEACE</span>
+    <br>
+    <span>🐘9pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4184677?feature_id=1319444&amp;occurrence_id=763189026&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/d3aa41d959bde750d39ce6054097d3054a647d7b/original/dr-james-polk.jpeg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4184677?feature_id=1319444&amp;occurrence_id=763189026&amp;popup=1">Dr. James Polk&#39;s CENTERPEACE</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4184677?feature_id=1319444&amp;occurrence_id=763189026&amp;popup=1">
+        <span>🐘9pm</span>
+        <span class="time"><span class="icon-clock"></span>9:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4184677?feature_id=1319444&amp;occurrence_id=763189026&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td><td class="border-accent text-secondary other-month text-tertiary">
+      
+<div class="with-events">
+  <div class="day bg-highlight">6</div>
+    <ul>
+        <li>
+            <a class="event_details no-pjax bg-highlight" data-featherlight="" href="/go/events/4464429?feature_id=1319444&amp;occurrence_id=763314684&amp;popup=1">
+  <span class="event-name alt-font">Pamela Hart Quintet</span>
+    <br>
+    <span>🐘9pm</span>
+</a>
+<div class="tooltip">
+    <div class="image">
+      <div class="highlight-image">
+        <a class="event_details no-pjax" data-featherlight="" href="/go/events/4464429?feature_id=1319444&amp;occurrence_id=763314684&amp;popup=1">
+          <img src="//images.zoogletools.com/s:bzglfiles/u/523260/52e97ac86a1beac668835ce3866023f9760dc586/original/paminred-1.jpg/!!/b%3AW1sicmVzaXplIixbMTI1LG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>      </div>
+    </div>
+
+  <div class="text">
+    <h2 class="alt-font text-main">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4464429?feature_id=1319444&amp;occurrence_id=763314684&amp;popup=1">Pamela Hart Quintet</a>
+    </h2>
+
+    <p class="meta text-tertiary">
+      <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4464429?feature_id=1319444&amp;occurrence_id=763314684&amp;popup=1">
+        <span>🐘9pm</span>
+        <span class="time"><span class="icon-clock"></span>9:00PM</span>
+</a>    </p>
+  </div>
+
+  <a class="event_details no-pjax" data-featherlight="" rel="nofollow" href="/go/events/4464429?feature_id=1319444&amp;occurrence_id=763314684&amp;popup=1"></a>
+</div>
+
+</li>    </ul>
+</div>
+</td></tr></tbody></table></div></div>
+
+</div>
+</section></div><div class="zoogle-feature block layout_full" data-block-id="26127579" id="feature_block_26127579"><section class="feature calendar_feature" data-feature-id="1147558" data-controller="content-width" data-content-width-name="feature" id="calendar_feature_1147558"><div class="calendar-wrap">
+      <section class="upcoming">
+      <article class="list-style">
+  
+<div class="event-detail" data-event-id="5871478" data-occurrence-id="762545969">
+  <div class="event-image image-social">
+      <a rel="event[5871478]" title="Stephen Summer Trio" class="thumbnail-popup" data-featherlight="//images.zoogletools.com/s:bzglfiles/u/523260/face1db3290e1d28217a29ec0adac450f66dd92f/original/image0.jpeg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" href="//images.zoogletools.com/s:bzglfiles/u/523260/face1db3290e1d28217a29ec0adac450f66dd92f/original/image0.jpeg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg">
+        <img alt="Stephen Summer Trio" src="//images.zoogletools.com/s:bzglfiles/u/523260/face1db3290e1d28217a29ec0adac450f66dd92f/original/image0.jpeg/!!/b%3AW1sicmVzaXplIixbMjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>  </div>
+
+  <div class="event-description">
+    <div class="event-info-wrapper">
+        <h2 class="event-info event-title heading-tertiary"><a href="https://elephantroom.com/event/5871478/762545969/stephen-summer-trio">Stephen Summer Trio</a></h2>
+
+        <p class="event-info event-datetime">
+          <i class="icon-clock"></i>
+          <span class="date-long"><span class="event-when with-time"><time class="from"><span class="date">Wednesday, May 13</span> @ <span class="time">6:00PM</span></time></span></span><span class="date-short"><span class="event-when with-time"><time class="from"><span class="date">Wed, May 13</span> @ <span class="time">6:00PM</span></time></span></span>
+        </p>
+
+        <p class="event-info event-location">
+          <i class="icon-location"></i>
+          <a target="_blank" rel="noopener" title="View on Google Maps" href="https://www.google.com/maps/search/?api=1&amp;query=%F0%9F%90%986pm">🐘6pm</a>
+        </p>
+    </div>
+
+      <div class="event-info event-notes"><p>Stephen Summer the drummer (credits include Kirk Whalum , BETO y los Fairlanes Tomas Ramirez and The Brew) leads this dynamic jazz Trio featuring Matt Russell on piano and Glenn Scheutz on bass.</p>
+</div>
+
+    <p class="event-info">
+      
+    </p>
+
+
+    <div class="event-info buying-options product-action pdf__hide">
+
+    <div data-controller="share-dialog" data-share-dialog-url-value="https://elephantroom.com/event/5871478/762545969/stephen-summer-trio" data-share-dialog-title-value="Stephen Summer Trio @ 🐘6pm on May 13, 6:00PM" data-share-dialog-text-value="Elephant Room @ Stephen Summer Trio @ 🐘6pm, May 13, 6:00PM" data-share-dialog-fb-app-id-value="286076425227">
+  <a class="button button-tertiary zoogle-share pdf__hide" title="Share Stephen Summer Trio @ 🐘6pm on May 13, 6:00PM" data-action="click-&gt;share-dialog#open" href="javascript:void(0)">
+    <i class="icon-share"></i>Share
+</a>
+  <dialog data-share-dialog-target="dialog" data-action="click->share-dialog#clickOutside" class="dialog dialog-share style-section-style-1">
+    <button class="dialog-close" data-action="click-&gt;share-dialog#close" aria-label="close">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11 11" class="icon" width="12px" height="12px"><path d="M6.755 5.502l3.836 3.97-1.438 1.39-3.81-3.942-3.926 3.942L0 9.452 3.953 5.48 0 1.39 1.438 0l3.927 4.064L9.41 0l1.417 1.411-4.073 4.091z" fill-rule="evenodd"></path></svg>
+</button>    <div class="share_desc">
+      <div>
+        <span data-share-dialog-target="title">Stephen Summer Trio @ 🐘6pm on May 13, 6:00PM</span>
+        <br>
+        <span class="byline" data-share-dialog-target="byline">
+        </span>
+      </div>
+    </div>
+
+    <ul class="share_icons">
+      <li class="threads">
+        <a href="#" data-share-dialog-target="threadsLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM23.7524 16.9806C23.8587 17.0263 23.9638 17.074 24.0671 17.1235C25.5284 17.8245 26.597 18.8859 27.1575 20.1926C27.9387 22.0149 28.0101 24.9832 25.6397 27.3514C23.828 29.1615 21.6287 29.9784 18.5087 30H18.4946C14.9852 29.9757 12.2865 28.7948 10.4735 26.4901C8.86024 24.4393 8.02805 21.5855 8.00009 18.0084L8 18L8.00009 17.9916C8.02805 14.4145 8.86024 11.5608 10.4735 9.50991C12.2865 7.20522 14.9852 6.02431 18.4946 6H18.5087C22.0252 6.02439 24.7545 7.20084 26.6206 9.49675C27.5414 10.6295 28.218 11.9953 28.648 13.5803L26.6296 14.1188C26.2749 12.8311 25.7368 11.7267 25.023 10.8485C23.5674 9.05767 21.3735 8.13891 18.5016 8.11756C15.6505 8.13875 13.4942 9.05311 12.0923 10.8353C10.7794 12.5042 10.101 14.9147 10.0757 18C10.101 21.0853 10.7794 23.4958 12.0923 25.1646C13.4942 26.9469 15.6505 27.8612 18.5017 27.8824C21.072 27.8635 22.7728 27.252 24.1876 25.8385C25.8025 24.225 25.7724 22.2459 25.2559 21.0415C24.9521 20.333 24.4021 19.7436 23.66 19.2957C23.4792 20.6429 23.0699 21.712 22.4226 22.537C21.5704 23.6234 20.3487 24.2175 18.7915 24.3029C17.6124 24.3673 16.4778 24.0829 15.5969 23.5014C14.555 22.8135 13.9452 21.7605 13.8799 20.5365C13.7514 18.1235 15.6656 16.3869 18.6431 16.2154C19.7001 16.1548 20.6889 16.2026 21.6031 16.358C21.4818 15.6156 21.2366 15.0274 20.8701 14.6018C20.3665 14.0171 19.5884 13.7173 18.5572 13.7107L18.5286 13.7106C17.7006 13.7106 16.5765 13.9423 15.8601 15.0291L14.1378 13.8476C15.0966 12.3926 16.6546 11.593 18.5278 11.593L18.5702 11.5931C21.702 11.6131 23.5671 13.5673 23.7524 16.9806ZM15.9524 20.4215C16.0193 21.6761 17.3751 22.2619 18.6801 22.1884C19.9578 22.1182 21.408 21.6169 21.6553 18.5291C20.9924 18.3842 20.2633 18.3085 19.4839 18.3085C19.247 18.3085 19.0059 18.3154 18.7602 18.3296C16.6145 18.4533 15.9029 19.4913 15.9524 20.4215Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="facebook">
+        <a href="#" data-share-dialog-target="facebookLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon"><path fill-rule="evenodd" d="M9 0a9 9 0 110 18A9 9 0 019 0zm2.606 4H10.24c-1.575 0-2.17.77-2.215 2.076l-.002.166v1.034H7V9h1.023V14h2.046V9h1.365l.181-1.724H10.07l.003-.862c0-.417.036-.655.553-.687l.128-.003h.853V4z"></path></svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="twitter">
+        <a href="#" data-share-dialog-target="twitterLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="685" data-popup-window-height-value="246" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM26.4163 9L19.7142 16.6226L27.0001 27H21.6396L16.7316 20.0104L10.5876 27H9L16.0278 19.0075L9 9H14.3604L19.0068 15.6173L24.8287 9H26.4163ZM13.5996 10.1714H11.1606L22.3878 25.8861H24.8275L13.5996 10.1714Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="email">
+        <a href="#" data-share-dialog-target="emailLink" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18 9C18 4.02944 13.9706 0 9 0C4.02944 0 0 4.02944 0 9C0 13.9706 4.02944 18 9 18C13.9706 18 18 13.9706 18 9ZM4.02511 5.73566C4.00872 5.77691 4.00004 5.82153 4.00004 5.86854L4 12.1317C4 12.1897 4.0135 12.2449 4.03762 12.2938C4.04581 12.2775 4.05691 12.2621 4.07041 12.2482L7.39793 8.87439L4.0772 5.81961C4.05116 5.79611 4.0338 5.76684 4.02511 5.73566ZM4.34327 12.4991L4.34195 12.499L7.67 9.12427L8.60412 9.98343C8.86598 10.2242 9.26962 10.2228 9.52956 9.98007L10.4564 9.11563L13.768 12.4736C13.7251 12.4904 13.6783 12.5 13.6296 12.5H4.3704C4.3612 12.5 4.35243 12.4996 4.34327 12.4991ZM13.9971 12.1795L10.727 8.86376L13.9913 5.81857C13.9932 5.81713 13.9947 5.81569 13.9961 5.81425C13.9986 5.832 14 5.85023 14 5.86846V12.1315C14 12.1478 13.999 12.1637 13.9971 12.1795ZM13.7686 5.52686C13.7257 5.50959 13.6789 5.5 13.6297 5.5L4.37041 5.50006C4.33617 5.50006 4.30338 5.50486 4.27155 5.5135C4.29229 5.52117 4.31158 5.53316 4.32846 5.549L8.85585 9.71283C8.97448 9.8222 9.15822 9.82172 9.27637 9.71139L13.7382 5.54989C13.7479 5.54077 13.758 5.5331 13.7686 5.52686Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+    </ul>
+    <div class="permalink" data-controller="clipboard">
+      <p>Share link</p>
+      <div class="control -has-addons">
+        <input type="text" value="https://elephantroom.com/event/5871478/762545969/stephen-summer-trio" data-clipboard-target="source" data-share-dialog-target="urlInput" data-action="click->share-dialog#selectUrl" readonly="true">
+        <span class="control__suffix">
+          <a class="button -simple -compact -icon-only" data-clipboard-target="button" data-action="clipboard#copy">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="icon" width="16px" height="18px"><path d="M4.166.597c-.184 0-.369.15-.369.342v1.365c0 .191.185.341.369.341h9.189v9.216c0 .191.15.342.341.342h1.365c.191 0 .342-.15.342-.342V.94a.338.338 0 00-.342-.342H4.166zm7.44 3.798H.34A.338.338 0 000 4.736v10.923c0 .19.15.341.341.341h10.923c.191 0 .341-.15.341-.341V4.395z" fill-rule="evenodd"></path></svg>
+          </a>
+        </span>
+      </div>
+    </div>
+  </dialog>
+</div>
+</div>
+
+
+      <div class="event-info map-link pdf__hide">
+        <a target="_blank" rel="noopener" href="https://www.google.com/maps/search/?api=1&amp;query=%F0%9F%90%986pm">View on Google Maps</a>
+      </div>
+  </div>
+</div>
+
+<div class="event-clear"></div>
+
+</article>
+<article class="list-style">
+  
+<div class="event-detail" data-event-id="4335451" data-occurrence-id="762545862">
+  <div class="event-image image-social">
+      <a rel="event[4335451]" title="BAKER&#39;s DOZEN led by Freddie Mendoza" class="thumbnail-popup" data-featherlight="//images.zoogletools.com/s:bzglfiles/u/523260/524e9899f5808648da94570f25c58624417b3e56/original/images-1.jpg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" href="//images.zoogletools.com/s:bzglfiles/u/523260/524e9899f5808648da94570f25c58624417b3e56/original/images-1.jpg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg">
+        <img alt="BAKER&#39;s DOZEN led by Freddie Mendoza" src="//images.zoogletools.com/s:bzglfiles/u/523260/524e9899f5808648da94570f25c58624417b3e56/original/images-1.jpg/!!/b%3AW1sicmVzaXplIixbMjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>  </div>
+
+  <div class="event-description">
+    <div class="event-info-wrapper">
+        <h2 class="event-info event-title heading-tertiary"><a href="https://elephantroom.com/event/4335451/762545862/baker-s-dozen-led-by-freddie-mendoza">BAKER&#39;s DOZEN led by Freddie Mendoza</a></h2>
+
+        <p class="event-info event-datetime">
+          <i class="icon-clock"></i>
+          <span class="date-long"><span class="event-when with-time"><time class="from"><span class="date">Wednesday, May 13</span> @ <span class="time">9:00PM</span></time></span></span><span class="date-short"><span class="event-when with-time"><time class="from"><span class="date">Wed, May 13</span> @ <span class="time">9:00PM</span></time></span></span>
+        </p>
+
+        <p class="event-info event-location">
+          <i class="icon-location"></i>
+          <a target="_blank" rel="noopener" title="View on Google Maps" href="https://www.google.com/maps/search/?api=1&amp;query=%F0%9F%90%989pm">🐘9pm</a>
+        </p>
+    </div>
+
+      <div class="event-info event-notes"><p>Freddie Mendoza brings back this 13 piece "Baker's Dozen" big band featuring the top jazz musicians performing the superb musical arrangements of Paul Baker.</p>
+</div>
+
+    <p class="event-info">
+      
+    </p>
+
+
+    <div class="event-info buying-options product-action pdf__hide">
+
+    <div data-controller="share-dialog" data-share-dialog-url-value="https://elephantroom.com/event/4335451/762545862/baker-s-dozen-led-by-freddie-mendoza" data-share-dialog-title-value="BAKER&#39;s DOZEN led by Freddie Mendoza @ 🐘9pm on May 13, 9:00PM" data-share-dialog-text-value="Elephant Room @ BAKER&#39;s DOZEN led by Freddie Mendoza @ 🐘9pm, May 13, 9:00PM" data-share-dialog-fb-app-id-value="286076425227">
+  <a class="button button-tertiary zoogle-share pdf__hide" title="Share BAKER&#39;s DOZEN led by Freddie Mendoza @ 🐘9pm on May 13, 9:00PM" data-action="click-&gt;share-dialog#open" href="javascript:void(0)">
+    <i class="icon-share"></i>Share
+</a>
+  <dialog data-share-dialog-target="dialog" data-action="click->share-dialog#clickOutside" class="dialog dialog-share style-section-style-1">
+    <button class="dialog-close" data-action="click-&gt;share-dialog#close" aria-label="close">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11 11" class="icon" width="12px" height="12px"><path d="M6.755 5.502l3.836 3.97-1.438 1.39-3.81-3.942-3.926 3.942L0 9.452 3.953 5.48 0 1.39 1.438 0l3.927 4.064L9.41 0l1.417 1.411-4.073 4.091z" fill-rule="evenodd"></path></svg>
+</button>    <div class="share_desc">
+      <div>
+        <span data-share-dialog-target="title">BAKER&#39;s DOZEN led by Freddie Mendoza @ 🐘9pm on May 13, 9:00PM</span>
+        <br>
+        <span class="byline" data-share-dialog-target="byline">
+        </span>
+      </div>
+    </div>
+
+    <ul class="share_icons">
+      <li class="threads">
+        <a href="#" data-share-dialog-target="threadsLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM23.7524 16.9806C23.8587 17.0263 23.9638 17.074 24.0671 17.1235C25.5284 17.8245 26.597 18.8859 27.1575 20.1926C27.9387 22.0149 28.0101 24.9832 25.6397 27.3514C23.828 29.1615 21.6287 29.9784 18.5087 30H18.4946C14.9852 29.9757 12.2865 28.7948 10.4735 26.4901C8.86024 24.4393 8.02805 21.5855 8.00009 18.0084L8 18L8.00009 17.9916C8.02805 14.4145 8.86024 11.5608 10.4735 9.50991C12.2865 7.20522 14.9852 6.02431 18.4946 6H18.5087C22.0252 6.02439 24.7545 7.20084 26.6206 9.49675C27.5414 10.6295 28.218 11.9953 28.648 13.5803L26.6296 14.1188C26.2749 12.8311 25.7368 11.7267 25.023 10.8485C23.5674 9.05767 21.3735 8.13891 18.5016 8.11756C15.6505 8.13875 13.4942 9.05311 12.0923 10.8353C10.7794 12.5042 10.101 14.9147 10.0757 18C10.101 21.0853 10.7794 23.4958 12.0923 25.1646C13.4942 26.9469 15.6505 27.8612 18.5017 27.8824C21.072 27.8635 22.7728 27.252 24.1876 25.8385C25.8025 24.225 25.7724 22.2459 25.2559 21.0415C24.9521 20.333 24.4021 19.7436 23.66 19.2957C23.4792 20.6429 23.0699 21.712 22.4226 22.537C21.5704 23.6234 20.3487 24.2175 18.7915 24.3029C17.6124 24.3673 16.4778 24.0829 15.5969 23.5014C14.555 22.8135 13.9452 21.7605 13.8799 20.5365C13.7514 18.1235 15.6656 16.3869 18.6431 16.2154C19.7001 16.1548 20.6889 16.2026 21.6031 16.358C21.4818 15.6156 21.2366 15.0274 20.8701 14.6018C20.3665 14.0171 19.5884 13.7173 18.5572 13.7107L18.5286 13.7106C17.7006 13.7106 16.5765 13.9423 15.8601 15.0291L14.1378 13.8476C15.0966 12.3926 16.6546 11.593 18.5278 11.593L18.5702 11.5931C21.702 11.6131 23.5671 13.5673 23.7524 16.9806ZM15.9524 20.4215C16.0193 21.6761 17.3751 22.2619 18.6801 22.1884C19.9578 22.1182 21.408 21.6169 21.6553 18.5291C20.9924 18.3842 20.2633 18.3085 19.4839 18.3085C19.247 18.3085 19.0059 18.3154 18.7602 18.3296C16.6145 18.4533 15.9029 19.4913 15.9524 20.4215Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="facebook">
+        <a href="#" data-share-dialog-target="facebookLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon"><path fill-rule="evenodd" d="M9 0a9 9 0 110 18A9 9 0 019 0zm2.606 4H10.24c-1.575 0-2.17.77-2.215 2.076l-.002.166v1.034H7V9h1.023V14h2.046V9h1.365l.181-1.724H10.07l.003-.862c0-.417.036-.655.553-.687l.128-.003h.853V4z"></path></svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="twitter">
+        <a href="#" data-share-dialog-target="twitterLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="685" data-popup-window-height-value="246" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM26.4163 9L19.7142 16.6226L27.0001 27H21.6396L16.7316 20.0104L10.5876 27H9L16.0278 19.0075L9 9H14.3604L19.0068 15.6173L24.8287 9H26.4163ZM13.5996 10.1714H11.1606L22.3878 25.8861H24.8275L13.5996 10.1714Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="email">
+        <a href="#" data-share-dialog-target="emailLink" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18 9C18 4.02944 13.9706 0 9 0C4.02944 0 0 4.02944 0 9C0 13.9706 4.02944 18 9 18C13.9706 18 18 13.9706 18 9ZM4.02511 5.73566C4.00872 5.77691 4.00004 5.82153 4.00004 5.86854L4 12.1317C4 12.1897 4.0135 12.2449 4.03762 12.2938C4.04581 12.2775 4.05691 12.2621 4.07041 12.2482L7.39793 8.87439L4.0772 5.81961C4.05116 5.79611 4.0338 5.76684 4.02511 5.73566ZM4.34327 12.4991L4.34195 12.499L7.67 9.12427L8.60412 9.98343C8.86598 10.2242 9.26962 10.2228 9.52956 9.98007L10.4564 9.11563L13.768 12.4736C13.7251 12.4904 13.6783 12.5 13.6296 12.5H4.3704C4.3612 12.5 4.35243 12.4996 4.34327 12.4991ZM13.9971 12.1795L10.727 8.86376L13.9913 5.81857C13.9932 5.81713 13.9947 5.81569 13.9961 5.81425C13.9986 5.832 14 5.85023 14 5.86846V12.1315C14 12.1478 13.999 12.1637 13.9971 12.1795ZM13.7686 5.52686C13.7257 5.50959 13.6789 5.5 13.6297 5.5L4.37041 5.50006C4.33617 5.50006 4.30338 5.50486 4.27155 5.5135C4.29229 5.52117 4.31158 5.53316 4.32846 5.549L8.85585 9.71283C8.97448 9.8222 9.15822 9.82172 9.27637 9.71139L13.7382 5.54989C13.7479 5.54077 13.758 5.5331 13.7686 5.52686Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+    </ul>
+    <div class="permalink" data-controller="clipboard">
+      <p>Share link</p>
+      <div class="control -has-addons">
+        <input type="text" value="https://elephantroom.com/event/4335451/762545862/baker-s-dozen-led-by-freddie-mendoza" data-clipboard-target="source" data-share-dialog-target="urlInput" data-action="click->share-dialog#selectUrl" readonly="true">
+        <span class="control__suffix">
+          <a class="button -simple -compact -icon-only" data-clipboard-target="button" data-action="clipboard#copy">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="icon" width="16px" height="18px"><path d="M4.166.597c-.184 0-.369.15-.369.342v1.365c0 .191.185.341.369.341h9.189v9.216c0 .191.15.342.341.342h1.365c.191 0 .342-.15.342-.342V.94a.338.338 0 00-.342-.342H4.166zm7.44 3.798H.34A.338.338 0 000 4.736v10.923c0 .19.15.341.341.341h10.923c.191 0 .341-.15.341-.341V4.395z" fill-rule="evenodd"></path></svg>
+          </a>
+        </span>
+      </div>
+    </div>
+  </dialog>
+</div>
+</div>
+
+
+      <div class="event-info map-link pdf__hide">
+        <a target="_blank" rel="noopener" href="https://www.google.com/maps/search/?api=1&amp;query=%F0%9F%90%989pm">View on Google Maps</a>
+      </div>
+  </div>
+</div>
+
+<div class="event-clear"></div>
+
+</article>
+<article class="list-style">
+  
+<div class="event-detail" data-event-id="4558295" data-occurrence-id="763189016">
+  <div class="event-image image-social">
+      <a rel="event[4558295]" title="Sarah Sharp Quintet" class="thumbnail-popup" data-featherlight="//images.zoogletools.com/s:bzglfiles/u/523260/d4c8a75373e01ff7aee47194935554f0e3df7688/original/sarah-sharp.jpg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" href="//images.zoogletools.com/s:bzglfiles/u/523260/d4c8a75373e01ff7aee47194935554f0e3df7688/original/sarah-sharp.jpg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg">
+        <img alt="Sarah Sharp Quintet" src="//images.zoogletools.com/s:bzglfiles/u/523260/d4c8a75373e01ff7aee47194935554f0e3df7688/original/sarah-sharp.jpg/!!/b%3AW1sicmVzaXplIixbMjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>  </div>
+
+  <div class="event-description">
+    <div class="event-info-wrapper">
+        <h2 class="event-info event-title heading-tertiary"><a href="https://elephantroom.com/event/4558295/763189016/sarah-sharp-quintet">Sarah Sharp Quintet</a></h2>
+
+        <p class="event-info event-datetime">
+          <i class="icon-clock"></i>
+          <span class="date-long"><span class="event-when with-time"><time class="from"><span class="date">Thursday, May 14</span> @ <span class="time">6:00PM</span></time></span></span><span class="date-short"><span class="event-when with-time"><time class="from"><span class="date">Thu, May 14</span> @ <span class="time">6:00PM</span></time></span></span>
+        </p>
+
+        <p class="event-info event-location">
+          <i class="icon-location"></i>
+          <a target="_blank" rel="noopener" title="View on Google Maps" href="https://www.google.com/maps/search/?api=1&amp;query=%F0%9F%90%986pm">🐘6pm</a>
+        </p>
+    </div>
+
+      <div class="event-info event-notes"><p>“Sarah Sharp's soft-spoken singing style and quiet instrumentations offer a living room, fireside closeness that keeps her away from the lounge-singer stereotypes of similarly jazz-influenced performers." — @nprmusic, All Songs Considered</p>
+
+<p>The Sarah Sharp Quartet performs every Tuesday evening in the basement, featuring John Fremgen, Masumi Jones, Oliver Steck, and Mitch Watkins.</p>
+
+<p>No cover Sunday-Wednesday</p>
+</div>
+
+    <p class="event-info">
+      
+    </p>
+
+
+    <div class="event-info buying-options product-action pdf__hide">
+
+    <div data-controller="share-dialog" data-share-dialog-url-value="https://elephantroom.com/event/4558295/763189016/sarah-sharp-quintet" data-share-dialog-title-value="Sarah Sharp Quintet @ 🐘6pm on May 14, 6:00PM" data-share-dialog-text-value="Elephant Room @ Sarah Sharp Quintet @ 🐘6pm, May 14, 6:00PM" data-share-dialog-fb-app-id-value="286076425227">
+  <a class="button button-tertiary zoogle-share pdf__hide" title="Share Sarah Sharp Quintet @ 🐘6pm on May 14, 6:00PM" data-action="click-&gt;share-dialog#open" href="javascript:void(0)">
+    <i class="icon-share"></i>Share
+</a>
+  <dialog data-share-dialog-target="dialog" data-action="click->share-dialog#clickOutside" class="dialog dialog-share style-section-style-1">
+    <button class="dialog-close" data-action="click-&gt;share-dialog#close" aria-label="close">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11 11" class="icon" width="12px" height="12px"><path d="M6.755 5.502l3.836 3.97-1.438 1.39-3.81-3.942-3.926 3.942L0 9.452 3.953 5.48 0 1.39 1.438 0l3.927 4.064L9.41 0l1.417 1.411-4.073 4.091z" fill-rule="evenodd"></path></svg>
+</button>    <div class="share_desc">
+      <div>
+        <span data-share-dialog-target="title">Sarah Sharp Quintet @ 🐘6pm on May 14, 6:00PM</span>
+        <br>
+        <span class="byline" data-share-dialog-target="byline">
+        </span>
+      </div>
+    </div>
+
+    <ul class="share_icons">
+      <li class="threads">
+        <a href="#" data-share-dialog-target="threadsLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM23.7524 16.9806C23.8587 17.0263 23.9638 17.074 24.0671 17.1235C25.5284 17.8245 26.597 18.8859 27.1575 20.1926C27.9387 22.0149 28.0101 24.9832 25.6397 27.3514C23.828 29.1615 21.6287 29.9784 18.5087 30H18.4946C14.9852 29.9757 12.2865 28.7948 10.4735 26.4901C8.86024 24.4393 8.02805 21.5855 8.00009 18.0084L8 18L8.00009 17.9916C8.02805 14.4145 8.86024 11.5608 10.4735 9.50991C12.2865 7.20522 14.9852 6.02431 18.4946 6H18.5087C22.0252 6.02439 24.7545 7.20084 26.6206 9.49675C27.5414 10.6295 28.218 11.9953 28.648 13.5803L26.6296 14.1188C26.2749 12.8311 25.7368 11.7267 25.023 10.8485C23.5674 9.05767 21.3735 8.13891 18.5016 8.11756C15.6505 8.13875 13.4942 9.05311 12.0923 10.8353C10.7794 12.5042 10.101 14.9147 10.0757 18C10.101 21.0853 10.7794 23.4958 12.0923 25.1646C13.4942 26.9469 15.6505 27.8612 18.5017 27.8824C21.072 27.8635 22.7728 27.252 24.1876 25.8385C25.8025 24.225 25.7724 22.2459 25.2559 21.0415C24.9521 20.333 24.4021 19.7436 23.66 19.2957C23.4792 20.6429 23.0699 21.712 22.4226 22.537C21.5704 23.6234 20.3487 24.2175 18.7915 24.3029C17.6124 24.3673 16.4778 24.0829 15.5969 23.5014C14.555 22.8135 13.9452 21.7605 13.8799 20.5365C13.7514 18.1235 15.6656 16.3869 18.6431 16.2154C19.7001 16.1548 20.6889 16.2026 21.6031 16.358C21.4818 15.6156 21.2366 15.0274 20.8701 14.6018C20.3665 14.0171 19.5884 13.7173 18.5572 13.7107L18.5286 13.7106C17.7006 13.7106 16.5765 13.9423 15.8601 15.0291L14.1378 13.8476C15.0966 12.3926 16.6546 11.593 18.5278 11.593L18.5702 11.5931C21.702 11.6131 23.5671 13.5673 23.7524 16.9806ZM15.9524 20.4215C16.0193 21.6761 17.3751 22.2619 18.6801 22.1884C19.9578 22.1182 21.408 21.6169 21.6553 18.5291C20.9924 18.3842 20.2633 18.3085 19.4839 18.3085C19.247 18.3085 19.0059 18.3154 18.7602 18.3296C16.6145 18.4533 15.9029 19.4913 15.9524 20.4215Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="facebook">
+        <a href="#" data-share-dialog-target="facebookLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon"><path fill-rule="evenodd" d="M9 0a9 9 0 110 18A9 9 0 019 0zm2.606 4H10.24c-1.575 0-2.17.77-2.215 2.076l-.002.166v1.034H7V9h1.023V14h2.046V9h1.365l.181-1.724H10.07l.003-.862c0-.417.036-.655.553-.687l.128-.003h.853V4z"></path></svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="twitter">
+        <a href="#" data-share-dialog-target="twitterLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="685" data-popup-window-height-value="246" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM26.4163 9L19.7142 16.6226L27.0001 27H21.6396L16.7316 20.0104L10.5876 27H9L16.0278 19.0075L9 9H14.3604L19.0068 15.6173L24.8287 9H26.4163ZM13.5996 10.1714H11.1606L22.3878 25.8861H24.8275L13.5996 10.1714Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="email">
+        <a href="#" data-share-dialog-target="emailLink" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18 9C18 4.02944 13.9706 0 9 0C4.02944 0 0 4.02944 0 9C0 13.9706 4.02944 18 9 18C13.9706 18 18 13.9706 18 9ZM4.02511 5.73566C4.00872 5.77691 4.00004 5.82153 4.00004 5.86854L4 12.1317C4 12.1897 4.0135 12.2449 4.03762 12.2938C4.04581 12.2775 4.05691 12.2621 4.07041 12.2482L7.39793 8.87439L4.0772 5.81961C4.05116 5.79611 4.0338 5.76684 4.02511 5.73566ZM4.34327 12.4991L4.34195 12.499L7.67 9.12427L8.60412 9.98343C8.86598 10.2242 9.26962 10.2228 9.52956 9.98007L10.4564 9.11563L13.768 12.4736C13.7251 12.4904 13.6783 12.5 13.6296 12.5H4.3704C4.3612 12.5 4.35243 12.4996 4.34327 12.4991ZM13.9971 12.1795L10.727 8.86376L13.9913 5.81857C13.9932 5.81713 13.9947 5.81569 13.9961 5.81425C13.9986 5.832 14 5.85023 14 5.86846V12.1315C14 12.1478 13.999 12.1637 13.9971 12.1795ZM13.7686 5.52686C13.7257 5.50959 13.6789 5.5 13.6297 5.5L4.37041 5.50006C4.33617 5.50006 4.30338 5.50486 4.27155 5.5135C4.29229 5.52117 4.31158 5.53316 4.32846 5.549L8.85585 9.71283C8.97448 9.8222 9.15822 9.82172 9.27637 9.71139L13.7382 5.54989C13.7479 5.54077 13.758 5.5331 13.7686 5.52686Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+    </ul>
+    <div class="permalink" data-controller="clipboard">
+      <p>Share link</p>
+      <div class="control -has-addons">
+        <input type="text" value="https://elephantroom.com/event/4558295/763189016/sarah-sharp-quintet" data-clipboard-target="source" data-share-dialog-target="urlInput" data-action="click->share-dialog#selectUrl" readonly="true">
+        <span class="control__suffix">
+          <a class="button -simple -compact -icon-only" data-clipboard-target="button" data-action="clipboard#copy">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="icon" width="16px" height="18px"><path d="M4.166.597c-.184 0-.369.15-.369.342v1.365c0 .191.185.341.369.341h9.189v9.216c0 .191.15.342.341.342h1.365c.191 0 .342-.15.342-.342V.94a.338.338 0 00-.342-.342H4.166zm7.44 3.798H.34A.338.338 0 000 4.736v10.923c0 .19.15.341.341.341h10.923c.191 0 .341-.15.341-.341V4.395z" fill-rule="evenodd"></path></svg>
+          </a>
+        </span>
+      </div>
+    </div>
+  </dialog>
+</div>
+</div>
+
+
+      <div class="event-info map-link pdf__hide">
+        <a target="_blank" rel="noopener" href="https://www.google.com/maps/search/?api=1&amp;query=%F0%9F%90%986pm">View on Google Maps</a>
+      </div>
+  </div>
+</div>
+
+<div class="event-clear"></div>
+
+</article>
+<article class="list-style">
+  
+<div class="event-detail" data-event-id="5646964" data-occurrence-id="762288846">
+  <div class="event-image image-social">
+      <a rel="event[5646964]" title="Brian Bettger&#39;s Texas Cool Quintet" class="thumbnail-popup" data-featherlight="//images.zoogletools.com/s:bzglfiles/u/523260/72a94664fa6eeefb60bcc4ad7647a559f10711ae/original/brian-bettger.jpg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" href="//images.zoogletools.com/s:bzglfiles/u/523260/72a94664fa6eeefb60bcc4ad7647a559f10711ae/original/brian-bettger.jpg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg">
+        <img alt="Brian Bettger&#39;s Texas Cool Quintet" src="//images.zoogletools.com/s:bzglfiles/u/523260/72a94664fa6eeefb60bcc4ad7647a559f10711ae/original/brian-bettger.jpg/!!/b%3AW1sicmVzaXplIixbMjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>  </div>
+
+  <div class="event-description">
+    <div class="event-info-wrapper">
+        <h2 class="event-info event-title heading-tertiary"><a href="https://elephantroom.com/event/5646964/762288846/brian-bettger-s-texas-cool-quintet">Brian Bettger&#39;s Texas Cool Quintet</a></h2>
+
+        <p class="event-info event-datetime">
+          <i class="icon-clock"></i>
+          <span class="date-long"><span class="event-when with-time"><time class="from"><span class="date">Thursday, May 14</span> @ <span class="time">9:00PM</span></time></span></span><span class="date-short"><span class="event-when with-time"><time class="from"><span class="date">Thu, May 14</span> @ <span class="time">9:00PM</span></time></span></span>
+        </p>
+
+        <p class="event-info event-location">
+          <i class="icon-location"></i>
+          <a target="_blank" rel="noopener" title="View on Google Maps" href="https://www.google.com/maps/search/?api=1&amp;query=%F0%9F%90%989pm">🐘9pm</a>
+        </p>
+    </div>
+
+      <div class="event-info event-notes"><ol>
+<li><ol>
+<li>Times Jazz Critic Leonard Feather described Brian Bettger as "an ultra-smooth trumpet player."  Brian relocated to the Austin area after years as performer, educator, arranger and conductor in the Southern California music scene. Brian has performed with a wide array of artists from Frank Sinatra to Chick Corea to Queen Latifa to U2.  His Texas Cool Quintet celebrates the West Coast 'Cool' School with music from Chet Baker, Gerry Mulligan, Miles Davis, Bill Evans, Stan Getz and beyond.</li>
+</ol>
+</li>
+</ol>
+
+</div>
+
+    <p class="event-info">
+      
+    </p>
+
+
+    <div class="event-info buying-options product-action pdf__hide">
+
+    <div data-controller="share-dialog" data-share-dialog-url-value="https://elephantroom.com/event/5646964/762288846/brian-bettger-s-texas-cool-quintet" data-share-dialog-title-value="Brian Bettger&#39;s Texas Cool Quintet @ 🐘9pm on May 14, 9:00PM" data-share-dialog-text-value="Elephant Room @ Brian Bettger&#39;s Texas Cool Quintet @ 🐘9pm, May 14, 9:00PM" data-share-dialog-fb-app-id-value="286076425227">
+  <a class="button button-tertiary zoogle-share pdf__hide" title="Share Brian Bettger&#39;s Texas Cool Quintet @ 🐘9pm on May 14, 9:00PM" data-action="click-&gt;share-dialog#open" href="javascript:void(0)">
+    <i class="icon-share"></i>Share
+</a>
+  <dialog data-share-dialog-target="dialog" data-action="click->share-dialog#clickOutside" class="dialog dialog-share style-section-style-1">
+    <button class="dialog-close" data-action="click-&gt;share-dialog#close" aria-label="close">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11 11" class="icon" width="12px" height="12px"><path d="M6.755 5.502l3.836 3.97-1.438 1.39-3.81-3.942-3.926 3.942L0 9.452 3.953 5.48 0 1.39 1.438 0l3.927 4.064L9.41 0l1.417 1.411-4.073 4.091z" fill-rule="evenodd"></path></svg>
+</button>    <div class="share_desc">
+      <div>
+        <span data-share-dialog-target="title">Brian Bettger&#39;s Texas Cool Quintet @ 🐘9pm on May 14, 9:00PM</span>
+        <br>
+        <span class="byline" data-share-dialog-target="byline">
+        </span>
+      </div>
+    </div>
+
+    <ul class="share_icons">
+      <li class="threads">
+        <a href="#" data-share-dialog-target="threadsLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM23.7524 16.9806C23.8587 17.0263 23.9638 17.074 24.0671 17.1235C25.5284 17.8245 26.597 18.8859 27.1575 20.1926C27.9387 22.0149 28.0101 24.9832 25.6397 27.3514C23.828 29.1615 21.6287 29.9784 18.5087 30H18.4946C14.9852 29.9757 12.2865 28.7948 10.4735 26.4901C8.86024 24.4393 8.02805 21.5855 8.00009 18.0084L8 18L8.00009 17.9916C8.02805 14.4145 8.86024 11.5608 10.4735 9.50991C12.2865 7.20522 14.9852 6.02431 18.4946 6H18.5087C22.0252 6.02439 24.7545 7.20084 26.6206 9.49675C27.5414 10.6295 28.218 11.9953 28.648 13.5803L26.6296 14.1188C26.2749 12.8311 25.7368 11.7267 25.023 10.8485C23.5674 9.05767 21.3735 8.13891 18.5016 8.11756C15.6505 8.13875 13.4942 9.05311 12.0923 10.8353C10.7794 12.5042 10.101 14.9147 10.0757 18C10.101 21.0853 10.7794 23.4958 12.0923 25.1646C13.4942 26.9469 15.6505 27.8612 18.5017 27.8824C21.072 27.8635 22.7728 27.252 24.1876 25.8385C25.8025 24.225 25.7724 22.2459 25.2559 21.0415C24.9521 20.333 24.4021 19.7436 23.66 19.2957C23.4792 20.6429 23.0699 21.712 22.4226 22.537C21.5704 23.6234 20.3487 24.2175 18.7915 24.3029C17.6124 24.3673 16.4778 24.0829 15.5969 23.5014C14.555 22.8135 13.9452 21.7605 13.8799 20.5365C13.7514 18.1235 15.6656 16.3869 18.6431 16.2154C19.7001 16.1548 20.6889 16.2026 21.6031 16.358C21.4818 15.6156 21.2366 15.0274 20.8701 14.6018C20.3665 14.0171 19.5884 13.7173 18.5572 13.7107L18.5286 13.7106C17.7006 13.7106 16.5765 13.9423 15.8601 15.0291L14.1378 13.8476C15.0966 12.3926 16.6546 11.593 18.5278 11.593L18.5702 11.5931C21.702 11.6131 23.5671 13.5673 23.7524 16.9806ZM15.9524 20.4215C16.0193 21.6761 17.3751 22.2619 18.6801 22.1884C19.9578 22.1182 21.408 21.6169 21.6553 18.5291C20.9924 18.3842 20.2633 18.3085 19.4839 18.3085C19.247 18.3085 19.0059 18.3154 18.7602 18.3296C16.6145 18.4533 15.9029 19.4913 15.9524 20.4215Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="facebook">
+        <a href="#" data-share-dialog-target="facebookLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon"><path fill-rule="evenodd" d="M9 0a9 9 0 110 18A9 9 0 019 0zm2.606 4H10.24c-1.575 0-2.17.77-2.215 2.076l-.002.166v1.034H7V9h1.023V14h2.046V9h1.365l.181-1.724H10.07l.003-.862c0-.417.036-.655.553-.687l.128-.003h.853V4z"></path></svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="twitter">
+        <a href="#" data-share-dialog-target="twitterLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="685" data-popup-window-height-value="246" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM26.4163 9L19.7142 16.6226L27.0001 27H21.6396L16.7316 20.0104L10.5876 27H9L16.0278 19.0075L9 9H14.3604L19.0068 15.6173L24.8287 9H26.4163ZM13.5996 10.1714H11.1606L22.3878 25.8861H24.8275L13.5996 10.1714Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="email">
+        <a href="#" data-share-dialog-target="emailLink" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18 9C18 4.02944 13.9706 0 9 0C4.02944 0 0 4.02944 0 9C0 13.9706 4.02944 18 9 18C13.9706 18 18 13.9706 18 9ZM4.02511 5.73566C4.00872 5.77691 4.00004 5.82153 4.00004 5.86854L4 12.1317C4 12.1897 4.0135 12.2449 4.03762 12.2938C4.04581 12.2775 4.05691 12.2621 4.07041 12.2482L7.39793 8.87439L4.0772 5.81961C4.05116 5.79611 4.0338 5.76684 4.02511 5.73566ZM4.34327 12.4991L4.34195 12.499L7.67 9.12427L8.60412 9.98343C8.86598 10.2242 9.26962 10.2228 9.52956 9.98007L10.4564 9.11563L13.768 12.4736C13.7251 12.4904 13.6783 12.5 13.6296 12.5H4.3704C4.3612 12.5 4.35243 12.4996 4.34327 12.4991ZM13.9971 12.1795L10.727 8.86376L13.9913 5.81857C13.9932 5.81713 13.9947 5.81569 13.9961 5.81425C13.9986 5.832 14 5.85023 14 5.86846V12.1315C14 12.1478 13.999 12.1637 13.9971 12.1795ZM13.7686 5.52686C13.7257 5.50959 13.6789 5.5 13.6297 5.5L4.37041 5.50006C4.33617 5.50006 4.30338 5.50486 4.27155 5.5135C4.29229 5.52117 4.31158 5.53316 4.32846 5.549L8.85585 9.71283C8.97448 9.8222 9.15822 9.82172 9.27637 9.71139L13.7382 5.54989C13.7479 5.54077 13.758 5.5331 13.7686 5.52686Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+    </ul>
+    <div class="permalink" data-controller="clipboard">
+      <p>Share link</p>
+      <div class="control -has-addons">
+        <input type="text" value="https://elephantroom.com/event/5646964/762288846/brian-bettger-s-texas-cool-quintet" data-clipboard-target="source" data-share-dialog-target="urlInput" data-action="click->share-dialog#selectUrl" readonly="true">
+        <span class="control__suffix">
+          <a class="button -simple -compact -icon-only" data-clipboard-target="button" data-action="clipboard#copy">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="icon" width="16px" height="18px"><path d="M4.166.597c-.184 0-.369.15-.369.342v1.365c0 .191.185.341.369.341h9.189v9.216c0 .191.15.342.341.342h1.365c.191 0 .342-.15.342-.342V.94a.338.338 0 00-.342-.342H4.166zm7.44 3.798H.34A.338.338 0 000 4.736v10.923c0 .19.15.341.341.341h10.923c.191 0 .341-.15.341-.341V4.395z" fill-rule="evenodd"></path></svg>
+          </a>
+        </span>
+      </div>
+    </div>
+  </dialog>
+</div>
+</div>
+
+
+      <div class="event-info map-link pdf__hide">
+        <a target="_blank" rel="noopener" href="https://www.google.com/maps/search/?api=1&amp;query=%F0%9F%90%989pm">View on Google Maps</a>
+      </div>
+  </div>
+</div>
+
+<div class="event-clear"></div>
+
+</article>
+<article class="list-style">
+  
+<div class="event-detail" data-event-id="6082513" data-occurrence-id="763314679">
+  <div class="event-image image-social">
+      <a rel="event[6082513]" title="Dave Scher Group" class="thumbnail-popup" data-featherlight="//images.zoogletools.com/s:bzglfiles/u/523260/222ce8f99b3cfa41c6163151c8de96090155cf97/original/bioguitarsm.jpg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" href="//images.zoogletools.com/s:bzglfiles/u/523260/222ce8f99b3cfa41c6163151c8de96090155cf97/original/bioguitarsm.jpg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg">
+        <img alt="Dave Scher Group" src="//images.zoogletools.com/s:bzglfiles/u/523260/222ce8f99b3cfa41c6163151c8de96090155cf97/original/bioguitarsm.jpg/!!/b%3AW1sicmVzaXplIixbMjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>  </div>
+
+  <div class="event-description">
+    <div class="event-info-wrapper">
+        <h2 class="event-info event-title heading-tertiary"><a href="https://elephantroom.com/event/6082513/763314679/dave-scher-group">Dave Scher Group</a></h2>
+
+        <p class="event-info event-datetime">
+          <i class="icon-clock"></i>
+          <span class="date-long"><span class="event-when with-time"><time class="from"><span class="date">Friday, May 15</span> @ <span class="time">6:00PM</span></time></span></span><span class="date-short"><span class="event-when with-time"><time class="from"><span class="date">Fri, May 15</span> @ <span class="time">6:00PM</span></time></span></span>
+        </p>
+
+        <p class="event-info event-location">
+          <i class="icon-location"></i>
+          <a target="_blank" rel="noopener" title="View on Google Maps" href="https://www.google.com/maps/search/?api=1&amp;query=%F0%9F%90%986pm">🐘6pm</a>
+        </p>
+    </div>
+
+      <div class="event-info event-notes"><p>Dave Scher is truly a treasured musician of Austin!  Literally a guitar player's guitar player (as he tours with Eric Johnson), Dave is multi-genre, multi-instrumentalist who will bring his unique blues-infused "dabble jazz" down to basement level.</p>
+</div>
+
+    <p class="event-info">
+      
+    </p>
+
+
+    <div class="event-info buying-options product-action pdf__hide">
+
+    <div data-controller="share-dialog" data-share-dialog-url-value="https://elephantroom.com/event/6082513/763314679/dave-scher-group" data-share-dialog-title-value="Dave Scher Group @ 🐘6pm on May 15, 6:00PM" data-share-dialog-text-value="Elephant Room @ Dave Scher Group @ 🐘6pm, May 15, 6:00PM" data-share-dialog-fb-app-id-value="286076425227">
+  <a class="button button-tertiary zoogle-share pdf__hide" title="Share Dave Scher Group @ 🐘6pm on May 15, 6:00PM" data-action="click-&gt;share-dialog#open" href="javascript:void(0)">
+    <i class="icon-share"></i>Share
+</a>
+  <dialog data-share-dialog-target="dialog" data-action="click->share-dialog#clickOutside" class="dialog dialog-share style-section-style-1">
+    <button class="dialog-close" data-action="click-&gt;share-dialog#close" aria-label="close">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11 11" class="icon" width="12px" height="12px"><path d="M6.755 5.502l3.836 3.97-1.438 1.39-3.81-3.942-3.926 3.942L0 9.452 3.953 5.48 0 1.39 1.438 0l3.927 4.064L9.41 0l1.417 1.411-4.073 4.091z" fill-rule="evenodd"></path></svg>
+</button>    <div class="share_desc">
+      <div>
+        <span data-share-dialog-target="title">Dave Scher Group @ 🐘6pm on May 15, 6:00PM</span>
+        <br>
+        <span class="byline" data-share-dialog-target="byline">
+        </span>
+      </div>
+    </div>
+
+    <ul class="share_icons">
+      <li class="threads">
+        <a href="#" data-share-dialog-target="threadsLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM23.7524 16.9806C23.8587 17.0263 23.9638 17.074 24.0671 17.1235C25.5284 17.8245 26.597 18.8859 27.1575 20.1926C27.9387 22.0149 28.0101 24.9832 25.6397 27.3514C23.828 29.1615 21.6287 29.9784 18.5087 30H18.4946C14.9852 29.9757 12.2865 28.7948 10.4735 26.4901C8.86024 24.4393 8.02805 21.5855 8.00009 18.0084L8 18L8.00009 17.9916C8.02805 14.4145 8.86024 11.5608 10.4735 9.50991C12.2865 7.20522 14.9852 6.02431 18.4946 6H18.5087C22.0252 6.02439 24.7545 7.20084 26.6206 9.49675C27.5414 10.6295 28.218 11.9953 28.648 13.5803L26.6296 14.1188C26.2749 12.8311 25.7368 11.7267 25.023 10.8485C23.5674 9.05767 21.3735 8.13891 18.5016 8.11756C15.6505 8.13875 13.4942 9.05311 12.0923 10.8353C10.7794 12.5042 10.101 14.9147 10.0757 18C10.101 21.0853 10.7794 23.4958 12.0923 25.1646C13.4942 26.9469 15.6505 27.8612 18.5017 27.8824C21.072 27.8635 22.7728 27.252 24.1876 25.8385C25.8025 24.225 25.7724 22.2459 25.2559 21.0415C24.9521 20.333 24.4021 19.7436 23.66 19.2957C23.4792 20.6429 23.0699 21.712 22.4226 22.537C21.5704 23.6234 20.3487 24.2175 18.7915 24.3029C17.6124 24.3673 16.4778 24.0829 15.5969 23.5014C14.555 22.8135 13.9452 21.7605 13.8799 20.5365C13.7514 18.1235 15.6656 16.3869 18.6431 16.2154C19.7001 16.1548 20.6889 16.2026 21.6031 16.358C21.4818 15.6156 21.2366 15.0274 20.8701 14.6018C20.3665 14.0171 19.5884 13.7173 18.5572 13.7107L18.5286 13.7106C17.7006 13.7106 16.5765 13.9423 15.8601 15.0291L14.1378 13.8476C15.0966 12.3926 16.6546 11.593 18.5278 11.593L18.5702 11.5931C21.702 11.6131 23.5671 13.5673 23.7524 16.9806ZM15.9524 20.4215C16.0193 21.6761 17.3751 22.2619 18.6801 22.1884C19.9578 22.1182 21.408 21.6169 21.6553 18.5291C20.9924 18.3842 20.2633 18.3085 19.4839 18.3085C19.247 18.3085 19.0059 18.3154 18.7602 18.3296C16.6145 18.4533 15.9029 19.4913 15.9524 20.4215Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="facebook">
+        <a href="#" data-share-dialog-target="facebookLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon"><path fill-rule="evenodd" d="M9 0a9 9 0 110 18A9 9 0 019 0zm2.606 4H10.24c-1.575 0-2.17.77-2.215 2.076l-.002.166v1.034H7V9h1.023V14h2.046V9h1.365l.181-1.724H10.07l.003-.862c0-.417.036-.655.553-.687l.128-.003h.853V4z"></path></svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="twitter">
+        <a href="#" data-share-dialog-target="twitterLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="685" data-popup-window-height-value="246" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM26.4163 9L19.7142 16.6226L27.0001 27H21.6396L16.7316 20.0104L10.5876 27H9L16.0278 19.0075L9 9H14.3604L19.0068 15.6173L24.8287 9H26.4163ZM13.5996 10.1714H11.1606L22.3878 25.8861H24.8275L13.5996 10.1714Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="email">
+        <a href="#" data-share-dialog-target="emailLink" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18 9C18 4.02944 13.9706 0 9 0C4.02944 0 0 4.02944 0 9C0 13.9706 4.02944 18 9 18C13.9706 18 18 13.9706 18 9ZM4.02511 5.73566C4.00872 5.77691 4.00004 5.82153 4.00004 5.86854L4 12.1317C4 12.1897 4.0135 12.2449 4.03762 12.2938C4.04581 12.2775 4.05691 12.2621 4.07041 12.2482L7.39793 8.87439L4.0772 5.81961C4.05116 5.79611 4.0338 5.76684 4.02511 5.73566ZM4.34327 12.4991L4.34195 12.499L7.67 9.12427L8.60412 9.98343C8.86598 10.2242 9.26962 10.2228 9.52956 9.98007L10.4564 9.11563L13.768 12.4736C13.7251 12.4904 13.6783 12.5 13.6296 12.5H4.3704C4.3612 12.5 4.35243 12.4996 4.34327 12.4991ZM13.9971 12.1795L10.727 8.86376L13.9913 5.81857C13.9932 5.81713 13.9947 5.81569 13.9961 5.81425C13.9986 5.832 14 5.85023 14 5.86846V12.1315C14 12.1478 13.999 12.1637 13.9971 12.1795ZM13.7686 5.52686C13.7257 5.50959 13.6789 5.5 13.6297 5.5L4.37041 5.50006C4.33617 5.50006 4.30338 5.50486 4.27155 5.5135C4.29229 5.52117 4.31158 5.53316 4.32846 5.549L8.85585 9.71283C8.97448 9.8222 9.15822 9.82172 9.27637 9.71139L13.7382 5.54989C13.7479 5.54077 13.758 5.5331 13.7686 5.52686Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+    </ul>
+    <div class="permalink" data-controller="clipboard">
+      <p>Share link</p>
+      <div class="control -has-addons">
+        <input type="text" value="https://elephantroom.com/event/6082513/763314679/dave-scher-group" data-clipboard-target="source" data-share-dialog-target="urlInput" data-action="click->share-dialog#selectUrl" readonly="true">
+        <span class="control__suffix">
+          <a class="button -simple -compact -icon-only" data-clipboard-target="button" data-action="clipboard#copy">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="icon" width="16px" height="18px"><path d="M4.166.597c-.184 0-.369.15-.369.342v1.365c0 .191.185.341.369.341h9.189v9.216c0 .191.15.342.341.342h1.365c.191 0 .342-.15.342-.342V.94a.338.338 0 00-.342-.342H4.166zm7.44 3.798H.34A.338.338 0 000 4.736v10.923c0 .19.15.341.341.341h10.923c.191 0 .341-.15.341-.341V4.395z" fill-rule="evenodd"></path></svg>
+          </a>
+        </span>
+      </div>
+    </div>
+  </dialog>
+</div>
+</div>
+
+
+      <div class="event-info map-link pdf__hide">
+        <a target="_blank" rel="noopener" href="https://www.google.com/maps/search/?api=1&amp;query=%F0%9F%90%986pm">View on Google Maps</a>
+      </div>
+  </div>
+</div>
+
+<div class="event-clear"></div>
+
+</article>
+<article class="list-style">
+  
+<div class="event-detail" data-event-id="5925515" data-occurrence-id="762545908">
+  <div class="event-image image-social">
+      <a rel="event[5925515]" title="Red Young TENOR MADNESS" class="thumbnail-popup" data-featherlight="//images.zoogletools.com/s:bzglfiles/u/523260/cd838d14a33c26c0474afb3bcd81261077b673eb/original/red-mkb-crop-1-300.jpg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" href="//images.zoogletools.com/s:bzglfiles/u/523260/cd838d14a33c26c0474afb3bcd81261077b673eb/original/red-mkb-crop-1-300.jpg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg">
+        <img alt="Red Young TENOR MADNESS" src="//images.zoogletools.com/s:bzglfiles/u/523260/cd838d14a33c26c0474afb3bcd81261077b673eb/original/red-mkb-crop-1-300.jpg/!!/b%3AW1sicmVzaXplIixbMjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>  </div>
+
+  <div class="event-description">
+    <div class="event-info-wrapper">
+        <h2 class="event-info event-title heading-tertiary"><a href="https://elephantroom.com/event/5925515/762545908/red-young-tenor-madness">Red Young TENOR MADNESS</a></h2>
+
+        <p class="event-info event-datetime">
+          <i class="icon-clock"></i>
+          <span class="date-long"><span class="event-when with-time"><time class="from"><span class="date">Friday, May 15</span> @ <span class="time">9:00PM</span></time></span></span><span class="date-short"><span class="event-when with-time"><time class="from"><span class="date">Fri, May 15</span> @ <span class="time">9:00PM</span></time></span></span>
+        </p>
+
+        <p class="event-info event-location">
+          <i class="icon-location"></i>
+          <a target="_blank" rel="noopener" title="View on Google Maps" href="https://www.google.com/maps/search/?api=1&amp;query=%F0%9F%90%989pm">🐘9pm</a>
+        </p>
+    </div>
+
+      <div class="event-info event-notes"><p>Red Young Trio brings down his big organ and two amazing tenor sax all stars with only the best drummer for an evening of musical madness!</p>
+</div>
+
+    <p class="event-info">
+      
+    </p>
+
+
+    <div class="event-info buying-options product-action pdf__hide">
+
+    <div data-controller="share-dialog" data-share-dialog-url-value="https://elephantroom.com/event/5925515/762545908/red-young-tenor-madness" data-share-dialog-title-value="Red Young TENOR MADNESS @ 🐘9pm on May 15, 9:00PM" data-share-dialog-text-value="Elephant Room @ Red Young TENOR MADNESS @ 🐘9pm, May 15, 9:00PM" data-share-dialog-fb-app-id-value="286076425227">
+  <a class="button button-tertiary zoogle-share pdf__hide" title="Share Red Young TENOR MADNESS @ 🐘9pm on May 15, 9:00PM" data-action="click-&gt;share-dialog#open" href="javascript:void(0)">
+    <i class="icon-share"></i>Share
+</a>
+  <dialog data-share-dialog-target="dialog" data-action="click->share-dialog#clickOutside" class="dialog dialog-share style-section-style-1">
+    <button class="dialog-close" data-action="click-&gt;share-dialog#close" aria-label="close">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11 11" class="icon" width="12px" height="12px"><path d="M6.755 5.502l3.836 3.97-1.438 1.39-3.81-3.942-3.926 3.942L0 9.452 3.953 5.48 0 1.39 1.438 0l3.927 4.064L9.41 0l1.417 1.411-4.073 4.091z" fill-rule="evenodd"></path></svg>
+</button>    <div class="share_desc">
+      <div>
+        <span data-share-dialog-target="title">Red Young TENOR MADNESS @ 🐘9pm on May 15, 9:00PM</span>
+        <br>
+        <span class="byline" data-share-dialog-target="byline">
+        </span>
+      </div>
+    </div>
+
+    <ul class="share_icons">
+      <li class="threads">
+        <a href="#" data-share-dialog-target="threadsLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM23.7524 16.9806C23.8587 17.0263 23.9638 17.074 24.0671 17.1235C25.5284 17.8245 26.597 18.8859 27.1575 20.1926C27.9387 22.0149 28.0101 24.9832 25.6397 27.3514C23.828 29.1615 21.6287 29.9784 18.5087 30H18.4946C14.9852 29.9757 12.2865 28.7948 10.4735 26.4901C8.86024 24.4393 8.02805 21.5855 8.00009 18.0084L8 18L8.00009 17.9916C8.02805 14.4145 8.86024 11.5608 10.4735 9.50991C12.2865 7.20522 14.9852 6.02431 18.4946 6H18.5087C22.0252 6.02439 24.7545 7.20084 26.6206 9.49675C27.5414 10.6295 28.218 11.9953 28.648 13.5803L26.6296 14.1188C26.2749 12.8311 25.7368 11.7267 25.023 10.8485C23.5674 9.05767 21.3735 8.13891 18.5016 8.11756C15.6505 8.13875 13.4942 9.05311 12.0923 10.8353C10.7794 12.5042 10.101 14.9147 10.0757 18C10.101 21.0853 10.7794 23.4958 12.0923 25.1646C13.4942 26.9469 15.6505 27.8612 18.5017 27.8824C21.072 27.8635 22.7728 27.252 24.1876 25.8385C25.8025 24.225 25.7724 22.2459 25.2559 21.0415C24.9521 20.333 24.4021 19.7436 23.66 19.2957C23.4792 20.6429 23.0699 21.712 22.4226 22.537C21.5704 23.6234 20.3487 24.2175 18.7915 24.3029C17.6124 24.3673 16.4778 24.0829 15.5969 23.5014C14.555 22.8135 13.9452 21.7605 13.8799 20.5365C13.7514 18.1235 15.6656 16.3869 18.6431 16.2154C19.7001 16.1548 20.6889 16.2026 21.6031 16.358C21.4818 15.6156 21.2366 15.0274 20.8701 14.6018C20.3665 14.0171 19.5884 13.7173 18.5572 13.7107L18.5286 13.7106C17.7006 13.7106 16.5765 13.9423 15.8601 15.0291L14.1378 13.8476C15.0966 12.3926 16.6546 11.593 18.5278 11.593L18.5702 11.5931C21.702 11.6131 23.5671 13.5673 23.7524 16.9806ZM15.9524 20.4215C16.0193 21.6761 17.3751 22.2619 18.6801 22.1884C19.9578 22.1182 21.408 21.6169 21.6553 18.5291C20.9924 18.3842 20.2633 18.3085 19.4839 18.3085C19.247 18.3085 19.0059 18.3154 18.7602 18.3296C16.6145 18.4533 15.9029 19.4913 15.9524 20.4215Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="facebook">
+        <a href="#" data-share-dialog-target="facebookLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon"><path fill-rule="evenodd" d="M9 0a9 9 0 110 18A9 9 0 019 0zm2.606 4H10.24c-1.575 0-2.17.77-2.215 2.076l-.002.166v1.034H7V9h1.023V14h2.046V9h1.365l.181-1.724H10.07l.003-.862c0-.417.036-.655.553-.687l.128-.003h.853V4z"></path></svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="twitter">
+        <a href="#" data-share-dialog-target="twitterLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="685" data-popup-window-height-value="246" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM26.4163 9L19.7142 16.6226L27.0001 27H21.6396L16.7316 20.0104L10.5876 27H9L16.0278 19.0075L9 9H14.3604L19.0068 15.6173L24.8287 9H26.4163ZM13.5996 10.1714H11.1606L22.3878 25.8861H24.8275L13.5996 10.1714Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="email">
+        <a href="#" data-share-dialog-target="emailLink" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18 9C18 4.02944 13.9706 0 9 0C4.02944 0 0 4.02944 0 9C0 13.9706 4.02944 18 9 18C13.9706 18 18 13.9706 18 9ZM4.02511 5.73566C4.00872 5.77691 4.00004 5.82153 4.00004 5.86854L4 12.1317C4 12.1897 4.0135 12.2449 4.03762 12.2938C4.04581 12.2775 4.05691 12.2621 4.07041 12.2482L7.39793 8.87439L4.0772 5.81961C4.05116 5.79611 4.0338 5.76684 4.02511 5.73566ZM4.34327 12.4991L4.34195 12.499L7.67 9.12427L8.60412 9.98343C8.86598 10.2242 9.26962 10.2228 9.52956 9.98007L10.4564 9.11563L13.768 12.4736C13.7251 12.4904 13.6783 12.5 13.6296 12.5H4.3704C4.3612 12.5 4.35243 12.4996 4.34327 12.4991ZM13.9971 12.1795L10.727 8.86376L13.9913 5.81857C13.9932 5.81713 13.9947 5.81569 13.9961 5.81425C13.9986 5.832 14 5.85023 14 5.86846V12.1315C14 12.1478 13.999 12.1637 13.9971 12.1795ZM13.7686 5.52686C13.7257 5.50959 13.6789 5.5 13.6297 5.5L4.37041 5.50006C4.33617 5.50006 4.30338 5.50486 4.27155 5.5135C4.29229 5.52117 4.31158 5.53316 4.32846 5.549L8.85585 9.71283C8.97448 9.8222 9.15822 9.82172 9.27637 9.71139L13.7382 5.54989C13.7479 5.54077 13.758 5.5331 13.7686 5.52686Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+    </ul>
+    <div class="permalink" data-controller="clipboard">
+      <p>Share link</p>
+      <div class="control -has-addons">
+        <input type="text" value="https://elephantroom.com/event/5925515/762545908/red-young-tenor-madness" data-clipboard-target="source" data-share-dialog-target="urlInput" data-action="click->share-dialog#selectUrl" readonly="true">
+        <span class="control__suffix">
+          <a class="button -simple -compact -icon-only" data-clipboard-target="button" data-action="clipboard#copy">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="icon" width="16px" height="18px"><path d="M4.166.597c-.184 0-.369.15-.369.342v1.365c0 .191.185.341.369.341h9.189v9.216c0 .191.15.342.341.342h1.365c.191 0 .342-.15.342-.342V.94a.338.338 0 00-.342-.342H4.166zm7.44 3.798H.34A.338.338 0 000 4.736v10.923c0 .19.15.341.341.341h10.923c.191 0 .341-.15.341-.341V4.395z" fill-rule="evenodd"></path></svg>
+          </a>
+        </span>
+      </div>
+    </div>
+  </dialog>
+</div>
+</div>
+
+
+      <div class="event-info map-link pdf__hide">
+        <a target="_blank" rel="noopener" href="https://www.google.com/maps/search/?api=1&amp;query=%F0%9F%90%989pm">View on Google Maps</a>
+      </div>
+  </div>
+</div>
+
+<div class="event-clear"></div>
+
+</article>
+<article class="list-style">
+  
+<div class="event-detail" data-event-id="4558265" data-occurrence-id="762545998">
+  <div class="event-image image-social">
+      <a rel="event[4558265]" title="Jerry Espinoza Quintet" class="thumbnail-popup" data-featherlight="//images.zoogletools.com/s:bzglfiles/u/523260/765f02e20b79fe17806d4e9eaf3b9acd0eb9fd21/original/jerry-espinoza.jpg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" href="//images.zoogletools.com/s:bzglfiles/u/523260/765f02e20b79fe17806d4e9eaf3b9acd0eb9fd21/original/jerry-espinoza.jpg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg">
+        <img alt="Jerry Espinoza Quintet" src="//images.zoogletools.com/s:bzglfiles/u/523260/765f02e20b79fe17806d4e9eaf3b9acd0eb9fd21/original/jerry-espinoza.jpg/!!/b%3AW1sicmVzaXplIixbMjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>  </div>
+
+  <div class="event-description">
+    <div class="event-info-wrapper">
+        <h2 class="event-info event-title heading-tertiary"><a href="https://elephantroom.com/event/4558265/762545998/jerry-espinoza-quintet">Jerry Espinoza Quintet</a></h2>
+
+        <p class="event-info event-datetime">
+          <i class="icon-clock"></i>
+          <span class="date-long"><span class="event-when with-time"><time class="from"><span class="date">Saturday, May 16</span> @ <span class="time">9:00PM</span></time></span></span><span class="date-short"><span class="event-when with-time"><time class="from"><span class="date">Sat, May 16</span> @ <span class="time">9:00PM</span></time></span></span>
+        </p>
+
+        <p class="event-info event-location">
+          <i class="icon-location"></i>
+          <a target="_blank" rel="noopener" title="View on Google Maps" href="https://www.google.com/maps/search/?api=1&amp;query=%F0%9F%90%989pm">🐘9pm</a>
+        </p>
+    </div>
+
+      <div class="event-info event-notes"><p>Sax man Jerry Espinoza will perform a mix of jazz standards and originals with his quintet.</p>
+</div>
+
+    <p class="event-info">
+      
+    </p>
+
+
+    <div class="event-info buying-options product-action pdf__hide">
+
+    <div data-controller="share-dialog" data-share-dialog-url-value="https://elephantroom.com/event/4558265/762545998/jerry-espinoza-quintet" data-share-dialog-title-value="Jerry Espinoza Quintet @ 🐘9pm on May 16, 9:00PM" data-share-dialog-text-value="Elephant Room @ Jerry Espinoza Quintet @ 🐘9pm, May 16, 9:00PM" data-share-dialog-fb-app-id-value="286076425227">
+  <a class="button button-tertiary zoogle-share pdf__hide" title="Share Jerry Espinoza Quintet @ 🐘9pm on May 16, 9:00PM" data-action="click-&gt;share-dialog#open" href="javascript:void(0)">
+    <i class="icon-share"></i>Share
+</a>
+  <dialog data-share-dialog-target="dialog" data-action="click->share-dialog#clickOutside" class="dialog dialog-share style-section-style-1">
+    <button class="dialog-close" data-action="click-&gt;share-dialog#close" aria-label="close">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11 11" class="icon" width="12px" height="12px"><path d="M6.755 5.502l3.836 3.97-1.438 1.39-3.81-3.942-3.926 3.942L0 9.452 3.953 5.48 0 1.39 1.438 0l3.927 4.064L9.41 0l1.417 1.411-4.073 4.091z" fill-rule="evenodd"></path></svg>
+</button>    <div class="share_desc">
+      <div>
+        <span data-share-dialog-target="title">Jerry Espinoza Quintet @ 🐘9pm on May 16, 9:00PM</span>
+        <br>
+        <span class="byline" data-share-dialog-target="byline">
+        </span>
+      </div>
+    </div>
+
+    <ul class="share_icons">
+      <li class="threads">
+        <a href="#" data-share-dialog-target="threadsLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM23.7524 16.9806C23.8587 17.0263 23.9638 17.074 24.0671 17.1235C25.5284 17.8245 26.597 18.8859 27.1575 20.1926C27.9387 22.0149 28.0101 24.9832 25.6397 27.3514C23.828 29.1615 21.6287 29.9784 18.5087 30H18.4946C14.9852 29.9757 12.2865 28.7948 10.4735 26.4901C8.86024 24.4393 8.02805 21.5855 8.00009 18.0084L8 18L8.00009 17.9916C8.02805 14.4145 8.86024 11.5608 10.4735 9.50991C12.2865 7.20522 14.9852 6.02431 18.4946 6H18.5087C22.0252 6.02439 24.7545 7.20084 26.6206 9.49675C27.5414 10.6295 28.218 11.9953 28.648 13.5803L26.6296 14.1188C26.2749 12.8311 25.7368 11.7267 25.023 10.8485C23.5674 9.05767 21.3735 8.13891 18.5016 8.11756C15.6505 8.13875 13.4942 9.05311 12.0923 10.8353C10.7794 12.5042 10.101 14.9147 10.0757 18C10.101 21.0853 10.7794 23.4958 12.0923 25.1646C13.4942 26.9469 15.6505 27.8612 18.5017 27.8824C21.072 27.8635 22.7728 27.252 24.1876 25.8385C25.8025 24.225 25.7724 22.2459 25.2559 21.0415C24.9521 20.333 24.4021 19.7436 23.66 19.2957C23.4792 20.6429 23.0699 21.712 22.4226 22.537C21.5704 23.6234 20.3487 24.2175 18.7915 24.3029C17.6124 24.3673 16.4778 24.0829 15.5969 23.5014C14.555 22.8135 13.9452 21.7605 13.8799 20.5365C13.7514 18.1235 15.6656 16.3869 18.6431 16.2154C19.7001 16.1548 20.6889 16.2026 21.6031 16.358C21.4818 15.6156 21.2366 15.0274 20.8701 14.6018C20.3665 14.0171 19.5884 13.7173 18.5572 13.7107L18.5286 13.7106C17.7006 13.7106 16.5765 13.9423 15.8601 15.0291L14.1378 13.8476C15.0966 12.3926 16.6546 11.593 18.5278 11.593L18.5702 11.5931C21.702 11.6131 23.5671 13.5673 23.7524 16.9806ZM15.9524 20.4215C16.0193 21.6761 17.3751 22.2619 18.6801 22.1884C19.9578 22.1182 21.408 21.6169 21.6553 18.5291C20.9924 18.3842 20.2633 18.3085 19.4839 18.3085C19.247 18.3085 19.0059 18.3154 18.7602 18.3296C16.6145 18.4533 15.9029 19.4913 15.9524 20.4215Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="facebook">
+        <a href="#" data-share-dialog-target="facebookLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon"><path fill-rule="evenodd" d="M9 0a9 9 0 110 18A9 9 0 019 0zm2.606 4H10.24c-1.575 0-2.17.77-2.215 2.076l-.002.166v1.034H7V9h1.023V14h2.046V9h1.365l.181-1.724H10.07l.003-.862c0-.417.036-.655.553-.687l.128-.003h.853V4z"></path></svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="twitter">
+        <a href="#" data-share-dialog-target="twitterLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="685" data-popup-window-height-value="246" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM26.4163 9L19.7142 16.6226L27.0001 27H21.6396L16.7316 20.0104L10.5876 27H9L16.0278 19.0075L9 9H14.3604L19.0068 15.6173L24.8287 9H26.4163ZM13.5996 10.1714H11.1606L22.3878 25.8861H24.8275L13.5996 10.1714Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="email">
+        <a href="#" data-share-dialog-target="emailLink" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18 9C18 4.02944 13.9706 0 9 0C4.02944 0 0 4.02944 0 9C0 13.9706 4.02944 18 9 18C13.9706 18 18 13.9706 18 9ZM4.02511 5.73566C4.00872 5.77691 4.00004 5.82153 4.00004 5.86854L4 12.1317C4 12.1897 4.0135 12.2449 4.03762 12.2938C4.04581 12.2775 4.05691 12.2621 4.07041 12.2482L7.39793 8.87439L4.0772 5.81961C4.05116 5.79611 4.0338 5.76684 4.02511 5.73566ZM4.34327 12.4991L4.34195 12.499L7.67 9.12427L8.60412 9.98343C8.86598 10.2242 9.26962 10.2228 9.52956 9.98007L10.4564 9.11563L13.768 12.4736C13.7251 12.4904 13.6783 12.5 13.6296 12.5H4.3704C4.3612 12.5 4.35243 12.4996 4.34327 12.4991ZM13.9971 12.1795L10.727 8.86376L13.9913 5.81857C13.9932 5.81713 13.9947 5.81569 13.9961 5.81425C13.9986 5.832 14 5.85023 14 5.86846V12.1315C14 12.1478 13.999 12.1637 13.9971 12.1795ZM13.7686 5.52686C13.7257 5.50959 13.6789 5.5 13.6297 5.5L4.37041 5.50006C4.33617 5.50006 4.30338 5.50486 4.27155 5.5135C4.29229 5.52117 4.31158 5.53316 4.32846 5.549L8.85585 9.71283C8.97448 9.8222 9.15822 9.82172 9.27637 9.71139L13.7382 5.54989C13.7479 5.54077 13.758 5.5331 13.7686 5.52686Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+    </ul>
+    <div class="permalink" data-controller="clipboard">
+      <p>Share link</p>
+      <div class="control -has-addons">
+        <input type="text" value="https://elephantroom.com/event/4558265/762545998/jerry-espinoza-quintet" data-clipboard-target="source" data-share-dialog-target="urlInput" data-action="click->share-dialog#selectUrl" readonly="true">
+        <span class="control__suffix">
+          <a class="button -simple -compact -icon-only" data-clipboard-target="button" data-action="clipboard#copy">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="icon" width="16px" height="18px"><path d="M4.166.597c-.184 0-.369.15-.369.342v1.365c0 .191.185.341.369.341h9.189v9.216c0 .191.15.342.341.342h1.365c.191 0 .342-.15.342-.342V.94a.338.338 0 00-.342-.342H4.166zm7.44 3.798H.34A.338.338 0 000 4.736v10.923c0 .19.15.341.341.341h10.923c.191 0 .341-.15.341-.341V4.395z" fill-rule="evenodd"></path></svg>
+          </a>
+        </span>
+      </div>
+    </div>
+  </dialog>
+</div>
+</div>
+
+
+      <div class="event-info map-link pdf__hide">
+        <a target="_blank" rel="noopener" href="https://www.google.com/maps/search/?api=1&amp;query=%F0%9F%90%989pm">View on Google Maps</a>
+      </div>
+  </div>
+</div>
+
+<div class="event-clear"></div>
+
+</article>
+<article class="list-style">
+  
+<div class="event-detail" data-event-id="6505037" data-occurrence-id="757033091">
+  <div class="event-image image-social">
+      <a rel="event[6505037]" title="Luke Allen Quartet" class="thumbnail-popup" data-featherlight="//images.zoogletools.com/s:bzglfiles/u/523260/e5cb77f23699b2b9749bbda0e44e374d30b324a3/original/d677ad31-ad85-4d1e-ac71-bece01a4909b-img-0603.jpeg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" href="//images.zoogletools.com/s:bzglfiles/u/523260/e5cb77f23699b2b9749bbda0e44e374d30b324a3/original/d677ad31-ad85-4d1e-ac71-bece01a4909b-img-0603.jpeg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg">
+        <img alt="Luke Allen Quartet" src="//images.zoogletools.com/s:bzglfiles/u/523260/e5cb77f23699b2b9749bbda0e44e374d30b324a3/original/d677ad31-ad85-4d1e-ac71-bece01a4909b-img-0603.jpeg/!!/b%3AW1sicmVzaXplIixbMjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>  </div>
+
+  <div class="event-description">
+    <div class="event-info-wrapper">
+        <h2 class="event-info event-title heading-tertiary"><a href="https://elephantroom.com/event/6505037/757033091/luke-allen-quartet">Luke Allen Quartet</a></h2>
+
+        <p class="event-info event-datetime">
+          <i class="icon-clock"></i>
+          <span class="date-long"><span class="event-when with-time"><time class="from"><span class="date">Sunday, May 17</span> @ <span class="time">8:00PM</span></time></span></span><span class="date-short"><span class="event-when with-time"><time class="from"><span class="date">Sun, May 17</span> @ <span class="time">8:00PM</span></time></span></span>
+        </p>
+
+        <p class="event-info event-location">
+          <i class="icon-location"></i>
+          <a target="_blank" rel="noopener" title="View on Google Maps" href="https://www.google.com/maps/search/?api=1&amp;query=%F0%9F%90%988pm">🐘8pm</a>
+        </p>
+    </div>
+
+      <div class="event-info event-notes"><p>Jazz trumpeter and vocalist Luke Allen has become known for his high energy stage presence, classic vocal style, and joyful delivery.  Inspired by the great jazz vocal recordings of Nat King Cole, Chet Baker and Ray Charles,
+Luke is dedicated to the American songbook. He's been heard with numerous local bands, including the
+Joymakers, the Jazz Pharaohs, the David Chao Quartet and now debuts his own band down in the basement!</p>
+</div>
+
+    <p class="event-info">
+      
+    </p>
+
+
+    <div class="event-info buying-options product-action pdf__hide">
+
+    <div data-controller="share-dialog" data-share-dialog-url-value="https://elephantroom.com/event/6505037/757033091/luke-allen-quartet" data-share-dialog-title-value="Luke Allen Quartet @ 🐘8pm on May 17, 8:00PM" data-share-dialog-text-value="Elephant Room @ Luke Allen Quartet @ 🐘8pm, May 17, 8:00PM" data-share-dialog-fb-app-id-value="286076425227">
+  <a class="button button-tertiary zoogle-share pdf__hide" title="Share Luke Allen Quartet @ 🐘8pm on May 17, 8:00PM" data-action="click-&gt;share-dialog#open" href="javascript:void(0)">
+    <i class="icon-share"></i>Share
+</a>
+  <dialog data-share-dialog-target="dialog" data-action="click->share-dialog#clickOutside" class="dialog dialog-share style-section-style-1">
+    <button class="dialog-close" data-action="click-&gt;share-dialog#close" aria-label="close">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11 11" class="icon" width="12px" height="12px"><path d="M6.755 5.502l3.836 3.97-1.438 1.39-3.81-3.942-3.926 3.942L0 9.452 3.953 5.48 0 1.39 1.438 0l3.927 4.064L9.41 0l1.417 1.411-4.073 4.091z" fill-rule="evenodd"></path></svg>
+</button>    <div class="share_desc">
+      <div>
+        <span data-share-dialog-target="title">Luke Allen Quartet @ 🐘8pm on May 17, 8:00PM</span>
+        <br>
+        <span class="byline" data-share-dialog-target="byline">
+        </span>
+      </div>
+    </div>
+
+    <ul class="share_icons">
+      <li class="threads">
+        <a href="#" data-share-dialog-target="threadsLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM23.7524 16.9806C23.8587 17.0263 23.9638 17.074 24.0671 17.1235C25.5284 17.8245 26.597 18.8859 27.1575 20.1926C27.9387 22.0149 28.0101 24.9832 25.6397 27.3514C23.828 29.1615 21.6287 29.9784 18.5087 30H18.4946C14.9852 29.9757 12.2865 28.7948 10.4735 26.4901C8.86024 24.4393 8.02805 21.5855 8.00009 18.0084L8 18L8.00009 17.9916C8.02805 14.4145 8.86024 11.5608 10.4735 9.50991C12.2865 7.20522 14.9852 6.02431 18.4946 6H18.5087C22.0252 6.02439 24.7545 7.20084 26.6206 9.49675C27.5414 10.6295 28.218 11.9953 28.648 13.5803L26.6296 14.1188C26.2749 12.8311 25.7368 11.7267 25.023 10.8485C23.5674 9.05767 21.3735 8.13891 18.5016 8.11756C15.6505 8.13875 13.4942 9.05311 12.0923 10.8353C10.7794 12.5042 10.101 14.9147 10.0757 18C10.101 21.0853 10.7794 23.4958 12.0923 25.1646C13.4942 26.9469 15.6505 27.8612 18.5017 27.8824C21.072 27.8635 22.7728 27.252 24.1876 25.8385C25.8025 24.225 25.7724 22.2459 25.2559 21.0415C24.9521 20.333 24.4021 19.7436 23.66 19.2957C23.4792 20.6429 23.0699 21.712 22.4226 22.537C21.5704 23.6234 20.3487 24.2175 18.7915 24.3029C17.6124 24.3673 16.4778 24.0829 15.5969 23.5014C14.555 22.8135 13.9452 21.7605 13.8799 20.5365C13.7514 18.1235 15.6656 16.3869 18.6431 16.2154C19.7001 16.1548 20.6889 16.2026 21.6031 16.358C21.4818 15.6156 21.2366 15.0274 20.8701 14.6018C20.3665 14.0171 19.5884 13.7173 18.5572 13.7107L18.5286 13.7106C17.7006 13.7106 16.5765 13.9423 15.8601 15.0291L14.1378 13.8476C15.0966 12.3926 16.6546 11.593 18.5278 11.593L18.5702 11.5931C21.702 11.6131 23.5671 13.5673 23.7524 16.9806ZM15.9524 20.4215C16.0193 21.6761 17.3751 22.2619 18.6801 22.1884C19.9578 22.1182 21.408 21.6169 21.6553 18.5291C20.9924 18.3842 20.2633 18.3085 19.4839 18.3085C19.247 18.3085 19.0059 18.3154 18.7602 18.3296C16.6145 18.4533 15.9029 19.4913 15.9524 20.4215Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="facebook">
+        <a href="#" data-share-dialog-target="facebookLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon"><path fill-rule="evenodd" d="M9 0a9 9 0 110 18A9 9 0 019 0zm2.606 4H10.24c-1.575 0-2.17.77-2.215 2.076l-.002.166v1.034H7V9h1.023V14h2.046V9h1.365l.181-1.724H10.07l.003-.862c0-.417.036-.655.553-.687l.128-.003h.853V4z"></path></svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="twitter">
+        <a href="#" data-share-dialog-target="twitterLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="685" data-popup-window-height-value="246" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM26.4163 9L19.7142 16.6226L27.0001 27H21.6396L16.7316 20.0104L10.5876 27H9L16.0278 19.0075L9 9H14.3604L19.0068 15.6173L24.8287 9H26.4163ZM13.5996 10.1714H11.1606L22.3878 25.8861H24.8275L13.5996 10.1714Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="email">
+        <a href="#" data-share-dialog-target="emailLink" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18 9C18 4.02944 13.9706 0 9 0C4.02944 0 0 4.02944 0 9C0 13.9706 4.02944 18 9 18C13.9706 18 18 13.9706 18 9ZM4.02511 5.73566C4.00872 5.77691 4.00004 5.82153 4.00004 5.86854L4 12.1317C4 12.1897 4.0135 12.2449 4.03762 12.2938C4.04581 12.2775 4.05691 12.2621 4.07041 12.2482L7.39793 8.87439L4.0772 5.81961C4.05116 5.79611 4.0338 5.76684 4.02511 5.73566ZM4.34327 12.4991L4.34195 12.499L7.67 9.12427L8.60412 9.98343C8.86598 10.2242 9.26962 10.2228 9.52956 9.98007L10.4564 9.11563L13.768 12.4736C13.7251 12.4904 13.6783 12.5 13.6296 12.5H4.3704C4.3612 12.5 4.35243 12.4996 4.34327 12.4991ZM13.9971 12.1795L10.727 8.86376L13.9913 5.81857C13.9932 5.81713 13.9947 5.81569 13.9961 5.81425C13.9986 5.832 14 5.85023 14 5.86846V12.1315C14 12.1478 13.999 12.1637 13.9971 12.1795ZM13.7686 5.52686C13.7257 5.50959 13.6789 5.5 13.6297 5.5L4.37041 5.50006C4.33617 5.50006 4.30338 5.50486 4.27155 5.5135C4.29229 5.52117 4.31158 5.53316 4.32846 5.549L8.85585 9.71283C8.97448 9.8222 9.15822 9.82172 9.27637 9.71139L13.7382 5.54989C13.7479 5.54077 13.758 5.5331 13.7686 5.52686Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+    </ul>
+    <div class="permalink" data-controller="clipboard">
+      <p>Share link</p>
+      <div class="control -has-addons">
+        <input type="text" value="https://elephantroom.com/event/6505037/757033091/luke-allen-quartet" data-clipboard-target="source" data-share-dialog-target="urlInput" data-action="click->share-dialog#selectUrl" readonly="true">
+        <span class="control__suffix">
+          <a class="button -simple -compact -icon-only" data-clipboard-target="button" data-action="clipboard#copy">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="icon" width="16px" height="18px"><path d="M4.166.597c-.184 0-.369.15-.369.342v1.365c0 .191.185.341.369.341h9.189v9.216c0 .191.15.342.341.342h1.365c.191 0 .342-.15.342-.342V.94a.338.338 0 00-.342-.342H4.166zm7.44 3.798H.34A.338.338 0 000 4.736v10.923c0 .19.15.341.341.341h10.923c.191 0 .341-.15.341-.341V4.395z" fill-rule="evenodd"></path></svg>
+          </a>
+        </span>
+      </div>
+    </div>
+  </dialog>
+</div>
+</div>
+
+
+      <div class="event-info map-link pdf__hide">
+        <a target="_blank" rel="noopener" href="https://www.google.com/maps/search/?api=1&amp;query=%F0%9F%90%988pm">View on Google Maps</a>
+      </div>
+  </div>
+</div>
+
+<div class="event-clear"></div>
+
+</article>
+<article class="list-style">
+  
+<div class="event-detail" data-event-id="4489021" data-occurrence-id="756908011">
+  <div class="event-image image-social">
+      <a rel="event[4489021]" title="Austin Jazz Band" class="thumbnail-popup" data-featherlight="//images.zoogletools.com/s:bzglfiles/u/523260/16e3711f5210635ea9ab2d02c56dd2d4d0dbf1c1/original/austinjazzband.png/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.png" href="//images.zoogletools.com/s:bzglfiles/u/523260/16e3711f5210635ea9ab2d02c56dd2d4d0dbf1c1/original/austinjazzband.png/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.png">
+        <img alt="Austin Jazz Band" src="//images.zoogletools.com/s:bzglfiles/u/523260/16e3711f5210635ea9ab2d02c56dd2d4d0dbf1c1/original/austinjazzband.png/!!/b%3AW1sicmVzaXplIixbMjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.png" />
+</a>  </div>
+
+  <div class="event-description">
+    <div class="event-info-wrapper">
+        <h2 class="event-info event-title heading-tertiary"><a href="https://elephantroom.com/event/4489021/756908011/austin-jazz-band">Austin Jazz Band</a></h2>
+
+        <p class="event-info event-datetime">
+          <i class="icon-clock"></i>
+          <span class="date-long"><span class="event-when with-time"><time class="from"><span class="date">Monday, May 18</span> @ <span class="time">7:00PM</span></time></span></span><span class="date-short"><span class="event-when with-time"><time class="from"><span class="date">Mon, May 18</span> @ <span class="time">7:00PM</span></time></span></span>
+        </p>
+
+        <p class="event-info event-location">
+          <i class="icon-location"></i>
+          <a target="_blank" rel="noopener" title="Visit venue website" href="https://austinjazzband.org/home">🐘7pm Show</a>
+        </p>
+    </div>
+
+      <div class="event-info event-notes"><p>Founded in 1993 by Bobby Davis and trumpeter Steve Fleckman to bring professionals and amateurs together to celebrate their love and respect for the art of jazz in a BIG way!  Now under the direction of Brian Bettger, this group has developed into one of the top  big bands in Texas.</p>
+</div>
+
+    <p class="event-info">
+      
+    </p>
+
+
+    <div class="event-info buying-options product-action pdf__hide">
+
+    <div data-controller="share-dialog" data-share-dialog-url-value="https://elephantroom.com/event/4489021/756908011/austin-jazz-band" data-share-dialog-title-value="Austin Jazz Band @ 🐘7pm Show on May 18, 7:00PM" data-share-dialog-text-value="Elephant Room @ Austin Jazz Band @ 🐘7pm Show, May 18, 7:00PM" data-share-dialog-fb-app-id-value="286076425227">
+  <a class="button button-tertiary zoogle-share pdf__hide" title="Share Austin Jazz Band @ 🐘7pm Show on May 18, 7:00PM" data-action="click-&gt;share-dialog#open" href="javascript:void(0)">
+    <i class="icon-share"></i>Share
+</a>
+  <dialog data-share-dialog-target="dialog" data-action="click->share-dialog#clickOutside" class="dialog dialog-share style-section-style-1">
+    <button class="dialog-close" data-action="click-&gt;share-dialog#close" aria-label="close">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11 11" class="icon" width="12px" height="12px"><path d="M6.755 5.502l3.836 3.97-1.438 1.39-3.81-3.942-3.926 3.942L0 9.452 3.953 5.48 0 1.39 1.438 0l3.927 4.064L9.41 0l1.417 1.411-4.073 4.091z" fill-rule="evenodd"></path></svg>
+</button>    <div class="share_desc">
+      <div>
+        <span data-share-dialog-target="title">Austin Jazz Band @ 🐘7pm Show on May 18, 7:00PM</span>
+        <br>
+        <span class="byline" data-share-dialog-target="byline">
+        </span>
+      </div>
+    </div>
+
+    <ul class="share_icons">
+      <li class="threads">
+        <a href="#" data-share-dialog-target="threadsLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM23.7524 16.9806C23.8587 17.0263 23.9638 17.074 24.0671 17.1235C25.5284 17.8245 26.597 18.8859 27.1575 20.1926C27.9387 22.0149 28.0101 24.9832 25.6397 27.3514C23.828 29.1615 21.6287 29.9784 18.5087 30H18.4946C14.9852 29.9757 12.2865 28.7948 10.4735 26.4901C8.86024 24.4393 8.02805 21.5855 8.00009 18.0084L8 18L8.00009 17.9916C8.02805 14.4145 8.86024 11.5608 10.4735 9.50991C12.2865 7.20522 14.9852 6.02431 18.4946 6H18.5087C22.0252 6.02439 24.7545 7.20084 26.6206 9.49675C27.5414 10.6295 28.218 11.9953 28.648 13.5803L26.6296 14.1188C26.2749 12.8311 25.7368 11.7267 25.023 10.8485C23.5674 9.05767 21.3735 8.13891 18.5016 8.11756C15.6505 8.13875 13.4942 9.05311 12.0923 10.8353C10.7794 12.5042 10.101 14.9147 10.0757 18C10.101 21.0853 10.7794 23.4958 12.0923 25.1646C13.4942 26.9469 15.6505 27.8612 18.5017 27.8824C21.072 27.8635 22.7728 27.252 24.1876 25.8385C25.8025 24.225 25.7724 22.2459 25.2559 21.0415C24.9521 20.333 24.4021 19.7436 23.66 19.2957C23.4792 20.6429 23.0699 21.712 22.4226 22.537C21.5704 23.6234 20.3487 24.2175 18.7915 24.3029C17.6124 24.3673 16.4778 24.0829 15.5969 23.5014C14.555 22.8135 13.9452 21.7605 13.8799 20.5365C13.7514 18.1235 15.6656 16.3869 18.6431 16.2154C19.7001 16.1548 20.6889 16.2026 21.6031 16.358C21.4818 15.6156 21.2366 15.0274 20.8701 14.6018C20.3665 14.0171 19.5884 13.7173 18.5572 13.7107L18.5286 13.7106C17.7006 13.7106 16.5765 13.9423 15.8601 15.0291L14.1378 13.8476C15.0966 12.3926 16.6546 11.593 18.5278 11.593L18.5702 11.5931C21.702 11.6131 23.5671 13.5673 23.7524 16.9806ZM15.9524 20.4215C16.0193 21.6761 17.3751 22.2619 18.6801 22.1884C19.9578 22.1182 21.408 21.6169 21.6553 18.5291C20.9924 18.3842 20.2633 18.3085 19.4839 18.3085C19.247 18.3085 19.0059 18.3154 18.7602 18.3296C16.6145 18.4533 15.9029 19.4913 15.9524 20.4215Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="facebook">
+        <a href="#" data-share-dialog-target="facebookLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon"><path fill-rule="evenodd" d="M9 0a9 9 0 110 18A9 9 0 019 0zm2.606 4H10.24c-1.575 0-2.17.77-2.215 2.076l-.002.166v1.034H7V9h1.023V14h2.046V9h1.365l.181-1.724H10.07l.003-.862c0-.417.036-.655.553-.687l.128-.003h.853V4z"></path></svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="twitter">
+        <a href="#" data-share-dialog-target="twitterLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="685" data-popup-window-height-value="246" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM26.4163 9L19.7142 16.6226L27.0001 27H21.6396L16.7316 20.0104L10.5876 27H9L16.0278 19.0075L9 9H14.3604L19.0068 15.6173L24.8287 9H26.4163ZM13.5996 10.1714H11.1606L22.3878 25.8861H24.8275L13.5996 10.1714Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="email">
+        <a href="#" data-share-dialog-target="emailLink" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18 9C18 4.02944 13.9706 0 9 0C4.02944 0 0 4.02944 0 9C0 13.9706 4.02944 18 9 18C13.9706 18 18 13.9706 18 9ZM4.02511 5.73566C4.00872 5.77691 4.00004 5.82153 4.00004 5.86854L4 12.1317C4 12.1897 4.0135 12.2449 4.03762 12.2938C4.04581 12.2775 4.05691 12.2621 4.07041 12.2482L7.39793 8.87439L4.0772 5.81961C4.05116 5.79611 4.0338 5.76684 4.02511 5.73566ZM4.34327 12.4991L4.34195 12.499L7.67 9.12427L8.60412 9.98343C8.86598 10.2242 9.26962 10.2228 9.52956 9.98007L10.4564 9.11563L13.768 12.4736C13.7251 12.4904 13.6783 12.5 13.6296 12.5H4.3704C4.3612 12.5 4.35243 12.4996 4.34327 12.4991ZM13.9971 12.1795L10.727 8.86376L13.9913 5.81857C13.9932 5.81713 13.9947 5.81569 13.9961 5.81425C13.9986 5.832 14 5.85023 14 5.86846V12.1315C14 12.1478 13.999 12.1637 13.9971 12.1795ZM13.7686 5.52686C13.7257 5.50959 13.6789 5.5 13.6297 5.5L4.37041 5.50006C4.33617 5.50006 4.30338 5.50486 4.27155 5.5135C4.29229 5.52117 4.31158 5.53316 4.32846 5.549L8.85585 9.71283C8.97448 9.8222 9.15822 9.82172 9.27637 9.71139L13.7382 5.54989C13.7479 5.54077 13.758 5.5331 13.7686 5.52686Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+    </ul>
+    <div class="permalink" data-controller="clipboard">
+      <p>Share link</p>
+      <div class="control -has-addons">
+        <input type="text" value="https://elephantroom.com/event/4489021/756908011/austin-jazz-band" data-clipboard-target="source" data-share-dialog-target="urlInput" data-action="click->share-dialog#selectUrl" readonly="true">
+        <span class="control__suffix">
+          <a class="button -simple -compact -icon-only" data-clipboard-target="button" data-action="clipboard#copy">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="icon" width="16px" height="18px"><path d="M4.166.597c-.184 0-.369.15-.369.342v1.365c0 .191.185.341.369.341h9.189v9.216c0 .191.15.342.341.342h1.365c.191 0 .342-.15.342-.342V.94a.338.338 0 00-.342-.342H4.166zm7.44 3.798H.34A.338.338 0 000 4.736v10.923c0 .19.15.341.341.341h10.923c.191 0 .341-.15.341-.341V4.395z" fill-rule="evenodd"></path></svg>
+          </a>
+        </span>
+      </div>
+    </div>
+  </dialog>
+</div>
+</div>
+
+
+      <div class="event-info map-link pdf__hide">
+        <a target="_blank" rel="noopener" href="https://www.google.com/maps/search/?api=1&amp;query=%F0%9F%90%987pm%20Show">View on Google Maps</a>
+      </div>
+  </div>
+</div>
+
+<div class="event-clear"></div>
+
+</article>
+<article class="list-style">
+  
+<div class="event-detail" data-event-id="4489016" data-occurrence-id="762545913">
+  <div class="event-image image-social">
+      <a rel="event[4489016]" title="Michael Mordecai Jazz Jam" class="thumbnail-popup" data-featherlight="//images.zoogletools.com/s:bzglfiles/u/523260/1075b1c93f99c59916fac0aa596ef3f936d4b6dc/original/michael-trombone-bell.jpg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" href="//images.zoogletools.com/s:bzglfiles/u/523260/1075b1c93f99c59916fac0aa596ef3f936d4b6dc/original/michael-trombone-bell.jpg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg">
+        <img alt="Michael Mordecai Jazz Jam" src="//images.zoogletools.com/s:bzglfiles/u/523260/1075b1c93f99c59916fac0aa596ef3f936d4b6dc/original/michael-trombone-bell.jpg/!!/b%3AW1sicmVzaXplIixbMjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>  </div>
+
+  <div class="event-description">
+    <div class="event-info-wrapper">
+        <h2 class="event-info event-title heading-tertiary"><a href="https://elephantroom.com/event/4489016/762545913/michael-mordecai-jazz-jam">Michael Mordecai Jazz Jam</a></h2>
+
+        <p class="event-info event-datetime">
+          <i class="icon-clock"></i>
+          <span class="date-long"><span class="event-when with-time"><time class="from"><span class="date">Monday, May 18</span> @ <span class="time">9:00PM</span></time></span></span><span class="date-short"><span class="event-when with-time"><time class="from"><span class="date">Mon, May 18</span> @ <span class="time">9:00PM</span></time></span></span>
+        </p>
+
+        <p class="event-info event-location">
+          <i class="icon-location"></i>
+          <a target="_blank" rel="noopener" title="Visit venue website" href="www.michaelmordecai.com">🐘9pm</a>
+        </p>
+    </div>
+
+      <div class="event-info event-notes"><p>Michael Mordecai has been hosting his Monday Night Jam since 1980.  When the Elephant Room opened in 1991 he found it's permanent home sweet home.  Many Austin Jazz greats cut their teeth at this unassuming Monday night hang.  You just never know who might show up or what musical jam moment might spark the next cool collaboration.</p>
+</div>
+
+    <p class="event-info">
+      
+    </p>
+
+
+    <div class="event-info buying-options product-action pdf__hide">
+
+    <div data-controller="share-dialog" data-share-dialog-url-value="https://elephantroom.com/event/4489016/762545913/michael-mordecai-jazz-jam" data-share-dialog-title-value="Michael Mordecai Jazz Jam @ 🐘9pm on May 18, 9:00PM" data-share-dialog-text-value="Elephant Room @ Michael Mordecai Jazz Jam @ 🐘9pm, May 18, 9:00PM" data-share-dialog-fb-app-id-value="286076425227">
+  <a class="button button-tertiary zoogle-share pdf__hide" title="Share Michael Mordecai Jazz Jam @ 🐘9pm on May 18, 9:00PM" data-action="click-&gt;share-dialog#open" href="javascript:void(0)">
+    <i class="icon-share"></i>Share
+</a>
+  <dialog data-share-dialog-target="dialog" data-action="click->share-dialog#clickOutside" class="dialog dialog-share style-section-style-1">
+    <button class="dialog-close" data-action="click-&gt;share-dialog#close" aria-label="close">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11 11" class="icon" width="12px" height="12px"><path d="M6.755 5.502l3.836 3.97-1.438 1.39-3.81-3.942-3.926 3.942L0 9.452 3.953 5.48 0 1.39 1.438 0l3.927 4.064L9.41 0l1.417 1.411-4.073 4.091z" fill-rule="evenodd"></path></svg>
+</button>    <div class="share_desc">
+      <div>
+        <span data-share-dialog-target="title">Michael Mordecai Jazz Jam @ 🐘9pm on May 18, 9:00PM</span>
+        <br>
+        <span class="byline" data-share-dialog-target="byline">
+        </span>
+      </div>
+    </div>
+
+    <ul class="share_icons">
+      <li class="threads">
+        <a href="#" data-share-dialog-target="threadsLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM23.7524 16.9806C23.8587 17.0263 23.9638 17.074 24.0671 17.1235C25.5284 17.8245 26.597 18.8859 27.1575 20.1926C27.9387 22.0149 28.0101 24.9832 25.6397 27.3514C23.828 29.1615 21.6287 29.9784 18.5087 30H18.4946C14.9852 29.9757 12.2865 28.7948 10.4735 26.4901C8.86024 24.4393 8.02805 21.5855 8.00009 18.0084L8 18L8.00009 17.9916C8.02805 14.4145 8.86024 11.5608 10.4735 9.50991C12.2865 7.20522 14.9852 6.02431 18.4946 6H18.5087C22.0252 6.02439 24.7545 7.20084 26.6206 9.49675C27.5414 10.6295 28.218 11.9953 28.648 13.5803L26.6296 14.1188C26.2749 12.8311 25.7368 11.7267 25.023 10.8485C23.5674 9.05767 21.3735 8.13891 18.5016 8.11756C15.6505 8.13875 13.4942 9.05311 12.0923 10.8353C10.7794 12.5042 10.101 14.9147 10.0757 18C10.101 21.0853 10.7794 23.4958 12.0923 25.1646C13.4942 26.9469 15.6505 27.8612 18.5017 27.8824C21.072 27.8635 22.7728 27.252 24.1876 25.8385C25.8025 24.225 25.7724 22.2459 25.2559 21.0415C24.9521 20.333 24.4021 19.7436 23.66 19.2957C23.4792 20.6429 23.0699 21.712 22.4226 22.537C21.5704 23.6234 20.3487 24.2175 18.7915 24.3029C17.6124 24.3673 16.4778 24.0829 15.5969 23.5014C14.555 22.8135 13.9452 21.7605 13.8799 20.5365C13.7514 18.1235 15.6656 16.3869 18.6431 16.2154C19.7001 16.1548 20.6889 16.2026 21.6031 16.358C21.4818 15.6156 21.2366 15.0274 20.8701 14.6018C20.3665 14.0171 19.5884 13.7173 18.5572 13.7107L18.5286 13.7106C17.7006 13.7106 16.5765 13.9423 15.8601 15.0291L14.1378 13.8476C15.0966 12.3926 16.6546 11.593 18.5278 11.593L18.5702 11.5931C21.702 11.6131 23.5671 13.5673 23.7524 16.9806ZM15.9524 20.4215C16.0193 21.6761 17.3751 22.2619 18.6801 22.1884C19.9578 22.1182 21.408 21.6169 21.6553 18.5291C20.9924 18.3842 20.2633 18.3085 19.4839 18.3085C19.247 18.3085 19.0059 18.3154 18.7602 18.3296C16.6145 18.4533 15.9029 19.4913 15.9524 20.4215Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="facebook">
+        <a href="#" data-share-dialog-target="facebookLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon"><path fill-rule="evenodd" d="M9 0a9 9 0 110 18A9 9 0 019 0zm2.606 4H10.24c-1.575 0-2.17.77-2.215 2.076l-.002.166v1.034H7V9h1.023V14h2.046V9h1.365l.181-1.724H10.07l.003-.862c0-.417.036-.655.553-.687l.128-.003h.853V4z"></path></svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="twitter">
+        <a href="#" data-share-dialog-target="twitterLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="685" data-popup-window-height-value="246" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM26.4163 9L19.7142 16.6226L27.0001 27H21.6396L16.7316 20.0104L10.5876 27H9L16.0278 19.0075L9 9H14.3604L19.0068 15.6173L24.8287 9H26.4163ZM13.5996 10.1714H11.1606L22.3878 25.8861H24.8275L13.5996 10.1714Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="email">
+        <a href="#" data-share-dialog-target="emailLink" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18 9C18 4.02944 13.9706 0 9 0C4.02944 0 0 4.02944 0 9C0 13.9706 4.02944 18 9 18C13.9706 18 18 13.9706 18 9ZM4.02511 5.73566C4.00872 5.77691 4.00004 5.82153 4.00004 5.86854L4 12.1317C4 12.1897 4.0135 12.2449 4.03762 12.2938C4.04581 12.2775 4.05691 12.2621 4.07041 12.2482L7.39793 8.87439L4.0772 5.81961C4.05116 5.79611 4.0338 5.76684 4.02511 5.73566ZM4.34327 12.4991L4.34195 12.499L7.67 9.12427L8.60412 9.98343C8.86598 10.2242 9.26962 10.2228 9.52956 9.98007L10.4564 9.11563L13.768 12.4736C13.7251 12.4904 13.6783 12.5 13.6296 12.5H4.3704C4.3612 12.5 4.35243 12.4996 4.34327 12.4991ZM13.9971 12.1795L10.727 8.86376L13.9913 5.81857C13.9932 5.81713 13.9947 5.81569 13.9961 5.81425C13.9986 5.832 14 5.85023 14 5.86846V12.1315C14 12.1478 13.999 12.1637 13.9971 12.1795ZM13.7686 5.52686C13.7257 5.50959 13.6789 5.5 13.6297 5.5L4.37041 5.50006C4.33617 5.50006 4.30338 5.50486 4.27155 5.5135C4.29229 5.52117 4.31158 5.53316 4.32846 5.549L8.85585 9.71283C8.97448 9.8222 9.15822 9.82172 9.27637 9.71139L13.7382 5.54989C13.7479 5.54077 13.758 5.5331 13.7686 5.52686Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+    </ul>
+    <div class="permalink" data-controller="clipboard">
+      <p>Share link</p>
+      <div class="control -has-addons">
+        <input type="text" value="https://elephantroom.com/event/4489016/762545913/michael-mordecai-jazz-jam" data-clipboard-target="source" data-share-dialog-target="urlInput" data-action="click->share-dialog#selectUrl" readonly="true">
+        <span class="control__suffix">
+          <a class="button -simple -compact -icon-only" data-clipboard-target="button" data-action="clipboard#copy">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="icon" width="16px" height="18px"><path d="M4.166.597c-.184 0-.369.15-.369.342v1.365c0 .191.185.341.369.341h9.189v9.216c0 .191.15.342.341.342h1.365c.191 0 .342-.15.342-.342V.94a.338.338 0 00-.342-.342H4.166zm7.44 3.798H.34A.338.338 0 000 4.736v10.923c0 .19.15.341.341.341h10.923c.191 0 .341-.15.341-.341V4.395z" fill-rule="evenodd"></path></svg>
+          </a>
+        </span>
+      </div>
+    </div>
+  </dialog>
+</div>
+</div>
+
+
+      <div class="event-info map-link pdf__hide">
+        <a target="_blank" rel="noopener" href="https://www.google.com/maps/search/?api=1&amp;query=%F0%9F%90%989pm">View on Google Maps</a>
+      </div>
+  </div>
+</div>
+
+<div class="event-clear"></div>
+
+</article>
+<article class="list-style">
+  
+<div class="event-detail" data-event-id="4315535" data-occurrence-id="763189023">
+  <div class="event-image image-social">
+      <a rel="event[4315535]" title="Mitch Watkins Trio" class="thumbnail-popup" data-featherlight="//images.zoogletools.com/s:bzglfiles/u/523260/96ac109ed301bc8b4d0400b31ecd30f84506e12b/original/mitchwatkins.jpg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" href="//images.zoogletools.com/s:bzglfiles/u/523260/96ac109ed301bc8b4d0400b31ecd30f84506e12b/original/mitchwatkins.jpg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg">
+        <img alt="Mitch Watkins Trio" src="//images.zoogletools.com/s:bzglfiles/u/523260/96ac109ed301bc8b4d0400b31ecd30f84506e12b/original/mitchwatkins.jpg/!!/b%3AW1sicmVzaXplIixbMjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>  </div>
+
+  <div class="event-description">
+    <div class="event-info-wrapper">
+        <h2 class="event-info event-title heading-tertiary"><a href="https://elephantroom.com/event/4315535/763189023/mitch-watkins-trio">Mitch Watkins Trio</a></h2>
+
+        <p class="event-info event-datetime">
+          <i class="icon-clock"></i>
+          <span class="date-long"><span class="event-when with-time"><time class="from"><span class="date">Tuesday, May 19</span> @ <span class="time">6:00PM</span></time></span></span><span class="date-short"><span class="event-when with-time"><time class="from"><span class="date">Tue, May 19</span> @ <span class="time">6:00PM</span></time></span></span>
+        </p>
+
+        <p class="event-info event-location">
+          <i class="icon-location"></i>
+          <a target="_blank" rel="noopener" title="Visit venue website" href="http://www.mitchwatkins.com/home.htm">🐘6pm</a>
+        </p>
+    </div>
+
+      <div class="event-info event-notes"><p>At 13 Mitch started playing guitar with a surf band in McAllen, Texas.  Years later he's traveling the world on multiple tours with Leonard Cohen.  You're gonna want to hear the sounds that have endeared this master guitarist to so many and who Jazz Times Magazine calls "a man for all musical seasons".</p>
+</div>
+
+    <p class="event-info">
+      
+    </p>
+
+
+    <div class="event-info buying-options product-action pdf__hide">
+
+    <div data-controller="share-dialog" data-share-dialog-url-value="https://elephantroom.com/event/4315535/763189023/mitch-watkins-trio" data-share-dialog-title-value="Mitch Watkins Trio @ 🐘6pm on May 19, 6:00PM" data-share-dialog-text-value="Elephant Room @ Mitch Watkins Trio @ 🐘6pm, May 19, 6:00PM" data-share-dialog-fb-app-id-value="286076425227">
+  <a class="button button-tertiary zoogle-share pdf__hide" title="Share Mitch Watkins Trio @ 🐘6pm on May 19, 6:00PM" data-action="click-&gt;share-dialog#open" href="javascript:void(0)">
+    <i class="icon-share"></i>Share
+</a>
+  <dialog data-share-dialog-target="dialog" data-action="click->share-dialog#clickOutside" class="dialog dialog-share style-section-style-1">
+    <button class="dialog-close" data-action="click-&gt;share-dialog#close" aria-label="close">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11 11" class="icon" width="12px" height="12px"><path d="M6.755 5.502l3.836 3.97-1.438 1.39-3.81-3.942-3.926 3.942L0 9.452 3.953 5.48 0 1.39 1.438 0l3.927 4.064L9.41 0l1.417 1.411-4.073 4.091z" fill-rule="evenodd"></path></svg>
+</button>    <div class="share_desc">
+      <div>
+        <span data-share-dialog-target="title">Mitch Watkins Trio @ 🐘6pm on May 19, 6:00PM</span>
+        <br>
+        <span class="byline" data-share-dialog-target="byline">
+        </span>
+      </div>
+    </div>
+
+    <ul class="share_icons">
+      <li class="threads">
+        <a href="#" data-share-dialog-target="threadsLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM23.7524 16.9806C23.8587 17.0263 23.9638 17.074 24.0671 17.1235C25.5284 17.8245 26.597 18.8859 27.1575 20.1926C27.9387 22.0149 28.0101 24.9832 25.6397 27.3514C23.828 29.1615 21.6287 29.9784 18.5087 30H18.4946C14.9852 29.9757 12.2865 28.7948 10.4735 26.4901C8.86024 24.4393 8.02805 21.5855 8.00009 18.0084L8 18L8.00009 17.9916C8.02805 14.4145 8.86024 11.5608 10.4735 9.50991C12.2865 7.20522 14.9852 6.02431 18.4946 6H18.5087C22.0252 6.02439 24.7545 7.20084 26.6206 9.49675C27.5414 10.6295 28.218 11.9953 28.648 13.5803L26.6296 14.1188C26.2749 12.8311 25.7368 11.7267 25.023 10.8485C23.5674 9.05767 21.3735 8.13891 18.5016 8.11756C15.6505 8.13875 13.4942 9.05311 12.0923 10.8353C10.7794 12.5042 10.101 14.9147 10.0757 18C10.101 21.0853 10.7794 23.4958 12.0923 25.1646C13.4942 26.9469 15.6505 27.8612 18.5017 27.8824C21.072 27.8635 22.7728 27.252 24.1876 25.8385C25.8025 24.225 25.7724 22.2459 25.2559 21.0415C24.9521 20.333 24.4021 19.7436 23.66 19.2957C23.4792 20.6429 23.0699 21.712 22.4226 22.537C21.5704 23.6234 20.3487 24.2175 18.7915 24.3029C17.6124 24.3673 16.4778 24.0829 15.5969 23.5014C14.555 22.8135 13.9452 21.7605 13.8799 20.5365C13.7514 18.1235 15.6656 16.3869 18.6431 16.2154C19.7001 16.1548 20.6889 16.2026 21.6031 16.358C21.4818 15.6156 21.2366 15.0274 20.8701 14.6018C20.3665 14.0171 19.5884 13.7173 18.5572 13.7107L18.5286 13.7106C17.7006 13.7106 16.5765 13.9423 15.8601 15.0291L14.1378 13.8476C15.0966 12.3926 16.6546 11.593 18.5278 11.593L18.5702 11.5931C21.702 11.6131 23.5671 13.5673 23.7524 16.9806ZM15.9524 20.4215C16.0193 21.6761 17.3751 22.2619 18.6801 22.1884C19.9578 22.1182 21.408 21.6169 21.6553 18.5291C20.9924 18.3842 20.2633 18.3085 19.4839 18.3085C19.247 18.3085 19.0059 18.3154 18.7602 18.3296C16.6145 18.4533 15.9029 19.4913 15.9524 20.4215Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="facebook">
+        <a href="#" data-share-dialog-target="facebookLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon"><path fill-rule="evenodd" d="M9 0a9 9 0 110 18A9 9 0 019 0zm2.606 4H10.24c-1.575 0-2.17.77-2.215 2.076l-.002.166v1.034H7V9h1.023V14h2.046V9h1.365l.181-1.724H10.07l.003-.862c0-.417.036-.655.553-.687l.128-.003h.853V4z"></path></svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="twitter">
+        <a href="#" data-share-dialog-target="twitterLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="685" data-popup-window-height-value="246" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM26.4163 9L19.7142 16.6226L27.0001 27H21.6396L16.7316 20.0104L10.5876 27H9L16.0278 19.0075L9 9H14.3604L19.0068 15.6173L24.8287 9H26.4163ZM13.5996 10.1714H11.1606L22.3878 25.8861H24.8275L13.5996 10.1714Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="email">
+        <a href="#" data-share-dialog-target="emailLink" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18 9C18 4.02944 13.9706 0 9 0C4.02944 0 0 4.02944 0 9C0 13.9706 4.02944 18 9 18C13.9706 18 18 13.9706 18 9ZM4.02511 5.73566C4.00872 5.77691 4.00004 5.82153 4.00004 5.86854L4 12.1317C4 12.1897 4.0135 12.2449 4.03762 12.2938C4.04581 12.2775 4.05691 12.2621 4.07041 12.2482L7.39793 8.87439L4.0772 5.81961C4.05116 5.79611 4.0338 5.76684 4.02511 5.73566ZM4.34327 12.4991L4.34195 12.499L7.67 9.12427L8.60412 9.98343C8.86598 10.2242 9.26962 10.2228 9.52956 9.98007L10.4564 9.11563L13.768 12.4736C13.7251 12.4904 13.6783 12.5 13.6296 12.5H4.3704C4.3612 12.5 4.35243 12.4996 4.34327 12.4991ZM13.9971 12.1795L10.727 8.86376L13.9913 5.81857C13.9932 5.81713 13.9947 5.81569 13.9961 5.81425C13.9986 5.832 14 5.85023 14 5.86846V12.1315C14 12.1478 13.999 12.1637 13.9971 12.1795ZM13.7686 5.52686C13.7257 5.50959 13.6789 5.5 13.6297 5.5L4.37041 5.50006C4.33617 5.50006 4.30338 5.50486 4.27155 5.5135C4.29229 5.52117 4.31158 5.53316 4.32846 5.549L8.85585 9.71283C8.97448 9.8222 9.15822 9.82172 9.27637 9.71139L13.7382 5.54989C13.7479 5.54077 13.758 5.5331 13.7686 5.52686Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+    </ul>
+    <div class="permalink" data-controller="clipboard">
+      <p>Share link</p>
+      <div class="control -has-addons">
+        <input type="text" value="https://elephantroom.com/event/4315535/763189023/mitch-watkins-trio" data-clipboard-target="source" data-share-dialog-target="urlInput" data-action="click->share-dialog#selectUrl" readonly="true">
+        <span class="control__suffix">
+          <a class="button -simple -compact -icon-only" data-clipboard-target="button" data-action="clipboard#copy">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="icon" width="16px" height="18px"><path d="M4.166.597c-.184 0-.369.15-.369.342v1.365c0 .191.185.341.369.341h9.189v9.216c0 .191.15.342.341.342h1.365c.191 0 .342-.15.342-.342V.94a.338.338 0 00-.342-.342H4.166zm7.44 3.798H.34A.338.338 0 000 4.736v10.923c0 .19.15.341.341.341h10.923c.191 0 .341-.15.341-.341V4.395z" fill-rule="evenodd"></path></svg>
+          </a>
+        </span>
+      </div>
+    </div>
+  </dialog>
+</div>
+</div>
+
+
+      <div class="event-info map-link pdf__hide">
+        <a target="_blank" rel="noopener" href="https://www.google.com/maps/search/?api=1&amp;query=%F0%9F%90%986pm">View on Google Maps</a>
+      </div>
+  </div>
+</div>
+
+<div class="event-clear"></div>
+
+</article>
+<article class="list-style">
+  
+<div class="event-detail" data-event-id="4912306" data-occurrence-id="763189033">
+  <div class="event-image image-social">
+      <a rel="event[4912306]" title="Zack Varner Quintet" class="thumbnail-popup" data-featherlight="//images.zoogletools.com/s:bzglfiles/u/523260/8a42a9e2a898cdc1cd1af240f36e18d4b34ac592/original/zack-varner.jpg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" href="//images.zoogletools.com/s:bzglfiles/u/523260/8a42a9e2a898cdc1cd1af240f36e18d4b34ac592/original/zack-varner.jpg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg">
+        <img alt="Zack Varner Quintet" src="//images.zoogletools.com/s:bzglfiles/u/523260/8a42a9e2a898cdc1cd1af240f36e18d4b34ac592/original/zack-varner.jpg/!!/b%3AW1sicmVzaXplIixbMjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>  </div>
+
+  <div class="event-description">
+    <div class="event-info-wrapper">
+        <h2 class="event-info event-title heading-tertiary"><a href="https://elephantroom.com/event/4912306/763189033/zack-varner-quintet">Zack Varner Quintet</a></h2>
+
+        <p class="event-info event-datetime">
+          <i class="icon-clock"></i>
+          <span class="date-long"><span class="event-when with-time"><time class="from"><span class="date">Tuesday, May 19</span> @ <span class="time">9:00PM</span></time></span></span><span class="date-short"><span class="event-when with-time"><time class="from"><span class="date">Tue, May 19</span> @ <span class="time">9:00PM</span></time></span></span>
+        </p>
+
+        <p class="event-info event-location">
+          <i class="icon-location"></i>
+          <a target="_blank" rel="noopener" title="View on Google Maps" href="https://www.google.com/maps/search/?api=1&amp;query=%F0%9F%90%98%209pm">🐘 9pm</a>
+        </p>
+    </div>
+
+      <div class="event-info event-notes"><p>Welcome back saxophonist extraordinaire Zack Varner!</p>
+</div>
+
+    <p class="event-info">
+      
+    </p>
+
+
+    <div class="event-info buying-options product-action pdf__hide">
+
+    <div data-controller="share-dialog" data-share-dialog-url-value="https://elephantroom.com/event/4912306/763189033/zack-varner-quintet" data-share-dialog-title-value="Zack Varner Quintet @ 🐘 9pm on May 19, 9:00PM" data-share-dialog-text-value="Elephant Room @ Zack Varner Quintet @ 🐘 9pm, May 19, 9:00PM" data-share-dialog-fb-app-id-value="286076425227">
+  <a class="button button-tertiary zoogle-share pdf__hide" title="Share Zack Varner Quintet @ 🐘 9pm on May 19, 9:00PM" data-action="click-&gt;share-dialog#open" href="javascript:void(0)">
+    <i class="icon-share"></i>Share
+</a>
+  <dialog data-share-dialog-target="dialog" data-action="click->share-dialog#clickOutside" class="dialog dialog-share style-section-style-1">
+    <button class="dialog-close" data-action="click-&gt;share-dialog#close" aria-label="close">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11 11" class="icon" width="12px" height="12px"><path d="M6.755 5.502l3.836 3.97-1.438 1.39-3.81-3.942-3.926 3.942L0 9.452 3.953 5.48 0 1.39 1.438 0l3.927 4.064L9.41 0l1.417 1.411-4.073 4.091z" fill-rule="evenodd"></path></svg>
+</button>    <div class="share_desc">
+      <div>
+        <span data-share-dialog-target="title">Zack Varner Quintet @ 🐘 9pm on May 19, 9:00PM</span>
+        <br>
+        <span class="byline" data-share-dialog-target="byline">
+        </span>
+      </div>
+    </div>
+
+    <ul class="share_icons">
+      <li class="threads">
+        <a href="#" data-share-dialog-target="threadsLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM23.7524 16.9806C23.8587 17.0263 23.9638 17.074 24.0671 17.1235C25.5284 17.8245 26.597 18.8859 27.1575 20.1926C27.9387 22.0149 28.0101 24.9832 25.6397 27.3514C23.828 29.1615 21.6287 29.9784 18.5087 30H18.4946C14.9852 29.9757 12.2865 28.7948 10.4735 26.4901C8.86024 24.4393 8.02805 21.5855 8.00009 18.0084L8 18L8.00009 17.9916C8.02805 14.4145 8.86024 11.5608 10.4735 9.50991C12.2865 7.20522 14.9852 6.02431 18.4946 6H18.5087C22.0252 6.02439 24.7545 7.20084 26.6206 9.49675C27.5414 10.6295 28.218 11.9953 28.648 13.5803L26.6296 14.1188C26.2749 12.8311 25.7368 11.7267 25.023 10.8485C23.5674 9.05767 21.3735 8.13891 18.5016 8.11756C15.6505 8.13875 13.4942 9.05311 12.0923 10.8353C10.7794 12.5042 10.101 14.9147 10.0757 18C10.101 21.0853 10.7794 23.4958 12.0923 25.1646C13.4942 26.9469 15.6505 27.8612 18.5017 27.8824C21.072 27.8635 22.7728 27.252 24.1876 25.8385C25.8025 24.225 25.7724 22.2459 25.2559 21.0415C24.9521 20.333 24.4021 19.7436 23.66 19.2957C23.4792 20.6429 23.0699 21.712 22.4226 22.537C21.5704 23.6234 20.3487 24.2175 18.7915 24.3029C17.6124 24.3673 16.4778 24.0829 15.5969 23.5014C14.555 22.8135 13.9452 21.7605 13.8799 20.5365C13.7514 18.1235 15.6656 16.3869 18.6431 16.2154C19.7001 16.1548 20.6889 16.2026 21.6031 16.358C21.4818 15.6156 21.2366 15.0274 20.8701 14.6018C20.3665 14.0171 19.5884 13.7173 18.5572 13.7107L18.5286 13.7106C17.7006 13.7106 16.5765 13.9423 15.8601 15.0291L14.1378 13.8476C15.0966 12.3926 16.6546 11.593 18.5278 11.593L18.5702 11.5931C21.702 11.6131 23.5671 13.5673 23.7524 16.9806ZM15.9524 20.4215C16.0193 21.6761 17.3751 22.2619 18.6801 22.1884C19.9578 22.1182 21.408 21.6169 21.6553 18.5291C20.9924 18.3842 20.2633 18.3085 19.4839 18.3085C19.247 18.3085 19.0059 18.3154 18.7602 18.3296C16.6145 18.4533 15.9029 19.4913 15.9524 20.4215Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="facebook">
+        <a href="#" data-share-dialog-target="facebookLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon"><path fill-rule="evenodd" d="M9 0a9 9 0 110 18A9 9 0 019 0zm2.606 4H10.24c-1.575 0-2.17.77-2.215 2.076l-.002.166v1.034H7V9h1.023V14h2.046V9h1.365l.181-1.724H10.07l.003-.862c0-.417.036-.655.553-.687l.128-.003h.853V4z"></path></svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="twitter">
+        <a href="#" data-share-dialog-target="twitterLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="685" data-popup-window-height-value="246" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM26.4163 9L19.7142 16.6226L27.0001 27H21.6396L16.7316 20.0104L10.5876 27H9L16.0278 19.0075L9 9H14.3604L19.0068 15.6173L24.8287 9H26.4163ZM13.5996 10.1714H11.1606L22.3878 25.8861H24.8275L13.5996 10.1714Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="email">
+        <a href="#" data-share-dialog-target="emailLink" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18 9C18 4.02944 13.9706 0 9 0C4.02944 0 0 4.02944 0 9C0 13.9706 4.02944 18 9 18C13.9706 18 18 13.9706 18 9ZM4.02511 5.73566C4.00872 5.77691 4.00004 5.82153 4.00004 5.86854L4 12.1317C4 12.1897 4.0135 12.2449 4.03762 12.2938C4.04581 12.2775 4.05691 12.2621 4.07041 12.2482L7.39793 8.87439L4.0772 5.81961C4.05116 5.79611 4.0338 5.76684 4.02511 5.73566ZM4.34327 12.4991L4.34195 12.499L7.67 9.12427L8.60412 9.98343C8.86598 10.2242 9.26962 10.2228 9.52956 9.98007L10.4564 9.11563L13.768 12.4736C13.7251 12.4904 13.6783 12.5 13.6296 12.5H4.3704C4.3612 12.5 4.35243 12.4996 4.34327 12.4991ZM13.9971 12.1795L10.727 8.86376L13.9913 5.81857C13.9932 5.81713 13.9947 5.81569 13.9961 5.81425C13.9986 5.832 14 5.85023 14 5.86846V12.1315C14 12.1478 13.999 12.1637 13.9971 12.1795ZM13.7686 5.52686C13.7257 5.50959 13.6789 5.5 13.6297 5.5L4.37041 5.50006C4.33617 5.50006 4.30338 5.50486 4.27155 5.5135C4.29229 5.52117 4.31158 5.53316 4.32846 5.549L8.85585 9.71283C8.97448 9.8222 9.15822 9.82172 9.27637 9.71139L13.7382 5.54989C13.7479 5.54077 13.758 5.5331 13.7686 5.52686Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+    </ul>
+    <div class="permalink" data-controller="clipboard">
+      <p>Share link</p>
+      <div class="control -has-addons">
+        <input type="text" value="https://elephantroom.com/event/4912306/763189033/zack-varner-quintet" data-clipboard-target="source" data-share-dialog-target="urlInput" data-action="click->share-dialog#selectUrl" readonly="true">
+        <span class="control__suffix">
+          <a class="button -simple -compact -icon-only" data-clipboard-target="button" data-action="clipboard#copy">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="icon" width="16px" height="18px"><path d="M4.166.597c-.184 0-.369.15-.369.342v1.365c0 .191.185.341.369.341h9.189v9.216c0 .191.15.342.341.342h1.365c.191 0 .342-.15.342-.342V.94a.338.338 0 00-.342-.342H4.166zm7.44 3.798H.34A.338.338 0 000 4.736v10.923c0 .19.15.341.341.341h10.923c.191 0 .341-.15.341-.341V4.395z" fill-rule="evenodd"></path></svg>
+          </a>
+        </span>
+      </div>
+    </div>
+  </dialog>
+</div>
+</div>
+
+
+      <div class="event-info map-link pdf__hide">
+        <a target="_blank" rel="noopener" href="https://www.google.com/maps/search/?api=1&amp;query=%F0%9F%90%98%209pm">View on Google Maps</a>
+      </div>
+  </div>
+</div>
+
+<div class="event-clear"></div>
+
+</article>
+<article class="list-style">
+  
+<div class="event-detail" data-event-id="4490173" data-occurrence-id="763701783">
+  <div class="event-image image-social">
+      <a rel="event[4490173]" title="Violet Crown Jazz Revue with Liz Morphis" class="thumbnail-popup" data-featherlight="//images.zoogletools.com/s:bzglfiles/u/523260/059f2500d5c0f6c6dda6e5e988627048524a1537/original/liz-morphis-thumbnail.jpg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" href="//images.zoogletools.com/s:bzglfiles/u/523260/059f2500d5c0f6c6dda6e5e988627048524a1537/original/liz-morphis-thumbnail.jpg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg">
+        <img alt="Violet Crown Jazz Revue with Liz Morphis" src="//images.zoogletools.com/s:bzglfiles/u/523260/059f2500d5c0f6c6dda6e5e988627048524a1537/original/liz-morphis-thumbnail.jpg/!!/b%3AW1sicmVzaXplIixbMjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>  </div>
+
+  <div class="event-description">
+    <div class="event-info-wrapper">
+        <h2 class="event-info event-title heading-tertiary"><a href="https://elephantroom.com/event/4490173/763701783/violet-crown-jazz-revue-with-liz-morphis">Violet Crown Jazz Revue with Liz Morphis</a></h2>
+
+        <p class="event-info event-datetime">
+          <i class="icon-clock"></i>
+          <span class="date-long"><span class="event-when with-time"><time class="from"><span class="date">Wednesday, May 20</span> @ <span class="time">6:00PM</span></time></span></span><span class="date-short"><span class="event-when with-time"><time class="from"><span class="date">Wed, May 20</span> @ <span class="time">6:00PM</span></time></span></span>
+        </p>
+
+        <p class="event-info event-location">
+          <i class="icon-location"></i>
+          <a target="_blank" rel="noopener" title="Visit venue website" href="https://www.lizmorphis.com">🐘6pm</a>
+        </p>
+    </div>
+
+      <div class="event-info event-notes"><p>Liz Morphis and the Violet Crown Revue are the perfect way to end your work day - even the crummy ones! They have the perfect musical fix to end your day on a high note.</p>
+</div>
+
+    <p class="event-info">
+      
+    </p>
+
+
+    <div class="event-info buying-options product-action pdf__hide">
+
+    <div data-controller="share-dialog" data-share-dialog-url-value="https://elephantroom.com/event/4490173/763701783/violet-crown-jazz-revue-with-liz-morphis" data-share-dialog-title-value="Violet Crown Jazz Revue with Liz Morphis @ 🐘6pm on May 20, 6:00PM" data-share-dialog-text-value="Elephant Room @ Violet Crown Jazz Revue with Liz Morphis @ 🐘6pm, May 20, 6:00PM" data-share-dialog-fb-app-id-value="286076425227">
+  <a class="button button-tertiary zoogle-share pdf__hide" title="Share Violet Crown Jazz Revue with Liz Morphis @ 🐘6pm on May 20, 6:00PM" data-action="click-&gt;share-dialog#open" href="javascript:void(0)">
+    <i class="icon-share"></i>Share
+</a>
+  <dialog data-share-dialog-target="dialog" data-action="click->share-dialog#clickOutside" class="dialog dialog-share style-section-style-1">
+    <button class="dialog-close" data-action="click-&gt;share-dialog#close" aria-label="close">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11 11" class="icon" width="12px" height="12px"><path d="M6.755 5.502l3.836 3.97-1.438 1.39-3.81-3.942-3.926 3.942L0 9.452 3.953 5.48 0 1.39 1.438 0l3.927 4.064L9.41 0l1.417 1.411-4.073 4.091z" fill-rule="evenodd"></path></svg>
+</button>    <div class="share_desc">
+      <div>
+        <span data-share-dialog-target="title">Violet Crown Jazz Revue with Liz Morphis @ 🐘6pm on May 20, 6:00PM</span>
+        <br>
+        <span class="byline" data-share-dialog-target="byline">
+        </span>
+      </div>
+    </div>
+
+    <ul class="share_icons">
+      <li class="threads">
+        <a href="#" data-share-dialog-target="threadsLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM23.7524 16.9806C23.8587 17.0263 23.9638 17.074 24.0671 17.1235C25.5284 17.8245 26.597 18.8859 27.1575 20.1926C27.9387 22.0149 28.0101 24.9832 25.6397 27.3514C23.828 29.1615 21.6287 29.9784 18.5087 30H18.4946C14.9852 29.9757 12.2865 28.7948 10.4735 26.4901C8.86024 24.4393 8.02805 21.5855 8.00009 18.0084L8 18L8.00009 17.9916C8.02805 14.4145 8.86024 11.5608 10.4735 9.50991C12.2865 7.20522 14.9852 6.02431 18.4946 6H18.5087C22.0252 6.02439 24.7545 7.20084 26.6206 9.49675C27.5414 10.6295 28.218 11.9953 28.648 13.5803L26.6296 14.1188C26.2749 12.8311 25.7368 11.7267 25.023 10.8485C23.5674 9.05767 21.3735 8.13891 18.5016 8.11756C15.6505 8.13875 13.4942 9.05311 12.0923 10.8353C10.7794 12.5042 10.101 14.9147 10.0757 18C10.101 21.0853 10.7794 23.4958 12.0923 25.1646C13.4942 26.9469 15.6505 27.8612 18.5017 27.8824C21.072 27.8635 22.7728 27.252 24.1876 25.8385C25.8025 24.225 25.7724 22.2459 25.2559 21.0415C24.9521 20.333 24.4021 19.7436 23.66 19.2957C23.4792 20.6429 23.0699 21.712 22.4226 22.537C21.5704 23.6234 20.3487 24.2175 18.7915 24.3029C17.6124 24.3673 16.4778 24.0829 15.5969 23.5014C14.555 22.8135 13.9452 21.7605 13.8799 20.5365C13.7514 18.1235 15.6656 16.3869 18.6431 16.2154C19.7001 16.1548 20.6889 16.2026 21.6031 16.358C21.4818 15.6156 21.2366 15.0274 20.8701 14.6018C20.3665 14.0171 19.5884 13.7173 18.5572 13.7107L18.5286 13.7106C17.7006 13.7106 16.5765 13.9423 15.8601 15.0291L14.1378 13.8476C15.0966 12.3926 16.6546 11.593 18.5278 11.593L18.5702 11.5931C21.702 11.6131 23.5671 13.5673 23.7524 16.9806ZM15.9524 20.4215C16.0193 21.6761 17.3751 22.2619 18.6801 22.1884C19.9578 22.1182 21.408 21.6169 21.6553 18.5291C20.9924 18.3842 20.2633 18.3085 19.4839 18.3085C19.247 18.3085 19.0059 18.3154 18.7602 18.3296C16.6145 18.4533 15.9029 19.4913 15.9524 20.4215Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="facebook">
+        <a href="#" data-share-dialog-target="facebookLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon"><path fill-rule="evenodd" d="M9 0a9 9 0 110 18A9 9 0 019 0zm2.606 4H10.24c-1.575 0-2.17.77-2.215 2.076l-.002.166v1.034H7V9h1.023V14h2.046V9h1.365l.181-1.724H10.07l.003-.862c0-.417.036-.655.553-.687l.128-.003h.853V4z"></path></svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="twitter">
+        <a href="#" data-share-dialog-target="twitterLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="685" data-popup-window-height-value="246" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM26.4163 9L19.7142 16.6226L27.0001 27H21.6396L16.7316 20.0104L10.5876 27H9L16.0278 19.0075L9 9H14.3604L19.0068 15.6173L24.8287 9H26.4163ZM13.5996 10.1714H11.1606L22.3878 25.8861H24.8275L13.5996 10.1714Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="email">
+        <a href="#" data-share-dialog-target="emailLink" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18 9C18 4.02944 13.9706 0 9 0C4.02944 0 0 4.02944 0 9C0 13.9706 4.02944 18 9 18C13.9706 18 18 13.9706 18 9ZM4.02511 5.73566C4.00872 5.77691 4.00004 5.82153 4.00004 5.86854L4 12.1317C4 12.1897 4.0135 12.2449 4.03762 12.2938C4.04581 12.2775 4.05691 12.2621 4.07041 12.2482L7.39793 8.87439L4.0772 5.81961C4.05116 5.79611 4.0338 5.76684 4.02511 5.73566ZM4.34327 12.4991L4.34195 12.499L7.67 9.12427L8.60412 9.98343C8.86598 10.2242 9.26962 10.2228 9.52956 9.98007L10.4564 9.11563L13.768 12.4736C13.7251 12.4904 13.6783 12.5 13.6296 12.5H4.3704C4.3612 12.5 4.35243 12.4996 4.34327 12.4991ZM13.9971 12.1795L10.727 8.86376L13.9913 5.81857C13.9932 5.81713 13.9947 5.81569 13.9961 5.81425C13.9986 5.832 14 5.85023 14 5.86846V12.1315C14 12.1478 13.999 12.1637 13.9971 12.1795ZM13.7686 5.52686C13.7257 5.50959 13.6789 5.5 13.6297 5.5L4.37041 5.50006C4.33617 5.50006 4.30338 5.50486 4.27155 5.5135C4.29229 5.52117 4.31158 5.53316 4.32846 5.549L8.85585 9.71283C8.97448 9.8222 9.15822 9.82172 9.27637 9.71139L13.7382 5.54989C13.7479 5.54077 13.758 5.5331 13.7686 5.52686Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+    </ul>
+    <div class="permalink" data-controller="clipboard">
+      <p>Share link</p>
+      <div class="control -has-addons">
+        <input type="text" value="https://elephantroom.com/event/4490173/763701783/violet-crown-jazz-revue-with-liz-morphis" data-clipboard-target="source" data-share-dialog-target="urlInput" data-action="click->share-dialog#selectUrl" readonly="true">
+        <span class="control__suffix">
+          <a class="button -simple -compact -icon-only" data-clipboard-target="button" data-action="clipboard#copy">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="icon" width="16px" height="18px"><path d="M4.166.597c-.184 0-.369.15-.369.342v1.365c0 .191.185.341.369.341h9.189v9.216c0 .191.15.342.341.342h1.365c.191 0 .342-.15.342-.342V.94a.338.338 0 00-.342-.342H4.166zm7.44 3.798H.34A.338.338 0 000 4.736v10.923c0 .19.15.341.341.341h10.923c.191 0 .341-.15.341-.341V4.395z" fill-rule="evenodd"></path></svg>
+          </a>
+        </span>
+      </div>
+    </div>
+  </dialog>
+</div>
+</div>
+
+
+      <div class="event-info map-link pdf__hide">
+        <a target="_blank" rel="noopener" href="https://www.google.com/maps/search/?api=1&amp;query=%F0%9F%90%986pm">View on Google Maps</a>
+      </div>
+  </div>
+</div>
+
+<div class="event-clear"></div>
+
+</article>
+<article class="list-style">
+  
+<div class="event-detail" data-event-id="5800473" data-occurrence-id="762545888">
+  <div class="event-image image-social">
+      <a rel="event[5800473]" title="Monster Big Band" class="thumbnail-popup" data-featherlight="//images.zoogletools.com/s:bzglfiles/u/523260/130dba579a79ddd969cb68e9fc639f3a47bb191b/original/view-recent-photos.png/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.png" href="//images.zoogletools.com/s:bzglfiles/u/523260/130dba579a79ddd969cb68e9fc639f3a47bb191b/original/view-recent-photos.png/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.png">
+        <img alt="Monster Big Band" src="//images.zoogletools.com/s:bzglfiles/u/523260/130dba579a79ddd969cb68e9fc639f3a47bb191b/original/view-recent-photos.png/!!/b%3AW1sicmVzaXplIixbMjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.png" />
+</a>  </div>
+
+  <div class="event-description">
+    <div class="event-info-wrapper">
+        <h2 class="event-info event-title heading-tertiary"><a href="https://elephantroom.com/event/5800473/762545888/monster-big-band">Monster Big Band</a></h2>
+
+        <p class="event-info event-datetime">
+          <i class="icon-clock"></i>
+          <span class="date-long"><span class="event-when with-time"><time class="from"><span class="date">Wednesday, May 20</span> @ <span class="time">9:00PM</span></time></span></span><span class="date-short"><span class="event-when with-time"><time class="from"><span class="date">Wed, May 20</span> @ <span class="time">9:00PM</span></time></span></span>
+        </p>
+
+        <p class="event-info event-location">
+          <i class="icon-location"></i>
+          <a target="_blank" rel="noopener" title="View on Google Maps" href="https://www.google.com/maps/search/?api=1&amp;query=%F0%9F%90%989pm">🐘9pm</a>
+        </p>
+    </div>
+
+      <div class="event-info event-notes"><p>Monster Big Band blows the walls down once a month at the Elephant Room. Austin's favorite 18-piece big band covers everything from Sinatra to Ella to Black Sabbath to Buddy Rich. Monster will leave you asking for more.</p>
+</div>
+
+    <p class="event-info">
+      
+    </p>
+
+
+    <div class="event-info buying-options product-action pdf__hide">
+
+    <div data-controller="share-dialog" data-share-dialog-url-value="https://elephantroom.com/event/5800473/762545888/monster-big-band" data-share-dialog-title-value="Monster Big Band @ 🐘9pm on May 20, 9:00PM" data-share-dialog-text-value="Elephant Room @ Monster Big Band @ 🐘9pm, May 20, 9:00PM" data-share-dialog-fb-app-id-value="286076425227">
+  <a class="button button-tertiary zoogle-share pdf__hide" title="Share Monster Big Band @ 🐘9pm on May 20, 9:00PM" data-action="click-&gt;share-dialog#open" href="javascript:void(0)">
+    <i class="icon-share"></i>Share
+</a>
+  <dialog data-share-dialog-target="dialog" data-action="click->share-dialog#clickOutside" class="dialog dialog-share style-section-style-1">
+    <button class="dialog-close" data-action="click-&gt;share-dialog#close" aria-label="close">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11 11" class="icon" width="12px" height="12px"><path d="M6.755 5.502l3.836 3.97-1.438 1.39-3.81-3.942-3.926 3.942L0 9.452 3.953 5.48 0 1.39 1.438 0l3.927 4.064L9.41 0l1.417 1.411-4.073 4.091z" fill-rule="evenodd"></path></svg>
+</button>    <div class="share_desc">
+      <div>
+        <span data-share-dialog-target="title">Monster Big Band @ 🐘9pm on May 20, 9:00PM</span>
+        <br>
+        <span class="byline" data-share-dialog-target="byline">
+        </span>
+      </div>
+    </div>
+
+    <ul class="share_icons">
+      <li class="threads">
+        <a href="#" data-share-dialog-target="threadsLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM23.7524 16.9806C23.8587 17.0263 23.9638 17.074 24.0671 17.1235C25.5284 17.8245 26.597 18.8859 27.1575 20.1926C27.9387 22.0149 28.0101 24.9832 25.6397 27.3514C23.828 29.1615 21.6287 29.9784 18.5087 30H18.4946C14.9852 29.9757 12.2865 28.7948 10.4735 26.4901C8.86024 24.4393 8.02805 21.5855 8.00009 18.0084L8 18L8.00009 17.9916C8.02805 14.4145 8.86024 11.5608 10.4735 9.50991C12.2865 7.20522 14.9852 6.02431 18.4946 6H18.5087C22.0252 6.02439 24.7545 7.20084 26.6206 9.49675C27.5414 10.6295 28.218 11.9953 28.648 13.5803L26.6296 14.1188C26.2749 12.8311 25.7368 11.7267 25.023 10.8485C23.5674 9.05767 21.3735 8.13891 18.5016 8.11756C15.6505 8.13875 13.4942 9.05311 12.0923 10.8353C10.7794 12.5042 10.101 14.9147 10.0757 18C10.101 21.0853 10.7794 23.4958 12.0923 25.1646C13.4942 26.9469 15.6505 27.8612 18.5017 27.8824C21.072 27.8635 22.7728 27.252 24.1876 25.8385C25.8025 24.225 25.7724 22.2459 25.2559 21.0415C24.9521 20.333 24.4021 19.7436 23.66 19.2957C23.4792 20.6429 23.0699 21.712 22.4226 22.537C21.5704 23.6234 20.3487 24.2175 18.7915 24.3029C17.6124 24.3673 16.4778 24.0829 15.5969 23.5014C14.555 22.8135 13.9452 21.7605 13.8799 20.5365C13.7514 18.1235 15.6656 16.3869 18.6431 16.2154C19.7001 16.1548 20.6889 16.2026 21.6031 16.358C21.4818 15.6156 21.2366 15.0274 20.8701 14.6018C20.3665 14.0171 19.5884 13.7173 18.5572 13.7107L18.5286 13.7106C17.7006 13.7106 16.5765 13.9423 15.8601 15.0291L14.1378 13.8476C15.0966 12.3926 16.6546 11.593 18.5278 11.593L18.5702 11.5931C21.702 11.6131 23.5671 13.5673 23.7524 16.9806ZM15.9524 20.4215C16.0193 21.6761 17.3751 22.2619 18.6801 22.1884C19.9578 22.1182 21.408 21.6169 21.6553 18.5291C20.9924 18.3842 20.2633 18.3085 19.4839 18.3085C19.247 18.3085 19.0059 18.3154 18.7602 18.3296C16.6145 18.4533 15.9029 19.4913 15.9524 20.4215Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="facebook">
+        <a href="#" data-share-dialog-target="facebookLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon"><path fill-rule="evenodd" d="M9 0a9 9 0 110 18A9 9 0 019 0zm2.606 4H10.24c-1.575 0-2.17.77-2.215 2.076l-.002.166v1.034H7V9h1.023V14h2.046V9h1.365l.181-1.724H10.07l.003-.862c0-.417.036-.655.553-.687l.128-.003h.853V4z"></path></svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="twitter">
+        <a href="#" data-share-dialog-target="twitterLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="685" data-popup-window-height-value="246" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM26.4163 9L19.7142 16.6226L27.0001 27H21.6396L16.7316 20.0104L10.5876 27H9L16.0278 19.0075L9 9H14.3604L19.0068 15.6173L24.8287 9H26.4163ZM13.5996 10.1714H11.1606L22.3878 25.8861H24.8275L13.5996 10.1714Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="email">
+        <a href="#" data-share-dialog-target="emailLink" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18 9C18 4.02944 13.9706 0 9 0C4.02944 0 0 4.02944 0 9C0 13.9706 4.02944 18 9 18C13.9706 18 18 13.9706 18 9ZM4.02511 5.73566C4.00872 5.77691 4.00004 5.82153 4.00004 5.86854L4 12.1317C4 12.1897 4.0135 12.2449 4.03762 12.2938C4.04581 12.2775 4.05691 12.2621 4.07041 12.2482L7.39793 8.87439L4.0772 5.81961C4.05116 5.79611 4.0338 5.76684 4.02511 5.73566ZM4.34327 12.4991L4.34195 12.499L7.67 9.12427L8.60412 9.98343C8.86598 10.2242 9.26962 10.2228 9.52956 9.98007L10.4564 9.11563L13.768 12.4736C13.7251 12.4904 13.6783 12.5 13.6296 12.5H4.3704C4.3612 12.5 4.35243 12.4996 4.34327 12.4991ZM13.9971 12.1795L10.727 8.86376L13.9913 5.81857C13.9932 5.81713 13.9947 5.81569 13.9961 5.81425C13.9986 5.832 14 5.85023 14 5.86846V12.1315C14 12.1478 13.999 12.1637 13.9971 12.1795ZM13.7686 5.52686C13.7257 5.50959 13.6789 5.5 13.6297 5.5L4.37041 5.50006C4.33617 5.50006 4.30338 5.50486 4.27155 5.5135C4.29229 5.52117 4.31158 5.53316 4.32846 5.549L8.85585 9.71283C8.97448 9.8222 9.15822 9.82172 9.27637 9.71139L13.7382 5.54989C13.7479 5.54077 13.758 5.5331 13.7686 5.52686Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+    </ul>
+    <div class="permalink" data-controller="clipboard">
+      <p>Share link</p>
+      <div class="control -has-addons">
+        <input type="text" value="https://elephantroom.com/event/5800473/762545888/monster-big-band" data-clipboard-target="source" data-share-dialog-target="urlInput" data-action="click->share-dialog#selectUrl" readonly="true">
+        <span class="control__suffix">
+          <a class="button -simple -compact -icon-only" data-clipboard-target="button" data-action="clipboard#copy">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="icon" width="16px" height="18px"><path d="M4.166.597c-.184 0-.369.15-.369.342v1.365c0 .191.185.341.369.341h9.189v9.216c0 .191.15.342.341.342h1.365c.191 0 .342-.15.342-.342V.94a.338.338 0 00-.342-.342H4.166zm7.44 3.798H.34A.338.338 0 000 4.736v10.923c0 .19.15.341.341.341h10.923c.191 0 .341-.15.341-.341V4.395z" fill-rule="evenodd"></path></svg>
+          </a>
+        </span>
+      </div>
+    </div>
+  </dialog>
+</div>
+</div>
+
+
+      <div class="event-info map-link pdf__hide">
+        <a target="_blank" rel="noopener" href="https://www.google.com/maps/search/?api=1&amp;query=%F0%9F%90%989pm">View on Google Maps</a>
+      </div>
+  </div>
+</div>
+
+<div class="event-clear"></div>
+
+</article>
+<article class="list-style">
+  
+<div class="event-detail" data-event-id="4558295" data-occurrence-id="763189017">
+  <div class="event-image image-social">
+      <a rel="event[4558295]" title="Sarah Sharp Quintet" class="thumbnail-popup" data-featherlight="//images.zoogletools.com/s:bzglfiles/u/523260/d4c8a75373e01ff7aee47194935554f0e3df7688/original/sarah-sharp.jpg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" href="//images.zoogletools.com/s:bzglfiles/u/523260/d4c8a75373e01ff7aee47194935554f0e3df7688/original/sarah-sharp.jpg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg">
+        <img alt="Sarah Sharp Quintet" src="//images.zoogletools.com/s:bzglfiles/u/523260/d4c8a75373e01ff7aee47194935554f0e3df7688/original/sarah-sharp.jpg/!!/b%3AW1sicmVzaXplIixbMjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>  </div>
+
+  <div class="event-description">
+    <div class="event-info-wrapper">
+        <h2 class="event-info event-title heading-tertiary"><a href="https://elephantroom.com/event/4558295/763189017/sarah-sharp-quintet">Sarah Sharp Quintet</a></h2>
+
+        <p class="event-info event-datetime">
+          <i class="icon-clock"></i>
+          <span class="date-long"><span class="event-when with-time"><time class="from"><span class="date">Thursday, May 21</span> @ <span class="time">6:00PM</span></time></span></span><span class="date-short"><span class="event-when with-time"><time class="from"><span class="date">Thu, May 21</span> @ <span class="time">6:00PM</span></time></span></span>
+        </p>
+
+        <p class="event-info event-location">
+          <i class="icon-location"></i>
+          <a target="_blank" rel="noopener" title="View on Google Maps" href="https://www.google.com/maps/search/?api=1&amp;query=%F0%9F%90%986pm">🐘6pm</a>
+        </p>
+    </div>
+
+      <div class="event-info event-notes"><p>“Sarah Sharp's soft-spoken singing style and quiet instrumentations offer a living room, fireside closeness that keeps her away from the lounge-singer stereotypes of similarly jazz-influenced performers." — @nprmusic, All Songs Considered</p>
+
+<p>The Sarah Sharp Quartet performs every Tuesday evening in the basement, featuring John Fremgen, Masumi Jones, Oliver Steck, and Mitch Watkins.</p>
+
+<p>No cover Sunday-Wednesday</p>
+</div>
+
+    <p class="event-info">
+      
+    </p>
+
+
+    <div class="event-info buying-options product-action pdf__hide">
+
+    <div data-controller="share-dialog" data-share-dialog-url-value="https://elephantroom.com/event/4558295/763189017/sarah-sharp-quintet" data-share-dialog-title-value="Sarah Sharp Quintet @ 🐘6pm on May 21, 6:00PM" data-share-dialog-text-value="Elephant Room @ Sarah Sharp Quintet @ 🐘6pm, May 21, 6:00PM" data-share-dialog-fb-app-id-value="286076425227">
+  <a class="button button-tertiary zoogle-share pdf__hide" title="Share Sarah Sharp Quintet @ 🐘6pm on May 21, 6:00PM" data-action="click-&gt;share-dialog#open" href="javascript:void(0)">
+    <i class="icon-share"></i>Share
+</a>
+  <dialog data-share-dialog-target="dialog" data-action="click->share-dialog#clickOutside" class="dialog dialog-share style-section-style-1">
+    <button class="dialog-close" data-action="click-&gt;share-dialog#close" aria-label="close">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11 11" class="icon" width="12px" height="12px"><path d="M6.755 5.502l3.836 3.97-1.438 1.39-3.81-3.942-3.926 3.942L0 9.452 3.953 5.48 0 1.39 1.438 0l3.927 4.064L9.41 0l1.417 1.411-4.073 4.091z" fill-rule="evenodd"></path></svg>
+</button>    <div class="share_desc">
+      <div>
+        <span data-share-dialog-target="title">Sarah Sharp Quintet @ 🐘6pm on May 21, 6:00PM</span>
+        <br>
+        <span class="byline" data-share-dialog-target="byline">
+        </span>
+      </div>
+    </div>
+
+    <ul class="share_icons">
+      <li class="threads">
+        <a href="#" data-share-dialog-target="threadsLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM23.7524 16.9806C23.8587 17.0263 23.9638 17.074 24.0671 17.1235C25.5284 17.8245 26.597 18.8859 27.1575 20.1926C27.9387 22.0149 28.0101 24.9832 25.6397 27.3514C23.828 29.1615 21.6287 29.9784 18.5087 30H18.4946C14.9852 29.9757 12.2865 28.7948 10.4735 26.4901C8.86024 24.4393 8.02805 21.5855 8.00009 18.0084L8 18L8.00009 17.9916C8.02805 14.4145 8.86024 11.5608 10.4735 9.50991C12.2865 7.20522 14.9852 6.02431 18.4946 6H18.5087C22.0252 6.02439 24.7545 7.20084 26.6206 9.49675C27.5414 10.6295 28.218 11.9953 28.648 13.5803L26.6296 14.1188C26.2749 12.8311 25.7368 11.7267 25.023 10.8485C23.5674 9.05767 21.3735 8.13891 18.5016 8.11756C15.6505 8.13875 13.4942 9.05311 12.0923 10.8353C10.7794 12.5042 10.101 14.9147 10.0757 18C10.101 21.0853 10.7794 23.4958 12.0923 25.1646C13.4942 26.9469 15.6505 27.8612 18.5017 27.8824C21.072 27.8635 22.7728 27.252 24.1876 25.8385C25.8025 24.225 25.7724 22.2459 25.2559 21.0415C24.9521 20.333 24.4021 19.7436 23.66 19.2957C23.4792 20.6429 23.0699 21.712 22.4226 22.537C21.5704 23.6234 20.3487 24.2175 18.7915 24.3029C17.6124 24.3673 16.4778 24.0829 15.5969 23.5014C14.555 22.8135 13.9452 21.7605 13.8799 20.5365C13.7514 18.1235 15.6656 16.3869 18.6431 16.2154C19.7001 16.1548 20.6889 16.2026 21.6031 16.358C21.4818 15.6156 21.2366 15.0274 20.8701 14.6018C20.3665 14.0171 19.5884 13.7173 18.5572 13.7107L18.5286 13.7106C17.7006 13.7106 16.5765 13.9423 15.8601 15.0291L14.1378 13.8476C15.0966 12.3926 16.6546 11.593 18.5278 11.593L18.5702 11.5931C21.702 11.6131 23.5671 13.5673 23.7524 16.9806ZM15.9524 20.4215C16.0193 21.6761 17.3751 22.2619 18.6801 22.1884C19.9578 22.1182 21.408 21.6169 21.6553 18.5291C20.9924 18.3842 20.2633 18.3085 19.4839 18.3085C19.247 18.3085 19.0059 18.3154 18.7602 18.3296C16.6145 18.4533 15.9029 19.4913 15.9524 20.4215Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="facebook">
+        <a href="#" data-share-dialog-target="facebookLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon"><path fill-rule="evenodd" d="M9 0a9 9 0 110 18A9 9 0 019 0zm2.606 4H10.24c-1.575 0-2.17.77-2.215 2.076l-.002.166v1.034H7V9h1.023V14h2.046V9h1.365l.181-1.724H10.07l.003-.862c0-.417.036-.655.553-.687l.128-.003h.853V4z"></path></svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="twitter">
+        <a href="#" data-share-dialog-target="twitterLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="685" data-popup-window-height-value="246" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM26.4163 9L19.7142 16.6226L27.0001 27H21.6396L16.7316 20.0104L10.5876 27H9L16.0278 19.0075L9 9H14.3604L19.0068 15.6173L24.8287 9H26.4163ZM13.5996 10.1714H11.1606L22.3878 25.8861H24.8275L13.5996 10.1714Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="email">
+        <a href="#" data-share-dialog-target="emailLink" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18 9C18 4.02944 13.9706 0 9 0C4.02944 0 0 4.02944 0 9C0 13.9706 4.02944 18 9 18C13.9706 18 18 13.9706 18 9ZM4.02511 5.73566C4.00872 5.77691 4.00004 5.82153 4.00004 5.86854L4 12.1317C4 12.1897 4.0135 12.2449 4.03762 12.2938C4.04581 12.2775 4.05691 12.2621 4.07041 12.2482L7.39793 8.87439L4.0772 5.81961C4.05116 5.79611 4.0338 5.76684 4.02511 5.73566ZM4.34327 12.4991L4.34195 12.499L7.67 9.12427L8.60412 9.98343C8.86598 10.2242 9.26962 10.2228 9.52956 9.98007L10.4564 9.11563L13.768 12.4736C13.7251 12.4904 13.6783 12.5 13.6296 12.5H4.3704C4.3612 12.5 4.35243 12.4996 4.34327 12.4991ZM13.9971 12.1795L10.727 8.86376L13.9913 5.81857C13.9932 5.81713 13.9947 5.81569 13.9961 5.81425C13.9986 5.832 14 5.85023 14 5.86846V12.1315C14 12.1478 13.999 12.1637 13.9971 12.1795ZM13.7686 5.52686C13.7257 5.50959 13.6789 5.5 13.6297 5.5L4.37041 5.50006C4.33617 5.50006 4.30338 5.50486 4.27155 5.5135C4.29229 5.52117 4.31158 5.53316 4.32846 5.549L8.85585 9.71283C8.97448 9.8222 9.15822 9.82172 9.27637 9.71139L13.7382 5.54989C13.7479 5.54077 13.758 5.5331 13.7686 5.52686Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+    </ul>
+    <div class="permalink" data-controller="clipboard">
+      <p>Share link</p>
+      <div class="control -has-addons">
+        <input type="text" value="https://elephantroom.com/event/4558295/763189017/sarah-sharp-quintet" data-clipboard-target="source" data-share-dialog-target="urlInput" data-action="click->share-dialog#selectUrl" readonly="true">
+        <span class="control__suffix">
+          <a class="button -simple -compact -icon-only" data-clipboard-target="button" data-action="clipboard#copy">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="icon" width="16px" height="18px"><path d="M4.166.597c-.184 0-.369.15-.369.342v1.365c0 .191.185.341.369.341h9.189v9.216c0 .191.15.342.341.342h1.365c.191 0 .342-.15.342-.342V.94a.338.338 0 00-.342-.342H4.166zm7.44 3.798H.34A.338.338 0 000 4.736v10.923c0 .19.15.341.341.341h10.923c.191 0 .341-.15.341-.341V4.395z" fill-rule="evenodd"></path></svg>
+          </a>
+        </span>
+      </div>
+    </div>
+  </dialog>
+</div>
+</div>
+
+
+      <div class="event-info map-link pdf__hide">
+        <a target="_blank" rel="noopener" href="https://www.google.com/maps/search/?api=1&amp;query=%F0%9F%90%986pm">View on Google Maps</a>
+      </div>
+  </div>
+</div>
+
+<div class="event-clear"></div>
+
+</article>
+<article class="list-style">
+  
+<div class="event-detail" data-event-id="4315520" data-occurrence-id="759226940">
+  <div class="event-image image-social">
+      <a rel="event[4315520]" title="Tony Bray Quintet" class="thumbnail-popup" data-featherlight="//images.zoogletools.com/s:bzglfiles/u/523260/2be86a757b2338f450cb20ea5229da1fff494de1/original/tony-bray.jpg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" href="//images.zoogletools.com/s:bzglfiles/u/523260/2be86a757b2338f450cb20ea5229da1fff494de1/original/tony-bray.jpg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg">
+        <img alt="Tony Bray Quintet" src="//images.zoogletools.com/s:bzglfiles/u/523260/2be86a757b2338f450cb20ea5229da1fff494de1/original/tony-bray.jpg/!!/b%3AW1sicmVzaXplIixbMjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>  </div>
+
+  <div class="event-description">
+    <div class="event-info-wrapper">
+        <h2 class="event-info event-title heading-tertiary"><a href="https://elephantroom.com/event/4315520/759226940/tony-bray-quintet">Tony Bray Quintet</a></h2>
+
+        <p class="event-info event-datetime">
+          <i class="icon-clock"></i>
+          <span class="date-long"><span class="event-when with-time"><time class="from"><span class="date">Thursday, May 21</span> @ <span class="time">9:00PM</span></time></span></span><span class="date-short"><span class="event-when with-time"><time class="from"><span class="date">Thu, May 21</span> @ <span class="time">9:00PM</span></time></span></span>
+        </p>
+
+        <p class="event-info event-location">
+          <i class="icon-location"></i>
+          <a target="_blank" rel="noopener" title="Visit venue website" href="http://www.tonybraymusic.com/">🐘9pm</a>
+        </p>
+    </div>
+
+      <div class="event-info event-notes"><p>Tony Bray leads his band of jazz players down to the basement with a mix of music to restore jazz in your heart!</p>
+</div>
+
+    <p class="event-info">
+      
+    </p>
+
+
+    <div class="event-info buying-options product-action pdf__hide">
+
+    <div data-controller="share-dialog" data-share-dialog-url-value="https://elephantroom.com/event/4315520/759226940/tony-bray-quintet" data-share-dialog-title-value="Tony Bray Quintet @ 🐘9pm on May 21, 9:00PM" data-share-dialog-text-value="Elephant Room @ Tony Bray Quintet @ 🐘9pm, May 21, 9:00PM" data-share-dialog-fb-app-id-value="286076425227">
+  <a class="button button-tertiary zoogle-share pdf__hide" title="Share Tony Bray Quintet @ 🐘9pm on May 21, 9:00PM" data-action="click-&gt;share-dialog#open" href="javascript:void(0)">
+    <i class="icon-share"></i>Share
+</a>
+  <dialog data-share-dialog-target="dialog" data-action="click->share-dialog#clickOutside" class="dialog dialog-share style-section-style-1">
+    <button class="dialog-close" data-action="click-&gt;share-dialog#close" aria-label="close">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11 11" class="icon" width="12px" height="12px"><path d="M6.755 5.502l3.836 3.97-1.438 1.39-3.81-3.942-3.926 3.942L0 9.452 3.953 5.48 0 1.39 1.438 0l3.927 4.064L9.41 0l1.417 1.411-4.073 4.091z" fill-rule="evenodd"></path></svg>
+</button>    <div class="share_desc">
+      <div>
+        <span data-share-dialog-target="title">Tony Bray Quintet @ 🐘9pm on May 21, 9:00PM</span>
+        <br>
+        <span class="byline" data-share-dialog-target="byline">
+        </span>
+      </div>
+    </div>
+
+    <ul class="share_icons">
+      <li class="threads">
+        <a href="#" data-share-dialog-target="threadsLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM23.7524 16.9806C23.8587 17.0263 23.9638 17.074 24.0671 17.1235C25.5284 17.8245 26.597 18.8859 27.1575 20.1926C27.9387 22.0149 28.0101 24.9832 25.6397 27.3514C23.828 29.1615 21.6287 29.9784 18.5087 30H18.4946C14.9852 29.9757 12.2865 28.7948 10.4735 26.4901C8.86024 24.4393 8.02805 21.5855 8.00009 18.0084L8 18L8.00009 17.9916C8.02805 14.4145 8.86024 11.5608 10.4735 9.50991C12.2865 7.20522 14.9852 6.02431 18.4946 6H18.5087C22.0252 6.02439 24.7545 7.20084 26.6206 9.49675C27.5414 10.6295 28.218 11.9953 28.648 13.5803L26.6296 14.1188C26.2749 12.8311 25.7368 11.7267 25.023 10.8485C23.5674 9.05767 21.3735 8.13891 18.5016 8.11756C15.6505 8.13875 13.4942 9.05311 12.0923 10.8353C10.7794 12.5042 10.101 14.9147 10.0757 18C10.101 21.0853 10.7794 23.4958 12.0923 25.1646C13.4942 26.9469 15.6505 27.8612 18.5017 27.8824C21.072 27.8635 22.7728 27.252 24.1876 25.8385C25.8025 24.225 25.7724 22.2459 25.2559 21.0415C24.9521 20.333 24.4021 19.7436 23.66 19.2957C23.4792 20.6429 23.0699 21.712 22.4226 22.537C21.5704 23.6234 20.3487 24.2175 18.7915 24.3029C17.6124 24.3673 16.4778 24.0829 15.5969 23.5014C14.555 22.8135 13.9452 21.7605 13.8799 20.5365C13.7514 18.1235 15.6656 16.3869 18.6431 16.2154C19.7001 16.1548 20.6889 16.2026 21.6031 16.358C21.4818 15.6156 21.2366 15.0274 20.8701 14.6018C20.3665 14.0171 19.5884 13.7173 18.5572 13.7107L18.5286 13.7106C17.7006 13.7106 16.5765 13.9423 15.8601 15.0291L14.1378 13.8476C15.0966 12.3926 16.6546 11.593 18.5278 11.593L18.5702 11.5931C21.702 11.6131 23.5671 13.5673 23.7524 16.9806ZM15.9524 20.4215C16.0193 21.6761 17.3751 22.2619 18.6801 22.1884C19.9578 22.1182 21.408 21.6169 21.6553 18.5291C20.9924 18.3842 20.2633 18.3085 19.4839 18.3085C19.247 18.3085 19.0059 18.3154 18.7602 18.3296C16.6145 18.4533 15.9029 19.4913 15.9524 20.4215Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="facebook">
+        <a href="#" data-share-dialog-target="facebookLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon"><path fill-rule="evenodd" d="M9 0a9 9 0 110 18A9 9 0 019 0zm2.606 4H10.24c-1.575 0-2.17.77-2.215 2.076l-.002.166v1.034H7V9h1.023V14h2.046V9h1.365l.181-1.724H10.07l.003-.862c0-.417.036-.655.553-.687l.128-.003h.853V4z"></path></svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="twitter">
+        <a href="#" data-share-dialog-target="twitterLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="685" data-popup-window-height-value="246" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM26.4163 9L19.7142 16.6226L27.0001 27H21.6396L16.7316 20.0104L10.5876 27H9L16.0278 19.0075L9 9H14.3604L19.0068 15.6173L24.8287 9H26.4163ZM13.5996 10.1714H11.1606L22.3878 25.8861H24.8275L13.5996 10.1714Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="email">
+        <a href="#" data-share-dialog-target="emailLink" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18 9C18 4.02944 13.9706 0 9 0C4.02944 0 0 4.02944 0 9C0 13.9706 4.02944 18 9 18C13.9706 18 18 13.9706 18 9ZM4.02511 5.73566C4.00872 5.77691 4.00004 5.82153 4.00004 5.86854L4 12.1317C4 12.1897 4.0135 12.2449 4.03762 12.2938C4.04581 12.2775 4.05691 12.2621 4.07041 12.2482L7.39793 8.87439L4.0772 5.81961C4.05116 5.79611 4.0338 5.76684 4.02511 5.73566ZM4.34327 12.4991L4.34195 12.499L7.67 9.12427L8.60412 9.98343C8.86598 10.2242 9.26962 10.2228 9.52956 9.98007L10.4564 9.11563L13.768 12.4736C13.7251 12.4904 13.6783 12.5 13.6296 12.5H4.3704C4.3612 12.5 4.35243 12.4996 4.34327 12.4991ZM13.9971 12.1795L10.727 8.86376L13.9913 5.81857C13.9932 5.81713 13.9947 5.81569 13.9961 5.81425C13.9986 5.832 14 5.85023 14 5.86846V12.1315C14 12.1478 13.999 12.1637 13.9971 12.1795ZM13.7686 5.52686C13.7257 5.50959 13.6789 5.5 13.6297 5.5L4.37041 5.50006C4.33617 5.50006 4.30338 5.50486 4.27155 5.5135C4.29229 5.52117 4.31158 5.53316 4.32846 5.549L8.85585 9.71283C8.97448 9.8222 9.15822 9.82172 9.27637 9.71139L13.7382 5.54989C13.7479 5.54077 13.758 5.5331 13.7686 5.52686Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+    </ul>
+    <div class="permalink" data-controller="clipboard">
+      <p>Share link</p>
+      <div class="control -has-addons">
+        <input type="text" value="https://elephantroom.com/event/4315520/759226940/tony-bray-quintet" data-clipboard-target="source" data-share-dialog-target="urlInput" data-action="click->share-dialog#selectUrl" readonly="true">
+        <span class="control__suffix">
+          <a class="button -simple -compact -icon-only" data-clipboard-target="button" data-action="clipboard#copy">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="icon" width="16px" height="18px"><path d="M4.166.597c-.184 0-.369.15-.369.342v1.365c0 .191.185.341.369.341h9.189v9.216c0 .191.15.342.341.342h1.365c.191 0 .342-.15.342-.342V.94a.338.338 0 00-.342-.342H4.166zm7.44 3.798H.34A.338.338 0 000 4.736v10.923c0 .19.15.341.341.341h10.923c.191 0 .341-.15.341-.341V4.395z" fill-rule="evenodd"></path></svg>
+          </a>
+        </span>
+      </div>
+    </div>
+  </dialog>
+</div>
+</div>
+
+
+      <div class="event-info map-link pdf__hide">
+        <a target="_blank" rel="noopener" href="https://www.google.com/maps/search/?api=1&amp;query=%F0%9F%90%989pm">View on Google Maps</a>
+      </div>
+  </div>
+</div>
+
+<div class="event-clear"></div>
+
+</article>
+<article class="list-style">
+  
+<div class="event-detail" data-event-id="6397039" data-occurrence-id="763314683">
+  <div class="event-image image-social">
+      <a rel="event[6397039]" title="Jazz Pharaohs" class="thumbnail-popup" data-featherlight="//images.zoogletools.com/s:bzglfiles/u/523260/63fad7585bcb441eaa2481836956ec36dc564854/original/mendoza-freddie.jpg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" href="//images.zoogletools.com/s:bzglfiles/u/523260/63fad7585bcb441eaa2481836956ec36dc564854/original/mendoza-freddie.jpg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg">
+        <img alt="Jazz Pharaohs" src="//images.zoogletools.com/s:bzglfiles/u/523260/63fad7585bcb441eaa2481836956ec36dc564854/original/mendoza-freddie.jpg/!!/b%3AW1sicmVzaXplIixbMjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>  </div>
+
+  <div class="event-description">
+    <div class="event-info-wrapper">
+        <h2 class="event-info event-title heading-tertiary"><a href="https://elephantroom.com/event/6397039/763314683/jazz-pharaohs">Jazz Pharaohs</a></h2>
+
+        <p class="event-info event-datetime">
+          <i class="icon-clock"></i>
+          <span class="date-long"><span class="event-when with-time"><time class="from"><span class="date">Friday, May 22</span> @ <span class="time">6:00PM</span></time></span></span><span class="date-short"><span class="event-when with-time"><time class="from"><span class="date">Fri, May 22</span> @ <span class="time">6:00PM</span></time></span></span>
+        </p>
+
+        <p class="event-info event-location">
+          <i class="icon-location"></i>
+          <span>🐘6pm</span>
+        </p>
+    </div>
+
+      <div class="event-info event-notes"><p>Freddie Mendoza brings back the legendary JAZZ PHARAOHS for a return performance.</p>
+</div>
+
+    <p class="event-info">
+      
+    </p>
+
+
+    <div class="event-info buying-options product-action pdf__hide">
+
+    <div data-controller="share-dialog" data-share-dialog-url-value="https://elephantroom.com/event/6397039/763314683/jazz-pharaohs" data-share-dialog-title-value="Jazz Pharaohs @ 🐘6pm on May 22, 6:00PM" data-share-dialog-text-value="Elephant Room @ Jazz Pharaohs @ 🐘6pm, May 22, 6:00PM" data-share-dialog-fb-app-id-value="286076425227">
+  <a class="button button-tertiary zoogle-share pdf__hide" title="Share Jazz Pharaohs @ 🐘6pm on May 22, 6:00PM" data-action="click-&gt;share-dialog#open" href="javascript:void(0)">
+    <i class="icon-share"></i>Share
+</a>
+  <dialog data-share-dialog-target="dialog" data-action="click->share-dialog#clickOutside" class="dialog dialog-share style-section-style-1">
+    <button class="dialog-close" data-action="click-&gt;share-dialog#close" aria-label="close">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11 11" class="icon" width="12px" height="12px"><path d="M6.755 5.502l3.836 3.97-1.438 1.39-3.81-3.942-3.926 3.942L0 9.452 3.953 5.48 0 1.39 1.438 0l3.927 4.064L9.41 0l1.417 1.411-4.073 4.091z" fill-rule="evenodd"></path></svg>
+</button>    <div class="share_desc">
+      <div>
+        <span data-share-dialog-target="title">Jazz Pharaohs @ 🐘6pm on May 22, 6:00PM</span>
+        <br>
+        <span class="byline" data-share-dialog-target="byline">
+        </span>
+      </div>
+    </div>
+
+    <ul class="share_icons">
+      <li class="threads">
+        <a href="#" data-share-dialog-target="threadsLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM23.7524 16.9806C23.8587 17.0263 23.9638 17.074 24.0671 17.1235C25.5284 17.8245 26.597 18.8859 27.1575 20.1926C27.9387 22.0149 28.0101 24.9832 25.6397 27.3514C23.828 29.1615 21.6287 29.9784 18.5087 30H18.4946C14.9852 29.9757 12.2865 28.7948 10.4735 26.4901C8.86024 24.4393 8.02805 21.5855 8.00009 18.0084L8 18L8.00009 17.9916C8.02805 14.4145 8.86024 11.5608 10.4735 9.50991C12.2865 7.20522 14.9852 6.02431 18.4946 6H18.5087C22.0252 6.02439 24.7545 7.20084 26.6206 9.49675C27.5414 10.6295 28.218 11.9953 28.648 13.5803L26.6296 14.1188C26.2749 12.8311 25.7368 11.7267 25.023 10.8485C23.5674 9.05767 21.3735 8.13891 18.5016 8.11756C15.6505 8.13875 13.4942 9.05311 12.0923 10.8353C10.7794 12.5042 10.101 14.9147 10.0757 18C10.101 21.0853 10.7794 23.4958 12.0923 25.1646C13.4942 26.9469 15.6505 27.8612 18.5017 27.8824C21.072 27.8635 22.7728 27.252 24.1876 25.8385C25.8025 24.225 25.7724 22.2459 25.2559 21.0415C24.9521 20.333 24.4021 19.7436 23.66 19.2957C23.4792 20.6429 23.0699 21.712 22.4226 22.537C21.5704 23.6234 20.3487 24.2175 18.7915 24.3029C17.6124 24.3673 16.4778 24.0829 15.5969 23.5014C14.555 22.8135 13.9452 21.7605 13.8799 20.5365C13.7514 18.1235 15.6656 16.3869 18.6431 16.2154C19.7001 16.1548 20.6889 16.2026 21.6031 16.358C21.4818 15.6156 21.2366 15.0274 20.8701 14.6018C20.3665 14.0171 19.5884 13.7173 18.5572 13.7107L18.5286 13.7106C17.7006 13.7106 16.5765 13.9423 15.8601 15.0291L14.1378 13.8476C15.0966 12.3926 16.6546 11.593 18.5278 11.593L18.5702 11.5931C21.702 11.6131 23.5671 13.5673 23.7524 16.9806ZM15.9524 20.4215C16.0193 21.6761 17.3751 22.2619 18.6801 22.1884C19.9578 22.1182 21.408 21.6169 21.6553 18.5291C20.9924 18.3842 20.2633 18.3085 19.4839 18.3085C19.247 18.3085 19.0059 18.3154 18.7602 18.3296C16.6145 18.4533 15.9029 19.4913 15.9524 20.4215Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="facebook">
+        <a href="#" data-share-dialog-target="facebookLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon"><path fill-rule="evenodd" d="M9 0a9 9 0 110 18A9 9 0 019 0zm2.606 4H10.24c-1.575 0-2.17.77-2.215 2.076l-.002.166v1.034H7V9h1.023V14h2.046V9h1.365l.181-1.724H10.07l.003-.862c0-.417.036-.655.553-.687l.128-.003h.853V4z"></path></svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="twitter">
+        <a href="#" data-share-dialog-target="twitterLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="685" data-popup-window-height-value="246" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM26.4163 9L19.7142 16.6226L27.0001 27H21.6396L16.7316 20.0104L10.5876 27H9L16.0278 19.0075L9 9H14.3604L19.0068 15.6173L24.8287 9H26.4163ZM13.5996 10.1714H11.1606L22.3878 25.8861H24.8275L13.5996 10.1714Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="email">
+        <a href="#" data-share-dialog-target="emailLink" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18 9C18 4.02944 13.9706 0 9 0C4.02944 0 0 4.02944 0 9C0 13.9706 4.02944 18 9 18C13.9706 18 18 13.9706 18 9ZM4.02511 5.73566C4.00872 5.77691 4.00004 5.82153 4.00004 5.86854L4 12.1317C4 12.1897 4.0135 12.2449 4.03762 12.2938C4.04581 12.2775 4.05691 12.2621 4.07041 12.2482L7.39793 8.87439L4.0772 5.81961C4.05116 5.79611 4.0338 5.76684 4.02511 5.73566ZM4.34327 12.4991L4.34195 12.499L7.67 9.12427L8.60412 9.98343C8.86598 10.2242 9.26962 10.2228 9.52956 9.98007L10.4564 9.11563L13.768 12.4736C13.7251 12.4904 13.6783 12.5 13.6296 12.5H4.3704C4.3612 12.5 4.35243 12.4996 4.34327 12.4991ZM13.9971 12.1795L10.727 8.86376L13.9913 5.81857C13.9932 5.81713 13.9947 5.81569 13.9961 5.81425C13.9986 5.832 14 5.85023 14 5.86846V12.1315C14 12.1478 13.999 12.1637 13.9971 12.1795ZM13.7686 5.52686C13.7257 5.50959 13.6789 5.5 13.6297 5.5L4.37041 5.50006C4.33617 5.50006 4.30338 5.50486 4.27155 5.5135C4.29229 5.52117 4.31158 5.53316 4.32846 5.549L8.85585 9.71283C8.97448 9.8222 9.15822 9.82172 9.27637 9.71139L13.7382 5.54989C13.7479 5.54077 13.758 5.5331 13.7686 5.52686Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+    </ul>
+    <div class="permalink" data-controller="clipboard">
+      <p>Share link</p>
+      <div class="control -has-addons">
+        <input type="text" value="https://elephantroom.com/event/6397039/763314683/jazz-pharaohs" data-clipboard-target="source" data-share-dialog-target="urlInput" data-action="click->share-dialog#selectUrl" readonly="true">
+        <span class="control__suffix">
+          <a class="button -simple -compact -icon-only" data-clipboard-target="button" data-action="clipboard#copy">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="icon" width="16px" height="18px"><path d="M4.166.597c-.184 0-.369.15-.369.342v1.365c0 .191.185.341.369.341h9.189v9.216c0 .191.15.342.341.342h1.365c.191 0 .342-.15.342-.342V.94a.338.338 0 00-.342-.342H4.166zm7.44 3.798H.34A.338.338 0 000 4.736v10.923c0 .19.15.341.341.341h10.923c.191 0 .341-.15.341-.341V4.395z" fill-rule="evenodd"></path></svg>
+          </a>
+        </span>
+      </div>
+    </div>
+  </dialog>
+</div>
+</div>
+
+
+  </div>
+</div>
+
+<div class="event-clear"></div>
+
+</article>
+<article class="list-style">
+  
+<div class="event-detail" data-event-id="5378796" data-occurrence-id="763189035">
+  <div class="event-image image-social">
+      <a rel="event[5378796]" title="Melissa Raquel Quartet featuring Andre Hayward" class="thumbnail-popup" data-featherlight="//images.zoogletools.com/s:bzglfiles/u/523260/f32900ec4aabc51851231d36f24859f714fd7796/original/images-1.jpg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" href="//images.zoogletools.com/s:bzglfiles/u/523260/f32900ec4aabc51851231d36f24859f714fd7796/original/images-1.jpg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg">
+        <img alt="Melissa Raquel Quartet featuring Andre Hayward" src="//images.zoogletools.com/s:bzglfiles/u/523260/f32900ec4aabc51851231d36f24859f714fd7796/original/images-1.jpg/!!/b%3AW1sicmVzaXplIixbMjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>  </div>
+
+  <div class="event-description">
+    <div class="event-info-wrapper">
+        <h2 class="event-info event-title heading-tertiary"><a href="https://elephantroom.com/event/5378796/763189035/melissa-raquel-quartet-featuring-andre-hayward">Melissa Raquel Quartet featuring Andre Hayward</a></h2>
+
+        <p class="event-info event-datetime">
+          <i class="icon-clock"></i>
+          <span class="date-long"><span class="event-when with-time"><time class="from"><span class="date">Friday, May 22</span> @ <span class="time">9:00PM</span></time></span></span><span class="date-short"><span class="event-when with-time"><time class="from"><span class="date">Fri, May 22</span> @ <span class="time">9:00PM</span></time></span></span>
+        </p>
+
+        <p class="event-info event-location">
+          <i class="icon-location"></i>
+          <a target="_blank" rel="noopener" title="View on Google Maps" href="https://www.google.com/maps/search/?api=1&amp;query=%F0%9F%90%988pm">🐘8pm</a>
+        </p>
+    </div>
+
+      <div class="event-info event-notes"><p>Vocalist Melissa Raquel Quintet features trombonist Andre Hayward and an all-star cast of players.</p>
+</div>
+
+    <p class="event-info">
+      
+    </p>
+
+
+    <div class="event-info buying-options product-action pdf__hide">
+
+    <div data-controller="share-dialog" data-share-dialog-url-value="https://elephantroom.com/event/5378796/763189035/melissa-raquel-quartet-featuring-andre-hayward" data-share-dialog-title-value="Melissa Raquel Quartet featuring Andre Hayward @ 🐘8pm on May 22, 9:00PM" data-share-dialog-text-value="Elephant Room @ Melissa Raquel Quartet featuring Andre Hayward @ 🐘8pm, May 22, 9:00PM" data-share-dialog-fb-app-id-value="286076425227">
+  <a class="button button-tertiary zoogle-share pdf__hide" title="Share Melissa Raquel Quartet featuring Andre Hayward @ 🐘8pm on May 22, 9:00PM" data-action="click-&gt;share-dialog#open" href="javascript:void(0)">
+    <i class="icon-share"></i>Share
+</a>
+  <dialog data-share-dialog-target="dialog" data-action="click->share-dialog#clickOutside" class="dialog dialog-share style-section-style-1">
+    <button class="dialog-close" data-action="click-&gt;share-dialog#close" aria-label="close">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11 11" class="icon" width="12px" height="12px"><path d="M6.755 5.502l3.836 3.97-1.438 1.39-3.81-3.942-3.926 3.942L0 9.452 3.953 5.48 0 1.39 1.438 0l3.927 4.064L9.41 0l1.417 1.411-4.073 4.091z" fill-rule="evenodd"></path></svg>
+</button>    <div class="share_desc">
+      <div>
+        <span data-share-dialog-target="title">Melissa Raquel Quartet featuring Andre Hayward @ 🐘8pm on May 22, 9:00PM</span>
+        <br>
+        <span class="byline" data-share-dialog-target="byline">
+        </span>
+      </div>
+    </div>
+
+    <ul class="share_icons">
+      <li class="threads">
+        <a href="#" data-share-dialog-target="threadsLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM23.7524 16.9806C23.8587 17.0263 23.9638 17.074 24.0671 17.1235C25.5284 17.8245 26.597 18.8859 27.1575 20.1926C27.9387 22.0149 28.0101 24.9832 25.6397 27.3514C23.828 29.1615 21.6287 29.9784 18.5087 30H18.4946C14.9852 29.9757 12.2865 28.7948 10.4735 26.4901C8.86024 24.4393 8.02805 21.5855 8.00009 18.0084L8 18L8.00009 17.9916C8.02805 14.4145 8.86024 11.5608 10.4735 9.50991C12.2865 7.20522 14.9852 6.02431 18.4946 6H18.5087C22.0252 6.02439 24.7545 7.20084 26.6206 9.49675C27.5414 10.6295 28.218 11.9953 28.648 13.5803L26.6296 14.1188C26.2749 12.8311 25.7368 11.7267 25.023 10.8485C23.5674 9.05767 21.3735 8.13891 18.5016 8.11756C15.6505 8.13875 13.4942 9.05311 12.0923 10.8353C10.7794 12.5042 10.101 14.9147 10.0757 18C10.101 21.0853 10.7794 23.4958 12.0923 25.1646C13.4942 26.9469 15.6505 27.8612 18.5017 27.8824C21.072 27.8635 22.7728 27.252 24.1876 25.8385C25.8025 24.225 25.7724 22.2459 25.2559 21.0415C24.9521 20.333 24.4021 19.7436 23.66 19.2957C23.4792 20.6429 23.0699 21.712 22.4226 22.537C21.5704 23.6234 20.3487 24.2175 18.7915 24.3029C17.6124 24.3673 16.4778 24.0829 15.5969 23.5014C14.555 22.8135 13.9452 21.7605 13.8799 20.5365C13.7514 18.1235 15.6656 16.3869 18.6431 16.2154C19.7001 16.1548 20.6889 16.2026 21.6031 16.358C21.4818 15.6156 21.2366 15.0274 20.8701 14.6018C20.3665 14.0171 19.5884 13.7173 18.5572 13.7107L18.5286 13.7106C17.7006 13.7106 16.5765 13.9423 15.8601 15.0291L14.1378 13.8476C15.0966 12.3926 16.6546 11.593 18.5278 11.593L18.5702 11.5931C21.702 11.6131 23.5671 13.5673 23.7524 16.9806ZM15.9524 20.4215C16.0193 21.6761 17.3751 22.2619 18.6801 22.1884C19.9578 22.1182 21.408 21.6169 21.6553 18.5291C20.9924 18.3842 20.2633 18.3085 19.4839 18.3085C19.247 18.3085 19.0059 18.3154 18.7602 18.3296C16.6145 18.4533 15.9029 19.4913 15.9524 20.4215Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="facebook">
+        <a href="#" data-share-dialog-target="facebookLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon"><path fill-rule="evenodd" d="M9 0a9 9 0 110 18A9 9 0 019 0zm2.606 4H10.24c-1.575 0-2.17.77-2.215 2.076l-.002.166v1.034H7V9h1.023V14h2.046V9h1.365l.181-1.724H10.07l.003-.862c0-.417.036-.655.553-.687l.128-.003h.853V4z"></path></svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="twitter">
+        <a href="#" data-share-dialog-target="twitterLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="685" data-popup-window-height-value="246" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM26.4163 9L19.7142 16.6226L27.0001 27H21.6396L16.7316 20.0104L10.5876 27H9L16.0278 19.0075L9 9H14.3604L19.0068 15.6173L24.8287 9H26.4163ZM13.5996 10.1714H11.1606L22.3878 25.8861H24.8275L13.5996 10.1714Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="email">
+        <a href="#" data-share-dialog-target="emailLink" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18 9C18 4.02944 13.9706 0 9 0C4.02944 0 0 4.02944 0 9C0 13.9706 4.02944 18 9 18C13.9706 18 18 13.9706 18 9ZM4.02511 5.73566C4.00872 5.77691 4.00004 5.82153 4.00004 5.86854L4 12.1317C4 12.1897 4.0135 12.2449 4.03762 12.2938C4.04581 12.2775 4.05691 12.2621 4.07041 12.2482L7.39793 8.87439L4.0772 5.81961C4.05116 5.79611 4.0338 5.76684 4.02511 5.73566ZM4.34327 12.4991L4.34195 12.499L7.67 9.12427L8.60412 9.98343C8.86598 10.2242 9.26962 10.2228 9.52956 9.98007L10.4564 9.11563L13.768 12.4736C13.7251 12.4904 13.6783 12.5 13.6296 12.5H4.3704C4.3612 12.5 4.35243 12.4996 4.34327 12.4991ZM13.9971 12.1795L10.727 8.86376L13.9913 5.81857C13.9932 5.81713 13.9947 5.81569 13.9961 5.81425C13.9986 5.832 14 5.85023 14 5.86846V12.1315C14 12.1478 13.999 12.1637 13.9971 12.1795ZM13.7686 5.52686C13.7257 5.50959 13.6789 5.5 13.6297 5.5L4.37041 5.50006C4.33617 5.50006 4.30338 5.50486 4.27155 5.5135C4.29229 5.52117 4.31158 5.53316 4.32846 5.549L8.85585 9.71283C8.97448 9.8222 9.15822 9.82172 9.27637 9.71139L13.7382 5.54989C13.7479 5.54077 13.758 5.5331 13.7686 5.52686Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+    </ul>
+    <div class="permalink" data-controller="clipboard">
+      <p>Share link</p>
+      <div class="control -has-addons">
+        <input type="text" value="https://elephantroom.com/event/5378796/763189035/melissa-raquel-quartet-featuring-andre-hayward" data-clipboard-target="source" data-share-dialog-target="urlInput" data-action="click->share-dialog#selectUrl" readonly="true">
+        <span class="control__suffix">
+          <a class="button -simple -compact -icon-only" data-clipboard-target="button" data-action="clipboard#copy">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="icon" width="16px" height="18px"><path d="M4.166.597c-.184 0-.369.15-.369.342v1.365c0 .191.185.341.369.341h9.189v9.216c0 .191.15.342.341.342h1.365c.191 0 .342-.15.342-.342V.94a.338.338 0 00-.342-.342H4.166zm7.44 3.798H.34A.338.338 0 000 4.736v10.923c0 .19.15.341.341.341h10.923c.191 0 .341-.15.341-.341V4.395z" fill-rule="evenodd"></path></svg>
+          </a>
+        </span>
+      </div>
+    </div>
+  </dialog>
+</div>
+</div>
+
+
+      <div class="event-info map-link pdf__hide">
+        <a target="_blank" rel="noopener" href="https://www.google.com/maps/search/?api=1&amp;query=%F0%9F%90%988pm">View on Google Maps</a>
+      </div>
+  </div>
+</div>
+
+<div class="event-clear"></div>
+
+</article>
+<article class="list-style">
+  
+<div class="event-detail" data-event-id="4933190" data-occurrence-id="762546051">
+  <div class="event-image image-social">
+      <a rel="event[4933190]" title="Ryan D Howard Organic Combo" class="thumbnail-popup" data-featherlight="//images.zoogletools.com/s:bzglfiles/u/523260/fdcdc67c4ce7f17ba44e06460968051142b6f8ba/original/ryan-howard.jpg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" href="//images.zoogletools.com/s:bzglfiles/u/523260/fdcdc67c4ce7f17ba44e06460968051142b6f8ba/original/ryan-howard.jpg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg">
+        <img alt="Ryan D Howard Organic Combo" src="//images.zoogletools.com/s:bzglfiles/u/523260/fdcdc67c4ce7f17ba44e06460968051142b6f8ba/original/ryan-howard.jpg/!!/b%3AW1sicmVzaXplIixbMjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>  </div>
+
+  <div class="event-description">
+    <div class="event-info-wrapper">
+        <h2 class="event-info event-title heading-tertiary"><a href="https://elephantroom.com/event/4933190/762546051/ryan-d-howard-organic-combo">Ryan D Howard Organic Combo</a></h2>
+
+        <p class="event-info event-datetime">
+          <i class="icon-clock"></i>
+          <span class="date-long"><span class="event-when with-time"><time class="from"><span class="date">Saturday, May 23</span> @ <span class="time">6:00PM</span></time></span></span><span class="date-short"><span class="event-when with-time"><time class="from"><span class="date">Sat, May 23</span> @ <span class="time">6:00PM</span></time></span></span>
+        </p>
+
+        <p class="event-info event-location">
+          <i class="icon-location"></i>
+          <a target="_blank" rel="noopener" title="View on Google Maps" href="https://www.google.com/maps/search/?api=1&amp;query=%F0%9F%90%98">🐘</a>
+        </p>
+    </div>
+
+      <div class="event-info event-notes"><p>Musically and visually Ryan brings energetic stage performances and authentic sound. Ryan is simply one of the best pianist, organist, keyboardist and vocalist in Texas.</p>
+</div>
+
+    <p class="event-info">
+      
+    </p>
+
+
+    <div class="event-info buying-options product-action pdf__hide">
+
+    <div data-controller="share-dialog" data-share-dialog-url-value="https://elephantroom.com/event/4933190/762546051/ryan-d-howard-organic-combo" data-share-dialog-title-value="Ryan D Howard Organic Combo @ 🐘 on May 23, 6:00PM" data-share-dialog-text-value="Elephant Room @ Ryan D Howard Organic Combo @ 🐘, May 23, 6:00PM" data-share-dialog-fb-app-id-value="286076425227">
+  <a class="button button-tertiary zoogle-share pdf__hide" title="Share Ryan D Howard Organic Combo @ 🐘 on May 23, 6:00PM" data-action="click-&gt;share-dialog#open" href="javascript:void(0)">
+    <i class="icon-share"></i>Share
+</a>
+  <dialog data-share-dialog-target="dialog" data-action="click->share-dialog#clickOutside" class="dialog dialog-share style-section-style-1">
+    <button class="dialog-close" data-action="click-&gt;share-dialog#close" aria-label="close">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11 11" class="icon" width="12px" height="12px"><path d="M6.755 5.502l3.836 3.97-1.438 1.39-3.81-3.942-3.926 3.942L0 9.452 3.953 5.48 0 1.39 1.438 0l3.927 4.064L9.41 0l1.417 1.411-4.073 4.091z" fill-rule="evenodd"></path></svg>
+</button>    <div class="share_desc">
+      <div>
+        <span data-share-dialog-target="title">Ryan D Howard Organic Combo @ 🐘 on May 23, 6:00PM</span>
+        <br>
+        <span class="byline" data-share-dialog-target="byline">
+        </span>
+      </div>
+    </div>
+
+    <ul class="share_icons">
+      <li class="threads">
+        <a href="#" data-share-dialog-target="threadsLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM23.7524 16.9806C23.8587 17.0263 23.9638 17.074 24.0671 17.1235C25.5284 17.8245 26.597 18.8859 27.1575 20.1926C27.9387 22.0149 28.0101 24.9832 25.6397 27.3514C23.828 29.1615 21.6287 29.9784 18.5087 30H18.4946C14.9852 29.9757 12.2865 28.7948 10.4735 26.4901C8.86024 24.4393 8.02805 21.5855 8.00009 18.0084L8 18L8.00009 17.9916C8.02805 14.4145 8.86024 11.5608 10.4735 9.50991C12.2865 7.20522 14.9852 6.02431 18.4946 6H18.5087C22.0252 6.02439 24.7545 7.20084 26.6206 9.49675C27.5414 10.6295 28.218 11.9953 28.648 13.5803L26.6296 14.1188C26.2749 12.8311 25.7368 11.7267 25.023 10.8485C23.5674 9.05767 21.3735 8.13891 18.5016 8.11756C15.6505 8.13875 13.4942 9.05311 12.0923 10.8353C10.7794 12.5042 10.101 14.9147 10.0757 18C10.101 21.0853 10.7794 23.4958 12.0923 25.1646C13.4942 26.9469 15.6505 27.8612 18.5017 27.8824C21.072 27.8635 22.7728 27.252 24.1876 25.8385C25.8025 24.225 25.7724 22.2459 25.2559 21.0415C24.9521 20.333 24.4021 19.7436 23.66 19.2957C23.4792 20.6429 23.0699 21.712 22.4226 22.537C21.5704 23.6234 20.3487 24.2175 18.7915 24.3029C17.6124 24.3673 16.4778 24.0829 15.5969 23.5014C14.555 22.8135 13.9452 21.7605 13.8799 20.5365C13.7514 18.1235 15.6656 16.3869 18.6431 16.2154C19.7001 16.1548 20.6889 16.2026 21.6031 16.358C21.4818 15.6156 21.2366 15.0274 20.8701 14.6018C20.3665 14.0171 19.5884 13.7173 18.5572 13.7107L18.5286 13.7106C17.7006 13.7106 16.5765 13.9423 15.8601 15.0291L14.1378 13.8476C15.0966 12.3926 16.6546 11.593 18.5278 11.593L18.5702 11.5931C21.702 11.6131 23.5671 13.5673 23.7524 16.9806ZM15.9524 20.4215C16.0193 21.6761 17.3751 22.2619 18.6801 22.1884C19.9578 22.1182 21.408 21.6169 21.6553 18.5291C20.9924 18.3842 20.2633 18.3085 19.4839 18.3085C19.247 18.3085 19.0059 18.3154 18.7602 18.3296C16.6145 18.4533 15.9029 19.4913 15.9524 20.4215Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="facebook">
+        <a href="#" data-share-dialog-target="facebookLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon"><path fill-rule="evenodd" d="M9 0a9 9 0 110 18A9 9 0 019 0zm2.606 4H10.24c-1.575 0-2.17.77-2.215 2.076l-.002.166v1.034H7V9h1.023V14h2.046V9h1.365l.181-1.724H10.07l.003-.862c0-.417.036-.655.553-.687l.128-.003h.853V4z"></path></svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="twitter">
+        <a href="#" data-share-dialog-target="twitterLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="685" data-popup-window-height-value="246" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM26.4163 9L19.7142 16.6226L27.0001 27H21.6396L16.7316 20.0104L10.5876 27H9L16.0278 19.0075L9 9H14.3604L19.0068 15.6173L24.8287 9H26.4163ZM13.5996 10.1714H11.1606L22.3878 25.8861H24.8275L13.5996 10.1714Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="email">
+        <a href="#" data-share-dialog-target="emailLink" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18 9C18 4.02944 13.9706 0 9 0C4.02944 0 0 4.02944 0 9C0 13.9706 4.02944 18 9 18C13.9706 18 18 13.9706 18 9ZM4.02511 5.73566C4.00872 5.77691 4.00004 5.82153 4.00004 5.86854L4 12.1317C4 12.1897 4.0135 12.2449 4.03762 12.2938C4.04581 12.2775 4.05691 12.2621 4.07041 12.2482L7.39793 8.87439L4.0772 5.81961C4.05116 5.79611 4.0338 5.76684 4.02511 5.73566ZM4.34327 12.4991L4.34195 12.499L7.67 9.12427L8.60412 9.98343C8.86598 10.2242 9.26962 10.2228 9.52956 9.98007L10.4564 9.11563L13.768 12.4736C13.7251 12.4904 13.6783 12.5 13.6296 12.5H4.3704C4.3612 12.5 4.35243 12.4996 4.34327 12.4991ZM13.9971 12.1795L10.727 8.86376L13.9913 5.81857C13.9932 5.81713 13.9947 5.81569 13.9961 5.81425C13.9986 5.832 14 5.85023 14 5.86846V12.1315C14 12.1478 13.999 12.1637 13.9971 12.1795ZM13.7686 5.52686C13.7257 5.50959 13.6789 5.5 13.6297 5.5L4.37041 5.50006C4.33617 5.50006 4.30338 5.50486 4.27155 5.5135C4.29229 5.52117 4.31158 5.53316 4.32846 5.549L8.85585 9.71283C8.97448 9.8222 9.15822 9.82172 9.27637 9.71139L13.7382 5.54989C13.7479 5.54077 13.758 5.5331 13.7686 5.52686Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+    </ul>
+    <div class="permalink" data-controller="clipboard">
+      <p>Share link</p>
+      <div class="control -has-addons">
+        <input type="text" value="https://elephantroom.com/event/4933190/762546051/ryan-d-howard-organic-combo" data-clipboard-target="source" data-share-dialog-target="urlInput" data-action="click->share-dialog#selectUrl" readonly="true">
+        <span class="control__suffix">
+          <a class="button -simple -compact -icon-only" data-clipboard-target="button" data-action="clipboard#copy">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="icon" width="16px" height="18px"><path d="M4.166.597c-.184 0-.369.15-.369.342v1.365c0 .191.185.341.369.341h9.189v9.216c0 .191.15.342.341.342h1.365c.191 0 .342-.15.342-.342V.94a.338.338 0 00-.342-.342H4.166zm7.44 3.798H.34A.338.338 0 000 4.736v10.923c0 .19.15.341.341.341h10.923c.191 0 .341-.15.341-.341V4.395z" fill-rule="evenodd"></path></svg>
+          </a>
+        </span>
+      </div>
+    </div>
+  </dialog>
+</div>
+</div>
+
+
+      <div class="event-info map-link pdf__hide">
+        <a target="_blank" rel="noopener" href="https://www.google.com/maps/search/?api=1&amp;query=%F0%9F%90%98">View on Google Maps</a>
+      </div>
+  </div>
+</div>
+
+<div class="event-clear"></div>
+
+</article>
+<article class="list-style">
+  
+<div class="event-detail" data-event-id="4558108" data-occurrence-id="762546025">
+  <div class="event-image image-social">
+      <a rel="event[4558108]" title="Jackie Myers Trio" class="thumbnail-popup" data-featherlight="//images.zoogletools.com/s:bzglfiles/u/523260/5b1137f1cdb7cbd5681009077670032809c1d7e3/original/images.jpeg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" href="//images.zoogletools.com/s:bzglfiles/u/523260/5b1137f1cdb7cbd5681009077670032809c1d7e3/original/images.jpeg/!!/b%3AW1sicmVzaXplIixbNjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg">
+        <img alt="Jackie Myers Trio" src="//images.zoogletools.com/s:bzglfiles/u/523260/5b1137f1cdb7cbd5681009077670032809c1d7e3/original/images.jpeg/!!/b%3AW1sicmVzaXplIixbMjAwLG51bGwseyJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWUsImZpdCI6Im91dHNpZGUifV1dXQ%3D%3D/meta%3AeyJzcmNCdWNrZXQiOiJiemdsZmlsZXMifQ%3D%3D.jpg" />
+</a>  </div>
+
+  <div class="event-description">
+    <div class="event-info-wrapper">
+        <h2 class="event-info event-title heading-tertiary"><a href="https://elephantroom.com/event/4558108/762546025/jackie-myers-trio">Jackie Myers Trio</a></h2>
+
+        <p class="event-info event-datetime">
+          <i class="icon-clock"></i>
+          <span class="date-long"><span class="event-when with-time"><time class="from"><span class="date">Sunday, May 24</span> @ <span class="time">8:00PM</span></time></span></span><span class="date-short"><span class="event-when with-time"><time class="from"><span class="date">Sun, May 24</span> @ <span class="time">8:00PM</span></time></span></span>
+        </p>
+
+        <p class="event-info event-location">
+          <i class="icon-location"></i>
+          <a target="_blank" rel="noopener" title="Visit venue website" href="https://jackiemyersmusic.com/home">🐘8pm</a>
+        </p>
+    </div>
+
+      <div class="event-info event-notes"><p>Jazz pianist, composer, and singer Jackie Myers returns to her home town of Austin Texas.  She held the position of music director and pianist for the nationally syndicated radio show "12th Street Jump",  taped live in Kansas City until 2020, when the show ended.  Jackie has held residencies at several of Kansas City's most notable jazz venues including Green Lady Lounge, Chaz on the Plaza and  Corvino Supper Club.has been based in Kansas City playing shows that feature a mix of jazz standards and her original compositions since 2017.  She recently released "What About The Butterfly" which spent 5 weeks on the top 50 national jazz radio chart; "The music is mostly dreamlike and yearningly silken" says Martin Longley of Downbeat Magazine.</p>
+</div>
+
+    <p class="event-info">
+      
+    </p>
+
+
+    <div class="event-info buying-options product-action pdf__hide">
+
+    <div data-controller="share-dialog" data-share-dialog-url-value="https://elephantroom.com/event/4558108/762546025/jackie-myers-trio" data-share-dialog-title-value="Jackie Myers Trio @ 🐘8pm on May 24, 8:00PM" data-share-dialog-text-value="Elephant Room @ Jackie Myers Trio @ 🐘8pm, May 24, 8:00PM" data-share-dialog-fb-app-id-value="286076425227">
+  <a class="button button-tertiary zoogle-share pdf__hide" title="Share Jackie Myers Trio @ 🐘8pm on May 24, 8:00PM" data-action="click-&gt;share-dialog#open" href="javascript:void(0)">
+    <i class="icon-share"></i>Share
+</a>
+  <dialog data-share-dialog-target="dialog" data-action="click->share-dialog#clickOutside" class="dialog dialog-share style-section-style-1">
+    <button class="dialog-close" data-action="click-&gt;share-dialog#close" aria-label="close">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11 11" class="icon" width="12px" height="12px"><path d="M6.755 5.502l3.836 3.97-1.438 1.39-3.81-3.942-3.926 3.942L0 9.452 3.953 5.48 0 1.39 1.438 0l3.927 4.064L9.41 0l1.417 1.411-4.073 4.091z" fill-rule="evenodd"></path></svg>
+</button>    <div class="share_desc">
+      <div>
+        <span data-share-dialog-target="title">Jackie Myers Trio @ 🐘8pm on May 24, 8:00PM</span>
+        <br>
+        <span class="byline" data-share-dialog-target="byline">
+        </span>
+      </div>
+    </div>
+
+    <ul class="share_icons">
+      <li class="threads">
+        <a href="#" data-share-dialog-target="threadsLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM23.7524 16.9806C23.8587 17.0263 23.9638 17.074 24.0671 17.1235C25.5284 17.8245 26.597 18.8859 27.1575 20.1926C27.9387 22.0149 28.0101 24.9832 25.6397 27.3514C23.828 29.1615 21.6287 29.9784 18.5087 30H18.4946C14.9852 29.9757 12.2865 28.7948 10.4735 26.4901C8.86024 24.4393 8.02805 21.5855 8.00009 18.0084L8 18L8.00009 17.9916C8.02805 14.4145 8.86024 11.5608 10.4735 9.50991C12.2865 7.20522 14.9852 6.02431 18.4946 6H18.5087C22.0252 6.02439 24.7545 7.20084 26.6206 9.49675C27.5414 10.6295 28.218 11.9953 28.648 13.5803L26.6296 14.1188C26.2749 12.8311 25.7368 11.7267 25.023 10.8485C23.5674 9.05767 21.3735 8.13891 18.5016 8.11756C15.6505 8.13875 13.4942 9.05311 12.0923 10.8353C10.7794 12.5042 10.101 14.9147 10.0757 18C10.101 21.0853 10.7794 23.4958 12.0923 25.1646C13.4942 26.9469 15.6505 27.8612 18.5017 27.8824C21.072 27.8635 22.7728 27.252 24.1876 25.8385C25.8025 24.225 25.7724 22.2459 25.2559 21.0415C24.9521 20.333 24.4021 19.7436 23.66 19.2957C23.4792 20.6429 23.0699 21.712 22.4226 22.537C21.5704 23.6234 20.3487 24.2175 18.7915 24.3029C17.6124 24.3673 16.4778 24.0829 15.5969 23.5014C14.555 22.8135 13.9452 21.7605 13.8799 20.5365C13.7514 18.1235 15.6656 16.3869 18.6431 16.2154C19.7001 16.1548 20.6889 16.2026 21.6031 16.358C21.4818 15.6156 21.2366 15.0274 20.8701 14.6018C20.3665 14.0171 19.5884 13.7173 18.5572 13.7107L18.5286 13.7106C17.7006 13.7106 16.5765 13.9423 15.8601 15.0291L14.1378 13.8476C15.0966 12.3926 16.6546 11.593 18.5278 11.593L18.5702 11.5931C21.702 11.6131 23.5671 13.5673 23.7524 16.9806ZM15.9524 20.4215C16.0193 21.6761 17.3751 22.2619 18.6801 22.1884C19.9578 22.1182 21.408 21.6169 21.6553 18.5291C20.9924 18.3842 20.2633 18.3085 19.4839 18.3085C19.247 18.3085 19.0059 18.3154 18.7602 18.3296C16.6145 18.4533 15.9029 19.4913 15.9524 20.4215Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="facebook">
+        <a href="#" data-share-dialog-target="facebookLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="550" data-popup-window-height-value="357" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon"><path fill-rule="evenodd" d="M9 0a9 9 0 110 18A9 9 0 019 0zm2.606 4H10.24c-1.575 0-2.17.77-2.215 2.076l-.002.166v1.034H7V9h1.023V14h2.046V9h1.365l.181-1.724H10.07l.003-.862c0-.417.036-.655.553-.687l.128-.003h.853V4z"></path></svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="twitter">
+        <a href="#" data-share-dialog-target="twitterLink" data-controller="popup-window" data-action="click->popup-window#open" data-popup-window-width-value="685" data-popup-window-height-value="246" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" class="icon">
+<path fill-rule="evenodd" d="M36 18C36 8.05887 27.9411 0 18 0C8.05887 0 0 8.05887 0 18C0 27.9411 8.05887 36 18 36C27.9411 36 36 27.9411 36 18ZM26.4163 9L19.7142 16.6226L27.0001 27H21.6396L16.7316 20.0104L10.5876 27H9L16.0278 19.0075L9 9H14.3604L19.0068 15.6173L24.8287 9H26.4163ZM13.5996 10.1714H11.1606L22.3878 25.8861H24.8275L13.5996 10.1714Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="email">
+        <a href="#" data-share-dialog-target="emailLink" target="_blank" rel="noopener">
+          <div class="share_icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" class="icon">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18 9C18 4.02944 13.9706 0 9 0C4.02944 0 0 4.02944 0 9C0 13.9706 4.02944 18 9 18C13.9706 18 18 13.9706 18 9ZM4.02511 5.73566C4.00872 5.77691 4.00004 5.82153 4.00004 5.86854L4 12.1317C4 12.1897 4.0135 12.2449 4.03762 12.2938C4.04581 12.2775 4.05691 12.2621 4.07041 12.2482L7.39793 8.87439L4.0772 5.81961C4.05116 5.79611 4.0338 5.76684 4.02511 5.73566ZM4.34327 12.4991L4.34195 12.499L7.67 9.12427L8.60412 9.98343C8.86598 10.2242 9.26962 10.2228 9.52956 9.98007L10.4564 9.11563L13.768 12.4736C13.7251 12.4904 13.6783 12.5 13.6296 12.5H4.3704C4.3612 12.5 4.35243 12.4996 4.34327 12.4991ZM13.9971 12.1795L10.727 8.86376L13.9913 5.81857C13.9932 5.81713 13.9947 5.81569 13.9961 5.81425C13.9986 5.832 14 5.85023 14 5.86846V12.1315C14 12.1478 13.999 12.1637 13.9971 12.1795ZM13.7686 5.52686C13.7257 5.50959 13.6789 5.5 13.6297 5.5L4.37041 5.50006C4.33617 5.50006 4.30338 5.50486 4.27155 5.5135C4.29229 5.52117 4.31158 5.53316 4.32846 5.549L8.85585 9.71283C8.97448 9.8222 9.15822 9.82172 9.27637 9.71139L13.7382 5.54989C13.7479 5.54077 13.758 5.5331 13.7686 5.52686Z"></path>
+</svg>
+          </div>
+        </a>
+      </li>
+
+    </ul>
+    <div class="permalink" data-controller="clipboard">
+      <p>Share link</p>
+      <div class="control -has-addons">
+        <input type="text" value="https://elephantroom.com/event/4558108/762546025/jackie-myers-trio" data-clipboard-target="source" data-share-dialog-target="urlInput" data-action="click->share-dialog#selectUrl" readonly="true">
+        <span class="control__suffix">
+          <a class="button -simple -compact -icon-only" data-clipboard-target="button" data-action="clipboard#copy">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="icon" width="16px" height="18px"><path d="M4.166.597c-.184 0-.369.15-.369.342v1.365c0 .191.185.341.369.341h9.189v9.216c0 .191.15.342.341.342h1.365c.191 0 .342-.15.342-.342V.94a.338.338 0 00-.342-.342H4.166zm7.44 3.798H.34A.338.338 0 000 4.736v10.923c0 .19.15.341.341.341h10.923c.191 0 .341-.15.341-.341V4.395z" fill-rule="evenodd"></path></svg>
+          </a>
+        </span>
+      </div>
+    </div>
+  </dialog>
+</div>
+</div>
+
+
+      <div class="event-info map-link pdf__hide">
+        <a target="_blank" rel="noopener" href="https://www.google.com/maps/search/?api=1&amp;query=%F0%9F%90%988pm">View on Google Maps</a>
+      </div>
+  </div>
+</div>
+
+<div class="event-clear"></div>
+
+</article>
+
+
+      <div class="pdf__hide">
+    <nav class="pagination">
+    <span class="first">
+  <span class='pagination-decoration icon icon-first'></span>First
+</span>
+
+    <span class="prev hidden">
+  <span class='pagination-decoration icon icon-previous'></span>Prev
+</span>
+        <span class="page current">
+  1
+</span>
+
+        <span class="page">
+  <a rel="next" href="/calendar/features/load/calendar_feature_1147558.turbo_stream?calendar_page=2">2</a>
+</span>
+
+        <span class="page gap">…</span>
+
+        <span class="page">
+  <a href="/calendar/features/load/calendar_feature_1147558.turbo_stream?calendar_page=8">8</a>
+</span>
+
+      <span class="next">
+  <a rel="next" href="/calendar/features/load/calendar_feature_1147558.turbo_stream?calendar_page=2">Next<span class='pagination-decoration icon icon-next'></span></a>
+</span>
+      <span class="last">
+  <a href="/calendar/features/load/calendar_feature_1147558.turbo_stream?calendar_page=8">Last<span class='pagination-decoration icon icon-last'></span></a>
+</span>
+
+  </nav>
+
+</div>
+
+    </section>
+
+  
+
+
+</div>
+</section></div><div class="zoogle-feature block layout_full" data-block-id="22744409" id="feature_block_22744409"><section class="feature text_feature" data-feature-id="5561309" data-controller="content-width" data-content-width-name="feature" id="text_feature_5561309"><div data-controller="zoogle-video" data-action="message@window->zoogle-video#handleVimeoPostMessage"><h2 style="text-align:center;"><span>Live Jazz in the Basement Since 1991</span></h2><div class="zoogle-column zoogle-column-1-of-1 col_1_of_1 layout_full" data-column-id="20524599" id="feature_column_20524599"><div class="zoogle-feature block layout_full" data-block-id="20402773" id="feature_block_20402773"><section data-feature-id="4900017" data-controller="content-width" data-content-width-name="feature" id="text_feature_4900017" feature-width="&gt;100 &gt;120 &gt;140 &gt;160 &gt;180 &gt;200 &gt;220 &gt;240 &gt;260 &gt;280 &gt;300 &gt;320 &gt;340 &gt;360 &gt;380 &gt;400 &gt;420 &gt;440 &gt;460 &gt;480 &gt;500 &gt;520 &gt;540 &gt;560 &gt;580 &gt;600 &gt;620 &gt;640 &gt;660 &gt;680 &gt;700 &gt;720 &gt;740 &gt;760 &gt;780 &gt;800 &gt;820 &gt;840 &gt;860 &gt;880 &gt;900 &gt;920 &gt;940 &gt;960 &gt;980 &gt;1000 &gt;1020 &gt;1040 &gt;1060 &lt;1080 &lt;1100 &lt;1120 &lt;1140 &lt;1160 &lt;1180 &lt;1200 &lt;1220 &lt;1240 &lt;1260 &lt;1280 &lt;1300 &lt;1320 &lt;1340 &lt;1360 &lt;1380 &lt;1400"><div data-controller="zoogle-video" data-action="message@window-&gt;zoogle-video#handleVimeoPostMessage">
+<p style="text-align:center;"><span class="text-big"><strong>All seating is first come, first serve. Reservations are neither required nor available.</strong></span></p>
+<p style="text-align:center;"><span class="text-big"><i><strong>Guests 21 and up only</strong></i></span></p>
+<p style="text-align:center;"><span class="text-huge">Daily Hours</span></p>
+<p style="text-align:center;"><span class="text-big">7pm-1am Sunday</span><br><span class="text-big">5pm-2am Monday-Friday</span><br><span class="text-big">8pm-2am Saturday</span></p>
+<p style="text-align:center;"><span class="text-big">$5 cover Sunday-Monday</span><br><span class="text-big">$7 cover Tuesday-Thursday</span><br><span class="text-big">$10 cover Friday-Saturday</span></p>
+<p style="text-align:center;"><span class="text-big">No cover charge before 8pm</span></p>
+<p style="text-align:center;"> </p>
+<p style="text-align:center;"><span style="color:#ffffff;">315 Congress Ave.</span></p>
+<p style="text-align:center;"><span style="color:#ffffff;">The Historic Swift Building</span></p>
+<p style="text-align:center;"><span style="color:#ffffff;">Austin, Texas</span></p>
+<p style="text-align:center;"><span style="color:#ffffff;">Management: aaron@elephantroom.com            Music Booking:  Mike@bbabooking.com </span></p>
+<p style="text-align:center;"><span style="color:#ffffff;">  Call or Text  </span><a class="no-pjax" href="tel:512-575-2925"><span style="color:#ffffff;">512-575-2925</span></a></p>
+</div></section></div></div></div></section></div>
+</div>
+</div>
+</moda-section></moda-sections></div>
+
+		</div>
+	</div>
+
+	
+		<div id="footer-wrap">
+			
+
+  <footer id="site-wide-footer" class="site-wide-footer"><moda-sections class="zoogle-content" data-arrangement-id="4721634" data-controller="content-width"><moda-section class="moda m-section m-shape m-masked m-style-feature-row-12716064 zoogle-columns zoogle-columns-3 zoogle-columns-33-33-33 default-section-style padding-none title-alignment-left block block-row layout_full" data-row-id="12716064" id="feature_row_12716064" variant="1">
+  
+  
+
+  
+
+  <div class="zoogle-columns-inner site-wrap">
+    
+
+
+    
+    <div class="zoogle-column zoogle-column-1-of-3 col_1_of_3 layout_third" data-column-id="15041353" id="feature_column_15041353">
+</div><div class="zoogle-column zoogle-column-2-of-3 col_2_of_3 layout_third" data-column-id="15064551" id="feature_column_15064551">
+</div><div class="zoogle-column zoogle-column-3-of-3 col_3_of_3 layout_third" data-column-id="15295083" id="feature_column_15295083">
+</div>
+</div>
+    <div class="zoogle-columns-inner site-wrap">  <div class="injected-footer">
+  <footer id="page-footer" data-controller="session" data-session-url-value="/go/member/profile">
+
+    <div class="zoogle-feature block layout_full" data-block-id="821627" id="sitewide_block_821627"><section class="feature text_feature" data-feature-id="3505973" data-controller="content-width" data-content-width-name="feature" id="text_feature_3505973"></section></div>
+
+
+    <p class="hide" data-controller="attributions">
+  Some images &copy; <span data-attributions-target="list"></span>
+</p>
+
+    <nav>
+  <ul>
+      <li class="if-logged-in"><a class="no-pjax link" data-turbo="false" rel="nofollow" data-method="delete" href="/user_sessions/logout">Log out</a></li>
+  </ul>
+</nav>
+
+    
+  <div class="branding text-tertiary">
+    
+    <small>
+      <a href="https://bandzoogle.com/?memref=r7fbfc&amp;utm_source=member&amp;utm_medium=website&amp;utm_campaign=footer" target="_blank" rel="nofollow noopener">Powered by Bandzoogle</a>
+      
+    </small>
+  </div>
+
+  </footer>
+</div>
+
+
+</div>
+</moda-section></moda-sections></footer>
+
+		</div>
+	
+</div>
+
+</div>
+
+
+  <!-- required for nav desktop hamburger plugin -->
+  <div class="mobile-nav-open-site-overlay"></div>
+</div>
+
+<script type="text/javascript">
+var _zaq = _zaq || [];
+var dntStatus = navigator.doNotTrack || window.doNotTrack || navigator.msDoNotTrack;
+var dontTrack = dntStatus === true || dntStatus === "1";
+var inEditor = document.querySelector('.fieri') !== null;
+
+if (!dontTrack && !inEditor) {
+  _zaq.push(['_setWebsite', '512129']);
+  _zaq.push(['_setZone', 'Central Time (US &amp; Canada)']);
+  _zaq.push(['_setHash', '3ada09f351b44fac65443289fbd2a4b7']);
+  _zaq.push(['_trackPage', '3839194']);
+
+  (function() {
+    var zs = document.createElement('script'); zs.type = 'text/javascript'; zs.async = true;
+    zs.src = "https://stats.zoogletools.net/stats.js?v=1";
+    zs.id = "zstats";
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(zs, s);
+  })();
+}
+</script>
+
+
+</div>  </div>
+</div>
+</body></html>

--- a/tests/Unit/BandzoogleExtractorTest.php
+++ b/tests/Unit/BandzoogleExtractorTest.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Bandzoogle Extractor Tests
+ *
+ * Covers detection of Bandzoogle CMS pages and extraction of events from the
+ * modern `event-detail` list view, using a real production snapshot of the
+ * Elephant Room (Austin, TX) calendar as the fixture.
+ *
+ * @package DataMachineEvents\Tests\Unit
+ * @since   0.15.x
+ */
+
+namespace DataMachineEvents\Tests\Unit;
+
+use WP_UnitTestCase;
+use DataMachineEvents\Steps\EventImport\Handlers\WebScraper\Extractors\BandzoogleExtractor;
+
+class BandzoogleExtractorTest extends WP_UnitTestCase {
+
+	private BandzoogleExtractor $extractor;
+	private string $fixture_path;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->extractor    = new BandzoogleExtractor();
+		$this->fixture_path = __DIR__ . '/../Fixtures/bandzoogle-elephant-room.html';
+	}
+
+	/**
+	 * Detect Bandzoogle from the Elephant Room production snapshot.
+	 *
+	 * The fixture contains `bndzgl.com` / `zoogletools.com` asset URLs and
+	 * `data-event-id` attributes on `.event-detail` blocks — any one of
+	 * those is sufficient.
+	 */
+	public function test_canExtract_detects_bandzoogle_fixture() {
+		if ( ! file_exists( $this->fixture_path ) ) {
+			$this->markTestSkipped( 'Bandzoogle fixture not present.' );
+		}
+
+		$html = file_get_contents( $this->fixture_path );
+		$this->assertTrue(
+			$this->extractor->canExtract( $html ),
+			'Should detect Bandzoogle from real Elephant Room calendar markup.'
+		);
+	}
+
+	/**
+	 * Reject non-Bandzoogle HTML.
+	 */
+	public function test_canExtract_rejects_non_bandzoogle() {
+		$html = '<html><head><title>Not a venue</title></head><body><p>Plain HTML, no platform fingerprint.</p></body></html>';
+		$this->assertFalse(
+			$this->extractor->canExtract( $html ),
+			'Plain HTML should not match Bandzoogle detection markers.'
+		);
+	}
+
+	/**
+	 * Empty input is rejected.
+	 */
+	public function test_canExtract_rejects_empty_string() {
+		$this->assertFalse( $this->extractor->canExtract( '' ) );
+	}
+
+	/**
+	 * Pull at least 5 events from the Elephant Room snapshot.
+	 *
+	 * The captured page shows ~20 events for the current month, so this
+	 * threshold is well below the real yield while leaving headroom for
+	 * future snapshot refreshes that may have a slower month.
+	 */
+	public function test_extract_returns_events_from_elephant_room_fixture() {
+		if ( ! file_exists( $this->fixture_path ) ) {
+			$this->markTestSkipped( 'Bandzoogle fixture not present.' );
+		}
+
+		$html   = file_get_contents( $this->fixture_path );
+		$events = $this->extractor->extract( $html, 'https://elephantroom.com/calendar' );
+
+		$this->assertGreaterThanOrEqual(
+			5,
+			count( $events ),
+			'Real Bandzoogle calendars should yield at least 5 extracted events.'
+		);
+	}
+
+	/**
+	 * Each extracted event has the fields downstream pipelines require.
+	 */
+	public function test_extract_event_has_required_fields() {
+		if ( ! file_exists( $this->fixture_path ) ) {
+			$this->markTestSkipped( 'Bandzoogle fixture not present.' );
+		}
+
+		$html   = file_get_contents( $this->fixture_path );
+		$events = $this->extractor->extract( $html, 'https://elephantroom.com/calendar' );
+
+		$this->assertNotEmpty( $events, 'Need at least one event to inspect.' );
+
+		$event = $events[0];
+
+		$this->assertNotEmpty( $event['title'], 'Event must have a non-empty title.' );
+		$this->assertMatchesRegularExpression(
+			'/^\d{4}-\d{2}-\d{2}$/',
+			$event['startDate'],
+			'startDate must be a YYYY-MM-DD string.'
+		);
+		// Bandzoogle's event-detail page always exists — fallback ensures ticketUrl is set.
+		$this->assertNotEmpty(
+			$event['ticketUrl'],
+			'ticketUrl must be populated (external vendor or event detail page fallback).'
+		);
+		// imageUrl populated for nearly every Bandzoogle event card.
+		$this->assertNotEmpty( $event['imageUrl'], 'imageUrl should be populated from event-image block.' );
+		$this->assertSame( 'bandzoogle', $this->extractor->getMethod() );
+	}
+
+	/**
+	 * Synthetic legacy `.gig-info` block without a `<time datetime>` attr.
+	 *
+	 * Confirms the legacy parser either yields a useful date (from time text)
+	 * or skips the event without throwing.
+	 */
+	public function test_extract_handles_missing_datetime_attr_gracefully() {
+		// Note the `bandzoogle.com` footer credit so detection passes.
+		$html = '<html><body>'
+			. '<div class="gig-info">'
+			. '<time>Wednesday, May 13 at 8:00 PM</time>'
+			. '<span class="gig-artist">Test Artist</span>'
+			. '</div>'
+			. '<p>powered by bandzoogle.com</p>'
+			. '</body></html>';
+
+		// Should not throw.
+		$events = $this->extractor->extract( $html, 'https://example.com/calendar' );
+		$this->assertIsArray( $events, 'extract() must always return an array, even with malformed markup.' );
+
+		// Either the legacy parser produces a usable event, or it skips it —
+		// both are acceptable. We just need NO fatal errors and a stable shape.
+		foreach ( $events as $event ) {
+			$this->assertArrayHasKey( 'title', $event );
+			$this->assertArrayHasKey( 'startDate', $event );
+		}
+	}
+
+	/**
+	 * Direct unit test against the legacy `.gig-info` parser with an
+	 * `<time datetime="...">` attribute (ISO 8601).
+	 *
+	 * Even though our production sample uses the newer markup, the issue
+	 * (#261) explicitly called out the legacy shape, so it gets a regression
+	 * test here.
+	 */
+	public function test_extract_parses_legacy_gig_info_with_iso_datetime() {
+		$html = '<html><body>'
+			. '<section class="gigs">'
+			. '<div class="gig-info">'
+			. '<time datetime="2026-05-20T20:00:00-05:00">Wed May 20</time>'
+			. '<span class="gig-artist">Brownout</span>'
+			. '<div class="gig-tickets"><a href="https://example.com/tickets/brownout">Tickets</a></div>'
+			. '</div>'
+			. '</section>'
+			. '<p>powered by bandzoogle.com</p>'
+			. '</body></html>';
+
+		$this->assertTrue( $this->extractor->canExtract( $html ) );
+
+		$events = $this->extractor->extract( $html, 'https://example.com/calendar' );
+		$this->assertNotEmpty( $events, 'Legacy gig-info block with ISO datetime should yield an event.' );
+
+		$event = $events[0];
+		$this->assertSame( 'Brownout', $event['title'] );
+		$this->assertSame( '2026-05-20', $event['startDate'] );
+		$this->assertSame( '20:00', $event['startTime'] );
+		$this->assertSame( 'https://example.com/tickets/brownout', $event['ticketUrl'] );
+	}
+}


### PR DESCRIPTION
Fixes #261.

## What this does

Replaces the in-tree Bandzoogle extractor (a draft that produced zero events on prod — see Elephant Room flow #56 below) with one that actually parses the inline `event-detail` list view real Bandzoogle calendars render. **20 real events extracted from a single HTTP fetch** against a fresh snapshot of https://elephantroom.com/calendar.

## Production evidence (per #261)

| Flow | URL | 14d runs | Events extracted |
|---|---|---|---|
| 56 | https://elephantroom.com/ | 42 | 0 |

The flow's `source_url` points at the homepage because qualify returned `qualified: true` via the Vision flyer fallback. The actual calendar lives at `/calendar`. After this lands and the qualify rework deploys, requalify-pending will move flow #56's `source_url` to the calendar path and this extractor will take over.

## Bandzoogle markup pattern

The fresh fixture confirmed the **modern** Bandzoogle "anthem" markup differs from what the issue described. Issue called out `.gig-info` / `.gig-artist` / `.gig-venue` / `time[datetime]` (legacy theme generation). Real Elephant Room markup is:

```html
<div class=\"event-detail\" data-event-id=\"...\" data-occurrence-id=\"...\">
  <div class=\"event-image\"><a><img src=\"...\" /></a></div>
  <div class=\"event-description\">
    <h2 class=\"event-info event-title\"><a href=\"...\">Title</a></h2>
    <p class=\"event-info event-datetime\">
      <time class=\"from\">
        <span class=\"date\">Wednesday, May 13</span> @ <span class=\"time\">6:00PM</span>
      </time>
    </p>
    <p class=\"event-info event-location\"><a href=\"...maps...\">Sub-venue</a></p>
    <div class=\"event-info event-notes\"><p>...description...</p></div>
    <div class=\"event-info buying-options\">...share + optional ticket link...</div>
  </div>
</div>
```

Year context lives separately in `<span class=\"month-name\">May 2026</span>` near the calendar header, because per-event datetime markup intentionally omits it. The parser resolves the year from there (with `?year=` pagination link fallback).

Bandzoogle ships everything from `bndzgl.com` (app assets) and `zoogletools.com` (image CDN). Detection accepts those plus the legacy markup markers from the issue, so both theme generations are covered without an extractor split.

## Parser strategy

- **Primary path:** parse inline `.event-detail` blocks directly. One HTTP request, all events on the page. The prior implementation N+1-fetched occurrence popups and crawled 12 forward months — easily 100+ network round trips for a small venue. Strictly worse, and the production zero-yield suggests it never worked end-to-end on real markup.
- **Title + detail URL:** `h2.event-title > a`.
- **Date + time:** `time.from > span.date` (\"Wednesday, May 13\") + `time.from > span.time` (\"6:00PM\"); year from calendar header; `parseTimeString()` for 12h → 24h.
- **Image:** `.event-image img[src]`, with `resolveUrl()` to normalize `//` protocol-relative CDN URLs.
- **Description:** `.event-notes` (via `wp_kses_post`).
- **ticketUrl:** prefers known external vendor domains (Eventbrite, Tixr, Etix, Dice, Ticketmaster, See Tickets, TicketWeb, Afton, Prekindle, Showclix, OpenTable, Resy, Tock, VenuePilot, Freshtix, Showare), falls back to any non-share / non-social / non-maps external link, then finally to the event detail page so downstream pipelines always have something to link to.
- **Venue:** falls through to `PageVenueExtractor` for page-level name + address. Per-event `.event-location` rarely carries a real second venue (usually a sub-room like \"🐘6pm\"), so we keep page-level venue when set.

A legacy `.gig-info` parser ships as a forward-compat fallback. We don't currently have a production sample for that shape, but the issue called it out and the parser is small + cheap.

## Detection

Any one of these is a positive match:

- `bndzgl.com` (Bandzoogle app asset host)
- `zoogletools.com` (Bandzoogle image CDN)
- `bandzoogle.com` (footer credit / \"powered by\")
- `data-event-id=` paired with `event-detail` class
- legacy `class=\"gig-info\"` / `class=\"gigs\"` / `class=\"bandzoogle-…\"`

Empty input is rejected.

## Test plan

`tests/Unit/BandzoogleExtractorTest.php` — six PHPUnit cases:

1. **`test_canExtract_detects_bandzoogle_fixture`** — feeds the Elephant Room snapshot, asserts `canExtract()` returns true.
2. **`test_canExtract_rejects_non_bandzoogle`** — plain HTML with no platform fingerprint, asserts false.
3. **`test_canExtract_rejects_empty_string`** — empty string, asserts false.
4. **`test_extract_returns_events_from_elephant_room_fixture`** — asserts ≥5 events from the snapshot (real yield is 20; threshold leaves headroom for slow months on future re-snapshots).
5. **`test_extract_event_has_required_fields`** — asserts the first event has non-empty `title`, `startDate` matching `^\d{4}-\d{2}-\d{2}$`, non-empty `ticketUrl` (vendor or detail-page fallback), non-empty `imageUrl`, and `getMethod() === 'bandzoogle'`.
6. **`test_extract_handles_missing_datetime_attr_gracefully`** — synthetic legacy `.gig-info` with no `<time datetime>`; asserts no fatal and stable array shape.
7. **`test_extract_parses_legacy_gig_info_with_iso_datetime`** — regression test for the markup originally described in #261; asserts title, date, time, ticketUrl extracted from a `<time datetime=\"2026-05-20T20:00:00-05:00\">` block.

Tests pass against an ad-hoc PHP harness with stubbed WP functions (no phpunit binary available in this worktree; the broader DM-core suite hits the same `WP_Agent_Memory_Layer` bootstrap issue prior PRs documented). `php -l` clean on all touched files.

## Out of scope

- **Do not auto-promote flows** — qualify rework in extrachill-events PR #76 owns flow URL movement.
- **Do not edit existing flow URLs** — `wp extrachill venues requalify-pending --platform=bandzoogle` will auto-resume any paused flows that fingerprinted as Bandzoogle once both this PR and qualify v2 are deployed.
- **Do not backfill the 8 zero-yield flows manually** — requalify-pending handles that too.
- **No reordering of `UniversalWebScraper::getExtractors()`** — the entry was already registered after `WebflowExtractor` and before `WordPressExtractor`; nothing moved.

## Notes for review

- The previous in-tree `BandzoogleExtractor.php` had been on `main` since `2f338eb` (shipped silently inside a Squarespace feature PR), which is why the issue described the extractor as \"already declared in `UniversalWebScraper::getExtractors()` but doesn't exist yet.\" It existed, it just didn't work. This PR is a full rewrite; the file diff shows `+432/-188` for that reason.
- The fixture (`tests/Fixtures/bandzoogle-elephant-room.html`, ~360 KB) is a raw `curl` of `/calendar` taken during this PR. Same convention as `squarespace-royal-american.html`.