### PR TITLE
fix(test-event-scraper): restore correct extraction count in qualify path

### DIFF
--- a/inc/Abilities/EventScraperTest.php
+++ b/inc/Abilities/EventScraperTest.php
@@ -145,9 +145,20 @@ class EventScraperTest {
 			return new \WP_Error( 'scraper_failed', 'Scraper returned no results. ' . implode( '; ', $warning_messages ), array( 'status' => 500 ) );
 		}
 
-		$packet       = $results[0];
-		$packet_array = $packet->addTo( array() );
-		$packet_entry = $packet_array[0] ?? array();
+		// Walk every packet returned by get_fetch_data(). One packet per extracted
+		// event — multi-event calendars (Bandzoogle, JSON-LD lists, Tribe REST,
+		// etc.) produce N packets and we must surface the full count to the
+		// qualify path (#265).
+		$packet_entries = array();
+		foreach ( $results as $packet_obj ) {
+			$packet_array = $packet_obj->addTo( array() );
+			$packet_entry = $packet_array[0] ?? array();
+			if ( ! empty( $packet_entry ) ) {
+				$packet_entries[] = $packet_entry;
+			}
+		}
+
+		$packet_entry = $packet_entries[0] ?? array();
 		$packet_data  = $packet_entry['data'] ?? array();
 		$packet_meta  = $packet_entry['metadata'] ?? array();
 
