### PR TITLE
fix(venue-dedup): normalize ampersand/HTML-entity/apostrophe in names + strip suite suffixes from addresses + migration CLI

### DIFF
--- a/data-machine-events.php
+++ b/data-machine-events.php
@@ -119,6 +119,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	\WP_CLI::add_command( 'data-machine-events check duplicates', \DataMachineEvents\Cli\Check\CheckDuplicatesCommand::class );
 	\WP_CLI::add_command( 'data-machine-events check clean-duplicates', \DataMachineEvents\Cli\Check\CleanDuplicatesCommand::class );
 	\WP_CLI::add_command( 'data-machine-events check merged-bills', \DataMachineEvents\Cli\Check\CheckMergedBillsCommand::class );
+	\WP_CLI::add_command( 'data-machine-events check merge-duplicate-venues', \DataMachineEvents\Cli\Check\CheckMergeDuplicateVenuesCommand::class );
 	\WP_CLI::add_command( 'data-machine-events check quality', \DataMachineEvents\Cli\Check\CheckQualityCommand::class );
 	\WP_CLI::add_command( 'data-machine-events check all', \DataMachineEvents\Cli\Check\CheckAllCommand::class );
 }

--- a/inc/Cli/Check/CheckMergeDuplicateVenuesCommand.php
+++ b/inc/Cli/Check/CheckMergeDuplicateVenuesCommand.php
@@ -1,0 +1,317 @@
+<?php
+/**
+ * `wp data-machine-events check merge-duplicate-venues`
+ *
+ * One-time migration that consolidates duplicate venue terms produced
+ * before PR #252 (address-aware venue resolution) and before issue #276
+ * (ampersand / HTML-entity / apostrophe + suite-suffix normalization)
+ * shipped.
+ *
+ * Scans every venue term, groups them by normalized name AND normalized
+ * address+city, and for each cluster picks the oldest term (lowest ID)
+ * as the winner. Loser terms are smart-merged into the winner via
+ * VenueMergeHelper: post-term relationships are reassigned, flow
+ * handler_config references are rewritten, then the loser term is
+ * deleted.
+ *
+ * Operator surface for issue #276. Mirrors the dry-run / apply shape of
+ * CleanDuplicatesCommand and the table/csv/json output shape of
+ * CheckMergedBillsCommand.
+ *
+ * @package DataMachineEvents\Cli\Check
+ * @since   0.35.0
+ */
+
+namespace DataMachineEvents\Cli\Check;
+
+use DataMachineEvents\Core\Venue_Taxonomy;
+use DataMachineEvents\Core\DuplicateDetection\VenueMergeHelper;
+
+defined( 'ABSPATH' ) || exit;
+
+class CheckMergeDuplicateVenuesCommand {
+
+	/**
+	 * Scan for and (optionally) merge duplicate venue term clusters.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--dry-run]
+	 * : Show what would be merged without writing. This is the default
+	 *   behavior — pass --apply to actually commit changes.
+	 *
+	 * [--apply]
+	 * : Actually perform the merges. Without this flag the command
+	 *   behaves as --dry-run.
+	 *
+	 * [--limit=<count>]
+	 * : Cap the number of clusters processed per run. Keeps single-run
+	 *   scope bounded for ops review.
+	 * ---
+	 * default: 50
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Output format for the per-cluster table.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - csv
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp data-machine-events check merge-duplicate-venues --dry-run
+	 *     wp data-machine-events check merge-duplicate-venues --apply --limit=10
+	 *     wp data-machine-events check merge-duplicate-venues --dry-run --format=csv
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Named arguments.
+	 */
+	public function __invoke( array $args, array $assoc_args ): void {
+		$apply  = isset( $assoc_args['apply'] );
+		$limit  = max( 1, (int) ( $assoc_args['limit'] ?? 50 ) );
+		$format = (string) ( $assoc_args['format'] ?? 'table' );
+
+		// Default to dry-run unless --apply is passed.
+		$dry_run = ! $apply;
+
+		$clusters = $this->find_clusters();
+
+		if ( empty( $clusters ) ) {
+			\WP_CLI::success( 'No duplicate venue clusters detected.' );
+			return;
+		}
+
+		\WP_CLI::log( sprintf( 'Detected %d cluster(s) of duplicate venue terms.', count( $clusters ) ) );
+
+		if ( count( $clusters ) > $limit ) {
+			\WP_CLI::log( sprintf( 'Processing first %d clusters this run (use --limit=N to change).', $limit ) );
+			$clusters = array_slice( $clusters, 0, $limit );
+		}
+
+		$rows = array();
+
+		foreach ( $clusters as $cluster ) {
+			$row = $this->process_cluster( $cluster, $dry_run );
+			$rows[] = $row;
+		}
+
+		\WP_CLI\Utils\format_items(
+			$format,
+			$rows,
+			array(
+				'cluster_key',
+				'winner_id',
+				'winner_name',
+				'loser_ids',
+				'loser_names',
+				'total_posts_reassigned',
+				'total_flows_reassigned',
+				'action_taken',
+			)
+		);
+
+		if ( $dry_run ) {
+			\WP_CLI::log( '' );
+			\WP_CLI::log( 'DRY RUN — no changes made. Re-run with --apply to commit.' );
+			return;
+		}
+
+		$total_posts = array_sum( array_column( $rows, 'total_posts_reassigned' ) );
+		$total_flows = array_sum( array_column( $rows, 'total_flows_reassigned' ) );
+
+		\WP_CLI::success(
+			sprintf(
+				'Processed %d cluster(s). Reassigned %d post(s) and %d flow handler_config reference(s).',
+				count( $rows ),
+				$total_posts,
+				$total_flows
+			)
+		);
+	}
+
+	/**
+	 * Walk every venue term and group by normalized name OR normalized
+	 * address+city. Returns only clusters with >=2 terms.
+	 *
+	 * The address key intentionally includes the city to keep two
+	 * different "123 Main St" venues (different cities) apart.
+	 *
+	 * @return array<int,array{key:string,term_ids:array<int,int>,terms:array}>
+	 */
+	private function find_clusters(): array {
+		$terms = get_terms(
+			array(
+				'taxonomy'   => 'venue',
+				'hide_empty' => false,
+				'number'     => 0,
+			)
+		);
+
+		if ( is_wp_error( $terms ) || empty( $terms ) ) {
+			return array();
+		}
+
+		$by_name    = array();
+		$by_address = array();
+
+		foreach ( $terms as $term ) {
+			$name_key = Venue_Taxonomy::normalize_venue_name_for_matching( $term->name );
+			if ( strlen( $name_key ) >= 3 ) {
+				$by_name[ $name_key ][] = $term;
+			}
+
+			$address = (string) get_term_meta( $term->term_id, '_venue_address', true );
+			$city    = (string) get_term_meta( $term->term_id, '_venue_city', true );
+
+			if ( '' === $address || '' === $city ) {
+				continue;
+			}
+
+			$addr_key = sprintf(
+				'%s|%s',
+				Venue_Taxonomy::normalize_address_for_matching( $address ),
+				strtolower( trim( $city ) )
+			);
+
+			if ( '|' === $addr_key || str_starts_with( $addr_key, '|' ) ) {
+				continue;
+			}
+
+			$by_address[ $addr_key ][] = $term;
+		}
+
+		$clusters     = array();
+		$seen_term_ids = array();
+
+		// Emit name-clusters first, then address-clusters. Each term is
+		// emitted in at most one cluster — once seen via name, the
+		// address loop ignores it.
+		foreach ( array( 'name' => $by_name, 'addr' => $by_address ) as $kind => $groups ) {
+			foreach ( $groups as $key => $group_terms ) {
+				if ( count( $group_terms ) < 2 ) {
+					continue;
+				}
+
+				$ids = array();
+				foreach ( $group_terms as $t ) {
+					$ids[] = (int) $t->term_id;
+				}
+
+				// Drop terms we've already clustered via the name pass.
+				$ids = array_values( array_diff( $ids, $seen_term_ids ) );
+
+				if ( count( $ids ) < 2 ) {
+					continue;
+				}
+
+				$cluster_terms = array_values(
+					array_filter(
+						$group_terms,
+						static fn( $t ) => in_array( (int) $t->term_id, $ids, true )
+					)
+				);
+
+				$clusters[] = array(
+					'key'      => $kind . ':' . $key,
+					'term_ids' => $ids,
+					'terms'    => $cluster_terms,
+				);
+
+				foreach ( $ids as $tid ) {
+					$seen_term_ids[] = $tid;
+				}
+			}
+		}
+
+		return $clusters;
+	}
+
+	/**
+	 * Pick winner/losers for a cluster and dispatch the merge (or describe
+	 * it under dry-run). Returns one row for the output table.
+	 *
+	 * @param array $cluster Cluster from find_clusters().
+	 * @param bool  $dry_run Whether to skip writes.
+	 * @return array Row for format_items().
+	 */
+	private function process_cluster( array $cluster, bool $dry_run ): array {
+		$ids   = $cluster['term_ids'];
+		$terms = $cluster['terms'];
+
+		sort( $ids );
+		$winner_id = (int) $ids[0];
+		$loser_ids = array_slice( $ids, 1 );
+
+		$name_by_id = array();
+		foreach ( $terms as $t ) {
+			$name_by_id[ (int) $t->term_id ] = (string) $t->name;
+		}
+
+		$winner_name = $name_by_id[ $winner_id ] ?? '';
+		$loser_names = array_map( static fn( $id ) => $name_by_id[ $id ] ?? '', $loser_ids );
+
+		$row = array(
+			'cluster_key'            => $cluster['key'],
+			'winner_id'              => $winner_id,
+			'winner_name'            => $winner_name,
+			'loser_ids'              => implode( ',', $loser_ids ),
+			'loser_names'            => implode( ' || ', $loser_names ),
+			'total_posts_reassigned' => 0,
+			'total_flows_reassigned' => 0,
+			'action_taken'           => $dry_run ? 'dry-run' : '',
+		);
+
+		if ( $dry_run ) {
+			return $row;
+		}
+
+		$skipped       = false;
+		$total_posts   = 0;
+		$total_flows   = 0;
+		$skip_reasons  = array();
+		$error_seen    = false;
+
+		foreach ( $loser_ids as $loser_id ) {
+			$result = VenueMergeHelper::merge( $winner_id, $loser_id );
+
+			if ( ! empty( $result['skipped_reason'] ) ) {
+				$skipped        = true;
+				$skip_reasons[] = sprintf( '%d: %s', $loser_id, $result['skipped_reason'] );
+				continue;
+			}
+
+			if ( ! $result['success'] ) {
+				$error_seen = true;
+				\WP_CLI::warning(
+					sprintf(
+						'Failed to merge loser %d into winner %d: %s',
+						$loser_id,
+						$winner_id,
+						$result['error'] ?? 'unknown error'
+					)
+				);
+				continue;
+			}
+
+			$total_posts += $result['posts_reassigned'];
+			$total_flows += $result['flows_reassigned'];
+		}
+
+		$row['total_posts_reassigned'] = $total_posts;
+		$row['total_flows_reassigned'] = $total_flows;
+
+		if ( $skipped && 0 === $total_posts && 0 === $total_flows ) {
+			$row['action_taken'] = 'skipped: ' . implode( '; ', $skip_reasons );
+		} elseif ( $error_seen ) {
+			$row['action_taken'] = 'partial';
+		} else {
+			$row['action_taken'] = 'merged';
+		}
+
+		return $row;
+	}
+}

