### PR TITLE
refactor(permissions): adopt canWrite() helper in move-event ability

### DIFF
--- a/inc/Abilities/MoveEventAbilities.php
+++ b/inc/Abilities/MoveEventAbilities.php
@@ -104,12 +104,7 @@ class MoveEventAbilities {
 						),
 					),
 					'execute_callback'    => array( $this, 'execute' ),
-					// TODO(#288): swap to the team-member permission helper introduced
-					// by the permission_callback audit. For now use manage_options to
-					// match the rest of the EC-events surface.
-					'permission_callback' => function () {
-						return current_user_can( 'manage_options' );
-					},
+					'permission_callback' => AbilityPermissions::canWrite(),
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);


### PR DESCRIPTION
Follow-up to #290 — adopts the shared `AbilityPermissions::canWrite()` helper from #288/#291 (which merged after #290). No functional change beyond the `permission_callback` shape.

Also removes the stale `TODO(#288)` comment that the original PR left as a marker.

Refs #287, #288, #290.