### PR TITLE
fix(permissions): allow team-member contributors to use event/venue write abilities

### DIFF
--- a/data-machine-events.php
+++ b/data-machine-events.php
@@ -325,6 +325,10 @@ class DATAMACHINE_Events {
 		require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Abilities/AbilityCategories.php';
 		\DataMachineEvents\Abilities\AbilityCategories::ensure_registered();
 
+		// Shared permission callbacks. Must load before any ability that
+		// references AbilityPermissions::canWrite()/canRead().
+		require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Abilities/AbilityPermissions.php';
+
 		// Load chat tools - self-register via ToolRegistrationTrait
 		new \DataMachineEvents\Api\Chat\Tools\VenueHealthCheck();
 		new \DataMachineEvents\Api\Chat\Tools\UpdateVenue();

--- a/inc/Abilities/AbilityPermissions.php
+++ b/inc/Abilities/AbilityPermissions.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Ability Permissions Helper
+ *
+ * Shared permission callbacks for Data Machine Events abilities.
+ *
+ * Team-member contributors (extrachill_team=1 user meta) are trusted to use
+ * write abilities even when their WP role does not grant manage_options /
+ * edit_others_posts. The Roadie chat layer already treats them as authorized
+ * via extrachill_roadie_team_access_bridge; this brings every underlying
+ * ability into agreement.
+ *
+ * Permission shape (Option A from issue #288):
+ *   1. If ec_is_team_member() returns true → allow.
+ *   2. Else fall back to a capability check appropriate to the operation.
+ *
+ * WP-CLI is always allowed (matches the existing admin-tool convention used
+ * by GeocodingAbilities, SettingsAbilities, VenueStatsAbilities).
+ *
+ * ec_is_team_member() is shipped by extrachill-users. Wrap with
+ * function_exists() so this plugin still loads in contexts where that plugin
+ * is absent (tests, isolated CLI runs).
+ *
+ * @package DataMachineEvents\Abilities
+ * @since 0.39.0
+ */
+
+namespace DataMachineEvents\Abilities;
+
+defined( 'ABSPATH' ) || exit;
+
+class AbilityPermissions {
+
+	/**
+	 * Permission callback for write abilities (event/venue mutations,
+	 * batch fixes, merges, geocoding sweeps, meta resyncs, etc).
+	 *
+	 * Admins pass via edit_others_posts (granted to administrators and
+	 * editors by default). Team members pass via the override. WP-CLI
+	 * always passes.
+	 *
+	 * @return \Closure
+	 */
+	public static function canWrite(): \Closure {
+		return static function () {
+			if ( defined( 'WP_CLI' ) && WP_CLI ) {
+				return true;
+			}
+
+			if ( function_exists( 'ec_is_team_member' ) && \ec_is_team_member() ) {
+				return true;
+			}
+
+			return current_user_can( 'edit_others_posts' );
+		};
+	}
+
+	/**
+	 * Permission callback for diagnostic / admin-only read abilities
+	 * that should still be gated but available to team members.
+	 *
+	 * Currently unused by default — read-only abilities in the audit
+	 * (issue #288) were intentionally left on their existing gate. Provided
+	 * here so future read abilities have a consistent shape if they want
+	 * the same team-member override without opening up to all readers.
+	 *
+	 * @return \Closure
+	 */
+	public static function canRead(): \Closure {
+		return static function () {
+			if ( defined( 'WP_CLI' ) && WP_CLI ) {
+				return true;
+			}
+
+			if ( function_exists( 'ec_is_team_member' ) && \ec_is_team_member() ) {
+				return true;
+			}
+
+			return current_user_can( 'edit_posts' );
+		};
+	}
+}

--- a/inc/Abilities/BatchTimeFixAbilities.php
+++ b/inc/Abilities/BatchTimeFixAbilities.php
@@ -121,9 +121,7 @@ class BatchTimeFixAbilities {
 						),
 					),
 					'execute_callback'    => array( $this, 'executeBatchTimeFix' ),
-					'permission_callback' => function () {
-						return current_user_can( 'manage_options' );
-					},
+					'permission_callback' => AbilityPermissions::canWrite(),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);

--- a/inc/Abilities/EncodingFixAbilities.php
+++ b/inc/Abilities/EncodingFixAbilities.php
@@ -95,9 +95,7 @@ class EncodingFixAbilities {
 						),
 					),
 					'execute_callback'    => array( $this, 'executeEncodingFix' ),