--- a/inc/Core/DuplicateDetection/VenueMergeHelper.php
+++ b/inc/Core/DuplicateDetection/VenueMergeHelper.php
@@ -1,0 +1,334 @@
+<?php
+/**
+ * VenueMergeHelper
+ *
+ * Shared primitive for merging a duplicate venue term (loser) into a
+ * canonical venue term (winner). Used by the `wp data-machine-events
+ * check merge-duplicate-venues` migration command and any future
+ * agent-driven venue consolidation flows.
+ *
+ * Merge order is non-negotiable:
+ *
+ *   1. Smart-merge venue meta (fill empties only on the winner).
+ *   2. Reassign post-term relationships via wp_set_object_terms() so
+ *      tt_count stays in sync.
+ *   3. Rewrite flow handler_config references that point at the loser.
+ *   4. Delete the loser term (cascades term meta cleanup).
+ *
+ * Posts and flows MUST be reassigned BEFORE the loser term is deleted —
+ * deleting first would orphan inbound references and break event
+ * tagging on the next pipeline run.
+ *
+ * @package DataMachineEvents\Core\DuplicateDetection
+ * @since   0.35.0
+ */
+
+namespace DataMachineEvents\Core\DuplicateDetection;
+
+use DataMachineEvents\Core\Venue_Taxonomy;
+
+defined( 'ABSPATH' ) || exit;
+
+class VenueMergeHelper {
+
+	/**
+	 * Term meta key signalling that a venue should never be auto-merged.
+	 * Set on either winner or loser to skip the cluster entirely.
+	 */
+	public const NO_MERGE_META_KEY = '_venue_no_merge';
+
+	/**
+	 * Merge a loser venue term into a winner venue term.
+	 *
+	 * @param int $winner_id Term ID to keep (lower IDs win in callers).
+	 * @param int $loser_id  Term ID to delete after reassignment.
+	 * @return array{
+	 *     success: bool,
+	 *     winner_id: int,
+	 *     loser_id: int,
+	 *     posts_reassigned: int,
+	 *     flows_reassigned: int,
+	 *     meta_filled: array<int,string>,
+	 *     skipped_reason: string|null,
+	 *     error: string|null,
+	 * }
+	 */
+	public static function merge( int $winner_id, int $loser_id ): array {
+		$result = array(
+			'success'          => false,
+			'winner_id'        => $winner_id,
+			'loser_id'         => $loser_id,
+			'posts_reassigned' => 0,
+			'flows_reassigned' => 0,
+			'meta_filled'      => array(),
+			'skipped_reason'   => null,
+			'error'            => null,
+		);
+
+		if ( $winner_id <= 0 || $loser_id <= 0 ) {
+			$result['error'] = 'Invalid term IDs.';
+			return $result;
+		}
+
+		if ( $winner_id === $loser_id ) {
+			$result['error'] = 'Winner and loser are the same term.';
+			return $result;
+		}
+
+		$winner = get_term( $winner_id, 'venue' );
+		$loser  = get_term( $loser_id, 'venue' );
+
+		if ( ! $winner || is_wp_error( $winner ) || ! $loser || is_wp_error( $loser ) ) {
+			$result['error'] = 'One or both terms do not exist.';
+			return $result;
+		}
+
+		// Opt-out protection: skip if either side is flagged.
+		$winner_optout = (int) get_term_meta( $winner_id, self::NO_MERGE_META_KEY, true );
+		$loser_optout  = (int) get_term_meta( $loser_id, self::NO_MERGE_META_KEY, true );
+
+		if ( $winner_optout || $loser_optout ) {
+			$result['skipped_reason'] = sprintf(
+				'opt-out flag set (winner=%d, loser=%d)',
+				$winner_optout,
+				$loser_optout
+			);
+			return $result;
+		}
+
+		// 1. Smart-merge meta from loser into winner (fill empties only).
+		$result['meta_filled'] = self::fill_empty_meta( $winner_id, $loser_id );
+
+		// 2. Reassign every post tagged with the loser → winner.
+		$result['posts_reassigned'] = self::reassign_post_terms( $winner_id, $loser_id );
+
+		// 3. Rewrite flow handler_config references that point at loser.
+		$result['flows_reassigned'] = self::reassign_flow_handler_configs( $winner_id, $loser_id );
+
+		// 4. Delete the loser term (cascades term meta).
+		$deleted = wp_delete_term( $loser_id, 'venue' );
+		if ( is_wp_error( $deleted ) || true !== $deleted ) {
+			$result['error'] = sprintf(
+				'Failed to delete loser term %d: %s',
+				$loser_id,
+				is_wp_error( $deleted ) ? $deleted->get_error_message() : 'unknown error'
+			);
+			return $result;
+		}
+
+		// 5. Audit trail.
+		do_action(
+			'datamachine_log',
+			'info',
+			'venue_merge',
+			array(
+				'winner_id'        => $winner_id,
+				'winner_name'      => $winner->name,
+				'loser_id'         => $loser_id,
+				'loser_name'       => $loser->name,
+				'posts_reassigned' => $result['posts_reassigned'],
+				'flows_reassigned' => $result['flows_reassigned'],
+				'meta_filled'      => $result['meta_filled'],
+			)
+		);
+
+		$result['success'] = true;
+		return $result;
+	}
+
+	/**
+	 * Fill empty winner meta from loser meta. Never overwrites a non-empty
+	 * winner value. Returns the list of meta keys that were populated.
+	 *
+	 * @param int $winner_id Winner term ID.
+	 * @param int $loser_id  Loser term ID.
+	 * @return array<int,string> Meta keys filled (e.g. ["_venue_phone", "_venue_zip"]).
+	 */
+	private static function fill_empty_meta( int $winner_id, int $loser_id ): array {
+		$filled = array();
+
+		foreach ( Venue_Taxonomy::$meta_fields as $field => $meta_key ) {
+			$winner_value = get_term_meta( $winner_id, $meta_key, true );
+			if ( ! empty( $winner_value ) ) {
+				continue;
+			}
+
+			$loser_value = get_term_meta( $loser_id, $meta_key, true );
+			if ( empty( $loser_value ) ) {
+				continue;
+			}
+
+			update_term_meta( $winner_id, $meta_key, $loser_value );
+			$filled[] = $meta_key;
+		}
+
+		return $filled;
+	}
+
+	/**
+	 * Reassign every post currently tagged with the loser term to the
+	 * winner term. Uses wp_set_object_terms() (not raw SQL) so the
+	 * taxonomy cache and tt_count stay correct.
+	 *
+	 * @param int $winner_id Winner term ID.
+	 * @param int $loser_id  Loser term ID.
+	 * @return int Number of posts reassigned.
+	 */
+	private static function reassign_post_terms( int $winner_id, int $loser_id ): int {
+		$post_ids = get_objects_in_term( $loser_id, 'venue' );
+
+		if ( is_wp_error( $post_ids ) || empty( $post_ids ) ) {
+			return 0;
+		}
+
+		$reassigned = 0;
+
+		foreach ( $post_ids as $post_id ) {
+			$post_id = (int) $post_id;
+
+			// Replace the loser term with the winner on this post, preserving
+			// any other venue terms the post might happen to carry (rare but
+			// possible during partial migrations). The boolean false `$append`
+			// arg means we hand wp_set_object_terms the FULL desired list.
+			$existing = wp_get_object_terms( $post_id, 'venue', array( 'fields' => 'ids' ) );
+
+			if ( is_wp_error( $existing ) ) {
+				continue;
+			}
+
+			$existing = array_map( 'intval', $existing );
+			$next     = array();
+
+			foreach ( $existing as $tid ) {
+				if ( $tid === $loser_id ) {
+					$next[] = $winner_id;
+				} else {
+					$next[] = $tid;
+				}
+			}
+
+			$next = array_values( array_unique( $next ) );
+
+			$set = wp_set_object_terms( $post_id, $next, 'venue', false );
+			if ( ! is_wp_error( $set ) ) {
+				++$reassigned;
+			}
+		}
+
+		return $reassigned;
+	}
+
+	/**
+	 * Rewrite Data Machine flow handler_config references that point at the
+	 * loser term ID. Stored shape (per VenueParameterProvider) is either:
+	 *
+	 *   handler_config: { "venue": "<term_id>" }
+	 *   handler_config: { "universal_web_scraper": { "venue": "<term_id>" } }
+	 *
+	 * The Ticketmaster handler uses `venue_id` but that points at an
+	 * external Ticketmaster venue identifier, NOT a WP term — we leave
+	 * those alone.
+	 *
+	 * @param int $winner_id Winner term ID.
+	 * @param int $loser_id  Loser term ID.
+	 * @return int Number of flow rows updated.
+	 */
+	private static function reassign_flow_handler_configs( int $winner_id, int $loser_id ): int {
+		global $wpdb;
+
+		$table = $wpdb->prefix . 'datamachine_flows';
+		// Bail quietly if the flows table is not present (e.g. unit-test env
+		// without Data Machine core schema installed).
+		$exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+		if ( $exists !== $table ) {
+			return 0;
+		}
+
+		$loser_str  = (string) $loser_id;
+		$winner_str = (string) $winner_id;
+
+		// Two LIKE shapes catch both flat ("venue":"123") and the nested
+		// universal_web_scraper variant — the JSON substring is identical
+		// for both since they both end in `"venue":"123"`.
+		$flows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT flow_id, flow_config FROM {$table}
+				 WHERE flow_config LIKE %s
+				 OR    flow_config LIKE %s",
+				'%"venue":"' . $wpdb->esc_like( $loser_str ) . '"%',
+				'%"venue":' . $wpdb->esc_like( $loser_str ) . '%'
+			)
+		);
+
+		if ( empty( $flows ) ) {
+			return 0;
+		}
+
+		$updated = 0;
+
+		foreach ( $flows as $row ) {
+			$decoded = json_decode( $row->flow_config, true );
+			if ( ! is_array( $decoded ) ) {
+				continue;
+			}
+
+			$changed = false;
+			self::rewrite_venue_refs( $decoded, $loser_str, $winner_str, $changed );
+
+			if ( ! $changed ) {
+				continue;
+			}
+
+			$encoded = wp_json_encode( $decoded );
+			if ( false === $encoded ) {
+				continue;
+			}
+
+			$result = $wpdb->update(
+				$table,
+				array( 'flow_config' => $encoded ),
+				array( 'flow_id' => (int) $row->flow_id ),
+				array( '%s' ),
+				array( '%d' )
+			);
+
+			if ( false !== $result ) {
+				++$updated;
+			}
+		}
+
+		return $updated;
+	}
+
+	/**
+	 * Recursively walk a decoded flow_config structure and rewrite any
+	 * `venue` field whose stringified value matches the loser term ID.
+	 *
+	 * Strings and numerics are both handled — handler_config historically
+	 * stores numeric IDs as strings, but a defensive int compare guards
+	 * against any future shape change.
+	 *
+	 * @param array  $node       Reference to current node.
+	 * @param string $loser_str  Loser term ID as string.
+	 * @param string $winner_str Winner term ID as string.
+	 * @param bool   $changed    Flips true if any rewrite occurred.
+	 */
+	private static function rewrite_venue_refs( array &$node, string $loser_str, string $winner_str, bool &$changed ): void {
+		foreach ( $node as $key => &$value ) {
+			if ( is_array( $value ) ) {
+				self::rewrite_venue_refs( $value, $loser_str, $winner_str, $changed );
+				continue;
+			}
+
+			if ( 'venue' !== $key ) {
+				continue;
+			}
+
+			$as_string = (string) $value;
+			if ( $as_string === $loser_str ) {
+				$value   = is_int( $value ) ? (int) $winner_str : $winner_str;
+				$changed = true;
+			}
+		}
+	}
+}

