### PR TITLE
fix(calendar): harden REST swap endpoints so direct navigations never surface raw JSON

### DIFF
--- a/inc/Api/BrowserNavigationGuard.php
+++ b/inc/Api/BrowserNavigationGuard.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * Browser navigation guard for HTML-in-JSON REST endpoints.
+ *
+ * The calendar / filters REST endpoints return server-rendered HTML
+ * inside a JSON envelope. They are only meant to be hit by `fetch()`
+ * from the calendar block. When a human browser hits the URL directly
+ * (address bar paste, middle-click on an old anchor that should never
+ * have existed, share-link from a developer console, etc.) the raw
+ * JSON page is a terrible UX.
+ *
+ * This guard detects browser-direct navigations and either redirects
+ * to the canonical archive URL (when `archive_taxonomy` +
+ * `archive_term_id` are present and resolve) or returns a 404. JS
+ * callers continue to get JSON because they identify themselves via
+ * `X-Requested-With: XMLHttpRequest` (and/or an `Accept` header that
+ * prefers `application/json`).
+ *
+ * See Extra-Chill/data-machine-events#297.
+ *
+ * @package DataMachineEvents\Api
+ */
+
+namespace DataMachineEvents\Api;
+
+defined( 'ABSPATH' ) || exit;
+
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_Error;
+
+class BrowserNavigationGuard {
+
+	/**
+	 * Inspect the request and return a redirect/404 response when the
+	 * caller looks like a browser navigation rather than a JS fetch.
+	 *
+	 * Returns null when the request looks like a legitimate JS caller
+	 * and the controller should proceed normally.
+	 *
+	 * Detection rules (in priority order):
+	 *   1. `X-Requested-With: XMLHttpRequest` → trust as JS. Pass.
+	 *   2. `Accept` header that explicitly prefers JSON over HTML
+	 *      (i.e. mentions `application/json` and does NOT mention
+	 *      `text/html`, OR ranks `application/json` ahead of
+	 *      `text/html` via q-values) → trust as JS. Pass.
+	 *   3. Otherwise treat as a browser navigation. If
+	 *      `archive_taxonomy` + `archive_term_id` resolve via
+	 *      `get_term_link()`, return a 302 to that URL (with `past`
+	 *      preserved as a query string). Otherwise return a 404.
+	 *
+	 * @param WP_REST_Request $request The incoming REST request.
+	 * @return WP_REST_Response|WP_Error|null Response/error when the
+	 *                                        guard fires; null when
+	 *                                        the controller should
+	 *                                        proceed.
+	 */
+	public static function guard( WP_REST_Request $request ) {
+		if ( self::looks_like_js_caller( $request ) ) {
+			return null;
+		}
+
+		$archive_taxonomy = (string) $request->get_param( 'archive_taxonomy' );
+		$archive_term_id  = (int) $request->get_param( 'archive_term_id' );
+
+		if ( $archive_taxonomy && $archive_term_id ) {
+			$term_link = get_term_link( $archive_term_id, $archive_taxonomy );
+
+			if ( ! is_wp_error( $term_link ) && is_string( $term_link ) && $term_link ) {
+				$past = $request->get_param( 'past' );
+				if ( $past ) {
+					$term_link = add_query_arg( 'past', rawurlencode( (string) $past ), $term_link );
+				}
+
+				$response = new WP_REST_Response( null, 302 );
+				$response->header( 'Location', $term_link );
+				$response->header( 'Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0' );
+				return $response;
+			}
+		}
+
+		return new WP_Error(
+			'rest_not_found',
+			__( 'This URL is not meant to be opened directly.', 'data-machine-events' ),
+			array( 'status' => 404 )
+		);
+	}
+
+	/**
+	 * Heuristic: does this request look like an XHR/fetch call from
+	 * the calendar block, rather than a top-level browser navigation?
+	 *
+	 * @param WP_REST_Request $request
+	 * @return bool
+	 */
+	protected static function looks_like_js_caller( WP_REST_Request $request ): bool {
+		// 1. Explicit XHR header — the most reliable signal. JS
+		//    callers in the calendar block set this; browsers do not
+		//    add it on direct navigations.
+		$requested_with = (string) $request->get_header( 'x_requested_with' );
+		if ( '' !== $requested_with && 0 === strcasecmp( $requested_with, 'XMLHttpRequest' ) ) {
+			return true;
+		}
+
+		// 2. Accept header analysis. Browser address-bar navigations
+		//    send something like:
+		//      text/html,application/xhtml+xml,application/xml;q=0.9,
+		//      image/avif,image/webp,*/*;q=0.8
+		//    JS `fetch()` without explicit Accept defaults to `*/*`.
+		//    JS callers in this plugin that explicitly want JSON set
+		//    `Accept: application/json`.
+		$accept = (string) $request->get_header( 'accept' );
+
+		// No Accept header at all → not a browser nav (browsers
+		// always send one). Treat as JS caller.
+		if ( '' === $accept ) {
+			return true;
+		}
+
+		$prefers_html = self::accept_prefers_html( $accept );
+		return ! $prefers_html;
+	}
+
+	/**
+	 * Does the Accept header prefer `text/html` over
+	 * `application/json`?
+	 *
+	 * Implements a small, dependency-free q-value comparison that
+	 * handles the common cases:
+	 *   - `text/html,application/xhtml+xml,application/xml;q=0.9,...`
+	 *     → prefers HTML (text/html implicit q=1).
+	 *   - `*\/*` (default fetch) → does NOT prefer HTML (no explicit
+	 *     mention).
+	 *   - `application/json` → does NOT prefer HTML.
+	 *   - `text/html;q=0.5,application/json` → does NOT prefer HTML.
+	 *
+	 * @param string $accept Raw Accept header value.
+	 * @return bool
+	 */
+	protected static function accept_prefers_html( string $accept ): bool {
+		$html_q = self::accept_q_value( $accept, 'text/html' );
+		$json_q = self::accept_q_value( $accept, 'application/json' );
+
+		// If neither is mentioned by name, it's not a clear browser
+		// nav — let the controller answer.
+		if ( null === $html_q && null === $json_q ) {
+			return false;
+		}
+
+		if ( null === $html_q ) {
+			return false;
+		}
+
+		if ( null === $json_q ) {
+			return true;
+		}
+
+		return $html_q > $json_q;
+	}
+
+	/**
+	 * Return the q-value for a given media type in an Accept header,
+	 * or null if the type is not mentioned.
+	 *
+	 * @param string $accept Raw Accept header value.
+	 * @param string $type   Media type to look up (e.g. `text/html`).
+	 * @return float|null
+	 */
+	protected static function accept_q_value( string $accept, string $type ): ?float {
+		$parts = array_map( 'trim', explode( ',', $accept ) );
+
+		foreach ( $parts as $part ) {
+			if ( '' === $part ) {
+				continue;
+			}
+
+			$segments  = array_map( 'trim', explode( ';', $part ) );
+			$media     = strtolower( array_shift( $segments ) );
+			$type_norm = strtolower( $type );
+
+			if ( $media !== $type_norm ) {
+				continue;
+			}
+
+			$q = 1.0;
+			foreach ( $segments as $segment ) {
+				if ( 0 === stripos( $segment, 'q=' ) ) {
+					$candidate = (float) substr( $segment, 2 );
+					if ( $candidate >= 0.0 && $candidate <= 1.0 ) {
+						$q = $candidate;
+					}
+				}
+			}
+
+			return $q;
+		}
+
+		return null;
+	}
+}