-					'permission_callback' => function () {
-						return current_user_can( 'manage_options' );
-					},
+					'permission_callback' => AbilityPermissions::canWrite(),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);

--- a/inc/Abilities/EventUpdateAbilities.php
+++ b/inc/Abilities/EventUpdateAbilities.php
@@ -161,9 +161,7 @@ class EventUpdateAbilities {
 						),
 					),
 					'execute_callback'    => array( $this, 'executeUpdateEvent' ),
-					'permission_callback' => function () {
-						return current_user_can( 'manage_options' );
-					},
+					'permission_callback' => AbilityPermissions::canWrite(),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);

--- a/inc/Abilities/GeocodingAbilities.php
+++ b/inc/Abilities/GeocodingAbilities.php
@@ -94,9 +94,7 @@ class GeocodingAbilities {
 					),
 				),
 				'execute_callback'    => array( $this, 'executeGeocodeAddress' ),
-				'permission_callback' => function () {
-					return current_user_can( 'manage_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
-				},
+				'permission_callback' => AbilityPermissions::canWrite(),
 				'meta'                => array( 'show_in_rest' => true ),
 			)
 		);
@@ -306,9 +304,7 @@ class GeocodingAbilities {
 					),
 				),
 				'execute_callback'    => array( $this, 'executeGeocodeVenues' ),
-				'permission_callback' => function () {
-					return current_user_can( 'manage_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
-				},
+				'permission_callback' => AbilityPermissions::canWrite(),
 				'meta'                => array( 'show_in_rest' => true ),
 			)
 		);
@@ -483,9 +479,7 @@ class GeocodingAbilities {
 					),
 				),
 				'execute_callback'    => array( $this, 'executeAuditVenues' ),
-				'permission_callback' => function () {
-					return current_user_can( 'manage_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
-				},
+				'permission_callback' => AbilityPermissions::canWrite(),
 				'meta'                => array( 'show_in_rest' => true ),
 			)
 		);

--- a/inc/Abilities/MergeEventPostsAbilities.php
+++ b/inc/Abilities/MergeEventPostsAbilities.php
@@ -63,9 +63,7 @@ class MergeEventPostsAbilities {
 						),
 					),
 					'execute_callback'    => array( $this, 'execute' ),
-					'permission_callback' => function () {
-						return current_user_can( 'manage_options' );
-					},
+					'permission_callback' => AbilityPermissions::canWrite(),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);

--- a/inc/Abilities/MergedBillDecideAbilities.php
+++ b/inc/Abilities/MergedBillDecideAbilities.php
@@ -61,9 +61,7 @@ class MergedBillDecideAbilities {
 						),
 					),
 					'execute_callback'    => array( $this, 'executeInspect' ),
-					'permission_callback' => function () {
-						return current_user_can( 'manage_options' );
-					},
+					'permission_callback' => AbilityPermissions::canWrite(),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
@@ -98,9 +96,7 @@ class MergedBillDecideAbilities {
 						),
 					),
 					'execute_callback'    => array( $this, 'executeDecide' ),
-					'permission_callback' => function () {
-						return current_user_can( 'manage_options' );
-					},
+					'permission_callback' => AbilityPermissions::canWrite(),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);

--- a/inc/Abilities/MetaSyncAbilities.php
+++ b/inc/Abilities/MetaSyncAbilities.php
@@ -70,9 +70,7 @@ class MetaSyncAbilities {
 						),
 					),
 					'execute_callback'    => array( $this, 'executeFindMissingMetaSync' ),
-					'permission_callback' => function () {
-						return current_user_can( 'manage_options' );
-					},
+					'permission_callback' => AbilityPermissions::canWrite(),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
@@ -131,9 +129,7 @@ class MetaSyncAbilities {
 						),
 					),
 					'execute_callback'    => array( $this, 'executeResyncEventMeta' ),
-					'permission_callback' => function () {
-						return current_user_can( 'manage_options' );
-					},
+					'permission_callback' => AbilityPermissions::canWrite(),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);

--- a/inc/Abilities/TicketUrlResyncAbilities.php
+++ b/inc/Abilities/TicketUrlResyncAbilities.php
@@ -88,9 +88,7 @@ class TicketUrlResyncAbilities {
 						),
 					),
 					'execute_callback'    => array( $this, 'executeResync' ),
