### PR TITLE
fix: zero badge bottom-margin in low-density day groups for inline alignment

### DIFF
--- a/inc/Blocks/Calendar/style.css
+++ b/inc/Blocks/Calendar/style.css
@@ -994,6 +994,21 @@
     gap: 0.75rem;
 }
 
+/* Badges sit inline with everything else in the row strip, so drop the
+ * stacked-layout bottom margin from .data-machine-taxonomy-badges /
+ * .taxonomy-badges (both selectors exist — host theme can supply either).
+ * Without this, the badge block keeps margin-bottom from its default
+ * stacked-card styling and visually pushes the title baseline out of
+ * alignment with the time and More Info button. */
+.data-machine-events-calendar .data-machine-date-group[data-event-count="1"] .data-machine-taxonomy-badges,
+.data-machine-events-calendar .data-machine-date-group[data-event-count="1"] .taxonomy-badges,
+.data-machine-events-calendar .data-machine-date-group[data-event-count="2"] .data-machine-taxonomy-badges,
+.data-machine-events-calendar .data-machine-date-group[data-event-count="2"] .taxonomy-badges {
+    margin-bottom: 0;
+    align-items: center;
+    flex: 0 0 auto;
+}
+
 /* Hide the carousel overflow "More" indicator on low-density days — irrelevant
  * when there's nothing to scroll. */
 .data-machine-events-calendar .data-machine-date-group[data-event-count="1"]::after,


### PR DESCRIPTION
## Summary

The low-density layout shipped in v0.36.0 (#275) collapses the event card to a single horizontal row strip — badges, title, time, and More Info button on one line. But the badge wrapper still carried its stacked-card `margin-bottom`:

```css
.taxonomy-badges,
.data-machine-taxonomy-badges {
    /* ... */
    margin-bottom: var(--spacing-md);   /* makes sense for stacked card */
    margin-bottom: var(--data-machine-taxonomy-badge-margin-bottom);
}
```

That bottom margin is correct for the default stacked layout (badges above title with breathing room). In a row strip it pushes the badge block out of vertical alignment with the title baseline and the More Info button.

## Fix

Override both badge wrapper selectors (host themes can supply either — extrachill theme uses `.taxonomy-badges`; data-machine-events provides `.data-machine-taxonomy-badges`) in the low-density context to:

- Zero `margin-bottom`
- `align-items: center` for the badges' own children
- `flex: 0 0 auto` so the badge block doesn't stretch and consume row width

Applies to `data-event-count="1"` and `data-event-count="2"` only. High-density days keep the default stacked layout and badge margin unchanged.

## Why both selectors

The two badge classes coexist on the same DOM element on extrachill.com because the theme applies its own class to the wrapper output by `\\DataMachineEvents\\Blocks\\Calendar\\Taxonomy\\Badges::render_taxonomy_badges()`. Targeting both is safe — same element, idempotent rules.

## Verification post-deploy

Visit https://events.extrachill.com/venue/the-royal-american/ and confirm:
- Badge block sits inline at the same vertical center as the title text and More Info button
- No extra space between badges and the title on 1-event and 2-event days
- High-density days (homepage, location archives) render unchanged

## Out of scope

- Restyling the badge component itself
- Changing the default badge margin in the stacked layout
- Other places `.taxonomy-badges` is used outside the calendar block

## Related

- #275 (low-density layout that introduced this alignment artifact)