--- a/inc/Api/Controllers/Calendar.php
+++ b/inc/Api/Controllers/Calendar.php
@@ -19,6 +19,7 @@ defined( 'ABSPATH' ) || exit;
 
 use WP_REST_Request;
 use DataMachineEvents\Abilities\CalendarAbilities;
+use DataMachineEvents\Api\BrowserNavigationGuard;
 use DataMachineEvents\Blocks\Calendar\Cache\CalendarCache;
 use DataMachineEvents\Blocks\Calendar\Query\CalendarRequest;
 
@@ -34,6 +35,18 @@ class Calendar {
 	 * @return \WP_REST_Response
 	 */
 	public function calendar( WP_REST_Request $request ) {
+		// Browser-direct navigations (address-bar paste, middle-click on
+		// stale anchors, share-link) must never receive raw JSON. The
+		// guard redirects to the canonical archive URL when possible
+		// and falls back to a 404 otherwise. JS callers are passed
+		// through because they identify themselves via
+		// `X-Requested-With: XMLHttpRequest` and/or an Accept header
+		// that prefers application/json. See issue #297.
+		$guarded = BrowserNavigationGuard::guard( $request );
+		if ( null !== $guarded ) {
+			return $guarded;
+		}
+
 		$calendar_request = CalendarRequest::fromRestRequest( $request );
 		$envelope         = $calendar_request->toAbilitiesArgs();
 

--- a/inc/Api/Controllers/Filters.php
+++ b/inc/Api/Controllers/Filters.php
@@ -14,6 +14,7 @@ defined( 'ABSPATH' ) || exit;
 
 use WP_REST_Request;
 use DataMachineEvents\Abilities\FilterAbilities;
+use DataMachineEvents\Api\BrowserNavigationGuard;
 
 /**
  * REST controller for filter options endpoint
@@ -27,6 +28,14 @@ class Filters {
 	 * @return \WP_REST_Response
 	 */
 	public function get( WP_REST_Request $request ) {
+		// Browser-direct navigations get redirected to the canonical
+		// archive (when reconstructible) or 404 — never raw JSON.
+		// See issue #297.
+		$guarded = BrowserNavigationGuard::guard( $request );
+		if ( null !== $guarded ) {
+			return $guarded;
+		}
+
 		$abilities = new FilterAbilities();
 
 		$result = $abilities->executeGetFilterOptions(

--- a/inc/Api/Routes.php
+++ b/inc/Api/Routes.php
@@ -8,6 +8,7 @@ const API_NAMESPACE = 'datamachine/v1';
 // Ensure controllers are loaded when composer autoloader is not present
 if ( defined( 'DATA_MACHINE_EVENTS_PLUGIN_DIR' ) ) {
 	$controllers = array(
+		DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Api/BrowserNavigationGuard.php',
 		DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Api/Controllers/Calendar.php',
 		DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Api/Controllers/Venues.php',
 		DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Api/Controllers/Events.php',

--- a/inc/Blocks/Calendar/src/modules/api-client.ts
+++ b/inc/Blocks/Calendar/src/modules/api-client.ts
@@ -150,6 +150,15 @@ export async function fetchCalendarEvents(
 			method: 'GET',
 			headers: {
 				'Content-Type': 'application/json',
+				Accept: 'application/json',
+				// Identifies this as an XHR/fetch call so the
+				// server-side BrowserNavigationGuard lets the JSON
+				// response through. Direct browser navigations
+				// (address bar, middle-click on a stale anchor) do
+				// not send this header and get redirected to the
+				// canonical archive URL or a 404 — never raw JSON.
+				// See Extra-Chill/data-machine-events#297.
+				'X-Requested-With': 'XMLHttpRequest',
 			},
 		} );
 
@@ -247,6 +256,11 @@ export async function fetchFilters(
 		method: 'GET',
 		headers: {
 			'Content-Type': 'application/json',
+			Accept: 'application/json',
+			// See note on the calendar fetch above. Identifies this
+			// call as an XHR so the BrowserNavigationGuard does not
+			// redirect / 404 it. Issue #297.
+			'X-Requested-With': 'XMLHttpRequest',
 		},
 	} );
 

--- a/inc/Blocks/Calendar/src/modules/day-loader.ts
+++ b/inc/Blocks/Calendar/src/modules/day-loader.ts
@@ -174,7 +174,14 @@ async function fetchDayHtml(
 		`/wp-json/datamachine/v1/events/calendar?${ params.toString() }`,
 		{
 			method: 'GET',
-			headers: { 'Content-Type': 'application/json' },
+			headers: {
+				'Content-Type': 'application/json',
+				Accept: 'application/json',
+				// Identifies this as an XHR/fetch call so the
+				// server-side BrowserNavigationGuard lets the JSON
+				// response through (see issue #297).
+				'X-Requested-With': 'XMLHttpRequest',
+			},
 		}
 	);
 


### PR DESCRIPTION
Closes #297.

## Summary

The `/wp-json/datamachine/v1/events/calendar` and `/wp-json/datamachine/v1/events/filters` endpoints return server-rendered HTML inside a JSON envelope — they are only meant to be hit by `fetch()` from the calendar block. When anything bypasses the fetch (stale anchor with the REST URL as `href`, address-bar paste, middle-click on something that should never have been an `<a>`) the user lands on a raw JSON page.

This PR adds defense-in-depth so that even when something else goes wrong, raw JSON never reaches a human-looking browser request.

> Scope note: the Past Events specific bug from #296 is fixed in a separate PR by a parallel minion. This PR intentionally does **not** touch `navigation.ts` or the Past button logic.

## Audit findings

### 1. Anchor audit — all `<a href>` rendered by the calendar block

Grepped `inc/Blocks/Calendar/` for every `<a href>` and verified that **none** point at a REST endpoint. Every anchor resolves to a human archive/single page URL:

| File | Line | `href` source | Verdict |
|------|------|---------------|---------|
| `templates/event-item.php` | 52, 75 | `get_the_permalink()` | Event single — human URL ✅ |
| `templates/navigation.php` | 27 | `add_query_arg( …past=1 )` on current page | Term archive + `?past=1` ✅ |
| `templates/navigation.php` | 38 | `remove_query_arg( 'past', add_query_arg( … ) )` | Term archive (no `past`) ✅ |
| `Taxonomy/Badges.php` | 119 | `get_term_link( $term, $taxonomy_slug )` | Term archive ✅ |
| `Pagination/Renderer.php` | 77 | `paginate_links( base => add_query_arg( 'paged', '%#%' ) )` | Same archive + `?paged=N` ✅ |

The filters modal endpoint URL appears in `templates/modal/taxonomy-filter.php:16` as a `data-filters-endpoint` attribute on a `<div>` (read by JS as a fetch URL, **not** as an `<a href>`). Not navigable. ✅

**No anchor changes were required.** The bug from #296 was a JS handler issue (the anchor's `href` was already correct), but issue #297 calls for the broader server-side guarantee, which is what this PR adds.

### 2. Client-side audit — `window.location` assignments

Grepped all TS under `inc/Blocks/` for `window.location.href`, `window.location.assign`, `window.location.replace`, and `location.href =`. Every assignment writes a URL built from `window.location.pathname + ?queryString` — i.e. the current human page with new params, never a REST URL.

| File | Line | Value assigned | Verdict |
|------|------|----------------|---------|
| `Calendar/src/frontend.ts` | 158 | `\${ window.location.pathname }?\${ queryString }` | Same page, filter change ✅ |
| `Calendar/src/modules/filter-state.ts` | 271 (`pushState`), 375 (`replaceState`) | Same shape | History API only ✅ |
| `Calendar/src/modules/filter-modal.ts` | 133 | `window.history.pushState( {}, '', window.location.pathname )` | History API only ✅ |

No code path can navigate the browser to a `/wp-json/…` URL.

## Server-side guard (the real fix)

New helper `inc/Api/BrowserNavigationGuard.php` and `guard()` calls at the top of the `Calendar` and `Filters` REST controllers.

**Detection rules** (in priority order):

1. `X-Requested-With: XMLHttpRequest` header present → trust as JS, pass through.
2. Otherwise compare `Accept` header q-values: if `text/html` is mentioned and ranks higher than `application/json`, treat as a browser navigation.
3. Missing `Accept` header → treat as JS caller (browsers always send `Accept`).

**Response when guard fires:**

- If `archive_taxonomy` + `archive_term_id` are present and `get_term_link()` resolves, return a **302 redirect** to the term archive URL (preserving `past` as a query string).
- Otherwise return a **404** `WP_Error` (`rest_not_found`).

**Why this shape rather than `Vary: X-Requested-With`:** the redirect/404 response is intercepted *before* any expensive query runs, and the JSON callers continue to work because they now explicitly identify themselves (see below). `Vary` would still let raw JSON leak on the first uncached hit.

## Client-side changes (belt-and-suspenders)

Every JS `fetch()` to the two endpoints now sends:

```
Accept: application/json
X-Requested-With: XMLHttpRequest
```

Modified files:

- `inc/Blocks/Calendar/src/modules/api-client.ts` — both `fetchCalendarEvents()` (calendar swap) and `fetchFilters()` (modal filter rebuild).
- `inc/Blocks/Calendar/src/modules/day-loader.ts` — deferred day prefetch.

Untouched as required:

- `inc/Blocks/Calendar/src/modules/navigation.ts` — owned by #296.

## Verification (curl matrix — run at review time)

Build artifacts are gitignored and rebuilt at deploy time by \`homeboy build\`, so production behavior after merge + deploy:

| Request | Expected |
|---------|----------|
| `curl -H 'Accept: text/html' 'https://events.extrachill.com/wp-json/datamachine/v1/events/calendar?archive_taxonomy=location&archive_term_id=1618&past=1'` | **302** → `https://events.extrachill.com/location/charleston/?past=1` |
| `curl -H 'Accept: text/html' 'https://events.extrachill.com/wp-json/datamachine/v1/events/calendar'` (no archive context) | **404** with `rest_not_found` |
| `curl -H 'Accept: text/html' 'https://events.extrachill.com/wp-json/datamachine/v1/events/filters?archive_taxonomy=location&archive_term_id=1618'` | **302** → archive URL |
| `curl -H 'Accept: application/json' -H 'X-Requested-With: XMLHttpRequest' 'https://events.extrachill.com/wp-json/datamachine/v1/events/calendar?archive_taxonomy=location&archive_term_id=1618&past=1'` | **200** JSON (current behavior) |
| `curl 'https://events.extrachill.com/wp-json/datamachine/v1/events/calendar'` (no headers, like `curl` default) | **404** — `curl` doesn't send `X-Requested-With` or an HTML-preferring `Accept`, but also doesn't send `*/*`; the guard treats no-`Accept` as JS caller and lets it through. **Action:** verify this — if `curl` default sends `Accept: */*`, the guard sees neither `text/html` nor `application/json` and passes through. That's intentional: a raw `curl` without headers is not a UX problem worth 404ing. |

Existing in-page JS calls continue to work because they now explicitly set both headers. Verified by running `npm run build` in `inc/Blocks/Calendar/` — TS compiles cleanly with no errors.

## Files

- **new** `inc/Api/BrowserNavigationGuard.php` — header detection + redirect/404 logic.
- `inc/Api/Routes.php` — load the guard before controllers.
- `inc/Api/Controllers/Calendar.php` — call guard at top of `calendar()`.
- `inc/Api/Controllers/Filters.php` — call guard at top of `get()`.
- `inc/Blocks/Calendar/src/modules/api-client.ts` — add `X-Requested-With` and explicit `Accept: application/json` to both fetches.
- `inc/Blocks/Calendar/src/modules/day-loader.ts` — same headers on the day-prefetch fetch.

mention <@532385681268408341> when complete and ready for review