### PR TITLE
fix(calendar): past events button must build URL from clean baseline, not polluted window.location.search

### DIFF
--- a/inc/Blocks/Calendar/src/modules/navigation.ts
+++ b/inc/Blocks/Calendar/src/modules/navigation.ts
@@ -2,6 +2,31 @@
  * Past/upcoming navigation and pagination link handling.
  */
 
+/**
+ * Params that must NEVER be carried over when toggling Past/Upcoming.
+ *
+ * - `lat`/`lng`/`radius`/`radius_unit`: geo-sync.ts pushState-rewrites these
+ *   into `window.location.search` after the map fires bounds-changed (see
+ *   issue #296). Past Events is a dataset switch, not a filter refinement —
+ *   carrying viewport-derived geo across the boundary makes no sense and,
+ *   combined with archive-context params injected downstream, can land the
+ *   browser on the raw REST JSON endpoint.
+ * - `paged`: a viewport/dataset change resets pagination by definition.
+ * - `archive_taxonomy`/`archive_term_id`: REST-only params injected by
+ *   `buildCalendarRequest()`. They have no business in a user-facing URL;
+ *   if they ever leak into `window.location.search`, drop them defensively
+ *   so we never bounce the user to a JSON endpoint.
+ */
+const STRIP_ON_PAST_TOGGLE = [
+	'lat',
+	'lng',
+	'radius',
+	'radius_unit',
+	'paged',
+	'archive_taxonomy',
+	'archive_term_id',
+];
+
 export function initNavigation(
 	calendar: HTMLElement,
 	onNavigate: ( params: URLSearchParams ) => void
@@ -31,8 +56,17 @@ function initPastUpcomingButtons(
 		if ( pastBtn || upcomingBtn ) {
 			e.preventDefault();
 
+			// Build the target from a CLEAN baseline — never from raw
+			// `window.location.search`, because geo-sync may have pushed
+			// transient viewport state (lat/lng/radius/radius_unit) into
+			// it. See issue #296.
+			//
+			// Non-geo, non-pagination filters the user explicitly applied
+			// (`tax_filter[*]`, `event_search`, `scope`, `date_start`,
+			// `date_end`, etc.) DO carry across the Past/Upcoming toggle
+			// because they're real filter intent, not viewport state.
 			const params = new URLSearchParams( window.location.search );
-			params.delete( 'paged' );
+			STRIP_ON_PAST_TOGGLE.forEach( ( key ) => params.delete( key ) );
 
 			if ( pastBtn ) {
 				params.set( 'past', '1' );


### PR DESCRIPTION
Closes #296.

## Root cause

On a location taxonomy archive that renders both the calendar and events-map blocks, geo-sync pushState-rewrites `window.location.search` to include `lat/lng/radius/radius_unit` after the map fires `data-machine-map-bounds-changed`. The Past/Upcoming button click handler in `navigation.ts` was reading `window.location.search` verbatim and feeding those viewport-derived params into the navigation target. Combined with `archive_taxonomy`/`archive_term_id` injected downstream by `buildCalendarRequest()`, this could land the browser on the raw REST JSON endpoint:

```
/wp-json/datamachine/v1/events/calendar?archive_taxonomy=location&archive_term_id=1618&lat=...&lng=...&radius=12&radius_unit=mi&past=1
```

## Fix

`inc/Blocks/Calendar/src/modules/navigation.ts` now strips `lat`, `lng`, `radius`, `radius_unit`, `paged`, `archive_taxonomy`, and `archive_term_id` from the params copied out of `window.location.search` before navigating. Past Events is a dataset switch, not a filter refinement, so carrying viewport state across the toggle is architecturally wrong regardless of whether it triggers the JSON-URL failure mode.

Non-geo, non-pagination filters the user explicitly applied (`tax_filter[*]`, `event_search`, `scope`, `date_start`, `date_end`) continue to carry across the Past/Upcoming toggle — that's real filter intent.

Full-reload behavior via `window.location.href = newUrl` in `frontend.ts:navigateToUrl` is unchanged; the bug was the polluted params source, not the navigation mechanism.

## Audit of the geo-sync pagination handler

Verified the delegated pagination click handler at `inc/Blocks/Calendar/src/modules/geo-sync.ts:246-289` cannot accidentally match `.data-machine-events-past-btn` clicks:

- Its selector is `closest('.data-machine-events-pagination a')`.
- The Past button is rendered inside `.data-machine-events-past-navigation`, never inside `.data-machine-events-pagination` (see `inc/Blocks/Calendar/templates/navigation.php`).
- `closest()` walks up the DOM; there's no path from a past-btn click target to a `.data-machine-events-pagination` ancestor.

No change needed there.

## Build artifacts

`inc/Blocks/Calendar/build/` is gitignored in this repo and rebuilt at release time by homeboy. Local rebuild via `npm install && npm run build` succeeded; verified the new strip list and the past-btn handler logic are present in the minified `build/frontend.js`:

```
closest(".data-machine-events-past-btn"),o=n.closest(".data-machine-events-upcoming-btn");
if(a||o){e.preventDefault();
  const n=new URLSearchParams(window.location.search);
  G.forEach(e=>n.delete(e)),
  a?n.set("past","1"):n.delete("past"),...
```

where `G` is the strip list including `archive_taxonomy`, `archive_term_id`, `radius_unit`, etc.

## Test plan

On `https://events.extrachill.com/location/charleston/` (or any location archive that loads the events-map block) while logged in:

1. Wait for the map to render and let geo-sync push `lat/lng/radius/radius_unit` into the URL via its `data-machine-map-bounds-changed` handler — verify those params appear in the address bar.
2. Click **← Past Events**.
3. **Expected:** full page reload to `/location/charleston/?past=1` (no `lat`/`lng`/`radius`/`radius_unit`/`archive_taxonomy`/`archive_term_id` in the URL, no raw JSON in the tab).
4. From the past-events view, click **Upcoming Events →**.
5. **Expected:** full page reload to `/location/charleston/` with `past` removed and geo params still absent.
6. Apply a `tax_filter[*]` or set `event_search`, then click Past/Upcoming — verify those filters DO survive the toggle (only geo + pagination get stripped).