### PR TITLE
fix(venue-merge): require name similarity on address-based clusters to prevent merging different venues at shared addresses

### DIFF
--- a/inc/Cli/Check/CheckMergeDuplicateVenuesCommand.php
+++ b/inc/Cli/Check/CheckMergeDuplicateVenuesCommand.php
@@ -190,44 +190,113 @@ class CheckMergeDuplicateVenuesCommand {
 		// Emit name-clusters first, then address-clusters. Each term is
 		// emitted in at most one cluster — once seen via name, the
 		// address loop ignores it.
+		//
+		// Name-clusters are accepted as-is: same normalized name = same
+		// venue (this IS Rule 1 of names_are_similar).
+		//
+		// Address-clusters are subdivided by name similarity to suppress
+		// false positives at multi-tenant addresses (issue #281). Two
+		// terms sharing an address+city are only kept together if their
+		// names pass VenueMergeHelper::names_are_similar().
 		foreach ( array( 'name' => $by_name, 'addr' => $by_address ) as $kind => $groups ) {
 			foreach ( $groups as $key => $group_terms ) {
 				if ( count( $group_terms ) < 2 ) {
 					continue;
 				}
 
-				$ids = array();
-				foreach ( $group_terms as $t ) {
-					$ids[] = (int) $t->term_id;
-				}
-
 				// Drop terms we've already clustered via the name pass.
-				$ids = array_values( array_diff( $ids, $seen_term_ids ) );
-
-				if ( count( $ids ) < 2 ) {
-					continue;
-				}
-
-				$cluster_terms = array_values(
+				$group_terms = array_values(
 					array_filter(
 						$group_terms,
-						static fn( $t ) => in_array( (int) $t->term_id, $ids, true )
+						static fn( $t ) => ! in_array( (int) $t->term_id, $seen_term_ids, true )
 					)
 				);
 
-				$clusters[] = array(
-					'key'      => $kind . ':' . $key,
-					'term_ids' => $ids,
-					'terms'    => $cluster_terms,
-				);
+				if ( count( $group_terms ) < 2 ) {
+					continue;
+				}
 
-				foreach ( $ids as $tid ) {
-					$seen_term_ids[] = $tid;
+				$subgroups = ( 'addr' === $kind )
+					? $this->split_by_name_similarity( $group_terms )
+					: array( $group_terms );
+
+				foreach ( $subgroups as $subgroup_index => $subgroup_terms ) {
+					if ( count( $subgroup_terms ) < 2 ) {
+						continue;
+					}
+
+					$ids = array();
+					foreach ( $subgroup_terms as $t ) {
+						$ids[] = (int) $t->term_id;
+					}
+
+					// When an address bucket is split, give each surviving
+					// sub-cluster a disambiguating suffix so the operator
+					// can tell them apart in the dry-run report.
+					$cluster_key = $kind . ':' . $key;
+					if ( 'addr' === $kind && count( $subgroups ) > 1 ) {
+						$cluster_key .= '#' . ( $subgroup_index + 1 );
+					}
+
+					$clusters[] = array(
+						'key'      => $cluster_key,
+						'term_ids' => $ids,
+						'terms'    => array_values( $subgroup_terms ),
+					);
+
+					foreach ( $ids as $tid ) {
+						$seen_term_ids[] = $tid;
+					}
 				}
 			}
 		}
 
 		return $clusters;
+	}
+
+	/**
+	 * Subdivide an address-bucket of venue terms into sub-clusters where
+	 * every term is name-similar to every other term in the sub-cluster
+	 * (complete-linkage clustering on VenueMergeHelper::names_are_similar).
+	 *
+	 * Complete-linkage (require similarity to ALL existing members, not
+	 * just one) is the safer choice for a destructive merge: it prevents
+	 * transitive chaining where A~B and B~C but A and C are not similar.
+	 *
+	 * Singleton sub-clusters are returned and filtered by the caller.
+	 *
+	 * @param array<int,\WP_Term> $terms Terms sharing an address+city.
+	 * @return array<int,array<int,\WP_Term>> List of sub-clusters.
+	 */
+	private function split_by_name_similarity( array $terms ): array {
+		$subgroups = array();
+
+		foreach ( $terms as $term ) {
+			$placed = false;
+
+			foreach ( $subgroups as $sub_idx => $sub_terms ) {
+				$similar_to_all = true;
+
+				foreach ( $sub_terms as $existing ) {
+					if ( ! VenueMergeHelper::names_are_similar( (string) $term->name, (string) $existing->name ) ) {
+						$similar_to_all = false;
+						break;
+					}
+				}
+
+				if ( $similar_to_all ) {
+					$subgroups[ $sub_idx ][] = $term;
+					$placed                  = true;
+					break;
+				}
+			}
+
+			if ( ! $placed ) {
+				$subgroups[] = array( $term );
+			}
+		}
+
+		return $subgroups;
 	}
 
 	/**

--- a/inc/Core/DuplicateDetection/VenueMergeHelper.php
+++ b/inc/Core/DuplicateDetection/VenueMergeHelper.php
@@ -38,6 +38,98 @@ class VenueMergeHelper {
 	public const NO_MERGE_META_KEY = '_venue_no_merge';
 
 	/**
+	 * Jaccard token-overlap threshold for Rule 3 of names_are_similar().
+	 * Stricter is safer for a destructive merge operation — do not lower
+	 * without revisiting the production false-positive set in issue #281.
+	 */
+	public const NAME_SIMILARITY_TOKEN_OVERLAP_THRESHOLD = 0.70;
+
+	/**
+	 * Decide whether two venue names are similar enough that two terms
+	 * sharing an address+city should be treated as the same venue.
+	 *
+	 * Used by the address-cluster path in CheckMergeDuplicateVenuesCommand
+	 * to suppress false positives at multi-tenant addresses (issue #281).
+	 * Multi-tenant buildings — Dolby Theatre vs Lucky Strike Hollywood,
+	 * Pancho's Tacos vs ATHICA, V Theater vs Saxe Theater at Planet
+	 * Hollywood — legitimately share a street address but are distinct
+	 * operators that must not be merged.
+	 *
+	 * Three rules — any single rule passing accepts the pair as "similar":
+	 *
+	 *   Rule 1: Exact equality after normalize_venue_name_for_matching().
+	 *           Handles "Hi-Fi Indianapolis" vs "HI-FI Indianapolis".
+	 *
+	 *   Rule 2: Substring containment after normalization, where the
+	 *           shorter normalized name is at least 4 characters.
+	 *           Handles "The Abbey" vs "The Abbey-Orlando".
+	 *
+	 *   Rule 3: Jaccard token overlap >= 70% after stop-word removal
+	 *           ("the", "a", "an", "and", "of", "at"). Handles
+	 *           "St Augustine Amphitheatre" vs "The St. Augustine
+	 *           Amphitheatre" (4/5 = 0.80). Correctly REJECTS
+	 *           "V Theater at Planet Hollywood" vs "Saxe Theater at
+	 *           Planet Hollywood" (3/5 = 0.60).
+	 *
+	 * If all three rules fail, the names are dissimilar and the pair
+	 * must NOT be clustered as duplicates even if they share an address.
+	 *
+	 * Empty / whitespace-only / sub-threshold inputs return false — when
+	 * in doubt the safer answer for a destructive merge is "not similar".
+	 *
+	 * @param string $a First venue name.
+	 * @param string $b Second venue name.
+	 * @return bool True if any of the three rules accepts the pair.
+	 */
+	public static function names_are_similar( string $a, string $b ): bool {
+		$norm_a = Venue_Taxonomy::normalize_venue_name_for_matching( $a );
+		$norm_b = Venue_Taxonomy::normalize_venue_name_for_matching( $b );
+
+		if ( '' === $norm_a || '' === $norm_b ) {
+			return false;
+		}
+
+		// Rule 1: exact match after normalization.
+		if ( $norm_a === $norm_b ) {
+			return true;
+		}
+
+		// Rule 2: substring containment with a 4-char floor on the shorter
+		// name. The floor stops tiny tokens like "joe" matching every
+		// "Joe's <something>" but allows "joes" (4 chars) through.
+		$shorter = strlen( $norm_a ) <= strlen( $norm_b ) ? $norm_a : $norm_b;
+		$longer  = strlen( $norm_a ) <= strlen( $norm_b ) ? $norm_b : $norm_a;
+		if ( strlen( $shorter ) >= 4 && str_contains( $longer, $shorter ) ) {
+			return true;
+		}
+
+		// Rule 3: Jaccard token overlap on stop-word-stripped tokens.
+		$stops = array( 'the', 'a', 'an', 'and', 'of', 'at' );
+
+		$tok_a = preg_split( '/\s+/', $norm_a, -1, PREG_SPLIT_NO_EMPTY );
+		$tok_b = preg_split( '/\s+/', $norm_b, -1, PREG_SPLIT_NO_EMPTY );
+		if ( ! is_array( $tok_a ) || ! is_array( $tok_b ) ) {
+			return false;
+		}
+
+		$tok_a = array_values( array_diff( $tok_a, $stops ) );
+		$tok_b = array_values( array_diff( $tok_b, $stops ) );
+
+		if ( empty( $tok_a ) || empty( $tok_b ) ) {
+			return false;
+		}
+
+		$intersection = count( array_intersect( $tok_a, $tok_b ) );
+		$union        = count( array_unique( array_merge( $tok_a, $tok_b ) ) );
+
+		if ( 0 === $union ) {
+			return false;
+		}
+
+		return ( $intersection / $union ) >= self::NAME_SIMILARITY_TOKEN_OVERLAP_THRESHOLD;
+	}
+
+	/**
 	 * Merge a loser venue term into a winner venue term.
 	 *
 	 * @param int $winner_id Term ID to keep (lower IDs win in callers).

--- a/tests/Unit/VenueMergeHelperTest.php
+++ b/tests/Unit/VenueMergeHelperTest.php
@@ -285,4 +285,314 @@ class VenueMergeHelperTest extends WP_UnitTestCase {
 			'Winner address must not be overwritten by loser address.'
 		);
 	}
+
+	// ---------------------------------------------------------------------
+	// names_are_similar() — three-rule guard for address-cluster path
+	// (issue #281)
+	// ---------------------------------------------------------------------
+
+	public function test_names_are_similar_exact_normalized_match(): void {
+		// Different casing only → Rule 1 (exact match after normalization).
+		$this->assertTrue(
+			VenueMergeHelper::names_are_similar( 'Hi-Fi Indianapolis', 'HI-FI Indianapolis' )
+		);
+	}
+
+	public function test_names_are_similar_substring_containment(): void {
+		// "the abbey" is substring of "the abbeyorlando" after normalization
+		// strips the dash. Shorter is well above the 4-char floor → Rule 2.
+		$this->assertTrue(
+			VenueMergeHelper::names_are_similar( 'The Abbey', 'The Abbey-Orlando' )
+		);
+	}
+
+	public function test_names_are_similar_token_overlap_above_threshold(): void {
+		// Token reordering keeps Rule 3 honest: same bag of tokens but
+		// not a substring of each other. 3/3 = 1.0, well over 0.70.
+		$this->assertTrue(
+			VenueMergeHelper::names_are_similar( 'Bowery Ballroom NYC', 'NYC Bowery Ballroom' )
+		);
+	}
+
+	public function test_names_are_similar_token_overlap_below_threshold(): void {
+		// {v, theater, planet, hollywood} vs {saxe, theater, planet, hollywood}
+		// intersection 3, union 5 → 0.60 → below the 0.70 cutoff.
+		$this->assertFalse(
+			VenueMergeHelper::names_are_similar(
+				'V Theater at Planet Hollywood',
+				'Saxe Theater at Planet Hollywood'
+			)
+		);
+	}
+
+	public function test_names_are_similar_completely_different(): void {
+		// Zero token overlap → 0/4 = 0.0 → false.
+		$this->assertFalse(
+			VenueMergeHelper::names_are_similar( 'Dolby Theatre', 'Lucky Strike Hollywood' )
+		);
+	}
+
+	public function test_names_are_similar_taco_vs_art_space(): void {
+		// "panchos tacos and tequila" vs "athica" → no token overlap → false.
+		$this->assertFalse(
+			VenueMergeHelper::names_are_similar( "Pancho's Tacos & Tequila", 'ATHICA' )
+		);
+	}
+
+	public function test_names_are_similar_short_substring_at_threshold(): void {
+		// Edge case: "joes" normalizes to exactly 4 chars, which meets the
+		// >=4 floor of Rule 2, and IS substring of "joes bar and grill"
+		// after normalization. This case PASSES — documenting the floor.
+		//
+		// Real-world impact is bounded: this only fires inside an
+		// address-bucket where both terms ALREADY share a normalized
+		// address+city, so spurious "Joe's" → "Joe's Bar and Grill" cross-
+		// city collisions are not possible.
+		$this->assertTrue(
+			VenueMergeHelper::names_are_similar( 'Joes', "Joe's Bar and Grill" )
+		);
+	}
+
+	public function test_names_are_similar_empty_or_whitespace(): void {
+		$this->assertFalse( VenueMergeHelper::names_are_similar( '', 'Anything' ) );
+		$this->assertFalse( VenueMergeHelper::names_are_similar( 'Anything', '' ) );
+		$this->assertFalse( VenueMergeHelper::names_are_similar( '   ', 'Anything' ) );
+		// Single-character "Z" normalizes to "z" (1 char) — fails Rule 1
+		// (not equal), Rule 2 (below 4-char floor), Rule 3 (no overlap).
+		$this->assertFalse( VenueMergeHelper::names_are_similar( 'Z', 'Anything' ) );
+	}
+
+	/**
+	 * Regression fixture: every production false-positive pair from the
+	 * issue #281 dry-run must be rejected by names_are_similar(). These
+	 * are the actual term-pair names from extrachill.com (Nov 2025), and
+	 * each one would have produced a destructive cross-venue merge if
+	 * we'd run --apply against the unguarded clustering logic.
+	 */
+	public function test_production_false_positive_pairs_rejected(): void {
+		$pairs = array(
+			array( 'Dolby Theatre', 'Lucky Strike Hollywood' ),
+			array( 'Come and Take It Live', "Emo's Austin" ),
+			array( "Pancho's Tacos & Tequila", 'ATHICA' ),
+			array( 'North Charleston Coliseum', 'North Charleston Performing Arts Center' ),
+			array( 'V Theater at Planet Hollywood', 'Saxe Theater at Planet Hollywood' ),
+			array( 'The Arrow Room', 'Haven City Market' ),
+		);
+
+		foreach ( $pairs as $pair ) {
+			$this->assertFalse(
+				VenueMergeHelper::names_are_similar( $pair[0], $pair[1] ),
+				sprintf(
+					'Pair MUST be rejected as dissimilar: "%s" vs "%s"',
+					$pair[0],
+					$pair[1]
+				)
+			);
+		}
+	}
+
+	/**
+	 * Regression fixture: legitimate venue-pair variants that the issue
+	 * #281 fix MUST keep clustering together. If any of these flip to
+	 * false the address-cluster path stops doing useful work and the
+	 * migration becomes a no-op.
+	 */
+	public function test_production_true_positive_pairs_accepted(): void {
+		$pairs = array(
+			// Rule 1 (exact normalized) — case-only variant.
+			array( 'Hi-Fi Indianapolis', 'HI-FI Indianapolis' ),
+			// Rule 2 (substring) — annex/suffix variant.
+			array( 'The Abbey', 'The Abbey-Orlando' ),
+			// Rule 1 — ampersand collapses to "and" via the existing
+			// normalize_venue_name_for_matching() pipeline so both sides
+			// reduce to the identical normalized string.
+			array( 'Hook & Ladder Theater', 'Hook and Ladder Theater' ),
+			// Rule 1 — leading "The" is stripped and periods removed by
+			// normalize_venue_name_for_matching(), so both sides reduce
+			// to "st augustine amphitheatre".
+			array( 'St Augustine Amphitheatre', 'The St. Augustine Amphitheatre' ),
+		);
+
+		foreach ( $pairs as $pair ) {
+			$this->assertTrue(
+				VenueMergeHelper::names_are_similar( $pair[0], $pair[1] ),
+				sprintf(
+					'Pair MUST be accepted as similar: "%s" vs "%s"',
+					$pair[0],
+					$pair[1]
+				)
+			);
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// Address-cluster integration: split_by_name_similarity() must keep
+	// legitimate pairs and drop multi-tenant false positives.
+	// ---------------------------------------------------------------------
+
+	public function test_address_cluster_excludes_dissimilar_names(): void {
+		// Two terms at the same address+city with completely different
+		// names. The address-cluster path must NOT emit a multi-term
+		// cluster for this address.
+		$this->make_venue(
+			'Dolby Theatre',
+			array(
+				'_venue_address' => '6801 Hollywood Blvd',
+				'_venue_city'    => 'Hollywood',
+			)
+		);
+		$this->make_venue(
+			'Lucky Strike Hollywood',
+			array(
+				'_venue_address' => '6801 Hollywood Blvd',
+				'_venue_city'    => 'Hollywood',
+			)
+		);
+
+		$cmd = new CheckMergeDuplicateVenuesCommand();
+		$reflection = new \ReflectionClass( $cmd );
+		$method     = $reflection->getMethod( 'find_clusters' );
+		$method->setAccessible( true );
+		$clusters = $method->invoke( $cmd );
+
+		foreach ( $clusters as $cluster ) {
+			$this->assertStringStartsNotWith(
+				'addr:',
+				$cluster['key'],
+				sprintf(
+					'Multi-tenant address must not produce an addr-cluster (got key %s with %d terms)',
+					$cluster['key'],
+					count( $cluster['term_ids'] )
+				)
+			);
+		}
+	}
+
+	public function test_address_cluster_includes_similar_names(): void {
+		// Two terms at the same address+city with case-only name variants.
+		// Both pass Rule 1 → address-cluster must contain them.
+		$winner = $this->make_venue(
+			'Hi-Fi Indianapolis',
+			array(
+				'_venue_address' => '1043 Virginia Ave',
+				'_venue_city'    => 'Indianapolis',
+			)
+		);
+		$loser = $this->make_venue(
+			'HI-FI Indianapolis Suite 4',
+			array(
+				'_venue_address' => '1043 Virginia Ave',
+				'_venue_city'    => 'Indianapolis',
+			)
+		);
+
+		$cmd        = new CheckMergeDuplicateVenuesCommand();
+		$reflection = new \ReflectionClass( $cmd );
+		$method     = $reflection->getMethod( 'find_clusters' );
+		$method->setAccessible( true );
+		$clusters = $method->invoke( $cmd );
+
+		// Either bucket may catch the pair (name-cluster wins first), but
+		// SOME cluster must contain both ids.
+		$found = false;
+		foreach ( $clusters as $cluster ) {
+			if (
+				in_array( $winner, $cluster['term_ids'], true )
+				&& in_array( $loser, $cluster['term_ids'], true )
+			) {
+				$found = true;
+				break;
+			}
+		}
+
+		$this->assertTrue(
+			$found,
+			'Similar-named terms at the same address must be clustered together.'
+		);
+	}
+
+	public function test_address_cluster_splits_multi_tenant_with_mixed_pair(): void {
+		// Three terms at the same address: two are name-similar to each
+		// other, the third is unrelated. The similar pair must cluster;
+		// the odd one out must be excluded.
+		$similar_a = $this->make_venue(
+			'Hi-Fi Indianapolis',
+			array(
+				'_venue_address' => '1043 Virginia Ave',
+				'_venue_city'    => 'Indianapolis',
+			)
+		);
+		$similar_b = $this->make_venue(
+			'HI-FI Indianapolis',
+			array(
+				'_venue_address' => '1043 Virginia Ave',
+				'_venue_city'    => 'Indianapolis',
+			)
+		);
+		$intruder = $this->make_venue(
+			'Completely Unrelated Bowling Alley',
+			array(
+				'_venue_address' => '1043 Virginia Ave',
+				'_venue_city'    => 'Indianapolis',
+			)
+		);
+
+		$cmd        = new CheckMergeDuplicateVenuesCommand();
+		$reflection = new \ReflectionClass( $cmd );
+		$method     = $reflection->getMethod( 'find_clusters' );
+		$method->setAccessible( true );
+		$clusters = $method->invoke( $cmd );
+
+		$cluster_with_similar = null;
+		foreach ( $clusters as $cluster ) {
+			if (
+				in_array( $similar_a, $cluster['term_ids'], true )
+				&& in_array( $similar_b, $cluster['term_ids'], true )
+			) {
+				$cluster_with_similar = $cluster;
+				break;
+			}
+		}
+
+		$this->assertNotNull(
+			$cluster_with_similar,
+			'Similar pair must be clustered.'
+		);
+		$this->assertNotContains(
+			$intruder,
+			$cluster_with_similar['term_ids'],
+			'Dissimilar third term must not join the cluster.'
+		);
+	}
+
+	public function test_name_cluster_unchanged(): void {
+		// Regression guard: name-only clusters (no shared address) still
+		// match by normalized-name equality, which IS Rule 1 of
+		// names_are_similar. The fix must not affect this path.
+		$winner = $this->make_venue( 'Hook and Ladder Theater' );
+		$loser  = $this->make_venue( 'Hook & Ladder Theater' );
+
+		$cmd        = new CheckMergeDuplicateVenuesCommand();
+		$reflection = new \ReflectionClass( $cmd );
+		$method     = $reflection->getMethod( 'find_clusters' );
+		$method->setAccessible( true );
+		$clusters = $method->invoke( $cmd );
+
+		$found = false;
+		foreach ( $clusters as $cluster ) {
+			if (
+				str_starts_with( $cluster['key'], 'name:' )
+				&& in_array( $winner, $cluster['term_ids'], true )
+				&& in_array( $loser, $cluster['term_ids'], true )
+			) {
+				$found = true;
+				break;
+			}
+		}
+
+		$this->assertTrue(
+			$found,
+			'Name-cluster for ampersand variant must survive the address-cluster guard.'
+		);
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #281.

`CheckMergeDuplicateVenuesCommand` (shipped in #278 / v0.37.2) clusters venue terms by **name OR by address+city**. The address-clustering path ignores names entirely, so multi-tenant buildings — where two unrelated venues legitimately share a street address — get merged into a single cluster.

Today's first production dry-run flagged 18 clusters; 6 of them are false positives that would have caused destructive cross-venue merges if anyone ran `--apply` blind.

This PR adds a **three-rule name-similarity guard** on the address-cluster path. Two terms sharing an address+city stay clustered only if their names also agree by at least one rule. The name-cluster path is unchanged (it already requires normalized-name equality, which IS Rule 1).

## The six production false-positive pairs (now rejected)

| Address | Pair |
|---|---|
| 6801 Hollywood Blvd | Dolby Theatre vs Lucky Strike Hollywood (Oscars venue vs bowling alley) |
| 2015 E Riverside Dr, Austin | Come and Take It Live vs Emo's Austin |
| 675 Pulaski St, Athens | Pancho's Tacos & Tequila vs ATHICA (taco shop vs art space) |
| 5001 Coliseum Dr, North Charleston | North Charleston Coliseum vs NC Performing Arts Center |
| 3663 Las Vegas Blvd S | V Theater vs Saxe Theater at Planet Hollywood |
| 8443 Haven Ave, Rancho Cucamonga | The Arrow Room vs Haven City Market |

## The three similarity rules

A pair is accepted as "similar" if **any** rule passes:

1. **Exact normalized name match** — after `Venue_Taxonomy::normalize_venue_name_for_matching()`, the two names are byte-equal. Handles trivial case/punctuation variants (e.g. `Hi-Fi Indianapolis` vs `HI-FI Indianapolis`).
2. **Substring containment** — one normalized name contains the other, and the shorter normalized name is at least 4 characters. Handles `The Abbey` vs `The Abbey-Orlando`.
3. **Jaccard token overlap >= 0.70** — tokenize on whitespace, strip stop-words (`the, a, an, and, of, at`), require intersection/union >= 0.70. Handles `Bowery Ballroom NYC` vs `NYC Bowery Ballroom` (token reorder, 3/3 = 1.0). Correctly rejects `V Theater at Planet Hollywood` vs `Saxe Theater at Planet Hollywood` (3/5 = 0.60, below threshold).

If all three fail, the pair is dissimilar and must not be clustered even when addresses match.

The 0.70 threshold is intentionally strict — stricter is safer for a destructive merge operation. The issue body and code constant `NAME_SIMILARITY_TOKEN_OVERLAP_THRESHOLD` document this rationale.

## Address-cluster splitting

When an address bucket holds 3+ terms with mixed similarity (e.g. two case-variants of "Hi-Fi Indianapolis" plus an unrelated "Bowling Alley" at the same address), the bucket is subdivided by **complete-linkage** clustering: a term joins a sub-cluster only if it is name-similar to **every** existing member, not just one. This prevents transitive chaining where A~B and B~C but A and C are not similar — which matters for a destructive merge.

Surviving sub-clusters are reported with a disambiguating `#N` suffix in their `cluster_key` so the operator can tell sibling sub-clusters apart in the dry-run output.

## Test cases

All in `tests/Unit/VenueMergeHelperTest.php`. The three-rule unit tests and the production fixtures were also verified standalone (PHP 8.4) — 16/16 pass.

### `names_are_similar()` unit tests

- `test_names_are_similar_exact_normalized_match` — case-only variant → Rule 1.
- `test_names_are_similar_substring_containment` — `The Abbey` vs `The Abbey-Orlando` → Rule 2.
- `test_names_are_similar_token_overlap_above_threshold` — token reorder `Bowery Ballroom NYC` ↔ `NYC Bowery Ballroom` → Rule 3 (1.0).
- `test_names_are_similar_token_overlap_below_threshold` — `V Theater at Planet Hollywood` vs `Saxe Theater at Planet Hollywood` → 0.60, rejected.
- `test_names_are_similar_completely_different` — `Dolby Theatre` vs `Lucky Strike Hollywood` → no overlap.
- `test_names_are_similar_taco_vs_art_space` — `Pancho's Tacos & Tequila` vs `ATHICA` → no overlap.
- `test_names_are_similar_short_substring_at_threshold` — documents the 4-char floor edge case (`Joes` vs `Joe's Bar and Grill` passes Rule 2; impact bounded because both must already share address+city).
- `test_names_are_similar_empty_or_whitespace` — empty / whitespace / single char → false.

### Regression fixtures

- `test_production_false_positive_pairs_rejected` — all six pairs from the issue body return false.
- `test_production_true_positive_pairs_accepted` — `Hi-Fi Indianapolis` case-variant, `The Abbey` suffix variant, `Hook & Ladder` ampersand, `St Augustine Amphitheatre` "The" stripping all return true.

### Address-cluster integration tests

- `test_address_cluster_excludes_dissimilar_names` — two dissimilar terms at the same address produce no `addr:` cluster.
- `test_address_cluster_includes_similar_names` — two similar-named terms at the same address are clustered.
- `test_address_cluster_splits_multi_tenant_with_mixed_pair` — three terms at one address (two similar + one unrelated) produces a 2-term sub-cluster excluding the intruder.
- `test_name_cluster_unchanged` — regression guard: name-only clusters still work.

## Test runner status

<callout accent="#f59e0b">
## Pre-existing test bootstrap blocker

`homeboy test` fails on this branch AND on plain `main` with the same error:

```
BOOTSTRAP FAILURE: load_deps:Error: Interface "WP_Agent_Token_Store" not found
at /wordpress/wp-content/plugins/data-machine/inc/Core/Database/Agents/AgentTokens.php:24
```

That is an upstream `data-machine` / `agents-api` plugin dependency missing from the test playground, not anything this PR introduces. Verified by stashing the diff and re-running on a clean `main` — identical failure.

To compensate, the three-rule logic was exercised standalone against a minimal harness loading only `VenueMergeHelper` + a copy of `normalize_venue_name_for_matching()`. All 16 fixture cases pass (every unit test in this PR plus all 6 production false-positives plus all 4 production true-positives).

`homeboy lint --changed-since main` reports 9 findings inside the two touched source files, all on **pre-existing** lines I did not modify. None of my added lines introduce new lint findings.
</callout>

## Verification after merge + deploy

Re-run on extrachill.com:

```bash
wp data-machine-events check merge-duplicate-venues --dry-run
```

Expected: cluster count drops from **18** to **~11** (the 6 multi-tenant false positives disappear; legitimate name-collision and suite-variant clusters survive).

## Out of scope

- Levenshtein-distance fuzzy matching beyond the three documented rules — adds false-positive risk on a destructive operation.
- Lowering the 0.70 Jaccard threshold to capture more matches — stricter is safer.
- Touching the name-cluster path — it already implements Rule 1 correctly.