### PR TITLE
refactor(permissions): replace ec_is_team_member with filterable capability (closes #294)

### DIFF
--- a/inc/Abilities/AbilityPermissions.php
+++ b/inc/Abilities/AbilityPermissions.php
@@ -4,22 +4,21 @@
  *
  * Shared permission callbacks for Data Machine Events abilities.
  *
- * Team-member contributors (extrachill_team=1 user meta) are trusted to use
- * write abilities even when their WP role does not grant manage_options /
- * edit_others_posts. The Roadie chat layer already treats them as authorized
- * via extrachill_roadie_team_access_bridge; this brings every underlying
- * ability into agreement.
+ * Permission shape:
+ *   1. WP-CLI is always allowed (matches the existing admin-tool
+ *      convention used by GeocodingAbilities, SettingsAbilities,
+ *      VenueStatsAbilities).
+ *   2. The capability the user must hold for the operation is
+ *      filterable so platform consumers can elevate trust beyond the
+ *      defaults (e.g. grant `edit_others_posts`-class privileges to a
+ *      non-editor role via a custom capability they map themselves).
  *
- * Permission shape (Option A from issue #288):
- *   1. If ec_is_team_member() returns true → allow.
- *   2. Else fall back to a capability check appropriate to the operation.
- *
- * WP-CLI is always allowed (matches the existing admin-tool convention used
- * by GeocodingAbilities, SettingsAbilities, VenueStatsAbilities).
- *
- * ec_is_team_member() is shipped by extrachill-users. Wrap with
- * function_exists() so this plugin still loads in contexts where that plugin
- * is absent (tests, isolated CLI runs).
+ * Filters:
+ *   - `datamachine_events_write_capability` — default
+ *     `edit_others_posts`. Platforms can return their own capability
+ *     to widen the trust pool for write operations.
+ *   - `datamachine_events_read_capability` — default `edit_posts`.
+ *     Same shape for the (currently unused) diagnostic read gate.
  *
  * @package DataMachineEvents\Abilities
  * @since 0.39.0
@@ -35,9 +34,9 @@ class AbilityPermissions {
 	 * Permission callback for write abilities (event/venue mutations,
 	 * batch fixes, merges, geocoding sweeps, meta resyncs, etc).
 	 *
-	 * Admins pass via edit_others_posts (granted to administrators and
-	 * editors by default). Team members pass via the override. WP-CLI
-	 * always passes.
+	 * Admins pass via `edit_others_posts` (granted to administrators
+	 * and editors by default). WP-CLI always passes. Platform consumers
+	 * can elevate additional roles by filtering the capability name.
 	 *
 	 * @return \Closure
 	 */
@@ -47,22 +46,29 @@ class AbilityPermissions {
 				return true;
 			}
 
-			if ( function_exists( 'ec_is_team_member' ) && \ec_is_team_member() ) {
-				return true;
-			}
+			/**
+			 * Filter the capability required for write abilities.
+			 *
+			 * Returning a custom capability lets a platform consumer
+			 * grant write access to a non-editor role without
+			 * monkey-patching the permission callback.
+			 *
+			 * @param string $capability Default capability name.
+			 */
+			$capability = (string) apply_filters( 'datamachine_events_write_capability', 'edit_others_posts' );
 
-			return current_user_can( 'edit_others_posts' );
+			return current_user_can( $capability );
 		};
 	}
 
 	/**
 	 * Permission callback for diagnostic / admin-only read abilities
-	 * that should still be gated but available to team members.
+	 * that should still be gated but available to elevated roles.
 	 *
-	 * Currently unused by default — read-only abilities in the audit
-	 * (issue #288) were intentionally left on their existing gate. Provided
-	 * here so future read abilities have a consistent shape if they want
-	 * the same team-member override without opening up to all readers.
+	 * Currently unused by default — read-only abilities were
+	 * intentionally left on their existing gate. Provided here so
+	 * future read abilities have a consistent shape if they want the
+	 * same elevation shape as the write gate.
 	 *
 	 * @return \Closure
 	 */
@@ -72,11 +78,16 @@ class AbilityPermissions {
 				return true;
 			}
 
-			if ( function_exists( 'ec_is_team_member' ) && \ec_is_team_member() ) {
-				return true;
-			}
+			/**
+			 * Filter the capability required for diagnostic read
+			 * abilities. See `datamachine_events_write_capability` for
+			 * the shape.
+			 *
+			 * @param string $capability Default capability name.
+			 */
+			$capability = (string) apply_filters( 'datamachine_events_read_capability', 'edit_posts' );
 
-			return current_user_can( 'edit_posts' );
+			return current_user_can( $capability );
 		};
 	}
 }


### PR DESCRIPTION
Closes #294.

## Why

\`inc/Abilities/AbilityPermissions.php\` was the only layer-purity violation in this plugin — a generic Data Machine extension that named Extra Chill specifics in its code:

- Called \`ec_is_team_member()\` (a function shipped by \`extrachill-users\`)
- Referenced \`extrachill_team=1\` user_meta in the docblock
- Referenced \`extrachill_roadie_team_access_bridge\` in the docblock

Per Extra Chill's site rules, generic agnostic layers must not reference, name, special-case, or know about anything below them — and the test is grep. This PR makes the grep return zero EC hits.

## The fix

Replaced the hard-coded \`ec_is_team_member()\` branch with two filters:

| Filter | Default |
|---|---|
| \`datamachine_events_write_capability\` | \`edit_others_posts\` |
| \`datamachine_events_read_capability\` | \`edit_posts\` |

Any platform consumer can override these from its own integration layer to elevate trust to a custom capability without monkey-patching the permission callback or modifying this plugin.

## What changes for Extra Chill

\`extrachill-roadie\` (the EC platform integration layer) gets a companion PR that hooks both filters and returns \`access_events_admin\` — the custom capability granted by the \`extra_chill_team\` role introduced in [Extra-Chill/extrachill-users#45](https://github.com/Extra-Chill/extrachill-users/pull/48). Net behavior is identical to today (team contributors retain write access), but the knowledge is in the right place.

## Verification

Behavior at the call sites is unchanged for everyone holding \`edit_others_posts\` (administrators, editors). The team-contributor elevation is preserved by the EC-side filter wiring.

## Refs

- Closes #294
- Companion PR in extrachill-roadie: wires \`access_events_admin\` via the new filter
- Builds on Extra-Chill/extrachill-users#45 (shipped today as v0.11.0 — introduces the \`access_events_admin\` capability via the \`extra_chill_team\` role)