-					'permission_callback' => function () {
-						return current_user_can( 'manage_options' );
-					},
+					'permission_callback' => AbilityPermissions::canWrite(),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);

--- a/inc/Abilities/TimezoneAbilities.php
+++ b/inc/Abilities/TimezoneAbilities.php
@@ -100,9 +100,7 @@ class TimezoneAbilities {
 						),
 					),
 					'execute_callback'    => array( $this, 'executeAbility' ),
-					'permission_callback' => function () {
-						return current_user_can( 'manage_options' );
-					},
+					'permission_callback' => AbilityPermissions::canWrite(),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
@@ -176,9 +174,7 @@ class TimezoneAbilities {
 						),
 					),
 					'execute_callback'    => array( $this, 'executeFixAbility' ),
-					'permission_callback' => function () {
-						return current_user_can( 'manage_options' );
-					},
+					'permission_callback' => AbilityPermissions::canWrite(),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);

--- a/inc/Abilities/VenueAbilities.php
+++ b/inc/Abilities/VenueAbilities.php
@@ -134,9 +134,7 @@ class VenueAbilities {
 					),
 				),
 				'execute_callback'    => array( $this, 'executeHealthCheck' ),
-				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
-				},
+				'permission_callback' => AbilityPermissions::canWrite(),
 				'meta'                => array( 'show_in_rest' => true ),
 			)
 		);
@@ -219,9 +217,7 @@ class VenueAbilities {
 					),
 				),
 				'execute_callback'    => array( $this, 'executeUpdateVenue' ),
-				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
-				},
+				'permission_callback' => AbilityPermissions::canWrite(),
 				'meta'                => array( 'show_in_rest' => true ),
 			)
 		);
@@ -265,9 +261,7 @@ class VenueAbilities {
 					),
 				),
 				'execute_callback'    => array( $this, 'executeGetVenue' ),
-				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
-				},
+				'permission_callback' => AbilityPermissions::canWrite(),
 				'meta'                => array( 'show_in_rest' => true ),
 			)
 		);
@@ -305,9 +299,7 @@ class VenueAbilities {
 					),
 				),
 				'execute_callback'    => array( $this, 'executeCheckDuplicate' ),
-				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
-				},
+				'permission_callback' => AbilityPermissions::canWrite(),
 				'meta'                => array( 'show_in_rest' => true ),
 			)
 		);


### PR DESCRIPTION
Closes #288.

## Summary

Every write ability in this plugin gated on `current_user_can( 'manage_options' )`, which locked out team-member contributors like Chris Gardner (`qrisg`, ID 38 — `extrachill_team=1`, no WP role on `events.extrachill.com`). The Roadie chat agent already treats team members as authorized via `extrachill_roadie_team_access_bridge`, but every underlying ability rejected them. Concrete blocker: qrisg couldn't resolve merged-bill duplicates via chat, even though Roadie offered him the tools.

This PR implements **Option A** from the issue body: a shared closure factory that combines `WP_CLI`, an `ec_is_team_member()` override, and an `edit_others_posts` fallback.

## Helper introduced

`DataMachineEvents\Abilities\AbilityPermissions` (`inc/Abilities/AbilityPermissions.php`) exposes two static closure factories:

- `AbilityPermissions::canWrite()` — `WP_CLI` ∨ `ec_is_team_member()` ∨ `current_user_can('edit_others_posts')`
- `AbilityPermissions::canRead()` — `WP_CLI` ∨ `ec_is_team_member()` ∨ `current_user_can('edit_posts')` (provided for future use; not consumed by this PR)

`ec_is_team_member()` is wrapped in `function_exists()` so the plugin still loads when `extrachill-users` is absent (tests, isolated CLI). The file is `require_once`-d from `data-machine-events.php` immediately after `AbilityCategories`, so every ability registration that runs later can reference it without further bootstrapping.

Every modified ability now reads as a single line:

```php
'permission_callback' => AbilityPermissions::canWrite(),
```

## Ability files touched

