### PR TITLE
fix: show upcoming event count in map venue popups instead of lifetime total

### DIFF
--- a/inc/Abilities/VenueMapAbilities.php
+++ b/inc/Abilities/VenueMapAbilities.php
@@ -238,6 +238,22 @@ class VenueMapAbilities {
 			unset( $venue );
 		}
 
+		// Replace placeholder event_count with upcoming-only counts.
+		// The query paths above seed event_count=0; the real number comes from
+		// a single batched query keyed by the term IDs actually being returned.
+		// This is what the popup label promises ("X upcoming events") rather
+		// than $term->count, which is the lifetime total of all published
+		// events ever assigned to the venue (past + future).
+		if ( ! empty( $venues ) ) {
+			$venue_ids       = array_map( 'intval', array_column( $venues, 'term_id' ) );
+			$upcoming_counts = $this->getUpcomingCountsForVenues( $venue_ids );
+
+			foreach ( $venues as &$venue ) {
+				$venue['event_count'] = (int) ( $upcoming_counts[ $venue['term_id'] ] ?? 0 );
+			}
+			unset( $venue );
+		}
+
 		// Sort by distance if geo filtering, otherwise by event count.
 		if ( $has_geo && ! empty( $distance_map ) ) {
 			usort( $venues, function ( $a, $b ) {
@@ -349,7 +365,7 @@ class VenueMapAbilities {
 				'lon'         => $venue_lon,
 				'address'     => $address,
 				'url'         => is_string( $url ) ? $url : '',
-				'event_count' => $term->count,
+				'event_count' => 0,
 			);
 		}
 
@@ -410,11 +426,73 @@ class VenueMapAbilities {
 				'lon'         => $venue_lon,
 				'address'     => $address,
 				'url'         => is_string( $url ) ? $url : '',
-				'event_count' => $venue->count,
+				'event_count' => 0,
 			);
 		}
 
 		return $venues;
+	}
+
+	/**
+	 * Get upcoming-event counts for a set of venue term IDs.
+	 *
+	 * Single batched query keyed by the IDs being rendered, returning a
+	 * `term_id => count` map. "Upcoming" means events with a
+	 * `start_datetime >= today` row in the event_dates table — matching
+	 * the semantics of the venue popup label ("X upcoming events") and
+	 * the location-archive venue badge graph (Extra-Chill/extrachill-events#88).
+	 *
+	 * Venues with zero upcoming events are intentionally absent from the
+	 * returned map; callers should default to 0 on missing keys. This avoids
+	 * a separate "empty" branch and keeps the query trivially indexable.
+	 *
+	 * @param int[] $venue_ids Term IDs from the venue taxonomy.
+	 * @return array<int,int> Map of term_id => upcoming event count.
+	 */
+	private function getUpcomingCountsForVenues( array $venue_ids ): array {
+		if ( empty( $venue_ids ) ) {
+			return array();
+		}
+
+		global $wpdb;
+
+		$post_type = Event_Post_Type::POST_TYPE;
+		$today     = gmdate( 'Y-m-d 00:00:00' );
+
+		$placeholders = implode( ',', array_fill( 0, count( $venue_ids ), '%d' ) );
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$query = $wpdb->prepare(
+			"SELECT tt.term_id, COUNT(DISTINCT p.ID) AS upcoming_count
+			FROM {$wpdb->term_relationships} tr
+			INNER JOIN {$wpdb->term_taxonomy} tt
+				ON tr.term_taxonomy_id = tt.term_taxonomy_id
+			INNER JOIN {$wpdb->posts} p
+				ON tr.object_id = p.ID
+			INNER JOIN {$wpdb->prefix}datamachine_event_dates ed
+				ON p.ID = ed.post_id
+			WHERE tt.taxonomy = 'venue'
+			AND tt.term_id IN ($placeholders)
+			AND p.post_type = %s
+			AND p.post_status = 'publish'
+			AND ed.start_datetime >= %s
+			GROUP BY tt.term_id",
+			array_merge( $venue_ids, array( $post_type, $today ) )
+		);
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results( $query );
+
+		if ( empty( $rows ) ) {
+			return array();
+		}
+
+		$counts = array();
+		foreach ( $rows as $row ) {
+			$counts[ (int) $row->term_id ] = (int) $row->upcoming_count;
+		}
+
+		return $counts;
 	}
 
 	/**


### PR DESCRIPTION
Closes #271

## Summary

The events-map venue popup label says **\"X upcoming events\"** but the value rendered was the WordPress lifetime term count — every event ever assigned to the venue, including past events. For active venues this was wildly wrong: the Charleston Pour House popup showed **\"356 upcoming events\"** when the actual upcoming count is **82**.

The label is the spec. This PR fixes the data, not the label.

## What changed

### `VenueMapAbilities::executeListVenues()`

After the venues array is built (and distances are attached), runs a single batched query against the term IDs being returned and substitutes the upcoming-only count into the `event_count` field, just before the count-sort.

### New private helper `getUpcomingCountsForVenues( int[] $venue_ids ): array<int,int>`

Single SQL: `term_relationships → term_taxonomy → posts → datamachine_event_dates`, filtered to `taxonomy='venue'`, `term_id IN (...)`, `post_status='publish'`, `start_datetime >= today`. Returns `term_id => upcoming_count`. Same join shape used by `extrachill/events-upcoming-counts` so badges and map popups now report identical numbers.

### Query path changes

Both `queryVenuesByBounds()` and `queryVenuesWithCoordinates()` now seed `event_count = 0` instead of `\$term->count`. The actual upcoming number is applied uniformly afterward, so there's a single source of truth for the field and no duplication.

### Sort behavior

The existing `event_count`-based sort now ranks venues by **upcoming activity** rather than **lifetime activity** — which matches the intuitive map UX of \"most active venues right now\" rather than \"venues with the most historical data\".

### Frontend

`inc/Blocks/EventsMap/src/frontend.tsx` — **no change**. Label already says \"upcoming\". The `if ( venue.event_count > 0 )` guard correctly hides the line for venues with no upcoming events.

## Verification

Live data on extrachill.com (current state):

| Venue | Lifetime (`\$term->count`) | Upcoming (this PR) |
|----|----|----|
| Charleston Pour House | 356 | **82** |
| The Royal American | 108 | **38** |
| Music Farm | 107 | **29** |
| The Refinery | 42 | **18** |
| Lo-Fi Brewing | 33 | **3** |
| The Windjammer | 96 | **30** |
| The Dinghy | 428 | **298** |

Upcoming numbers match exactly what the venue badge graph on the location archive shows (Extra-Chill/extrachill-events#88).

## Performance

- **No N+1.** Single batched query for all venue IDs being returned per request (capped at `MAX_VENUES = 200`).
- `term_id IN (...)` is trivially indexable; same join shape already proven on the location-archive badge endpoint (6h transient hit rate ~100% in normal operation).
- No new transient. The map endpoint is already lightweight per-request and the upcoming-counts query is fast over indexed columns. If profiling later shows hot-path pressure, a transient can be added without changing the interface.

## Acceptance criteria

- [x] Clicking a venue marker shows the same number as the venue badge graph
- [x] Charleston Pour House popup shows 82, not 356
- [x] Single batched query for upcoming counts (no N+1)
- [x] Frontend unchanged — label already correct
- [x] Venues with zero upcoming events: `event_count` is 0, frontend hides the line (existing guard still works)
- [x] PHP syntax check passes

## Out of scope

- Hiding venues with zero upcoming events from the map entirely (separate UX decision)
- Other places that surface `\$term->count` with potentially misleading labels (audit-venues CLI, filter abilities) — not the bug reported in #271
- Adding a separate `total_event_count` field for backward compatibility — no consumer of this endpoint relies on lifetime counts

## Related

- #271 (this bug)
- Extra-Chill/extrachill-events#88 (badge graph that already shows correct upcoming counts — same data, same intent, different surface — now agrees with the map)
- Extra-Chill/extrachill-events#86 (parent feature on location archive UX)