### PR TITLE
fix: sync block.json versions on release so style/script changes bust caches

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -21,6 +21,18 @@
     {
       "file": "readme.txt",
       "pattern": "(?m)^Stable tag:\\s*([0-9.]+)"
+    },
+    {
+      "file": "inc/Blocks/Calendar/block.json",
+      "pattern": "\"version\":\\s*\"([0-9.]+)\""
+    },
+    {
+      "file": "inc/Blocks/EventDetails/block.json",
+      "pattern": "\"version\":\\s*\"([0-9.]+)\""
+    },
+    {
+      "file": "inc/Blocks/EventsMap/block.json",
+      "pattern": "\"version\":\\s*\"([0-9.]+)\""
     }
   ]
 }

--- a/inc/Blocks/Calendar/block.json
+++ b/inc/Blocks/Calendar/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "data-machine-events/calendar",
-  "version": "0.22.0",
+  "version": "0.36.0",
 	"title": "Data Machine Events Calendar",
 	"category": "widgets",
 	"icon": "calendar-alt",

--- a/inc/Blocks/EventDetails/block.json
+++ b/inc/Blocks/EventDetails/block.json
@@ -1,7 +1,7 @@
 {
     "apiVersion": 2,
     "name": "data-machine-events/event-details",
-    "version": "0.12.1",
+    "version": "0.36.0",
     "title": "Event Details",
     "category": "data-machine-events",
     "icon": "calendar-alt",

--- a/inc/Blocks/EventsMap/block.json
+++ b/inc/Blocks/EventsMap/block.json
@@ -2,7 +2,7 @@
     "$schema": "https://schemas.wp.org/trunk/block.json",
     "apiVersion": 3,
     "name": "data-machine-events/events-map",
-    "version": "0.2.0",
+    "version": "0.36.0",
     "title": "Events Map",
     "category": "data-machine-events",
     "icon": "location-alt",


### PR DESCRIPTION
## Summary

WordPress uses each block's `block.json` `\"version\"` field as the cache-bust query string on style/script handles registered via the block. Until this PR, none of the three blocks (Calendar, EventDetails, EventsMap) had their version bumped by homeboy on release. The plugin header was at **0.36.0** but the block versions had drifted to **0.22.0**, **0.12.1**, and **0.2.0** respectively — so every CSS change since those versions has been served as the **same asset URL** (`?ver=0.22.0` etc.) and stale-cached by browsers and CDNs for repeat visitors.

## Trigger

The low-density card layout shipped in v0.36.0 (#275) did not appear for users who had already loaded the Calendar block's CSS, because the cache-bust string was unchanged. The CSS file on disk was correct, the deploy succeeded, but the browser never refetched it.

Live evidence — the rendered HTML on a venue archive linked the asset like this **after** v0.36.0 deploy:

```
<link rel='stylesheet' id='data-machine-events-calendar-style-css'
      href='.../inc/Blocks/Calendar/style.css?ver=0.22.0' media='all' />
```

`?ver=0.22.0` is the Calendar block's `block.json` version — never bumped since v0.22.0 of the plugin.

## Fix (two parts)

### 1. Align all three block.json versions to the current plugin version (0.36.0)

Surgical single-line edits to preserve the existing tab indentation and key ordering:

- `inc/Blocks/Calendar/block.json`: `0.22.0` → `0.36.0`
- `inc/Blocks/EventDetails/block.json`: `0.12.1` → `0.36.0`
- `inc/Blocks/EventsMap/block.json`: `0.2.0` → `0.36.0`

### 2. Add the three block.json files to homeboy.json version_targets

```jsonc
{
  \"file\": \"inc/Blocks/Calendar/block.json\",
  \"pattern\": \"\\\"version\\\":\\\\s*\\\"([0-9.]+)\\\"\"
},
// ...same for EventDetails and EventsMap
```

The regex `\"version\":\\s*\"([0-9.]+)\"` matches the top-level `version` field without disturbing nested `version` keys (none currently exist, but the pattern is intentionally tight).

Future `homeboy release` runs will bump all three blocks in lockstep with the plugin header.

## Verification plan post-merge

1. Run `homeboy release data-machine-events patch` → expect versions to bump to 0.36.1 across **all six** version targets (3 existing + 3 new block.json files)
2. Deploy
3. Confirm the rendered HTML on a venue archive shows `?ver=0.36.1` on the Calendar block CSS handle
4. Hard-refresh on the same venue archive to confirm low-density card CSS now applies

## Out of scope

- A homeboy check that warns when block.json files exist but aren't in version_targets (separate process improvement; track if it recurs)
- Auditing other components in the network for the same drift class (likely candidates: any plugin with a Gutenberg block — should be checked, but each is its own PR)