@@ -159,10 +170,16 @@ class EventScraperTest {
 		$payload = json_decode( (string) $body, true );
 		$event   = is_array( $payload ) ? ( $payload['event'] ?? null ) : null;
 
+		// Build a summary list of every event across all packets. Compatible
+		// with QualifyFingerprinter::count_events() which already handles
+		// $event_data['items'] / $event_data['events'] as the multi-event signal.
+		$all_events = $this->summarizeEventsFromPackets( $packet_entries );
+
 		$extraction_info = array(
 			'packet_title'      => $packet_data['title'] ?? '',
 			'source_type'       => $packet_meta['source_type'] ?? '',
 			'extraction_method' => $packet_meta['extraction_method'] ?? '',
+			'event_count'       => count( $packet_entries ),
 		);
 
 		if ( is_array( $payload ) && isset( $payload['raw_html'] ) && is_string( $payload['raw_html'] ) ) {
@@ -258,6 +275,16 @@ class EventScraperTest {
 		$event_data['venueState']   = $venue_state;
 		$event_data['venueZip']     = $venue_zip;
 
+		// Surface the full event list and total count so qualify-path consumers
+		// (extrachill-events QualifyFingerprinter::count_events) see the true
+		// extraction count instead of just the first event (#265).
+		//
+		// `items` is the field QualifyFingerprinter::count_events() already
+		// inspects (`isset($event_data['items'])`) — populating it lets the fix
+		// land without requiring a matching change in extrachill-events.
+		$event_data['items']       = $all_events;
+		$event_data['event_count'] = count( $all_events );
+
 		$extraction_info['payload_type'] = 'event';
 
 		$time_data_warning = false;
@@ -317,5 +344,52 @@ class EventScraperTest {
 
 	private function buildErrorResponse( string $message ): \WP_Error {
 		return new \WP_Error( 'test_error', $message, array( 'status' => 400 ) );
+	}
+
+	/**
+	 * Build a lightweight summary list of every event represented in the
+	 * DataPacket array returned by UniversalWebScraper::get_fetch_data().
+	 *
+	 * Each input packet entry is the array shape produced by DataPacket::addTo()
+	 * (i.e. has `data.body` as a JSON-encoded `{ event: {...}, ... }` blob, as
+	 * built by StructuredDataProcessor::process()).
+	 *
+	 * Packets whose body is non-event (raw_html / vision_flyer) are skipped —
+	 * those payload types are inherently single-event and already counted via
+	 * the existing `event_data.title` / `event_data.raw_html` heuristics in
+	 * QualifyFingerprinter::count_events().
+	 *
+	 * @param array $packet_entries Packet entries from DataPacket::addTo().
+	 * @return array<int, array{title:string,startDate:string,startTime:string,ticketUrl:string}>
+	 */
+	private function summarizeEventsFromPackets( array $packet_entries ): array {
+		$summary = array();
+
+		foreach ( $packet_entries as $entry ) {
+			$data = $entry['data'] ?? array();
+			$body = $data['body'] ?? '';
+			if ( '' === $body ) {
+				continue;
+			}
+
+			$decoded = json_decode( (string) $body, true );
+			if ( ! is_array( $decoded ) ) {
+				continue;
+			}
+
+			$event = $decoded['event'] ?? null;
+			if ( ! is_array( $event ) ) {
+				continue;
+			}
+
+			$summary[] = array(
+				'title'     => (string) ( $event['title'] ?? '' ),
+				'startDate' => (string) ( $event['startDate'] ?? '' ),
+				'startTime' => (string) ( $event['startTime'] ?? '' ),
+				'ticketUrl' => (string) ( $event['ticketUrl'] ?? '' ),
+			);
+		}
+
+		return $summary;
 	}
 }

--- a/inc/Abilities/EventScraperTest.php
+++ b/inc/Abilities/EventScraperTest.php
@@ -5,6 +5,27 @@
  * Tests universal web scraper compatibility with a target URL.
  * Provides structured JSON output via WordPress Abilities API and Chat Tools.
  *
+ * Qualify-path divergence (issue #265, fixed in #266):
+ * -----------------------------------------------------
+ * UniversalWebScraper::executeFetch() returns `{ items: [...] }` when an
+ * extractor yields multiple events on a calendar page. FetchHandler::get_fetch_data()
+ * normalizes that into one DataPacket per event — so for a Bandzoogle calendar with
+ * 19 events, `$handler->get_fetch_data()` returns an array of 19 DataPackets.
+ *
+ * Prior to the #265 fix, this ability read only `$results[0]` — the first packet —
+ * and returned its single event as `event_data`. The qualify path
+ * (extrachill-events/QualifyFingerprinter::count_events()) then saw a single-event
+ * payload and recorded `extractor_attempts[i].events: 1` regardless of how many
+ * events the extractor actually found. That undercount caused every Bandzoogle /
+ * multi-event JSON-LD venue to be flagged `extraction_gap` on its first qualify run.
+ *
+ * Fix shape (Shape A from the issue): walk all packets, build an `event_data.events[]`
+ * summary array (compatible with `QualifyFingerprinter::count_events()`'s existing
+ * `items[]` check), and surface `event_count` in both `event_data` and
+ * `extraction_info`. The first event's full record stays at `event_data` top-level
+ * for backwards compatibility with the chat tool and the CLI command, which only
+ * read a single event's fields.
+ *
  * @package DataMachineEvents\Abilities
  */
 

--- a/inc/Cli/UniversalWebScraperTestCommand.php
+++ b/inc/Cli/UniversalWebScraperTestCommand.php
@@ -92,6 +92,11 @@ class UniversalWebScraperTestCommand {
 		} else {
 			$event_data = $result['event_data'] ?? array();
 			\WP_CLI::log( 'Payload type: event' );
+			if ( isset( $event_data['event_count'] ) && (int) $event_data['event_count'] > 1 ) {
+				\WP_CLI::log( 'Events extracted: ' . (int) $event_data['event_count'] . ' (showing first below)' );
+			} elseif ( isset( $event_data['event_count'] ) ) {
+				\WP_CLI::log( 'Events extracted: ' . (int) $event_data['event_count'] );
+			}
 			\WP_CLI::log( 'Title: ' . ( $event_data['title'] ?? '' ) );
 			\WP_CLI::log( 'Start Date: ' . ( $event_data['startDate'] ?? '' ) );
 			\WP_CLI::log( 'Start Time: ' . ( $event_data['startTime'] ?? '' ) );

--- a/tests/Unit/EventScraperTestAbilityTest.php
+++ b/tests/Unit/EventScraperTestAbilityTest.php
@@ -1,0 +1,306 @@
+<?php
+/**
+ * EventScraperTest Ability — qualify-path regression tests.
+ *
+ * Issue #265: the test-event-scraper ability was reading only the first
+ * DataPacket returned by UniversalWebScraper::get_fetch_data() and
+ * discarding the rest, so multi-event calendars (Bandzoogle, multi-event
+ * JSON-LD pages, Tribe REST, etc.) appeared to qualify v2 as `events: 1`
+ * regardless of how many events were actually extracted. The fix walks
+ * every packet and surfaces the full count via event_data.items[],
+ * event_data.event_count, and extraction_info.event_count.
+ *
+ * These tests cover:
+ *   1. The internal summarizer (summarizeEventsFromPackets) — gives a
+ *      deterministic unit-level check independent of the HTTP layer.
+ *   2. End-to-end runs against committed Bandzoogle and JSON-LD fixtures,
+ *      with the HTTP layer mocked via the `pre_http_request` filter so
+ *      UniversalWebScraper::fetch_html() returns the fixture content.
+ *      Each end-to-end test asserts the ability's count matches what the
+ *      underlying extractor's direct `extract()` call returns on the same
+ *      HTML, including the inverse case (single-event JSON-LD page should
+ *      still report exactly 1).
+ *
+ * @package DataMachineEvents\Tests\Unit
+ * @since   0.36.0
+ */
+
+namespace DataMachineEvents\Tests\Unit;
+
+use WP_UnitTestCase;
+use ReflectionClass;
+use DataMachineEvents\Abilities\EventScraperTest;
+use DataMachineEvents\Steps\EventImport\Handlers\WebScraper\Extractors\BandzoogleExtractor;
+use DataMachineEvents\Steps\EventImport\Handlers\WebScraper\Extractors\JsonLdExtractor;
+
+class EventScraperTestAbilityTest extends WP_UnitTestCase {
+
+	private string $fixtures_dir;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->fixtures_dir = dirname( __DIR__ ) . '/Fixtures';
+	}
+
+	public function tearDown(): void {
+		remove_all_filters( 'pre_http_request' );
+		parent::tearDown();
+	}
+
+	// ────────────────────────────────────────────────────────────────────
+	// Unit-level: summarizer reads every packet's event payload
+	// ────────────────────────────────────────────────────────────────────
+
+	/**
+	 * Synthesizes the exact packet entry shape produced by
+	 * StructuredDataProcessor::process() → FetchHandler::toDataPackets() →
+	 * DataPacket::addTo() and asserts the summarizer counts each packet's
+	 * inner event correctly.
+	 *
+	 * This is the lowest-level guarantee that the fix cannot regress to
+	 * "first packet only" without breaking this test.
+	 */
+	public function test_summarizer_counts_every_packet_event() {
+		$ability = new EventScraperTest();
+		$method  = ( new ReflectionClass( $ability ) )->getMethod( 'summarizeEventsFromPackets' );
+		$method->setAccessible( true );
+
+		$packets = array();
+		foreach ( range( 1, 5 ) as $i ) {
+			$packets[] = $this->buildPacketEntry(
+				array(
+					'title'     => 'Event ' . $i,
+					'startDate' => sprintf( '2026-06-%02d', $i ),
+					'startTime' => '20:00',
+					'ticketUrl' => 'https://example.com/tickets/' . $i,
+				)
+			);
+		}
+
+		$summary = $method->invoke( $ability, $packets );
+
+		$this->assertCount( 5, $summary, 'Summarizer must return one entry per packet.' );
+		$this->assertSame( 'Event 1', $summary[0]['title'] );
+		$this->assertSame( '2026-06-05', $summary[4]['startDate'] );
+	}
+
+	/**
+	 * Skipping non-event packets (raw_html / vision_flyer / malformed JSON)
+	 * keeps the summary list focused on extractable structured events.
+	 */
+	public function test_summarizer_skips_non_event_packets() {
+		$ability = new EventScraperTest();
+		$method  = ( new ReflectionClass( $ability ) )->getMethod( 'summarizeEventsFromPackets' );
+		$method->setAccessible( true );
+
+		$packets = array(
+			$this->buildPacketEntry( array( 'title' => 'Real Event', 'startDate' => '2026-06-01' ) ),
+			array( 'data' => array( 'body' => '' ) ),
+			array( 'data' => array( 'body' => 'not-json' ) ),
+			array( 'data' => array( 'body' => wp_json_encode( array( 'raw_html' => '<p>section</p>' ) ) ) ),
+		);
+
+		$summary = $method->invoke( $ability, $packets );
+
+		$this->assertCount( 1, $summary, 'Only the one decodable event packet should be summarized.' );
+		$this->assertSame( 'Real Event', $summary[0]['title'] );
+	}
+
+	// ────────────────────────────────────────────────────────────────────
+	// End-to-end: ability count matches direct extractor count
+	// ────────────────────────────────────────────────────────────────────
+
+	/**
+	 * Regression for #265.
+	 *
+	 * For the committed Bandzoogle Elephant Room snapshot, the ability MUST
+	 * report the same count BandzoogleExtractor::extract() returns directly
+	 * on the same HTML. Prior to the fix this returned 1 regardless of how
+	 * many events the snapshot contained.
+	 */
+	public function test_test_event_scraper_returns_correct_event_count_for_bandzoogle_fixture() {
+		$fixture_path = $this->fixtures_dir . '/bandzoogle-elephant-room.html';
+		if ( ! file_exists( $fixture_path ) ) {
+			$this->markTestSkipped( 'Bandzoogle fixture not present.' );
+		}
+
+		$html         = (string) file_get_contents( $fixture_path );
+		$target_url   = 'https://elephantroom.com/calendar';
+		$direct       = ( new BandzoogleExtractor() )->extract( $html, $target_url );
+		$direct_count = count( $direct );
+
+		// Sanity: fixture must contain >1 event, otherwise this test cannot
+		// catch the regression it's named after.
+		$this->assertGreaterThan(
+			1,
+			$direct_count,
+			'Bandzoogle fixture must contain multiple events to exercise the qualify-path fix.'
+		);
+
+		$this->mockHttpResponse( $html );
+
+		$ability = new EventScraperTest();
+		$result  = $ability->test( $target_url );
+
+		$this->assertIsArray( $result, 'Ability must succeed against the Bandzoogle fixture.' );
+		$this->assertTrue( $result['success'] ?? false, 'Ability must report success.' );
+		$this->assertSame(
+			$direct_count,
+			$result['event_data']['event_count'] ?? null,
+			'event_data.event_count must match BandzoogleExtractor::extract() count exactly.'
+		);
+		$this->assertSame(
+			$direct_count,
+			count( $result['event_data']['items'] ?? array() ),
+			'event_data.items[] length must match BandzoogleExtractor::extract() count exactly.'
+		);
+		$this->assertSame(
+			$direct_count,
+			$result['extraction_info']['event_count'] ?? null,
+			'extraction_info.event_count must mirror event_data.event_count.'
+		);
+	}
+
+	/**
+	 * Regression for the JSON-LD half of #265.
+	 *
+	 * Multi-event JSON-LD pages (Charleston Pour House — 12 events in the
+	 * committed fixture) must report the same count JsonLdExtractor returns
+	 * directly. Previously the ability undercounted these the same way as
+	 * Bandzoogle calendars.
+	 */
+	public function test_test_event_scraper_returns_correct_count_for_jsonld_fixture() {
+		$fixture_path = $this->fixtures_dir . '/ld+json/charleston-pour-house.html';
+		if ( ! file_exists( $fixture_path ) ) {
+			$this->markTestSkipped( 'Charleston Pour House JSON-LD fixture not present.' );
+		}
+
+		$html         = (string) file_get_contents( $fixture_path );
+		$target_url   = 'https://charlestonpourhouse.com';
+		$direct       = ( new JsonLdExtractor() )->extract( $html, $target_url );
+		$direct_count = count( $direct );
+
+		$this->assertGreaterThan(
+			1,
+			$direct_count,
+			'JSON-LD fixture must contain multiple events to exercise this regression.'
+		);
+
+		$this->mockHttpResponse( $html );
+
+		$ability = new EventScraperTest();
+		$result  = $ability->test( $target_url );
+
+		$this->assertIsArray( $result, 'Ability must succeed against the JSON-LD fixture.' );
+		$this->assertTrue( $result['success'] ?? false, 'Ability must report success.' );
+		$this->assertSame(
+			$direct_count,
+			$result['event_data']['event_count'] ?? null,
+			'event_data.event_count must match JsonLdExtractor::extract() count exactly.'
+		);
+		$this->assertSame(
+			$direct_count,
+			count( $result['event_data']['items'] ?? array() ),
+			'event_data.items[] length must match JsonLdExtractor::extract() count exactly.'
+		);
+	}
+
+	/**
+	 * Inverse-regression guard: a single-event JSON-LD page (Royal American
+	 * detail page in #264's fixture set) must STILL report exactly 1. This
+	 * protects against an over-counting bug where the fix could
+	 * accidentally double-count via both `items[]` and the top-level event
+	 * record, or where a future refactor could insert spurious entries.
+	 */
+	public function test_test_event_scraper_returns_correct_count_for_single_event_jsonld() {
+		$fixture_path = $this->fixtures_dir . '/ld+json/royal-american-single-event.html';
+		if ( ! file_exists( $fixture_path ) ) {
+			$this->markTestSkipped( 'Royal American single-event fixture not present.' );
+		}
+
+		$html         = (string) file_get_contents( $fixture_path );
+		$target_url   = 'https://royalamerican.com/events/single';
+		$direct       = ( new JsonLdExtractor() )->extract( $html, $target_url );
+		$direct_count = count( $direct );
+
+		$this->assertSame(
+			1,
+			$direct_count,
+			'Single-event JSON-LD fixture must yield exactly 1 event from JsonLdExtractor.'
+		);
+
+		$this->mockHttpResponse( $html );
+
+		$ability = new EventScraperTest();
+		$result  = $ability->test( $target_url );
+
+		$this->assertIsArray( $result, 'Ability must succeed against the single-event fixture.' );
+		$this->assertTrue( $result['success'] ?? false, 'Ability must report success.' );
+		$this->assertSame(
+			1,
+			$result['event_data']['event_count'] ?? null,
+			'Single-event JSON-LD page must report event_count of exactly 1.'
+		);
+		$this->assertCount(
+			1,
+			$result['event_data']['items'] ?? array(),
+			'Single-event JSON-LD page must produce items[] with exactly one entry.'
+		);
+	}
+
+	// ────────────────────────────────────────────────────────────────────
+	// Helpers
+	// ────────────────────────────────────────────────────────────────────
+
+	/**
+	 * Build a packet entry shaped like DataPacket::addTo() output, with a
+	 * body that matches StructuredDataProcessor::process()'s JSON layout.
+	 *
+	 * @param array $event Event fields (title / startDate / startTime / ticketUrl).
+	 * @return array Packet entry.
+	 */
+	private function buildPacketEntry( array $event ): array {
+		return array(
+			'type'      => 'fetch',
+			'timestamp' => time(),
+			'data'      => array(
+				'title' => $event['title'] ?? '',
+				'body'  => wp_json_encode(
+					array(
+						'event'             => $event,
+						'import_source'     => 'universal_web_scraper',
+						'extraction_method' => 'test',
+					)
+				),
+			),
+			'metadata'  => array(
+				'source_type' => 'universal_web_scraper',
+			),
+		);
+	}
+
+	/**
+	 * Short-circuit WP_Http so UniversalWebScraper::fetch_html() returns
+	 * the supplied HTML instead of making a network call. Returns a
+	 * synthetic 200 response shaped to satisfy DataMachine\Core\HttpClient::get().
+	 */
+	private function mockHttpResponse( string $html ): void {
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) use ( $html ) {
+				return array(
+					'headers'  => array(),
+					'body'     => $html,
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'cookies'  => array(),
+					'filename' => null,
+				);
+			},
+			10,
+			3
+		);
+	}
+}


### PR DESCRIPTION
Fixes #265.

## Production fingerprint (from the issue, verbatim)

Verdict log on extrachill-events v0.20.0 after the data-machine-events v0.35.0 (Bandzoogle handler) deploy:

```
qualified_at        url                              verdict          event_count
2026-05-16 21:11    https://elephantroom.com         extraction_gap   0
```

Fingerprint shows the Bandzoogle extractor was attempted and matched, but reported `events: 1`:

```json
{
  "platforms_detected": ["bandzoogle"],
  "extractor_attempts": [
    {
      "name": "BandzoogleExtractor",
      "url": "https://elephantroom.com/calendar",
      "events_url": "https://elephantroom.com/calendar",
      "exists": true,
      "matched": true,
      "ran": true,
      "events": 1,
      "source_type": "universal_web_scraper",
      "method": "nav_link"
    }
  ],
  "structured_data": { "jsonld_events": 0, "vision_image_candidates": 0 }
}
```

## Verified live count

```
$ curl -s -A "Mozilla/5.0" "https://elephantroom.com/calendar" | grep -oE 'data-event-id="[^"]*"' | sort -u | wc -l
19
```

19 events on the live page. The Bandzoogle extractor's own unit test extracts ≥5 events from the committed snapshot of the same page. So the bug was between the extractor and the qualify path, not in the extractor itself.

## Investigation findings — qualify-path vs direct-call divergence

The flow looks like this:

1. `UniversalWebScraper::executeFetch()` finds 19 events in the Bandzoogle calendar and returns `{ items: [...19 events...] }`.
2. `FetchHandler::get_fetch_data()` normalizes that into **one `DataPacket` per event** — so for 19 events you get an array of 19 `DataPacket` objects, each whose body is a JSON-encoded `{ event: {...}, ... }` blob (StructuredDataProcessor::process layout).
3. `EventScraperTest::test()` (the ability behind `data-machine-events/test-event-scraper`) calls `get_fetch_data()`, then reads **`$results[0]` only** — the first DataPacket — and decodes its body into a single `event` object. The remaining 18 packets are dropped on the floor.
4. The returned payload has `event_data` populated with one event's fields (`title`, `startDate`, `venue`, etc.) — no `items[]`, no count.
5. `QualifyFingerprinter::count_events()` in extrachill-events runs:
   ```php
   if ( isset( $event_data['items'] ) && is_array( $event_data['items'] ) ) {
       return count( $event_data['items'] );
   }
   if ( ! empty( $event_data['title'] ) || ! empty( $event_data['raw_html'] ) ) {
       return 1;
   }
   ```
   It sees no `items`, sees `title` set, returns 1. Every multi-event Bandzoogle / JSON-LD / Tribe page records `events: 1` regardless of the real extraction count.

Meanwhile `BandzoogleExtractor::extract()` called directly on the same HTML in `tests/Unit/BandzoogleExtractorTest::test_extract_returns_events_from_elephant_room_fixture` returns ≥5 events (and on a fresh production fetch, 19) — proving the extractor itself is fine.

## Root cause shape

**Shape A** from the issue body: the ability was implicitly truncating to the first event for "test response brevity." There was no intentional contract for it — just an artifact of the single-DataPacket assumption the ability was written against.

## The fix

`inc/Abilities/EventScraperTest.php`:

- Walk **every** `DataPacket` in `$results`, not just `$results[0]`.
- Add a private helper `summarizeEventsFromPackets()` that decodes each packet body and pulls a `{ title, startDate, startTime, ticketUrl }` summary.
- Surface the full summary as `event_data.items[]` — the field `QualifyFingerprinter::count_events()` **already** inspects, so this fix lands cleanly without requiring a matching change in extrachill-events.
- Add an explicit `event_data.event_count` and `extraction_info.event_count` for new consumers.
- Keep the first event's full record at the top level of `event_data` so the chat tool, the `wp data-machine-events test-event-scraper` CLI command, and the qualify-path source_type / payload_type inspection all continue to behave unchanged.

`inc/Cli/UniversalWebScraperTestCommand.php`:

- Print `Events extracted: N` so manual smoke tests immediately surface the count.

## Regression tests (`tests/Unit/EventScraperTestAbilityTest.php`)

1. `test_summarizer_counts_every_packet_event` — unit-level: synthesizes 5 packets, asserts the summarizer returns 5 entries with the right titles/dates.
2. `test_summarizer_skips_non_event_packets` — asserts raw_html / malformed-JSON / empty-body packets are skipped.
3. `test_test_event_scraper_returns_correct_event_count_for_bandzoogle_fixture` — end-to-end against `tests/Fixtures/bandzoogle-elephant-room.html` with HTTP mocked via `pre_http_request`. Asserts the ability's `event_data.event_count` and `items[]` length match `BandzoogleExtractor::extract()` direct call. **Direct regression for #265.**
4. `test_test_event_scraper_returns_correct_count_for_jsonld_fixture` — same shape against `tests/Fixtures/ld+json/charleston-pour-house.html` and `JsonLdExtractor` (#264's multi-event JSON-LD fixture).
5. `test_test_event_scraper_returns_correct_count_for_single_event_jsonld` — inverse-regression guard. `tests/Fixtures/ld+json/royal-american-single-event.html` must still report exactly 1.

## Out of scope

- `BandzoogleExtractor` is unchanged — its unit tests already prove it extracts ≥5-20 events from the fixture.
- `JsonLdExtractor` is unchanged — #264 shipped today with full unit coverage.
- `UniversalWebScraper` is unchanged — its `{ items: [...] }` return shape and the packet fan-out in `FetchHandler::get_fetch_data()` were already correct.
- Qualify v2's `MIN_EVENTS_FOR_STRUCTURED_QUALIFICATION` threshold (a separate bug filed in extrachill-events).

## What happens next

Once this lands and qualify v2 is re-run via `wp extrachill venues requalify-pending`, `extraction_gap` verdicts for Bandzoogle and multi-event JSON-LD venues will flip to `qualified_structured` naturally — no extrachill-events change required, because `QualifyFingerprinter::count_events()` already reads `event_data.items[]`.