| File | Abilities |
|------|-----------|
| `inc/Abilities/EventUpdateAbilities.php` | `update-event` |
| `inc/Abilities/MergeEventPostsAbilities.php` | `merge-event-posts` |
| `inc/Abilities/MergedBillDecideAbilities.php` | `merged-bill-inspect`, `merged-bill-decide` |
| `inc/Abilities/VenueAbilities.php` | `venue-health-check`, `update-venue`, `get-venue`, `check-duplicate-venue` |
| `inc/Abilities/BatchTimeFixAbilities.php` | `batch-time-fix` |
| `inc/Abilities/TimezoneAbilities.php` | `find-broken-timezone-events`, `fix-event-timezone` |
| `inc/Abilities/EncodingFixAbilities.php` | `encoding-fix` |
| `inc/Abilities/GeocodingAbilities.php` | `geocode-address`, `geocode-venues`, `audit-venues` (also drops redundant inline `WP_CLI` checks) |
| `inc/Abilities/TicketUrlResyncAbilities.php` | `resync-ticket-urls` |
| `inc/Abilities/MetaSyncAbilities.php` | `find-missing-meta-sync`, `resync-event-meta` |

Plus the loader wiring in `data-machine-events.php` and the new helper at `inc/Abilities/AbilityPermissions.php`.

## Read-only abilities intentionally left alone

The issue body said: *"Read-only abilities (`event-query`, `venue-stats`, `event-health`, audits) likely stay as-is or open up further — separate decision."* So this PR does **not** touch:

- `EventHealthAbilities` (`event-health-check`) — still admin-gated
- `EventQualityAuditAbilities` (`event-quality-audit`) — still admin-gated
- `EventQueryAbilities` (`get-venue-events`) — still admin-gated
- `VenueStatsAbilities` (`venue-stats`) — still admin-gated (already had `WP_CLI` exemption)
- `DuplicateDetectionAbilities` (`find-duplicate-event`) — still admin-gated
- `MergedBillDetectAbilities` (`detect-merged-bill`) — still admin-gated
- `SettingsAbilities` (`get-settings`, `update-setting`) — still admin-gated (settings touch is sensitive)
- `EventScraperTest`, `DiceFmTest`, `TicketmasterTest` — still admin-gated (debug/diagnostic)

These are out of scope per the issue. They can be opened up in a follow-up if Roadie needs team members to call them as well.

### Why some `VenueAbilities` read abilities **were** opened up

`VenueAbilities` registers four abilities in one file (`venue-health-check`, `update-venue`, `get-venue`, `check-duplicate-venue`). The issue explicitly lists `VenueAbilities` for the write fix, and all four are part of the same Roadie venue-edit flow (look up the venue → check for duplicates → update). Opening them as a group keeps the permission shape consistent and matches the "venue create/update/delete" scope in the issue. Same reasoning for `find-broken-timezone-events` (precursor to `fix-event-timezone`) and `merged-bill-inspect` (precursor to `merged-bill-decide`).

## How to verify

Run on `events.extrachill.com` after this branch is deployed (or against any subsite where the target user is a contributor with `extrachill_team=1`):

```bash
wp --allow-root --path=/var/www/extrachill.com --url=events.extrachill.com \
   eval 'wp_set_current_user(38); var_dump( wp_get_ability( "data-machine-events/update-event" )->has_permission() );'
```

Expected: `bool(true)`.

Before this PR the same snippet returned `bool(false)` (qrisg has no WP role on the events subsite, so `current_user_can('manage_options')` was false). With this PR, `ec_is_team_member()` returns true for user 38 and the override fires.

A separate sanity check against `admin` (user 1) should still return `bool(true)` because admins have `edit_others_posts`:

```bash
wp --allow-root --path=/var/www/extrachill.com --url=events.extrachill.com \
   eval 'wp_set_current_user(1); var_dump( wp_get_ability( "data-machine-events/update-event" )->has_permission() );'
```

And for a true outsider (any non-team subscriber):

```bash
wp --allow-root --path=/var/www/extrachill.com --url=events.extrachill.com \
   eval 'wp_set_current_user( /* some non-team user id */ ); var_dump( wp_get_ability( "data-machine-events/update-event" )->has_permission() );'
```

Expected: `bool(false)`.

## Notes

- This is the foundation for #286 (`delete_event` chat tool) and #287 (`move_event` chat tool); both will reuse `AbilityPermissions::canWrite()`.
- No release / no deploy — PR only.
- No CHANGELOG / version bump — homeboy owns both.

cc <@532385681268408341>