--- a/inc/Core/Venue_Taxonomy.php
+++ b/inc/Core/Venue_Taxonomy.php
@@ -272,10 +272,19 @@ class Venue_Taxonomy {
 		// Lowercase.
 		$text = strtolower( $text );
 
+		// Normalize ampersand variants to "and" so "Hook & Ladder" and
+		// "Hook and Ladder" collapse to the same key. Spaced ampersand
+		// becomes " and " (one token); tight ampersand (e.g. "rock&roll")
+		// becomes "and" without surrounding spaces — the subsequent
+		// alphanumeric strip + whitespace collapse normalizes both shapes.
+		$text = preg_replace( '/\s*&\s*/', ' and ', $text );
+
 		// Remove articles at the start.
 		$text = preg_replace( '/^(the|a|an)\s+/i', '', $text );
 
 		// Remove all non-alphanumeric characters (keeps spaces).
+		// This also strips apostrophes, so "Amos' Southend" → "amos southend"
+		// matches "Amos Southend".
 		$text = preg_replace( '/[^a-z0-9\s]/', '', $text );
 
 		// Collapse whitespace and trim.
@@ -712,11 +721,29 @@ class Venue_Taxonomy {
 	/**
 	 * Normalize address string for consistent comparison
 	 *
+	 * Strips suite/unit/apartment suffixes BEFORE running the
+	 * street-suffix replacements so "3010 Minnehaha Ave STE 420"
+	 * and "3010 Minnehaha Ave" collapse to the same key.
+	 *
 	 * @param string $address Raw address string
 	 * @return string Normalized address for matching
 	 */
-	private static function normalize_address_for_matching( string $address ): string {
+	public static function normalize_address_for_matching( string $address ): string {
 		$address = strtolower( trim( $address ) );
+
+		// Strip suite/unit/apartment/room suffixes that produce false
+		// non-matches for the same physical street address. Runs first
+		// so the downstream replacements operate on the cleaned street.
+		// Two passes:
+		//   1. Word-prefixed suffix tokens (ste, suite, unit, apt, …) — \b works.
+		//   2. Bare `#NNN` style — handled separately because `#` is not a
+		//      word character and \b would not anchor it.
+		$address = preg_replace(
+			'/\b(ste|suite|unit|apt|apartment|room|rm)\s*[a-z0-9\-]+\b/i',
+			'',
+			$address
+		);
+		$address = preg_replace( '/#\s*[a-z0-9\-]+/i', '', $address );
 
 		$replacements = array(
 			'/\bstreet\b/'    => 'st',
@@ -739,7 +766,12 @@ class Venue_Taxonomy {
 			$address = preg_replace( $pattern, $replacement, $address );
 		}
 
-		return preg_replace( '/\s+/', ' ', trim( $address ) );
+		// Collapse whitespace and strip stray trailing separators
+		// (suite-suffix removal can leave a dangling comma).
+		$address = preg_replace( '/\s+/', ' ', trim( $address ) );
+		$address = trim( $address, ' ,-' );
+
+		return $address;
 	}
 
 	/**

--- a/tests/Unit/VenueMergeHelperTest.php
+++ b/tests/Unit/VenueMergeHelperTest.php
@@ -1,0 +1,288 @@
+<?php
+/**
+ * VenueMergeHelper + CheckMergeDuplicateVenuesCommand Tests
+ *
+ * Covers the term-level merge primitive that backs the issue #276
+ * migration: loser meta smart-merged into winner, posts reassigned via
+ * wp_set_object_terms() (tt_count stays sane), flow handler_config
+ * references rewritten, loser term deleted, and the no-merge opt-out
+ * honored.
+ *
+ * @package DataMachineEvents\Tests\Unit
+ * @since   0.35.0
+ */
+
+namespace DataMachineEvents\Tests\Unit;
+
+use WP_UnitTestCase;
+use DataMachineEvents\Core\Event_Post_Type;
+use DataMachineEvents\Core\Venue_Taxonomy;
+use DataMachineEvents\Core\DuplicateDetection\VenueMergeHelper;
+use DataMachineEvents\Cli\Check\CheckMergeDuplicateVenuesCommand;
+
+class VenueMergeHelperTest extends WP_UnitTestCase {
+
+	public function setUp(): void {
+		parent::setUp();
+
+		if ( ! post_type_exists( Event_Post_Type::POST_TYPE ) ) {
+			Event_Post_Type::register();
+		}
+
+		if ( ! taxonomy_exists( 'venue' ) ) {
+			Venue_Taxonomy::register();
+		}
+
+		$this->ensure_flows_table();
+	}
+
+	private function ensure_flows_table(): void {
+		global $wpdb;
+
+		$table = $wpdb->prefix . 'datamachine_flows';
+		$exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+
+		if ( $exists === $table ) {
+			$wpdb->query( "TRUNCATE TABLE {$table}" );
+			return;
+		}
+
+		// Minimal schema matching the production shape we care about.
+		$wpdb->query(
+			"CREATE TABLE {$table} (
+				flow_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+				pipeline_id BIGINT UNSIGNED NOT NULL DEFAULT 0,
+				flow_name VARCHAR(255) NOT NULL DEFAULT '',
+				flow_config LONGTEXT NOT NULL,
+				PRIMARY KEY (flow_id)
+			)"
+		);
+	}
+
+	private function make_venue( string $name, array $meta = array() ): int {
+		$term = wp_insert_term( $name, 'venue' );
+		$this->assertNotInstanceOf( \WP_Error::class, $term );
+
+		$term_id = (int) $term['term_id'];
+		foreach ( $meta as $key => $value ) {
+			update_term_meta( $term_id, $key, $value );
+		}
+
+		return $term_id;
+	}
+
+	private function make_event_with_venue( string $title, int $venue_term_id ): int {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => Event_Post_Type::POST_TYPE,
+				'post_title'  => $title,
+				'post_status' => 'publish',
+			)
+		);
+
+		$this->assertIsInt( $post_id );
+		$this->assertGreaterThan( 0, $post_id );
+
+		wp_set_object_terms( $post_id, array( $venue_term_id ), 'venue', false );
+		return $post_id;
+	}
+
+	private function insert_flow( string $flow_config_json ): int {
+		global $wpdb;
+
+		$wpdb->insert(
+			$wpdb->prefix . 'datamachine_flows',
+			array(
+				'pipeline_id' => 1,
+				'flow_name'   => 'test flow',
+				'flow_config' => $flow_config_json,
+			),
+			array( '%d', '%s', '%s' )
+		);
+
+		return (int) $wpdb->insert_id;
+	}
+
+	private function get_flow_config( int $flow_id ): string {
+		global $wpdb;
+
+		return (string) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT flow_config FROM {$wpdb->prefix}datamachine_flows WHERE flow_id = %d",
+				$flow_id
+			)
+		);
+	}
+
+	// ---------------------------------------------------------------------
+	// Migration command behavior
+	// ---------------------------------------------------------------------
+
+	public function test_merge_command_dry_run_lists_clusters_without_writes(): void {
+		$winner = $this->make_venue( 'Hook and Ladder Theater' );
+		$loser  = $this->make_venue( 'Hook & Ladder Theater' );
+
+		$winner_post = $this->make_event_with_venue( 'Show A', $winner );
+		$loser_post  = $this->make_event_with_venue( 'Show B', $loser );
+
+		$cmd = new CheckMergeDuplicateVenuesCommand();
+		ob_start();
+		$cmd( array(), array( 'dry-run' => true ) );
+		ob_end_clean();
+
+		// Both terms still exist after a dry run.
+		$this->assertNotNull( get_term( $winner, 'venue' ) );
+		$this->assertNotNull( get_term( $loser, 'venue' ) );
+
+		// Loser still tagged on its post.
+		$terms = wp_get_object_terms( $loser_post, 'venue', array( 'fields' => 'ids' ) );
+		$this->assertContains( $loser, array_map( 'intval', $terms ) );
+
+		// Winner still tagged on its post.
+		$terms = wp_get_object_terms( $winner_post, 'venue', array( 'fields' => 'ids' ) );
+		$this->assertContains( $winner, array_map( 'intval', $terms ) );
+	}
+
+	public function test_merge_command_apply_reassigns_posts_and_deletes_loser(): void {
+		$winner = $this->make_venue(
+			'Hook and Ladder Theater',
+			array( '_venue_city' => 'Minneapolis' )
+		);
+		$loser  = $this->make_venue(
+			'Hook & Ladder Theater',
+			array(
+				'_venue_city'    => 'Minneapolis',
+				'_venue_address' => '3010 Minnehaha Ave',
+				'_venue_phone'   => '555-0100',
+			)
+		);
+
+		$winner_post = $this->make_event_with_venue( 'Show A', $winner );
+		$loser_post  = $this->make_event_with_venue( 'Show B', $loser );
+
+		$cmd = new CheckMergeDuplicateVenuesCommand();
+		ob_start();
+		$cmd( array(), array( 'apply' => true ) );
+		ob_end_clean();
+
+		// Loser term is gone.
+		$this->assertNull( get_term( $loser, 'venue' ) );
+
+		// Winner remains.
+		$this->assertNotNull( get_term( $winner, 'venue' ) );
+
+		// Loser's post is now tagged with the winner.
+		$loser_post_terms = wp_get_object_terms( $loser_post, 'venue', array( 'fields' => 'ids' ) );
+		$this->assertContains( $winner, array_map( 'intval', $loser_post_terms ) );
+		$this->assertNotContains( $loser, array_map( 'intval', $loser_post_terms ) );
+
+		// Winner's post unchanged.
+		$winner_post_terms = wp_get_object_terms( $winner_post, 'venue', array( 'fields' => 'ids' ) );
+		$this->assertContains( $winner, array_map( 'intval', $winner_post_terms ) );
+
+		// Smart-merge: winner inherited empty fields from loser.
+		$this->assertSame( '3010 Minnehaha Ave', get_term_meta( $winner, '_venue_address', true ) );
+		$this->assertSame( '555-0100', get_term_meta( $winner, '_venue_phone', true ) );
+
+		// Winner's pre-existing city was not overwritten.
+		$this->assertSame( 'Minneapolis', get_term_meta( $winner, '_venue_city', true ) );
+	}
+
+	public function test_merge_command_apply_reassigns_flow_handler_configs(): void {
+		$winner = $this->make_venue( 'Hook and Ladder Theater' );
+		$loser  = $this->make_venue( 'Hook & Ladder Theater' );
+
+		// Two flow shapes from production: flat venue and nested
+		// universal_web_scraper.venue. Both must be rewritten.
+		$flat_flow_id = $this->insert_flow(
+			wp_json_encode(
+				array(
+					'step_1' => array(
+						'handler_config' => array(
+							'venue' => (string) $loser,
+						),
+					),
+				)
+			)
+		);
+
+		$nested_flow_id = $this->insert_flow(
+			wp_json_encode(
+				array(
+					'step_1' => array(
+						'handler_config' => array(
+							'universal_web_scraper' => array(
+								'venue' => (string) $loser,
+							),
+						),
+					),
+				)
+			)
+		);
+
+		$cmd = new CheckMergeDuplicateVenuesCommand();
+		ob_start();
+		$cmd( array(), array( 'apply' => true ) );
+		ob_end_clean();
+
+		$flat_after   = json_decode( $this->get_flow_config( $flat_flow_id ), true );
+		$nested_after = json_decode( $this->get_flow_config( $nested_flow_id ), true );
+
+		$this->assertSame(
+			(string) $winner,
+			$flat_after['step_1']['handler_config']['venue']
+		);
+
+		$this->assertSame(
+			(string) $winner,
+			$nested_after['step_1']['handler_config']['universal_web_scraper']['venue']
+		);
+	}
+
+	public function test_merge_command_respects_no_merge_opt_out(): void {
+		$winner = $this->make_venue(
+			'Hook and Ladder Theater',
+			array( VenueMergeHelper::NO_MERGE_META_KEY => '1' )
+		);
+		$loser = $this->make_venue( 'Hook & Ladder Theater' );
+
+		$loser_post = $this->make_event_with_venue( 'Show B', $loser );
+
+		$cmd = new CheckMergeDuplicateVenuesCommand();
+		ob_start();
+		$cmd( array(), array( 'apply' => true ) );
+		ob_end_clean();
+
+		// Both terms intact.
+		$this->assertNotNull( get_term( $winner, 'venue' ) );
+		$this->assertNotNull( get_term( $loser, 'venue' ) );
+
+		// Loser's post still tagged with the loser.
+		$terms = wp_get_object_terms( $loser_post, 'venue', array( 'fields' => 'ids' ) );
+		$this->assertContains( $loser, array_map( 'intval', $terms ) );
+	}
+
+	public function test_merge_command_smart_merge_does_not_overwrite_winner(): void {
+		// Winner created first (lower ID), with a clean canonical address.
+		$winner = $this->make_venue(
+			'Hook and Ladder Theater',
+			array( '_venue_address' => '3010 Minnehaha Ave' )
+		);
+
+		// Loser has a different address string — smart-merge MUST NOT replace
+		// the winner's existing non-empty address.
+		$loser = $this->make_venue(
+			'Hook & Ladder Theater',
+			array( '_venue_address' => '3010 Minnehaha Ave Suite 420' )
+		);
+
+		$result = VenueMergeHelper::merge( $winner, $loser );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame(
+			'3010 Minnehaha Ave',
+			get_term_meta( $winner, '_venue_address', true ),
+			'Winner address must not be overwritten by loser address.'
+		);
+	}
+}

