### PR TITLE
feat(chat-tools): add move_event primitive with venue-change audit trail

### DIFF
--- a/data-machine-events.php
+++ b/data-machine-events.php
@@ -331,6 +331,7 @@ class DATAMACHINE_Events {
 		new \DataMachineEvents\Api\Chat\Tools\EventHealthCheck();
 		new \DataMachineEvents\Api\Chat\Tools\EventQualityAudit();
 		new \DataMachineEvents\Api\Chat\Tools\UpdateEvent();
+		new \DataMachineEvents\Api\Chat\Tools\MoveEvent();
 		new \DataMachineEvents\Api\Chat\Tools\GetVenueEvents();
 		new \DataMachineEvents\Api\Chat\Tools\FindBrokenTimezoneEvents();
 		new \DataMachineEvents\Api\Chat\Tools\FixEventTimezone();
@@ -360,6 +361,11 @@ class DATAMACHINE_Events {
 		if ( file_exists( DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Abilities/EventUpdateAbilities.php' ) ) {
 			require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Abilities/EventUpdateAbilities.php';
 			new \DataMachineEvents\Abilities\EventUpdateAbilities();
+		}
+
+		if ( file_exists( DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Abilities/MoveEventAbilities.php' ) ) {
+			require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Abilities/MoveEventAbilities.php';
+			new \DataMachineEvents\Abilities\MoveEventAbilities();
 		}
 
 		if ( file_exists( DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Abilities/BatchTimeFixAbilities.php' ) ) {

--- a/inc/Abilities/MoveEventAbilities.php
+++ b/inc/Abilities/MoveEventAbilities.php
@@ -1,0 +1,314 @@
+<?php
+/**
+ * Move Event Abilities
+ *
+ * Moves a single event post from one venue to another, recording an
+ * audit-log entry capturing the from/to venue, reason, and actor. This is
+ * the named primitive for "the show moved venues" — for generic block
+ * attribute updates use data-machine-events/update-event; for duplicate
+ * cleanup use data-machine-events/delete-event (issue #286).
+ *
+ * Behavior:
+ *  1. Validate event post exists and is the correct post type.
+ *  2. Validate to_venue term exists in the 'venue' taxonomy.
+ *  3. Capture the current ("from") venue term before changing anything.
+ *  4. Reuse EventUpdateAbilities to perform the actual venue swap so the
+ *     block-update + taxonomy logic is not duplicated.
+ *  5. Append a record to post meta '_dme_venue_history' and fire the
+ *     'dme_event_venue_changed' action so listeners (analytics, audit
+ *     log, etc.) can react.
+ *
+ * @package DataMachineEvents\Abilities
+ * @since   0.39.0
+ */
+
+namespace DataMachineEvents\Abilities;
+
+use DataMachineEvents\Core\Event_Post_Type;
+
+defined( 'ABSPATH' ) || exit;
+
+class MoveEventAbilities {
+
+	/**
+	 * Post-meta key storing the venue-change history array.
+	 *
+	 * Each entry is an associative array:
+	 *   array(
+	 *     'from_venue_id'   => int,
+	 *     'from_venue_name' => string,
+	 *     'to_venue_id'     => int,
+	 *     'to_venue_name'   => string,
+	 *     'reason'          => string,
+	 *     'actor_id'        => int,
+	 *     'recorded_at'     => string ISO 8601 UTC,
+	 *   )
+	 */
+	public const VENUE_HISTORY_META_KEY = '_dme_venue_history';
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( ! self::$registered ) {
+			$this->registerAbility();
+			self::$registered = true;
+		}
+	}
+
+	private function registerAbility(): void {
+		$register_callback = function () {
+			wp_register_ability(
+				'data-machine-events/move-event',
+				array(
+					'label'               => __( 'Move Event', 'data-machine-events' ),
+					'description'         => __( 'Move a single event post to a new venue and record an audit-log entry capturing the from/to venue and reason.', 'data-machine-events' ),
+					'category'            => 'datamachine-events-events',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'required'   => array( 'event', 'to_venue' ),
+						'properties' => array(
+							'event'    => array(
+								'type'        => 'integer',
+								'description' => 'Event post ID to move.',
+							),
+							'to_venue' => array(
+								'type'        => 'integer',
+								'description' => 'Destination venue term ID. Must exist in the venue taxonomy.',
+							),
+							'reason'   => array(
+								'type'        => 'string',
+								'description' => 'Free-form rationale recorded in the venue history (e.g. "moved from Firefly to Refinery per @qrisg").',
+							),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'event_id'    => array( 'type' => 'integer' ),
+							'from_venue'  => array(
+								'type'       => 'object',
+								'properties' => array(
+									'id'   => array( 'type' => 'integer' ),
+									'name' => array( 'type' => 'string' ),
+								),
+							),
+							'to_venue'    => array(
+								'type'       => 'object',
+								'properties' => array(
+									'id'   => array( 'type' => 'integer' ),
+									'name' => array( 'type' => 'string' ),
+								),
+							),
+							'start_date'  => array( 'type' => 'string' ),
+							'recorded_at' => array( 'type' => 'string' ),
+						),
+					),
+					'execute_callback'    => array( $this, 'execute' ),
+					// TODO(#288): swap to the team-member permission helper introduced
+					// by the permission_callback audit. For now use manage_options to
+					// match the rest of the EC-events surface.
+					'permission_callback' => function () {
+						return current_user_can( 'manage_options' );
+					},
+					'meta'                => array( 'show_in_rest' => true ),
+				)
+			);
+		};
+
+		if ( did_action( 'wp_abilities_api_init' ) ) {
+			$register_callback();
+		} else {
+			add_action( 'wp_abilities_api_init', $register_callback );
+		}
+	}
+
+	/**
+	 * Execute the move.
+	 *
+	 * @param array $input {
+	 *     @type int    $event    Required. Event post ID.
+	 *     @type int    $to_venue Required. Destination venue term ID.
+	 *     @type string $reason   Optional. Free-form rationale.
+	 * }
+	 * @return array|\WP_Error
+	 */
+	public function execute( array $input ): array|\WP_Error {
+		$post_id     = (int) ( $input['event'] ?? 0 );
+		$to_venue_id = (int) ( $input['to_venue'] ?? 0 );
+		$reason      = trim( (string) ( $input['reason'] ?? '' ) );
+
+		if ( $post_id <= 0 ) {
+			return new \WP_Error(
+				'invalid_event',
+				'event (post ID) is required and must be a positive integer.',
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( $to_venue_id <= 0 ) {
+			return new \WP_Error(
+				'invalid_to_venue',
+				'to_venue (venue term ID) is required and must be a positive integer.',
+				array( 'status' => 400 )
+			);
+		}
+
+		$post = get_post( $post_id );
+		if ( ! $post || Event_Post_Type::POST_TYPE !== $post->post_type ) {
+			return new \WP_Error(
+				'event_not_found',
+				sprintf( 'Event post %d not found or wrong post_type.', $post_id ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$to_term = get_term( $to_venue_id, 'venue' );
+		if ( ! $to_term || is_wp_error( $to_term ) ) {
+			return new \WP_Error(
+				'to_venue_not_found',
+				sprintf( 'Venue term %d not found in venue taxonomy.', $to_venue_id ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$from_venue = $this->captureCurrentVenue( $post_id );
+
+		if ( null !== $from_venue && $from_venue['id'] === $to_venue_id ) {
+			return new \WP_Error(
+				'venue_unchanged',
+				sprintf( 'Event %d is already assigned to venue %d.', $post_id, $to_venue_id ),
+				array( 'status' => 400 )
+			);
+		}
+
+		// Reuse EventUpdateAbilities so the block-update + taxonomy assignment
+		// logic stays in one place. Calling executeUpdateEvent with just the
+		// venue field triggers updateVenue() and skips the block rewrite.
+		$update_abilities = new EventUpdateAbilities();
+		$update_result    = $update_abilities->executeUpdateEvent(
+			array(
+				'event' => $post_id,
+				'venue' => $to_venue_id,
+			)
+		);
+
+		if ( is_wp_error( $update_result ) ) {
+			return $update_result;
+		}
+
+		$results = $update_result['results'][0] ?? array();
+		if ( ( $results['status'] ?? '' ) !== 'updated' || ! in_array( 'venue', $results['updated_fields'] ?? array(), true ) ) {
+			$warnings = $results['warnings'] ?? array();
+			$error    = $results['error'] ?? ( ! empty( $warnings ) ? implode( '; ', $warnings ) : 'Venue assignment did not complete.' );
+			return new \WP_Error( 'venue_update_failed', $error, array( 'status' => 500 ) );
+		}
+
+		$recorded_at = gmdate( 'c' );
+		$actor_id    = get_current_user_id();
+
+		$history_entry = array(
+			'from_venue_id'   => $from_venue['id'] ?? 0,
+			'from_venue_name' => $from_venue['name'] ?? '',
+			'to_venue_id'     => $to_venue_id,
+			'to_venue_name'   => $to_term->name,
+			'reason'          => $reason,
+			'actor_id'        => $actor_id,
+			'recorded_at'     => $recorded_at,
+		);
+
+		$history   = get_post_meta( $post_id, self::VENUE_HISTORY_META_KEY, true );
+		$history   = is_array( $history ) ? $history : array();
+		$history[] = $history_entry;
+		update_post_meta( $post_id, self::VENUE_HISTORY_META_KEY, $history );
+
+		/**
+		 * Fires after an event has been moved to a new venue.
+		 *
+		 * @param int    $post_id     Event post ID.
+		 * @param array  $from_venue  array{id:int,name:string}|array{} The previous venue, if any.
+		 * @param array  $to_venue    array{id:int,name:string} The new venue.
+		 * @param string $reason      Free-form rationale supplied by the caller.
+		 * @param int    $actor_id    User ID that initiated the move (0 if none).
+		 * @param string $recorded_at ISO 8601 UTC timestamp.
+		 */
+		do_action(
+			'dme_event_venue_changed',
+			$post_id,
+			$from_venue ?? array(),
+			array(
+				'id'   => $to_venue_id,
+				'name' => $to_term->name,
+			),
+			$reason,
+			$actor_id,
+			$recorded_at
+		);
+
+		do_action(
+			'datamachine_log',
+			'info',
+			'Moved event to new venue.',
+			array(
+				'event_id'      => $post_id,
+				'from_venue_id' => $from_venue['id'] ?? 0,
+				'to_venue_id'   => $to_venue_id,
+				'reason'        => $reason,
+			)
+		);
+
+		$start_date = $this->resolveStartDate( $post );
+
+		return array(
+			'event_id'    => $post_id,
+			'from_venue'  => $from_venue ?? array(
+				'id'   => 0,
+				'name' => '',
+			),
+			'to_venue'    => array(
+				'id'   => $to_venue_id,
+				'name' => $to_term->name,
+			),
+			'start_date'  => $start_date,
+			'recorded_at' => $recorded_at,
+		);
+	}
+
+	/**
+	 * Capture the event's current venue term (if any) before the move.
+	 *
+	 * @param int $post_id Event post ID.
+	 * @return array{id:int,name:string}|null Null when the event has no venue assigned.
+	 */
+	private function captureCurrentVenue( int $post_id ): ?array {
+		$terms = get_the_terms( $post_id, 'venue' );
+		if ( empty( $terms ) || is_wp_error( $terms ) ) {
+			return null;
+		}
+
+		$term = reset( $terms );
+		if ( ! $term instanceof \WP_Term ) {
+			return null;
+		}
+
+		return array(
+			'id'   => (int) $term->term_id,
+			'name' => $term->name,
+		);
+	}
+
+	/**
+	 * Resolve the event's startDate from the event-details block, if available.
+	 *
+	 * @param \WP_Post $post
+	 * @return string Empty string when no startDate is set.
+	 */
+	private function resolveStartDate( \WP_Post $post ): string {
+		$blocks = parse_blocks( $post->post_content );
+		foreach ( $blocks as $block ) {
+			if ( 'data-machine-events/event-details' === ( $block['blockName'] ?? '' ) ) {
+				return (string) ( $block['attrs']['startDate'] ?? '' );
+			}
+		}
+		return '';
+	}
+}

--- a/inc/Api/Chat/Tools/MoveEvent.php
+++ b/inc/Api/Chat/Tools/MoveEvent.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Move Event Tool
+ *
+ * Chat tool wrapper for MoveEventAbilities. Use when a single event post
+ * needs its venue changed (the show moved venues). Records an audit-log
+ * entry capturing the from/to venue and reason.
+ *
+ * For wrong-venue DUPLICATES (two posts exist for the same show), use
+ * delete_event (issue #286) instead. For generic block-attribute updates
+ * use update_event.
+ *
+ * @package DataMachineEvents\Api\Chat\Tools
+ * @since   0.39.0
+ */
+
+namespace DataMachineEvents\Api\Chat\Tools;
+
+defined( 'ABSPATH' ) || exit;
+
+use DataMachine\Engine\AI\Tools\BaseTool;
+use DataMachineEvents\Abilities\MoveEventAbilities;
+
+class MoveEvent extends BaseTool {
+
+	public function __construct() {
+		$this->registerTool(
+			'move_event',
+			array( $this, 'getToolDefinition' ),
+			array( 'chat' ),
+			array( 'ability' => 'data-machine-events/move-event' )
+		);
+	}
+
+	public function getToolDefinition(): array {
+		return array(
+			'class'       => self::class,
+			'method'      => 'handle_tool_call',
+			'description' => 'Use when a single event post needs its venue changed (the show moved venues). Records an audit-log entry capturing the from/to venue and reason. For wrong-venue DUPLICATES (two posts exist), use delete_event instead. For generic block-attribute updates, use update_event.',
+			'parameters'  => array(
+				'type'       => 'object',
+				'required'   => array( 'event', 'to_venue' ),
+				'properties' => array(
+					'event'    => array(
+						'type'        => 'integer',
+						'description' => 'Event post ID to move.',
+					),
+					'to_venue' => array(
+						'type'        => 'integer',
+						'description' => 'Destination venue term ID. Must exist in the venue taxonomy.',
+					),
+					'reason'   => array(
+						'type'        => 'string',
+						'description' => 'Free-form rationale for the move (e.g. "moved from Firefly to Refinery per @qrisg"). Recorded in the venue history.',
+					),
+				),
+			),
+		);
+	}
+
+	public function handle_tool_call( array $parameters, array $tool_def = array() ): array {
+		$abilities = new MoveEventAbilities();
+		$result    = $abilities->execute( $parameters );
+
+		if ( is_wp_error( $result ) ) {
+			return $this->buildErrorResponse( $result->get_error_message(), 'move_event' );
+		}
+
+		return array(
+			'success'   => true,
+			'data'      => $result,
+			'tool_name' => 'move_event',
+		);
+	}
+}


### PR DESCRIPTION
Closes #287

## Summary

Adds a dedicated `move_event` chat tool wrapping a new `data-machine-events/move-event` ability. Today, moving a show from venue X to venue Y goes through `update_event { venue: <id> }` — that works but loses **intent** ("this is specifically a venue move") and **audit** ("when did the venue change, why, and from what"). The `move_event` primitive gives the model a named tool to reach for and records the move.

## New files

- `inc/Abilities/MoveEventAbilities.php` — registers `data-machine-events/move-event` (input: `event`, `to_venue`, optional `reason`; output: `event_id`, `from_venue`, `to_venue`, `start_date`, `recorded_at`).
- `inc/Api/Chat/Tools/MoveEvent.php` — `move_event` chat tool wrapper extending `BaseTool`.

Plus a two-line bootstrap edit in `data-machine-events.php` to load both alongside the existing tools/abilities.

## Behavior

1. Validates the event post exists and matches `Event_Post_Type::POST_TYPE`.
2. Validates the destination venue term exists in the `venue` taxonomy.
3. Captures the current ("from") venue term before the change (null if none).
4. Rejects no-op moves (current venue already equals `to_venue`).
5. Delegates the venue swap to `EventUpdateAbilities::executeUpdateEvent({ event, venue })` — **no duplicated block-update logic**; the underlying `updateVenue()` path handles the `wp_set_post_terms` call.
6. Records the audit entry (see below).

## Audit-log mechanism

I chose **both** mechanisms because they serve different consumers:

- **Post meta `_dme_venue_history`** (publicly declared as `MoveEventAbilities::VENUE_HISTORY_META_KEY`) — a serialized array of entries, each capturing `{ from_venue_id, from_venue_name, to_venue_id, to_venue_name, reason, actor_id, recorded_at }`. This gives us a durable, per-post history that any reader (admin UI, REST endpoint, future analytics digest) can introspect without subscribing to a hook.
- **`do_action( 'dme_event_venue_changed', $post_id, $from_venue, $to_venue, $reason, $actor_id, $recorded_at )`** — fired immediately after the meta write so listeners (other plugins, analytics writers, Slack notifiers, etc.) can react in real time without scanning post meta.

This matches the style of `MergeEventPostsAbilities`, which already uses `do_action( 'datamachine_log', ... )` for its merge-log entry. The post-meta layer is the new piece — there was no existing `_merge_log` or `_dme_audit` precedent for the merge ability to reuse, so the meta key is fresh.

## Permission shape

`permission_callback` is currently `current_user_can( 'manage_options' )` with a TODO referencing **#288**:

```php
// TODO(#288): swap to the team-member permission helper introduced
// by the permission_callback audit. For now use manage_options to
// match the rest of the EC-events surface.
```

Once #288 lands the team-member helper, this callback needs to be updated to match (along with `update_event`, `delete_event`, and friends).

## Relationship to sibling PRs

- **#288** (`fix-288-team-member-permissions`) — owns the permission_callback audit. This PR will adopt whatever helper #288 introduces; merge order is **#288 first**.
- **#286** (`feat-286-delete-event`) — sibling tool for the duplicate-post case. `move_event` is for the clean case (single post, swap the venue); `delete_event` is for "two posts exist, one is wrong-venue". Tool descriptions in both explicitly cross-reference each other so the model knows which to pick. No file overlap; this PR and #286 can land in either order after #288.

## Out of scope (matches the issue)

- No batch move support — single event per call.
- No cross-date moves — that's just `update_event` with a new `startDate`.
- No duplicate auto-detection — that's `delete_event`'s job (#286).

## How to verify

### Via chat
> "The Sept 12 Susto show at Refinery actually moved to The Royal American — reason: venue swap announced on the band's IG. Find it and move it."

The model should:
1. Call `get_venue_events { venue: <refinery_id> }` (or similar discovery) to find the post.
2. Call `move_event { event: <post_id>, to_venue: <royal_american_id>, reason: "venue swap per band IG" }`.
3. Receive the structured result with `from_venue: { id, name: "Refinery" }`, `to_venue: { id, name: "The Royal American" }`, `start_date`, and `recorded_at`.

### Via WP-CLI (direct ability invocation)
```bash
wp --allow-root --path=/var/www/extrachill.com --url=events.extrachill.com \
  eval 'print_r( wp_get_ability("data-machine-events/move-event")->execute([
    "event" => 12345,
    "to_venue" => 678,
    "reason" => "venue swap test",
  ]) );'
```

### Verifying the audit trail
```bash
wp --allow-root --path=/var/www/extrachill.com --url=events.extrachill.com \
  post meta get 12345 _dme_venue_history --format=json
```

Should return the array of move records, newest appended last.

### Verifying the action fires
```php
add_action( 'dme_event_venue_changed', function( $post_id, $from, $to, $reason, $actor, $when ) {
    error_log( "move_event: {$post_id} from {$from['id']} to {$to['id']} ({$reason})" );
}, 10, 6 );
```

## Notes for reviewer

- No release/deploy from this PR — version bumps and changelog are owned by homeboy.
- Conventional commit (`feat(chat-tools): ...`) so homeboy picks up the minor bump on the next release.