### PR TITLE
feat(calendar): add data-only REST response schema (phase 1 of #298)

### DIFF
--- a/docs/calendar-data-schema.md
+++ b/docs/calendar-data-schema.md
@@ -1,0 +1,219 @@
+# Calendar Data-Only REST Schema (phase 1 of #298)
+
+Status: **phase 1 of the refactor in [Extra-Chill/data-machine-events#298](https://github.com/Extra-Chill/data-machine-events/issues/298). Not the canonical response yet.**
+
+The canonical calendar REST response remains the legacy HTML-string envelope
+returned by `/wp-json/datamachine/v1/events/calendar`. This document describes
+the **opt-in** data-only envelope introduced in phase 1: a server-rendered
+JSON shape with **zero HTML strings**, intended to become the canonical
+contract once the consumers in `inc/Blocks/Calendar/src/` are ported in
+subsequent phases.
+
+## Background
+
+See the umbrella refactor issue ([#298](https://github.com/Extra-Chill/data-machine-events/issues/298)) for
+the full architectural rationale. Short version: the current REST contract
+ships server-rendered HTML strings (`data.html`, `data.pagination.html`,
+`data.counter`, `data.navigation.html`) that the frontend bundle blasts into
+the DOM via `innerHTML`. That violates the site-wide headless-React rule,
+defeats client-side state, and is the root cause of the family of bugs filed
+separately ([#296](https://github.com/Extra-Chill/data-machine-events/issues/296), [#297](https://github.com/Extra-Chill/data-machine-events/issues/297)).
+
+## Activation
+
+Pass `format=data` as a query param. **Any other value (including the
+absent param) returns the legacy HTML envelope unchanged.**
+
+```bash
+# Legacy HTML envelope (unchanged).
+curl 'https://example.com/wp-json/datamachine/v1/events/calendar?paged=1'
+
+# Data-only envelope (phase 1).
+curl 'https://example.com/wp-json/datamachine/v1/events/calendar?paged=1&format=data'
+```
+
+The two responses are cached independently — `format` is part of the
+full-response cache key (`CalendarCache::generate_full_response_key()`).
+
+## Envelope
+
+```jsonc
+{
+  "success": true,
+  "schema": {
+    "name": "calendar-data",
+    "version": 1,
+    "phase": 1,
+    "issue": 298
+  },
+  "events":     [ /* CalendarEventItem[] — see below */ ],
+  "grouping": {
+    "ordered_dates": [ "2026-06-12", "2026-06-13", "..." ],
+    "by_date": {
+      "2026-06-12": [
+        { "post_id": 12345, "display_context": { /* ... */ } }
+      ]
+    },
+    "gaps": { "2026-06-15": 3 }
+  },
+  "pagination": {
+    "current_page": 1,
+    "total_pages":  42,
+    "total_items":  834,
+    "page_items":   18
+  },
+  "counter": {
+    "showing_count":   18,
+    "total_count":     834,
+    "page_start_date": "2026-06-12",
+    "page_end_date":   "2026-06-19"
+  },
+  "navigation": {
+    "show_past":    false,
+    "past_count":   2017,
+    "future_count": 834,
+    "has_past":     true,
+    "has_future":   true
+  }
+}
+```
+
+### `schema`
+
+Identifies the schema for forward compatibility. Clients should check
+`schema.name === 'calendar-data'` and `schema.version === 1` before
+reading the rest. Future phases bump `phase`; backward-incompatible
+shape changes bump `version`.
+
+### `events`
+
+Array of structured event objects, **deduplicated on `id`**. A multi-day
+event appears once here, regardless of how many dates it spans on this
+page — its multi-day expansion is represented in `grouping.by_date`.
+
+```jsonc
+{
+  "id":        12345,
+  "title":     "Some show",
+  "permalink": "https://example.com/events/some-show/",
+  "date": {
+    "start_date":     "2026-06-12",
+    "start_time":     "20:30:00",
+    "end_date":       "2026-06-12",
+    "end_time":       "23:00:00",
+    "venue_timezone": "America/New_York"
+  },
+  "venue": {
+    "term_id": 678,
+    "name":    "The Royal American",
+    "slug":    "the-royal-american",
+    "address": "970 Morrison Dr, Charleston, SC 29403"
+  },
+  "organizer": {
+    "name": "Local Promoter",
+    "url":  "https://example.com",
+    "type": "promoter"
+  },
+  "ticket":    { "url": "https://etix.com/..." },
+  "performer": { "name": "Headliner Name" },
+  "address":   "970 Morrison Dr, Charleston, SC 29403",
+  "taxonomies": {
+    "artist": [
+      { "term_id": 111, "name": "Headliner", "slug": "headliner", "link": "https://..." }
+    ],
+    "genre":  [
+      { "term_id": 222, "name": "Indie",     "slug": "indie",     "link": "https://..." }
+    ]
+  }
+}
+```
+
+Notes:
+
+- `venue` and `organizer` are `null` when no term is attached. The legacy
+  HTML templates rendered an empty slot in that case; clients should do
+  the same.
+- `taxonomies` honors the `data_machine_events_excluded_taxonomies`
+  filter (context: `'badge'`), so the data envelope matches what the
+  legacy badge HTML would have surfaced.
+- The `address` field is denormalized from `venue.address` for clients
+  that don't want to walk into the venue subobject. It is identical when
+  a venue is present.
+
+### `grouping`
+
+Captures the date-bucket structure that the server produced via
+`DateGrouper::group_events_by_date()`. Multi-day events are expanded —
+the same `post_id` appears under every spanned date, each with its own
+`display_context` (continuation flags, day number, total days).
+
+- `ordered_dates`: the canonical order the calendar renders dates in
+  (ascending for upcoming, descending for past).
+- `by_date`: `Y-m-d => occurrence[]`. Mirrors `ordered_dates` for
+  iteration.
+- `gaps`: `Y-m-d => gap_days` map for `gap_days >= 2`. Clients render
+  the "X days gap" separator between buckets using this.
+
+`display_context` shape:
+
+```jsonc
+{
+  "is_multi_day":        false,
+  "is_start_day":        true,
+  "is_end_day":          true,
+  "is_continuation":     false,
+  "display_date":        "2026-06-12",
+  "original_start_date": "2026-06-12",
+  "original_end_date":   "2026-06-12",
+  "day_number":          1,
+  "total_days":          1
+}
+```
+
+### `pagination`, `counter`, `navigation`
+
+Pure metadata — no HTML strings. Field meanings mirror the legacy
+envelope's metadata fields (`pagination.current_page`,
+`navigation.past_count`, etc.), with the HTML-rendering fields
+(`pagination.html`, `counter` as string, `navigation.html`) removed.
+
+## What this phase does NOT change
+
+- The default REST response shape (i.e. without `format=data`) is
+  **byte-for-byte unchanged**. The Calendar block's frontend bundle does
+  not send `format=data` yet, so its contract is intact.
+- No consumer in `inc/Blocks/Calendar/src/` is ported. Pagination, date
+  range, taxonomy filters, and geo-sync still consume the HTML envelope.
+- The `data-machine-calendar-content-updated` event lifecycle is
+  untouched.
+- The progressive-rendering path (`day-loader`) is untouched; on the
+  data path `progressive` is forced false because progressive rendering
+  is a server-render concern.
+
+## Caching
+
+`CalendarCache::generate_full_response_key()` includes `format` in its
+key surface as of this phase. HTML and data responses for the same
+envelope are stored in separate cache buckets.
+
+## TypeScript
+
+See `inc/Blocks/Calendar/src/types.ts` for the matching interfaces:
+`CalendarDataResponse`, `CalendarEventItem`, `CalendarGrouping`, etc.
+They live alongside the existing `CalendarResponse` (HTML envelope) and
+are not yet consumed by `api-client.ts`.
+
+## Phase 2+ (out of scope for this PR)
+
+- Port pagination consumer to consume `pagination` from the data
+  envelope, drop `pagination.html`.
+- Port counter consumer to read `counter.*` numerics directly, drop the
+  `counter` string field.
+- Port navigation (past / upcoming buttons) to read
+  `navigation.{past,future}_count` + `navigation.show_past`, drop
+  `navigation.html`.
+- Port the event-card renderer in TypeScript so `data.html` and the
+  per-day group HTML strings can be removed.
+- Remove the `data-machine-calendar-content-updated` re-init ceremony.
+- Drop the HTML-string fields from the REST response, retire the
+  `format` query param (data becomes canonical).

--- a/inc/Api/Controllers/Calendar.php
+++ b/inc/Api/Controllers/Calendar.php
@@ -11,6 +11,22 @@
  * venue/artist archive with distinct geo params produced one expensive
  * query per request because the underlying bucket cache was keyed
  * without geo params.
+ *
+ * Response envelopes
+ * ------------------
+ * - Default (no `format` param, or any value other than `data`):
+ *   the legacy HTML-string envelope (`html`, `pagination.html`,
+ *   `counter`, `navigation.html`) used by the current Calendar block
+ *   frontend bundle. UNCHANGED in phase 1.
+ *
+ * - `?format=data`: the structured data-only envelope introduced in
+ *   phase 1 of refactor #298. Returns event objects, pagination /
+ *   counter / navigation metadata, gap map, and a `by_date` grouping
+ *   index — zero HTML strings. See `docs/calendar-data-schema.md`.
+ *
+ * Both envelopes are cached independently via
+ * `CalendarCache::generate_full_response_key()`, which includes
+ * `format` in its key surface as of this phase.
  */
 
 namespace DataMachineEvents\Api\Controllers;
@@ -21,6 +37,7 @@ use WP_REST_Request;
 use DataMachineEvents\Abilities\CalendarAbilities;
 use DataMachineEvents\Blocks\Calendar\Cache\CalendarCache;
 use DataMachineEvents\Blocks\Calendar\Query\CalendarRequest;
+use DataMachineEvents\Blocks\Calendar\Taxonomy\Badges;
 
 /**
  * Calendar API controller
@@ -36,6 +53,14 @@ class Calendar {
 	public function calendar( WP_REST_Request $request ) {
 		$calendar_request = CalendarRequest::fromRestRequest( $request );
 		$envelope         = $calendar_request->toAbilitiesArgs();
+
+		// Thread the format selector into the cache-key envelope so the
+		// HTML and data-only response shapes never share a cache bucket.
+		// `toAbilitiesArgs()` already gates `include_html` on the format,
+		// but the cache key needs an explicit `format` field of its own
+		// (the ability-side envelope only sees the derived `include_html`).
+		$envelope['format'] = $calendar_request->format();
+		$is_data_format     = ( 'data' === $envelope['format'] );
 
 		// Editors with `manage_options` always bypass the cache so they
 		// see fresh data immediately after publishing / editing events.
@@ -54,7 +79,33 @@ class Calendar {
 		$abilities = new CalendarAbilities();
 		$result    = $abilities->executeGetCalendarPage( $envelope );
 
-		$response_body = array(
+		$response_body = $is_data_format
+			? $this->build_data_response( $result, $calendar_request )
+			: $this->build_html_response( $result, $request );
+
+		if ( ! $bypass_cache ) {
+			CalendarCache::set_full_response(
+				$cache_key,
+				$response_body,
+				CalendarCache::ttl_for_envelope( $envelope )
+			);
+		}
+
+		return rest_ensure_response( $response_body );
+	}
+
+	/**
+	 * Build the legacy HTML-string response envelope.
+	 *
+	 * Existing consumers (the Calendar block's frontend bundle as of phase 1)
+	 * receive this shape. Unchanged contract.
+	 *
+	 * @param array           $result  CalendarAbilities::executeGetCalendarPage() output with HTML strings.
+	 * @param WP_REST_Request $request REST request (used to surface the `past` flag in `navigation.show_past`).
+	 * @return array<string,mixed>
+	 */
+	private function build_html_response( array $result, WP_REST_Request $request ): array {
+		return array(
 			'success'    => true,
 			'html'       => $result['html']['events'],
 			'pagination' => array(
@@ -71,15 +122,244 @@ class Calendar {
 				'show_past'    => ! empty( $request->get_param( 'past' ) ),
 			),
 		);
+	}
 
-		if ( ! $bypass_cache ) {
-			CalendarCache::set_full_response(
-				$cache_key,
-				$response_body,
-				CalendarCache::ttl_for_envelope( $envelope )
-			);
+	/**
+	 * Build the data-only response envelope (phase 1 of refactor #298).
+	 *
+	 * Returns structured event objects, pagination / counter / navigation
+	 * metadata, gap map, and a `by_date` grouping index. NO HTML strings.
+	 *
+	 * Performance note: this path NEVER calls `ob_start()` or any template
+	 * loader. `CalendarAbilities::executeGetCalendarPage()` was already
+	 * invoked with `include_html: false`, so the ability skipped its
+	 * `renderHtml()` branch entirely. The work here is pure array
+	 * restructuring on top of `paged_date_groups`.
+	 *
+	 * Schema: see `docs/calendar-data-schema.md`.
+	 *
+	 * @param array           $result   CalendarAbilities::executeGetCalendarPage() output (no HTML).
+	 * @param CalendarRequest $req      Sanitized request, used for navigation context (`past`) and schema versioning.
+	 * @return array<string,mixed>
+	 */
+	private function build_data_response( array $result, CalendarRequest $req ): array {
+		$paged_date_groups = $result['paged_date_groups'] ?? array();
+		$gaps_detected     = $result['gaps_detected'] ?? array();
+
+		// Flatten paged_date_groups (already serialized by
+		// CalendarAbilities::serializeDateGroups()) into:
+		//   - `events`: a deduplicated array of structured event objects.
+		//   - `grouping.by_date`: a `Y-m-d => [post_id, ...]` index that
+		//     preserves the day-bucket ordering AND multi-day expansion
+		//     produced by DateGrouper (a multi-day event appears under
+		//     every spanned date, in order).
+		//
+		// Deduplication is keyed on post_id so a multi-day event ships
+		// once in `events` but reappears as needed in `grouping.by_date`.
+		// The display_context (is_continuation / is_start_day / day_number)
+		// lives on the grouping entry, not on the event itself, because
+		// the same post can be a "start day" on one date and a
+		// "continuation" on the next.
+		$events_by_id   = array();
+		$grouping       = array();
+		$ordered_dates  = array();
+
+		foreach ( $paged_date_groups as $date_group ) {
+			$date_key = $date_group['date'] ?? '';
+			if ( '' === $date_key ) {
+				continue;
+			}
+
+			$ordered_dates[]       = $date_key;
+			$grouping[ $date_key ] = array();
+
+			foreach ( $date_group['events'] as $event_entry ) {
+				$post_id = (int) ( $event_entry['post_id'] ?? 0 );
+				if ( $post_id <= 0 ) {
+					continue;
+				}
+
+				if ( ! isset( $events_by_id[ $post_id ] ) ) {
+					$events_by_id[ $post_id ] = $this->serialize_event( $post_id, $event_entry );
+				}
+
+				$grouping[ $date_key ][] = array(
+					'post_id'         => $post_id,
+					'display_context' => $event_entry['display_context'] ?? array(),
+				);
+			}
 		}
 
-		return rest_ensure_response( $response_body );
+		$events = array_values( $events_by_id );
+
+		$show_past = $req->past();
+
+		return array(
+			'success'    => true,
+			'schema'     => array(
+				'name'    => 'calendar-data',
+				'version' => 1,
+				'phase'   => 1,
+				'issue'   => 298,
+			),
+			'events'     => $events,
+			'grouping'   => array(
+				'ordered_dates' => $ordered_dates,
+				'by_date'       => $grouping,
+				'gaps'          => $gaps_detected,
+			),
+			'pagination' => array(
+				'current_page' => (int) ( $result['current_page'] ?? 1 ),
+				'total_pages'  => (int) ( $result['max_pages'] ?? 1 ),
+				'total_items'  => (int) ( $result['total_event_count'] ?? 0 ),
+				'page_items'   => (int) ( $result['event_count'] ?? 0 ),
+			),
+			'counter'    => array(
+				'showing_count'   => (int) ( $result['event_count'] ?? 0 ),
+				'total_count'     => (int) ( $result['total_event_count'] ?? 0 ),
+				'page_start_date' => (string) ( $result['date_boundaries']['start_date'] ?? '' ),
+				'page_end_date'   => (string) ( $result['date_boundaries']['end_date'] ?? '' ),
+			),
+			'navigation' => array(
+				'show_past'    => $show_past,
+				'past_count'   => (int) ( $result['event_counts']['past'] ?? 0 ),
+				'future_count' => (int) ( $result['event_counts']['future'] ?? 0 ),
+				'has_past'     => (int) ( $result['event_counts']['past'] ?? 0 ) > 0,
+				'has_future'   => (int) ( $result['event_counts']['future'] ?? 0 ) > 0,
+			),
+		);
+	}
+
+	/**
+	 * Build the structured event object for the data envelope.
+	 *
+	 * Pulls authoritative data from `EventHydrator::parse_event_data()` (already
+	 * baked into `event_entry['event_data']` by the ability) and supplements
+	 * with permalink, post title, venue term metadata, and taxonomy term lists.
+	 *
+	 * Field choices mirror what the HTML templates render server-side so the
+	 * client can produce the same surface without a second round-trip. Anything
+	 * the server currently inlines into `data.html` should be representable
+	 * here as JSON.
+	 *
+	 * Schema notes:
+	 * - `taxonomies` is a flat `slug => [term_summary, ...]` map, NOT a nested
+	 *   structure. Mirrors the shape used by FilterAbilities and keeps the
+	 *   client free to render badges / facets without a second mapping pass.
+	 * - `venue` is denormalized out of taxonomies into its own field because
+	 *   it's a first-class display attribute (every event has at most one
+	 *   venue, the templates render it in a fixed slot, the geo system keys
+	 *   off it).
+	 *
+	 * @param int   $post_id     Event post ID.
+	 * @param array $event_entry The serialized entry from `paged_date_groups`.
+	 * @return array<string,mixed>
+	 */
+	private function serialize_event( int $post_id, array $event_entry ): array {
+		$event_data = $event_entry['event_data'] ?? array();
+		$title      = (string) ( $event_entry['title'] ?? get_the_title( $post_id ) );
+
+		return array(
+			'id'        => $post_id,
+			'title'     => $title,
+			'permalink' => (string) get_permalink( $post_id ),
+			'date'      => array(
+				'start_date'     => (string) ( $event_data['startDate'] ?? '' ),
+				'start_time'     => (string) ( $event_data['startTime'] ?? '' ),
+				'end_date'       => (string) ( $event_data['endDate'] ?? '' ),
+				'end_time'       => (string) ( $event_data['endTime'] ?? '' ),
+				'venue_timezone' => (string) ( $event_data['venueTimezone'] ?? '' ),
+			),
+			'venue'     => $this->serialize_venue( $post_id, $event_data ),
+			'organizer' => $this->serialize_organizer( $event_data ),
+			'ticket'    => array(
+				'url' => (string) ( $event_data['ticketUrl'] ?? '' ),
+			),
+			'performer' => array(
+				'name' => (string) ( $event_data['performerName'] ?? '' ),
+			),
+			'address'   => (string) ( $event_data['address'] ?? '' ),
+			'taxonomies' => $this->serialize_taxonomies( $post_id ),
+		);
+	}
+
+	/**
+	 * Serialize the venue term attached to an event, when present.
+	 *
+	 * Returns null when the event has no venue term, mirroring the optional
+	 * nature of the venue slot in the HTML templates.
+	 *
+	 * @param int   $post_id    Event post ID.
+	 * @param array $event_data Already-hydrated event_data array.
+	 * @return array<string,mixed>|null
+	 */
+	private function serialize_venue( int $post_id, array $event_data ): ?array {
+		$venue_terms = get_the_terms( $post_id, 'venue' );
+		if ( ! $venue_terms || is_wp_error( $venue_terms ) ) {
+			return null;
+		}
+		$term = $venue_terms[0];
+
+		return array(
+			'term_id' => (int) $term->term_id,
+			'name'    => (string) ( $event_data['venue'] ?? $term->name ),
+			'slug'    => (string) $term->slug,
+			'address' => (string) ( $event_data['address'] ?? '' ),
+		);
+	}
+
+	/**
+	 * Serialize organizer (promoter) data from the hydrated event_data.
+	 *
+	 * Returns null when no organizer is attached. Promoter data already
+	 * lives on the hydrated event_data via
+	 * `EventHydrator::hydrate_promoter_from_taxonomy()`.
+	 *
+	 * @param array $event_data Hydrated event_data array.
+	 * @return array<string,mixed>|null
+	 */
+	private function serialize_organizer( array $event_data ): ?array {
+		if ( empty( $event_data['organizer'] ) ) {
+			return null;
+		}
+		return array(
+			'name' => (string) $event_data['organizer'],
+			'url'  => (string) ( $event_data['organizerUrl'] ?? '' ),
+			'type' => (string) ( $event_data['organizerType'] ?? '' ),
+		);
+	}
+
+	/**
+	 * Serialize taxonomy term assignments for an event.
+	 *
+	 * Honors the `data_machine_events_excluded_taxonomies` filter (context:
+	 * 'badge') so the data envelope matches what the badge HTML would have
+	 * surfaced. Returns a `slug => [{term_id, name, slug, link}, ...]` map.
+	 *
+	 * @param int $post_id Event post ID.
+	 * @return array<string,array<int,array<string,mixed>>>
+	 */
+	private function serialize_taxonomies( int $post_id ): array {
+		$taxonomies = Badges::get_event_taxonomies( $post_id );
+		$out        = array();
+
+		foreach ( $taxonomies as $taxonomy_slug => $bundle ) {
+			$terms = $bundle['terms'] ?? array();
+			$list  = array();
+			foreach ( $terms as $term ) {
+				$link = get_term_link( $term, $taxonomy_slug );
+				$list[] = array(
+					'term_id' => (int) $term->term_id,
+					'name'    => (string) $term->name,
+					'slug'    => (string) $term->slug,
+					'link'    => is_wp_error( $link ) ? '' : (string) $link,
+				);
+			}
+			if ( ! empty( $list ) ) {
+				$out[ $taxonomy_slug ] = $list;
+			}
+		}
+
+		return $out;
 	}
 }

--- a/inc/Api/Routes.php
+++ b/inc/Api/Routes.php
@@ -91,6 +91,12 @@ function register_routes() {
 					'type'              => 'string',
 					'sanitize_callback' => 'sanitize_text_field',
 				),
+				'format'           => array(
+					'type'              => 'string',
+					'default'           => '',
+					'sanitize_callback' => 'sanitize_key',
+					'description'       => 'Response format. Default (empty) returns the legacy HTML-string envelope. "data" returns the structured data-only envelope (phase 1 of refactor #298). All other values fall back to the default envelope.',
+				),
 			),
 		)
 	);

--- a/inc/Blocks/Calendar/Cache/CalendarCache.php
+++ b/inc/Blocks/Calendar/Cache/CalendarCache.php
@@ -117,6 +117,11 @@ class CalendarCache {
 			'geo_radius'       => (int) ( $envelope['geo_radius'] ?? 0 ),
 			'geo_radius_unit'  => (string) ( $envelope['geo_radius_unit'] ?? '' ),
 			'cutoff_hour'      => \DataMachineEvents\Blocks\Calendar\Grouping\LateNightCutoff::cutoff_hour(),
+			// Phase 1 of refactor #298: HTML and data-only responses
+			// have different shapes and MUST live in separate cache
+			// buckets — otherwise the first response shape served
+			// for a given envelope sticks for the cache TTL.
+			'format'           => (string) ( $envelope['format'] ?? '' ),
 		);
 
 		return self::FULL_PREFIX . md5( wp_json_encode( $key_data ) );

--- a/inc/Blocks/Calendar/Query/CalendarRequest.php
+++ b/inc/Blocks/Calendar/Query/CalendarRequest.php
@@ -70,6 +70,15 @@ final class CalendarRequest {
 	private string $geo_radius_unit;
 
 	/**
+	 * Response format selector. Empty string = legacy HTML-string envelope.
+	 * `'data'` = structured data-only envelope (phase 1 of refactor #298).
+	 *
+	 * Only REST callers populate this. The block render path (fromQueryArgs)
+	 * always leaves it empty because server-render only ever produces HTML.
+	 */
+	private string $format;
+
+	/**
 	 * @param array<string,int[]> $tax_filter
 	 */
 	private function __construct(
@@ -85,7 +94,8 @@ final class CalendarRequest {
 		string $geo_lat,
 		string $geo_lng,
 		int $geo_radius,
-		string $geo_radius_unit
+		string $geo_radius_unit,
+		string $format = ''
 	) {
 		$this->paged            = $paged;
 		$this->past             = $past;
@@ -100,6 +110,7 @@ final class CalendarRequest {
 		$this->geo_lng          = $geo_lng;
 		$this->geo_radius       = $geo_radius;
 		$this->geo_radius_unit  = $geo_radius_unit;
+		$this->format           = $format;
 	}
 
 	/**
@@ -149,7 +160,8 @@ final class CalendarRequest {
 			$geo_lat,
 			$geo_lng,
 			$geo_radius,
-			$geo_radius_unit
+			$geo_radius_unit,
+			'' // format is REST-only.
 		);
 	}
 
@@ -184,6 +196,14 @@ final class CalendarRequest {
 		$archive_taxonomy = sanitize_key( (string) ( $request->get_param( 'archive_taxonomy' ) ?? '' ) );
 		$archive_term_id  = absint( $request->get_param( 'archive_term_id' ) ?? 0 );
 
+		// Phase 1 of refactor #298: `format=data` opts into the structured
+		// data-only envelope. Any other value (including the absent param)
+		// falls back to the legacy HTML-string envelope. We whitelist `'data'`
+		// explicitly so future format names (`v2`, `summary`, etc.) can be
+		// added without silently activating.
+		$format_raw = sanitize_key( (string) ( $request->get_param( 'format' ) ?? '' ) );
+		$format     = ( 'data' === $format_raw ) ? 'data' : '';
+
 		return new self(
 			$paged,
 			$past,
@@ -197,7 +217,8 @@ final class CalendarRequest {
 			$geo_lat,
 			$geo_lng,
 			$geo_radius,
-			$geo_radius_unit
+			$geo_radius_unit,
+			$format
 		);
 	}
 
@@ -205,14 +226,23 @@ final class CalendarRequest {
 	 * Serialize to the args dict consumed by
 	 * `CalendarAbilities::executeGetCalendarPage()`.
 	 *
-	 * The `include_html`, `include_gaps`, and `progressive` flags are
-	 * always true here — they were hardcoded copies in render.php and
-	 * Calendar.php before this refactor; the value object is now their
-	 * single home.
+	 * - `include_html` follows the response format: the HTML envelope path
+	 *   needs server-rendered strings, the data envelope path does not.
+	 *   Skipping HTML rendering on the data path saves the `ob_start()`
+	 *   template runs in CalendarAbilities::renderHtml().
+	 * - `progressive` is also gated on the HTML path. Progressive rendering
+	 *   is a server-render concern (only emit the first day's events as
+	 *   real DOM, defer the rest as shells) — irrelevant once the client
+	 *   owns rendering from data.
+	 * - `include_gaps` stays true regardless: gap detection is a data
+	 *   transformation, the data envelope exposes the `gaps_detected` map
+	 *   so the client can render time-gap separators itself.
 	 *
 	 * @return array<string,mixed>
 	 */
 	public function toAbilitiesArgs(): array {
+		$is_data_format = ( 'data' === $this->format );
+
 		return array(
 			'paged'            => $this->paged,
 			'past'             => $this->past,
@@ -227,9 +257,9 @@ final class CalendarRequest {
 			'geo_lng'          => $this->geo_lng,
 			'geo_radius'       => $this->geo_radius,
 			'geo_radius_unit'  => $this->geo_radius_unit,
-			'include_html'     => true,
+			'include_html'     => ! $is_data_format,
 			'include_gaps'     => true,
-			'progressive'      => true,
+			'progressive'      => ! $is_data_format,
 		);
 	}
 
@@ -291,6 +321,18 @@ final class CalendarRequest {
 
 	public function geoRadiusUnit(): string {
 		return $this->geo_radius_unit;
+	}
+
+	/**
+	 * Response format. Empty string for the legacy HTML envelope, `'data'`
+	 * for the structured data-only envelope (phase 1 of refactor #298).
+	 *
+	 * Used by the REST controller to branch into the data envelope builder
+	 * AND fed into the full-response cache key so HTML and data responses
+	 * never share a cache bucket.
+	 */
+	public function format(): string {
+		return $this->format;
 	}
 
 	/* ------------------------------------------------------------------ */

--- a/inc/Blocks/Calendar/src/types.ts
+++ b/inc/Blocks/Calendar/src/types.ts
@@ -112,6 +112,142 @@ export interface CalendarResponse {
 	navigation: { html: string } | null;
 }
 
+/* ------------------------------------------------------------------ */
+/*  Data-only REST response (phase 1 of refactor #298)                 */
+/* ------------------------------------------------------------------ */
+/*  Activated by passing `format=data` to                              */
+/*  `/wp-json/datamachine/v1/events/calendar`. The legacy              */
+/*  `CalendarResponse` schema above remains the default. No existing   */
+/*  consumer is wired to this shape yet — porting consumers is the     */
+/*  scope of phase 2+ in #298.                                         */
+/*                                                                     */
+/*  See `docs/calendar-data-schema.md` for the full schema doc.        */
+/* ------------------------------------------------------------------ */
+
+/** Identifies the schema version + phase the server returned. */
+export interface CalendarDataSchemaMeta {
+	name: 'calendar-data';
+	version: 1;
+	phase: 1;
+	issue: 298;
+}
+
+/** Date / time slot for a single event, sourced from EventHydrator. */
+export interface CalendarEventDate {
+	start_date: string;
+	start_time: string;
+	end_date: string;
+	end_time: string;
+	venue_timezone: string;
+}
+
+/** Venue term attached to an event, or null when none. */
+export interface CalendarEventVenue {
+	term_id: number;
+	name: string;
+	slug: string;
+	address: string;
+}
+
+/** Organizer (promoter) attached to an event, or null when none. */
+export interface CalendarEventOrganizer {
+	name: string;
+	url: string;
+	type: string;
+}
+
+/** Single taxonomy term summary as surfaced in `event.taxonomies`. */
+export interface CalendarEventTaxonomyTerm {
+	term_id: number;
+	name: string;
+	slug: string;
+	link: string;
+}
+
+/** Structured event object. One entry per post_id regardless of multi-day expansion. */
+export interface CalendarEventItem {
+	id: number;
+	title: string;
+	permalink: string;
+	date: CalendarEventDate;
+	venue: CalendarEventVenue | null;
+	organizer: CalendarEventOrganizer | null;
+	ticket: { url: string };
+	performer: { name: string };
+	address: string;
+	taxonomies: Record<string, CalendarEventTaxonomyTerm[]>;
+}
+
+/**
+ * Per-occurrence display context carried by `grouping.by_date`.
+ * Mirrors the `display_context` slot produced by `DateGrouper::group_events_by_date()`:
+ * an event can appear under multiple dates (multi-day), and each occurrence
+ * carries its own continuation / start-day / day-number flags.
+ */
+export interface CalendarEventOccurrenceContext {
+	is_multi_day?: boolean;
+	is_start_day?: boolean;
+	is_end_day?: boolean;
+	is_continuation?: boolean;
+	display_date?: string;
+	original_start_date?: string;
+	original_end_date?: string;
+	day_number?: number;
+	total_days?: number;
+}
+
+/** A single occurrence of an event on a specific date. */
+export interface CalendarEventOccurrence {
+	post_id: number;
+	display_context: CalendarEventOccurrenceContext;
+}
+
+/** Date grouping index. Date keys are `Y-m-d` strings. */
+export interface CalendarGrouping {
+	/** Ordered list of dates as rendered on this page. */
+	ordered_dates: string[];
+	/** `Y-m-d => occurrence[]` map matching `ordered_dates`. */
+	by_date: Record<string, CalendarEventOccurrence[]>;
+	/** `Y-m-d => gap_days` map; gaps >= 2 days from `DateGrouper::detect_time_gaps`. */
+	gaps: Record<string, number>;
+}
+
+/** Pagination metadata as JSON — no HTML. */
+export interface CalendarDataPagination {
+	current_page: number;
+	total_pages: number;
+	total_items: number;
+	page_items: number;
+}
+
+/** "Showing X of Y events between A and B" counter as JSON. */
+export interface CalendarDataCounter {
+	showing_count: number;
+	total_count: number;
+	page_start_date: string;
+	page_end_date: string;
+}
+
+/** Past / future navigation state as JSON. */
+export interface CalendarDataNavigation {
+	show_past: boolean;
+	past_count: number;
+	future_count: number;
+	has_past: boolean;
+	has_future: boolean;
+}
+
+/** Full data-only response envelope. */
+export interface CalendarDataResponse {
+	success: boolean;
+	schema: CalendarDataSchemaMeta;
+	events: CalendarEventItem[];
+	grouping: CalendarGrouping;
+	pagination: CalendarDataPagination;
+	counter: CalendarDataCounter;
+	navigation: CalendarDataNavigation;
+}
+
 export interface FilterResponse {
 	success: boolean;
 	taxonomies: Record<string, TaxonomyData>;

--- a/tests/Unit/CalendarCacheTest.php
+++ b/tests/Unit/CalendarCacheTest.php
@@ -100,6 +100,39 @@ class CalendarCacheTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The `format` envelope field MUST be part of the cache key so the
+	 * legacy HTML-string envelope and the phase-1 data-only envelope
+	 * never collide in the same bucket. See refactor #298.
+	 */
+	public function test_full_response_key_includes_format() {
+		$html_envelope = array(
+			'paged'            => 1,
+			'past'             => false,
+			'event_search'     => '',
+			'date_start'       => '',
+			'date_end'         => '',
+			'scope'            => '',
+			'tax_filter'       => array(),
+			'archive_taxonomy' => '',
+			'archive_term_id'  => 0,
+			'geo_lat'          => '',
+			'geo_lng'          => '',
+			'geo_radius'       => 25,
+			'geo_radius_unit'  => 'mi',
+			'format'           => '',
+		);
+
+		$data_envelope           = $html_envelope;
+		$data_envelope['format'] = 'data';
+
+		$this->assertNotEquals(
+			CalendarCache::generate_full_response_key( $html_envelope ),
+			CalendarCache::generate_full_response_key( $data_envelope ),
+			'format=data MUST produce a distinct cache key from the legacy HTML envelope'
+		);
+	}
+
+	/**
 	 * Past=1 requests MUST be served from cache on the second hit
 	 * without re-running EventQueryBuilder. We pre-seed the cache with
 	 * a sentinel response body that no real query could produce; if


### PR DESCRIPTION
## Summary

Phase 1 of the umbrella calendar refactor in #298. Introduces an **opt-in** structured response envelope on `/wp-json/datamachine/v1/events/calendar` activated via `?format=data`. The legacy HTML-string envelope is **byte-for-byte unchanged** when `format` is absent (or anything other than `'data'`), so no existing consumer is touched.

Refs #298 — **not** a `closes` because the umbrella issue spans multiple PRs.

## Why scoped this narrowly

The full refactor is multi-PR by design (see issue #298 sequencing). This PR establishes the new schema and exposes it behind a query-param toggle so subsequent PRs can port one consumer at a time (pagination, date range, taxonomy filters, geo-sync) without ever breaking the live frontend.

## Changes

### REST surface

- **`inc/Api/Routes.php`** — register a new `format` arg on the calendar route. Sanitized via `sanitize_key`, defaults to empty.
- **`inc/Api/Controllers/Calendar.php`** — branch on format. `build_html_response()` preserves the legacy shape exactly; `build_data_response()` emits the new structured envelope.
- **`inc/Blocks/Calendar/Query/CalendarRequest.php`** — carry a `format` field, expose via `format()` accessor. `toAbilitiesArgs()` now gates BOTH `include_html` AND `progressive` on format: the data path skips template rendering and progressive day-loader shells entirely (both are pure server-render concerns).
- **`inc/Blocks/Calendar/Cache/CalendarCache.php`** — include `format` in `generate_full_response_key()` so HTML and data envelopes never share a cache bucket.

### Data envelope shape (new)

```jsonc
{
  "success": true,
  "schema": { "name": "calendar-data", "version": 1, "phase": 1, "issue": 298 },
  "events": [
    {
      "id": 12345,
      "title": "...",
      "permalink": "...",
      "date": { "start_date", "start_time", "end_date", "end_time", "venue_timezone" },
      "venue": { "term_id", "name", "slug", "address" } | null,
      "organizer": { "name", "url", "type" } | null,
      "ticket": { "url" },
      "performer": { "name" },
      "address": "...",
      "taxonomies": { "<slug>": [ { "term_id", "name", "slug", "link" } ] }
    }
  ],
  "grouping": {
    "ordered_dates": [ "Y-m-d", ... ],
    "by_date": { "Y-m-d": [ { "post_id", "display_context" } ] },
    "gaps":    { "Y-m-d": <gap_days> }
  },
  "pagination": { "current_page", "total_pages", "total_items", "page_items" },
  "counter":    { "showing_count", "total_count", "page_start_date", "page_end_date" },
  "navigation": { "show_past", "past_count", "future_count", "has_past", "has_future" }
}
```

Key design choices:

- **Events are deduplicated on `post_id`.** A multi-day event ships once in `events` and is referenced once per spanned date in `grouping.by_date`. `display_context` (is_continuation / day_number / total_days) lives on the **grouping entry**, not on the event itself — same post can be a "start day" on one date and a "continuation" on the next.
- **`venue` is denormalized** out of `taxonomies` into its own field. Every event has at most one venue, templates render it in a fixed slot, geo system keys off it. Mirroring that in the data shape avoids forcing every client to walk into `taxonomies.venue[0]`.
- **`taxonomies` honors `data_machine_events_excluded_taxonomies`** (context: `'badge'`) so the data envelope matches what the legacy badge HTML would have surfaced.
- **`schema` block** identifies version + phase so clients can forward-compat. Phase bumps for additive expansion; version bumps for breaking shape changes.

### Frontend types

- **`inc/Blocks/Calendar/src/types.ts`** — add `CalendarDataResponse`, `CalendarEventItem`, `CalendarGrouping`, etc. alongside the existing `CalendarResponse`. **Type-only additions**, no runtime code modified, **no rebuild required**.

### Docs

- **`docs/calendar-data-schema.md`** (new) — full schema reference, activation instructions, scoping, and the phase 2+ TODO list.

### Tests

- **`tests/Unit/CalendarCacheTest.php`** — assert that `format=data` and the empty default produce **distinct cache keys**.

## What this PR does NOT change

- Default REST response shape (no `format` param) — **byte-for-byte unchanged**.
- `inc/Blocks/Calendar/src/modules/api-client.ts` and all client-side consumer logic — **untouched**.
- The `data-machine-calendar-content-updated` re-init lifecycle — **untouched**.
- Pagination, date range, taxonomy filter, geo-sync consumers — **untouched** (phase 2+).
- Past Events button (#296) — **separate scope**.
- REST swap endpoint hardening (#297) — **separate scope**.
- Editor / EventsMap / any other block — **untouched**.

## Verification

### Curl matrix

Default (legacy HTML envelope) — must produce the same shape as `main`:

```bash
curl -s 'https://extrachill.com/wp-json/datamachine/v1/events/calendar?paged=1' \
  | jq 'keys'
# Expected: ["counter","html","navigation","pagination","success"]
```

New (data envelope) — must return structured JSON, no HTML strings anywhere:

```bash
curl -s 'https://extrachill.com/wp-json/datamachine/v1/events/calendar?paged=1&format=data' \
  | jq 'keys'
# Expected: ["counter","events","grouping","navigation","pagination","schema","success"]

curl -s 'https://extrachill.com/wp-json/datamachine/v1/events/calendar?paged=1&format=data' \
  | jq '.schema, (.events[0] | keys), (.grouping | keys)'
# Expected:
# { "name": "calendar-data", "version": 1, "phase": 1, "issue": 298 }
# ["address","date","id","organizer","performer","permalink","taxonomies","ticket","title","venue"]
# ["by_date","gaps","ordered_dates"]
```

Unknown format values must silently fall back to the legacy envelope (no surprise activation):

```bash
curl -s 'https://extrachill.com/wp-json/datamachine/v1/events/calendar?paged=1&format=v99' \
  | jq 'has("html"), has("events")'
# Expected: true / false
```

### Regression check

- The existing Calendar block frontend bundle does not send `format=data` → its REST contract is intact, `paged_date_groups`-based rendering continues identically.
- `render.php` uses `CalendarRequest::fromQueryArgs()` which defaults `format` to empty → server-render path unaffected.
- `CalendarCacheTest::test_full_response_key_includes_geo_params` still asserts independent variation; the existing test continues to pass (new key field doesn't change the inequality semantics).
- `CalendarCacheTest::test_full_response_key_includes_format` (new) asserts the data and HTML envelopes occupy separate cache buckets.

### What to look at in review

- The data envelope's denormalization choices (`venue` and `address` outside `taxonomies`, `display_context` on grouping not event) — these are the load-bearing schema decisions for phase 2+.
- The `progressive: false` flip on the data path. Confirmed this is the right call: progressive day-loader shells are server-rendered placeholders; once the client owns rendering from data, the optimization moves client-side and no longer needs the server to fragment its response.
- Whether the `schema` block is necessary at all. I think yes — it gives the porting work in phase 2+ a stable contract to depend on.

mention <@532385681268408341> when complete and ready for review