--- a/tests/Unit/VenueNormalizationTest.php
+++ b/tests/Unit/VenueNormalizationTest.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * Venue Normalization Tests
+ *
+ * Covers Venue_Taxonomy::normalize_venue_name_for_matching() and
+ * normalize_address_for_matching() — the two primitives that decide
+ * whether two venue terms collide.
+ *
+ * Issue #276: ampersand / HTML-entity / apostrophe and suite-suffix
+ * variants must all collapse to the same key.
+ *
+ * @package DataMachineEvents\Tests\Unit
+ * @since   0.35.0
+ */
+
+namespace DataMachineEvents\Tests\Unit;
+
+use WP_UnitTestCase;
+use DataMachineEvents\Core\Venue_Taxonomy;
+
+class VenueNormalizationTest extends WP_UnitTestCase {
+
+	public function setUp(): void {
+		parent::setUp();
+
+		if ( ! taxonomy_exists( 'venue' ) ) {
+			Venue_Taxonomy::register();
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// Part A: name normalization
+	// ---------------------------------------------------------------------
+
+	public function test_normalize_venue_name_collapses_ampersand_and_and(): void {
+		$canonical = Venue_Taxonomy::normalize_venue_name_for_matching( 'Hook and Ladder Theater' );
+
+		$this->assertSame(
+			$canonical,
+			Venue_Taxonomy::normalize_venue_name_for_matching( 'Hook & Ladder Theater' )
+		);
+
+		$this->assertSame(
+			$canonical,
+			Venue_Taxonomy::normalize_venue_name_for_matching( 'Hook &amp; Ladder Theater' )
+		);
+
+		$this->assertSame(
+			$canonical,
+			Venue_Taxonomy::normalize_venue_name_for_matching( 'hook  &amp;  ladder    theater' )
+		);
+
+		// Sanity check the canonical form itself.
+		$this->assertSame( 'hook and ladder theater', $canonical );
+	}
+
+	public function test_normalize_venue_name_collapses_apostrophes(): void {
+		$canonical = Venue_Taxonomy::normalize_venue_name_for_matching( 'Amos Southend' );
+
+		$this->assertSame(
+			$canonical,
+			Venue_Taxonomy::normalize_venue_name_for_matching( "Amos' Southend" )
+		);
+
+		$this->assertSame(
+			$canonical,
+			Venue_Taxonomy::normalize_venue_name_for_matching( "Amos&#8217; Southend" )
+		);
+
+		$this->assertSame( 'amos southend', $canonical );
+
+		// Cliff Bell's variant from the issue.
+		$this->assertSame(
+			Venue_Taxonomy::normalize_venue_name_for_matching( 'Cliff Bells' ),
+			Venue_Taxonomy::normalize_venue_name_for_matching( "Cliff Bell's" )
+		);
+
+		// Proctor's Theatre variant from the issue.
+		$this->assertSame(
+			Venue_Taxonomy::normalize_venue_name_for_matching( 'Proctors Theatre' ),
+			Venue_Taxonomy::normalize_venue_name_for_matching( "Proctor's Theatre" )
+		);
+	}
+
+	public function test_normalize_venue_name_idempotent(): void {
+		$already = 'hook and ladder theater';
+
+		$this->assertSame(
+			$already,
+			Venue_Taxonomy::normalize_venue_name_for_matching( $already )
+		);
+
+		// Run it twice to be safe — normalization is a fixed point.
+		$this->assertSame(
+			$already,
+			Venue_Taxonomy::normalize_venue_name_for_matching(
+				Venue_Taxonomy::normalize_venue_name_for_matching( 'Hook & Ladder Theater' )
+			)
+		);
+	}
+
+	// ---------------------------------------------------------------------
+	// Part B: address normalization
+	// ---------------------------------------------------------------------
+
+	public function test_normalize_address_strips_suite_suffix(): void {
+		$canonical = Venue_Taxonomy::normalize_address_for_matching( '3010 Minnehaha Ave' );
+
+		$this->assertSame(
+			$canonical,
+			Venue_Taxonomy::normalize_address_for_matching( '3010 Minnehaha Ave STE 420' )
+		);
+
+		$this->assertSame(
+			$canonical,
+			Venue_Taxonomy::normalize_address_for_matching( '3010 Minnehaha Ave Suite 420' )
+		);
+
+		$this->assertSame(
+			$canonical,
+			Venue_Taxonomy::normalize_address_for_matching( '3010 Minnehaha Ave Unit 420' )
+		);
+
+		$this->assertSame(
+			$canonical,
+			Venue_Taxonomy::normalize_address_for_matching( '3010 Minnehaha Ave #420' )
+		);
+
+		$this->assertSame(
+			$canonical,
+			Venue_Taxonomy::normalize_address_for_matching( '3010 minnehaha ave, ste 420' )
+		);
+	}
+
+	public function test_normalize_address_idempotent(): void {
+		$already = Venue_Taxonomy::normalize_address_for_matching( '3010 Minnehaha Ave STE 420' );
+
+		$this->assertSame(
+			$already,
+			Venue_Taxonomy::normalize_address_for_matching( $already )
+		);
+
+		// Plain, already-canonical address.
+		$plain = '123 main st';
+		$this->assertSame( $plain, Venue_Taxonomy::normalize_address_for_matching( $plain ) );
+	}
+
+	// ---------------------------------------------------------------------
+	// Integration: find_or_create_venue collapses variants
+	// ---------------------------------------------------------------------
+
+	public function test_find_or_create_venue_returns_same_id_for_ampersand_variants(): void {
+		$venue_data = array(
+			'address' => '3010 Minnehaha Ave',
+			'city'    => 'Minneapolis',
+			'state'   => 'MN',
+		);
+
+		$first = Venue_Taxonomy::find_or_create_venue( 'Hook & Ladder Theater', $venue_data );
+		$this->assertIsArray( $first );
+		$this->assertNotNull( $first['term_id'], 'First call should create a venue term.' );
+		$this->assertTrue( $first['was_created'] );
+
+		$second = Venue_Taxonomy::find_or_create_venue( 'Hook and Ladder Theater', $venue_data );
+		$this->assertIsArray( $second );
+		$this->assertSame(
+			$first['term_id'],
+			$second['term_id'],
+			'Ampersand vs "and" variant should resolve to the same venue term.'
+		);
+		$this->assertFalse( $second['was_created'] );
+	}
+
+	public function test_find_or_create_venue_returns_same_id_for_suite_address_variants(): void {
+		$venue_data_plain = array(
+			'address' => '3010 Minnehaha Ave',
+			'city'    => 'Minneapolis',
+			'state'   => 'MN',
+		);
+
+		$first = Venue_Taxonomy::find_or_create_venue( 'Hook and Ladder Theater', $venue_data_plain );
+		$this->assertIsArray( $first );
+		$this->assertNotNull( $first['term_id'] );
+
+		$venue_data_suite = array(
+			'address' => '3010 Minnehaha Ave STE 420',
+			'city'    => 'Minneapolis',
+			'state'   => 'MN',
+		);
+
+		$second = Venue_Taxonomy::find_or_create_venue( 'Hook and Ladder Theater', $venue_data_suite );
+		$this->assertSame(
+			$first['term_id'],
+			$second['term_id'],
+			'Suite-suffix address variant should resolve to the same venue term.'
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #276.

Today's discovery batches keep producing duplicate venue terms because the two collision normalizers introduced by PR #252 (address-aware venue resolution) miss two well-defined cases:

1. **Name normalization** does not collapse `&` ↔ `and`, does not decode `&amp;`, and never normalized apostrophes against terms that were created by pre-PR-252 codepaths.
2. **Address normalization** does not strip `STE`, `Suite`, `Unit`, `Apt`, `#NNN`, etc. — so `3010 Minnehaha Ave STE 420` and `3010 Minnehaha Ave` look like two different addresses.

A network audit today surfaced **6 production-confirmed collision clusters**:

| norm_name | count | terms |
| --- | --- | --- |
| amos southend | 2 | 17731 `Amos Southend` ‖ 50476 `Amos' Southend` |
| cliff bells | 2 | 27397 `Cliff Bells` ‖ 50459 `Cliff Bell's` |
| guitars and cadillacs | 2 | 32935 `Guitars and Cadillacs` ‖ 48049 `Guitars &amp; Cadillacs` |
| harvard and stone | 2 | 9523 `Harvard &amp; Stone` ‖ 38934 `Harvard and Stone` |
| hook and ladder theater | 2 | 27373 `Hook and Ladder Theater` ‖ 50460 `Hook &amp; Ladder Theater` |
| proctors theatre | 2 | 27296 `Proctor's Theatre` ‖ 27297 `Proctors Theatre` |

Plus the suite-suffix variant for Hook & Ladder Theater:
- 27373 — `3010 Minnehaha Ave STE 420` (Minneapolis)
- 50460 — `3010 Minnehaha Ave` (Minneapolis)

Each pair is the same physical venue with two term IDs, two stat lines, two location-archive entries, and split event counts. PR #252 will not fix this on its own — the existing duplicates need a one-time migration.

## What changed

### Part A — name normalization (`Venue_Taxonomy::normalize_venue_name_for_matching`)

- `html_entity_decode` was already first; now also converts every `&` variant (spaced, tight, decoded from `&amp;`) to literal ` and ` before the alphanumeric strip.
- Apostrophes were already stripped via the non-alphanumeric pass; documented alongside the ampersand handling so the full collision surface is covered in one place.

After this:
- `Hook & Ladder Theater` → `hook and ladder theater`
- `Hook and Ladder Theater` → `hook and ladder theater`
- `Hook &amp; Ladder Theater` → `hook and ladder theater`
- `Amos Southend`, `Amos' Southend` → `amos southend`
- `Cliff Bells`, `Cliff Bell's` → `cliff bells`

### Part B — address normalization (`Venue_Taxonomy::normalize_address_for_matching`)

- Strips `ste`/`suite`/`unit`/`apt`/`apartment`/`room`/`rm`/`#NNN` suffixes **before** the existing street-suffix replacements. Two passes: word-boundary suffixes plus a dedicated `#NNN` pattern (since `#` is non-word and `\b` does not anchor against it).
- Trailing comma/dash is trimmed so substring comparison stays clean.
- Method is now `public` so the migration helper and unit tests can call it directly.

After this all of these collapse to `3010 minnehaha ave`:
`3010 Minnehaha Ave`, `3010 Minnehaha Ave STE 420`, `3010 Minnehaha Ave Suite 420`, `3010 Minnehaha Ave Unit 420`, `3010 Minnehaha Ave #420`, `3010 minnehaha ave, ste 420`.

### Part C — one-time migration command

`wp data-machine-events check merge-duplicate-venues [--dry-run] [--apply] [--limit=N] [--format=table|csv|json]`

Defaults to dry-run. `--apply` commits. Walks every venue term, groups by normalized name AND normalized address+city, and for each cluster picks the lowest term_id as winner. Hands each `(winner, loser)` pair to the new `VenueMergeHelper::merge()` which performs the merge in this strict order:

1. **Smart-merge** loser meta into winner (fill empties only — never overwrites winner data).
2. **Reassign posts** via `wp_set_object_terms()` so `tt_count` stays in sync (no raw `term_relationships` SQL).
3. **Rewrite flow handler_config** references in `{prefix}datamachine_flows` that point at the loser term_id — handles both flat `handler_config.venue` and nested `handler_config.universal_web_scraper.venue` shapes observed in production. Ticketmaster's `venue_id` is intentionally left alone (external venue identifier, not a WP term).
4. **Delete the loser term** last (order matters — reassign first so no inbound reference orphans).
5. Emits a structured `venue_merge` info entry via the `datamachine_log` action for the audit trail.

Respects a `_venue_no_merge=1` term-meta opt-out on either side of a cluster (operator protection for legit multi-room buildings or otherwise-similar venues that must stay separate).

Output table columns: `cluster_key, winner_id, winner_name, loser_ids, loser_names, total_posts_reassigned, total_flows_reassigned, action_taken`.

## Tests

**`tests/Unit/VenueNormalizationTest.php`**
- `test_normalize_venue_name_collapses_ampersand_and_and`
- `test_normalize_venue_name_collapses_apostrophes`
- `test_normalize_venue_name_idempotent`
- `test_normalize_address_strips_suite_suffix`
- `test_normalize_address_idempotent`
- `test_find_or_create_venue_returns_same_id_for_ampersand_variants` (integration)
- `test_find_or_create_venue_returns_same_id_for_suite_address_variants` (integration)

**`tests/Unit/VenueMergeHelperTest.php`**
- `test_merge_command_dry_run_lists_clusters_without_writes`
- `test_merge_command_apply_reassigns_posts_and_deletes_loser`
- `test_merge_command_apply_reassigns_flow_handler_configs`
- `test_merge_command_respects_no_merge_opt_out`
- `test_merge_command_smart_merge_does_not_overwrite_winner`

Live smoke-test of the normalizers via `php -r` on the production WP load confirms every variant in the issue body collapses correctly. `homeboy audit .` reports zero new outliers attributable to the new files.

> **Test runner caveat**: this repo's `phpunit.xml` points at `tests/bootstrap.php` which is not checked in (no `vendor/` directory either). PHPUnit tests do not execute locally in the worktree — they are designed to run in CI against a WP-PHPUnit harness. The test files follow the existing `tests/Unit/*Test.php` conventions and will be picked up by the same suite that exercises `EventMergeHelperTest` etc.

## Migration playbook

After merge + deploy, run on each subsite that owns venue terms (events.extrachill.com is the primary):

```
wp --url=events.extrachill.com data-machine-events check merge-duplicate-venues --dry-run
```

Review the cluster table, sanity-check the winners, then commit:

```
wp --url=events.extrachill.com data-machine-events check merge-duplicate-venues --apply
```

Use `--limit=N` to throttle batches if a single run would be too large.

## Constraints honored

- Conventional commits (`fix(venue-dedup):` and `feat(check):`).
- No version bump. No `CHANGELOG.md` edits. No release. No deploy.
- Worktree-only changes (`/var/lib/datamachine/workspace/data-machine-events@fix-venue-dedup-normalization`).
- PR against `main`. Not merged.