### PR TITLE
refactor(geocoding): consolidate Nominatim HTTP into NominatimClient helper

### DIFF
--- a/inc/Abilities/GeocodingAbilities.php
+++ b/inc/Abilities/GeocodingAbilities.php
@@ -15,6 +15,7 @@
 
 namespace DataMachineEvents\Abilities;
 
+use DataMachineEvents\Core\NominatimClient;
 use DataMachineEvents\Core\Venue_Taxonomy;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -25,18 +26,24 @@ class GeocodingAbilities {
 
 	/**
 	 * Transient cache TTL for geocoded addresses (30 days).
+	 *
+	 * @deprecated Use NominatimClient::CACHE_TTL.
 	 */
-	private const CACHE_TTL = 30 * DAY_IN_SECONDS;
+	private const CACHE_TTL = NominatimClient::CACHE_TTL;
 
 	/**
 	 * Transient prefix for cached geocoding results.
+	 *
+	 * @deprecated Use NominatimClient::CACHE_PREFIX.
 	 */
-	private const CACHE_PREFIX = 'dme_geocode_';
+	private const CACHE_PREFIX = NominatimClient::CACHE_PREFIX;
 
 	/**
 	 * Rate limit: seconds between Nominatim requests.
+	 *
+	 * @deprecated Use NominatimClient::RATE_LIMIT_SECONDS.
 	 */
-	private const RATE_LIMIT_SECONDS = 2;
+	private const RATE_LIMIT_SECONDS = NominatimClient::RATE_LIMIT_SECONDS;
 
 	private static bool $registered = false;
 
@@ -113,37 +120,22 @@ class GeocodingAbilities {
 			return new \WP_Error( 'invalid_query', 'Query must be at least 3 characters.', array( 'status' => 400 ) );
 		}
 
-		// Sanitize
+		// Sanitize before handing to the shared client. NominatimClient owns
+		// the cache key derivation + 30d transient TTL so the warm cache
+		// stays bit-compatible with pre-refactor entries.
 		$query = sanitize_text_field( $query );
-		$query = substr( $query, 0, 500 );
 
-		// Check cache
-		$cache_key = self::CACHE_PREFIX . md5( strtolower( $query ) );
-		$cached    = get_transient( $cache_key );
+		// display_name in the cached payload is the user-supplied query
+		// (back-compat with the original behavior); preserve that contract
+		// by overriding NominatimClient's display_name (which echoes
+		// Nominatim's longer response value).
+		$result = NominatimClient::geocodeOne( $query );
 
-		if ( false !== $cached && is_array( $cached ) ) {
-			$cached['cached'] = true;
-			return $cached;
+		if ( is_wp_error( $result ) ) {
+			return $result;
 		}
 
-		// Query Nominatim via the Venue_Taxonomy method
-		$coordinates = Venue_Taxonomy::query_nominatim( $query );
-
-		if ( ! $coordinates ) {
-			return new \WP_Error( 'geocode_failed', 'Could not geocode address: no results from Nominatim.', array( 'status' => 404 ) );
-		}
-
-		$parts = explode( ',', $coordinates );
-
-		$result = array(
-			'lat'          => $parts[0],
-			'lng'          => $parts[1],
-			'display_name' => $query,
-			'cached'       => false,
-		);
-
-		// Cache result
-		set_transient( $cache_key, $result, self::CACHE_TTL );
+		$result['display_name'] = substr( $query, 0, 500 );
 
 		return $result;
 	}
@@ -216,41 +208,15 @@ class GeocodingAbilities {
 		$query = substr( $query, 0, 500 );
 		$limit = min( max( 1, (int) ( $input['limit'] ?? 5 ) ), 10 );
 
-		$url_args = array(
-			'format'         => 'json',
-			'addressdetails' => '1',
-			'limit'          => (string) $limit,
-			'q'              => $query,
-		);
-
+		$countrycodes = '';
 		if ( ! empty( $input['countrycodes'] ) ) {
-			$url_args['countrycodes'] = sanitize_text_field( $input['countrycodes'] );
+			$countrycodes = sanitize_text_field( $input['countrycodes'] );
 		}
 
-		$url = add_query_arg( $url_args, 'https://nominatim.openstreetmap.org/search' );
+		$data = NominatimClient::searchAddress( $query, $limit, $countrycodes );
 
-		$response = wp_remote_get(
-			$url,
-			array(
-				'timeout'    => 10,
-				'user-agent' => 'DataMachineEvents/1.0 (https://extrachill.com)',
-			)
-		);
-
-		if ( is_wp_error( $response ) ) {
-			return new \WP_Error( 'nominatim_request_failed', 'Nominatim request failed: ' . $response->get_error_message(), array( 'status' => 500 ) );
-		}
-
-		$status_code = wp_remote_retrieve_response_code( $response );
-		if ( 200 !== $status_code ) {
-			return new \WP_Error( 'nominatim_error', 'Nominatim returned status ' . $status_code, array( 'status' => 500 ) );
-		}
-
-		$body = wp_remote_retrieve_body( $response );
-		$data = json_decode( $body, true );
-
-		if ( ! is_array( $data ) ) {
-			return new \WP_Error( 'nominatim_invalid_response', 'Invalid response from Nominatim.', array( 'status' => 500 ) );
+		if ( is_wp_error( $data ) ) {
+			return $data;
 		}
 
 		return array(
@@ -410,7 +376,7 @@ class GeocodingAbilities {
 
 			// Rate limit — respect Nominatim's usage policy.
 			if ( $processed < $limit ) {
-				sleep( self::RATE_LIMIT_SECONDS );
+				NominatimClient::sleepForRateLimit();
 			}
 		}
 

--- a/inc/Cli/Check/CheckMissingVenueAddressesCommand.php
+++ b/inc/Cli/Check/CheckMissingVenueAddressesCommand.php
@@ -50,7 +50,7 @@
 
 namespace DataMachineEvents\Cli\Check;
 
-use DataMachine\Core\HttpClient;
+use DataMachineEvents\Core\NominatimClient;
 use DataMachineEvents\Core\Venue_Taxonomy;
 use DataMachineEvents\Core\DuplicateDetection\VenueMergeHelper;
 
@@ -58,20 +58,9 @@ defined( 'ABSPATH' ) || exit;
 
 class CheckMissingVenueAddressesCommand {
 
-	/**
-	 * Nominatim endpoints. Same host the forward geocoder
-	 * (Venue_Taxonomy::query_nominatim) already uses.
-	 */
-	private const NOMINATIM_REVERSE_API = 'https://nominatim.openstreetmap.org/reverse';
-	private const NOMINATIM_SEARCH_API  = 'https://nominatim.openstreetmap.org/search';
-	private const NOMINATIM_USER_AGENT  = 'DataMachineEvents/1.0 (https://extrachill.com)';
-
-	/**
-	 * Seconds to sleep between Nominatim requests. Matches the rate-limit
-	 * in GeocodingAbilities so this command does not get
-	 * rate-limited / banned during a large --apply run.
-	 */
-	private const RATE_LIMIT_SECONDS = 2;
+	// Nominatim endpoints, user-agent, and rate-limit live in
+	// NominatimClient — the single point of HTTP plumbing for every
+	// OSM call in this plugin.
 
 	/**
 	 * Address-component meta keys filled by the repair pass. Subset of
@@ -356,34 +345,15 @@ class CheckMissingVenueAddressesCommand {
 			return null;
 		}
 
-		$url = add_query_arg(
-			array(
-				'format'         => 'jsonv2',
-				'lat'            => $lat,
-				'lon'            => $lon,
-				'addressdetails' => '1',
-			),
-			self::NOMINATIM_REVERSE_API
-		);
+		$data = NominatimClient::reverseGeocode( (float) $lat, (float) $lon );
 
-		$result = HttpClient::get(
-			$url,
-			array(
-				'timeout' => 10,
-				'headers' => array(
-					'User-Agent' => self::NOMINATIM_USER_AGENT,
-				),
-				'context' => 'Venue Reverse Geocoding',
-			)
-		);
-
-		if ( empty( $result['success'] ) ) {
+		if ( is_wp_error( $data ) ) {
 			do_action(
 				'datamachine_log',
 				'warning',
 				'Reverse geocoding request failed',
 				array(
-					'error'       => $result['error'] ?? 'unknown error',
+					'error'       => $data->get_error_message(),
 					'coordinates' => $coordinates,
 				)
 			);
@@ -392,11 +362,9 @@ class CheckMissingVenueAddressesCommand {
 
 		// Be nice to Nominatim between successive lookups when a single
 		// --apply run touches many venues.
-		usleep( self::RATE_LIMIT_SECONDS * 1_000_000 );
+		NominatimClient::sleepForRateLimit();
 
-		$body = is_string( $result['data'] ?? null ) ? $result['data'] : '';
-		$data = json_decode( $body, true );
-		if ( ! is_array( $data ) || empty( $data['address'] ) ) {
+		if ( empty( $data['address'] ) ) {
 			return null;
 		}
 
@@ -425,46 +393,24 @@ class CheckMissingVenueAddressesCommand {
 
 		$query = sprintf( '%s %s', $name, $city );
 
-		$url = add_query_arg(
-			array(
-				'format'         => 'jsonv2',
-				'q'              => $query,
-				'limit'          => '1',
-				'addressdetails' => '1',
-			),
-			self::NOMINATIM_SEARCH_API
-		);
+		$data = NominatimClient::searchAddress( $query, 1 );
 
-		$result = HttpClient::get(
-			$url,
-			array(
-				'timeout' => 10,
-				'headers' => array(
-					'User-Agent' => self::NOMINATIM_USER_AGENT,
-				),
-				'context' => 'Venue Places Lookup',
-			)
-		);
-
-		if ( empty( $result['success'] ) ) {
+		if ( is_wp_error( $data ) ) {
 			do_action(
 				'datamachine_log',
 				'warning',
 				'Places lookup request failed',
 				array(
-					'error' => $result['error'] ?? 'unknown error',
+					'error' => $data->get_error_message(),
 					'query' => $query,
 				)
 			);
 			return null;
 		}
 
-		usleep( self::RATE_LIMIT_SECONDS * 1_000_000 );
+		NominatimClient::sleepForRateLimit();
 
-		$body = is_string( $result['data'] ?? null ) ? $result['data'] : '';
-		$data = json_decode( $body, true );
-
-		if ( ! is_array( $data ) || empty( $data[0] ) || empty( $data[0]['address'] ) ) {
+		if ( empty( $data[0] ) || empty( $data[0]['address'] ) ) {
 			return null;
 		}
 

--- a/inc/Core/NominatimClient.php
+++ b/inc/Core/NominatimClient.php
@@ -1,0 +1,280 @@
+<?php
+/**
+ * Nominatim Client — single point of HTTP plumbing for OpenStreetMap Nominatim.
+ *
+ * Consolidates user-agent, rate-limit sleep, cache key prefix/TTL, and HTTP
+ * surface across every Nominatim callsite in the plugin.
+ *
+ * Before this helper existed three callsites talked to Nominatim with three
+ * different levels of cache/rate-limit/user-agent discipline:
+ *
+ *   - GeocodingAbilities::executeGeocodeAddress() — delegated to
+ *     Venue_Taxonomy::query_nominatim(), cached 30d (dme_geocode_ prefix).
+ *   - GeocodingAbilities::executeGeocodeSearch()  — inline wp_remote_get(),
+ *     no cache, no rate-limit, own user-agent.
+ *   - Venue_Taxonomy::query_nominatim()           — HttpClient::get(), no
+ *     cache, single-result only.
+ *   - CheckMissingVenueAddressesCommand           — inline reverse + forward
+ *     HTTP via HttpClient::get(), own constants.
+ *
+ * All of those now route through one of three public methods on this class:
+ *
+ *   - searchAddress(query, limit, countrycodes) — multi-result with
+ *     addressdetails, used for autocomplete UIs.
+ *   - geocodeOne(query)                         — single-result, used by
+ *     backend geocoding. Returns array with lat/lng/display_name keys.
+ *   - reverseGeocode(lat, lng)                  — used by the address audit
+ *     command.
+ *
+ * Cache prefix and TTL match the pre-existing transient contract
+ * (`dme_geocode_` + 30 days) so warm cache entries are not orphaned.
+ *
+ * @package DataMachineEvents\Core
+ * @since   0.40.0
+ */
+
+namespace DataMachineEvents\Core;
+
+use DataMachine\Core\HttpClient;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class NominatimClient {
+
+	/**
+	 * Single canonical user-agent for every Nominatim request from this plugin.
+	 *
+	 * Matches the value previously hard-coded across three call sites; do not
+	 * change without coordinating with OSM usage policy.
+	 */
+	public const USER_AGENT = 'DataMachineEvents/1.0 (https://extrachill.com)';
+
+	/**
+	 * Transient prefix for cached geocoding results.
+	 *
+	 * Kept identical to the pre-helper value so warm cache entries written
+	 * by GeocodingAbilities::executeGeocodeAddress() remain readable.
+	 */
+	public const CACHE_PREFIX = 'dme_geocode_';
+
+	/**
+	 * Cache TTL for `geocodeOne()` results (30 days). Matches the previous
+	 * GeocodingAbilities::CACHE_TTL exactly.
+	 */
+	public const CACHE_TTL = 30 * DAY_IN_SECONDS;
+
+	/**
+	 * Seconds to sleep between batched Nominatim requests to respect OSM's
+	 * usage policy. Mirrors the value previously used by
+	 * GeocodingAbilities::executeGeocodeVenues() and
+	 * CheckMissingVenueAddressesCommand.
+	 */
+	public const RATE_LIMIT_SECONDS = 2;
+
+	private const ENDPOINT_SEARCH  = 'https://nominatim.openstreetmap.org/search';
+	private const ENDPOINT_REVERSE = 'https://nominatim.openstreetmap.org/reverse';
+
+	private const HTTP_TIMEOUT = 10;
+
+	/**
+	 * Forward-search Nominatim and return multiple results with full address
+	 * details. Used by autocomplete UIs (geocode-search ability).
+	 *
+	 * @param string $query        Search query (address, city, or place name).
+	 * @param int    $limit        Max results to return (1-10).
+	 * @param string $countrycodes Comma-separated country codes to restrict
+	 *                              results (e.g. "us" or "us,ca").
+	 * @return array<int,array<string,mixed>>|\WP_Error Array of Nominatim
+	 *   result rows on success, or WP_Error on transport/decode failure.
+	 */
+	public static function searchAddress( string $query, int $limit = 5, string $countrycodes = '' ): array|\WP_Error {
+		$query = trim( $query );
+		if ( '' === $query ) {
+			return new \WP_Error( 'invalid_query', 'Query is required.', array( 'status' => 400 ) );
+		}
+
+		$limit = min( max( 1, $limit ), 10 );
+
+		$args = array(
+			'format'         => 'json',
+			'addressdetails' => '1',
+			'limit'          => (string) $limit,
+			'q'              => $query,
+		);
+
+		if ( '' !== $countrycodes ) {
+			$args['countrycodes'] = $countrycodes;
+		}
+
+		$url = add_query_arg( $args, self::ENDPOINT_SEARCH );
+
+		$data = self::request( $url, 'Nominatim Search' );
+
+		if ( is_wp_error( $data ) ) {
+			return $data;
+		}
+
+		if ( ! is_array( $data ) ) {
+			return new \WP_Error( 'nominatim_invalid_response', 'Invalid response from Nominatim.', array( 'status' => 500 ) );
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Geocode a single address string to lat/lng with 30-day transient cache.
+	 *
+	 * Returns an associative array on hit:
+	 *   - lat          (string) Latitude as returned by Nominatim.
+	 *   - lng          (string) Longitude as returned by Nominatim.
+	 *   - display_name (string) Display name from Nominatim (or the input
+	 *                            query when Nominatim omits it).
+	 *   - cached       (bool)   true when the result was served from the
+	 *                            transient cache, false on a fresh lookup.
+	 *
+	 * @param string $query Address string (3-500 chars after sanitization).
+	 * @return array{lat:string,lng:string,display_name:string,cached:bool}|\WP_Error
+	 */
+	public static function geocodeOne( string $query ): array|\WP_Error {
+		$query = trim( $query );
+		if ( '' === $query || strlen( $query ) < 3 ) {
+			return new \WP_Error( 'invalid_query', 'Query must be at least 3 characters.', array( 'status' => 400 ) );
+		}
+
+		$query = substr( $query, 0, 500 );
+
+		$cache_key = self::CACHE_PREFIX . md5( strtolower( $query ) );
+		$cached    = get_transient( $cache_key );
+
+		if ( false !== $cached && is_array( $cached ) ) {
+			$cached['cached'] = true;
+			return $cached;
+		}
+
+		$url = add_query_arg(
+			array(
+				'format' => 'json',
+				'limit'  => '1',
+				'q'      => $query,
+			),
+			self::ENDPOINT_SEARCH
+		);
+
+		$data = self::request( $url, 'Nominatim Geocode' );
+
+		if ( is_wp_error( $data ) ) {
+			return $data;
+		}
+
+		if ( ! is_array( $data ) || empty( $data[0] ) || ! isset( $data[0]['lat'], $data[0]['lon'] ) ) {
+			return new \WP_Error( 'geocode_failed', 'Could not geocode address: no results from Nominatim.', array( 'status' => 404 ) );
+		}
+
+		$top = $data[0];
+
+		$result = array(
+			'lat'          => (string) $top['lat'],
+			'lng'          => (string) $top['lon'],
+			'display_name' => isset( $top['display_name'] ) ? (string) $top['display_name'] : $query,
+			'cached'       => false,
+		);
+
+		set_transient( $cache_key, $result, self::CACHE_TTL );
+
+		return $result;
+	}
+
+	/**
+	 * Reverse-geocode lat/lng coordinates to an address payload (raw
+	 * Nominatim response). Used by the address-audit CLI to repair venues
+	 * that already have coordinates but lack structured address fields.
+	 *
+	 * Returns the decoded JSON payload on success — callers parse the
+	 * `address` block themselves because the granular component mapping
+	 * (`house_number` + `road` → street, `city`/`town`/`village` cascade,
+	 * etc.) is domain-specific and belongs at the callsite.
+	 *
+	 * @param float $lat Latitude.
+	 * @param float $lng Longitude.
+	 * @return array<string,mixed>|\WP_Error Decoded Nominatim payload, or
+	 *   WP_Error on transport/decode failure.
+	 */
+	public static function reverseGeocode( float $lat, float $lng ): array|\WP_Error {
+		$url = add_query_arg(
+			array(
+				'format'         => 'jsonv2',
+				'lat'            => (string) $lat,
+				'lon'            => (string) $lng,
+				'addressdetails' => '1',
+			),
+			self::ENDPOINT_REVERSE
+		);
+
+		$data = self::request( $url, 'Nominatim Reverse' );
+
+		if ( is_wp_error( $data ) ) {
+			return $data;
+		}
+
+		if ( ! is_array( $data ) ) {
+			return new \WP_Error( 'nominatim_invalid_response', 'Invalid response from Nominatim reverse endpoint.', array( 'status' => 500 ) );
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Sleep RATE_LIMIT_SECONDS — call between successive Nominatim requests
+	 * in batch loops to respect OSM's usage policy.
+	 *
+	 * Centralized here so callers don't carry their own sleep constants.
+	 */
+	public static function sleepForRateLimit(): void {
+		sleep( self::RATE_LIMIT_SECONDS );
+	}
+
+	/**
+	 * Issue a single HTTP GET via the shared HttpClient wrapper and return
+	 * the JSON-decoded payload (or WP_Error).
+	 *
+	 * @param string $url     Fully built Nominatim URL.
+	 * @param string $context HttpClient context string for logs.
+	 * @return mixed Decoded JSON value or WP_Error on transport/decode failure.
+	 */
+	private static function request( string $url, string $context ) {
+		$result = HttpClient::get(
+			$url,
+			array(
+				'timeout' => self::HTTP_TIMEOUT,
+				'headers' => array(
+					'User-Agent' => self::USER_AGENT,
+				),
+				'context' => $context,
+			)
+		);
+
+		if ( empty( $result['success'] ) ) {
+			$error = isset( $result['error'] ) ? (string) $result['error'] : 'Unknown error';
+			return new \WP_Error(
+				'nominatim_request_failed',
+				'Nominatim request failed: ' . $error,
+				array( 'status' => 500 )
+			);
+		}
+
+		$body = is_string( $result['data'] ?? null ) ? $result['data'] : '';
+		$data = json_decode( $body, true );
+
+		if ( null === $data && JSON_ERROR_NONE !== json_last_error() ) {
+			return new \WP_Error(
+				'nominatim_invalid_response',
+				'Invalid JSON from Nominatim: ' . json_last_error_msg(),
+				array( 'status' => 500 )
+			);
+		}
+
+		return $data;
+	}
+}

--- a/inc/Core/Venue_Taxonomy.php
+++ b/inc/Core/Venue_Taxonomy.php
@@ -7,8 +7,8 @@
 
 namespace DataMachineEvents\Core;
 
-use DataMachine\Core\HttpClient;
 use DataMachineEvents\Core\GeoNamesService;
+use DataMachineEvents\Core\NominatimClient;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -19,8 +19,12 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Venue_Taxonomy {
 
-	private const NOMINATIM_API        = 'https://nominatim.openstreetmap.org/search';
-	private const NOMINATIM_USER_AGENT = 'DataMachineEvents/1.0 (https://extrachill.com)';
+	/**
+	 * @deprecated 0.40.0 Use NominatimClient::USER_AGENT. Retained as a
+	 *             private alias because removing the constant entirely
+	 *             would break any reflective consumer.
+	 */
+	private const NOMINATIM_USER_AGENT = NominatimClient::USER_AGENT;
 
 	public static $meta_fields = array(
 		'address'     => '_venue_address',
@@ -659,63 +663,51 @@ class Venue_Taxonomy {
 	}
 
 	/**
-	 * Query Nominatim API for coordinates
+	 * Query Nominatim API for coordinates.
 	 *
-	 * @param string $query Search query string
-	 * @return string|null Coordinates as "lat,lng" or null on failure
+	 * @deprecated 0.40.0 Use {@see NominatimClient::geocodeOne()} which
+	 *             returns a richer array (`lat` / `lng` / `display_name` /
+	 *             `cached`) instead of the legacy comma-joined string.
+	 *             This method is preserved as a back-compat shim because
+	 *             external consumers may still depend on the
+	 *             `"lat,lng"` return contract.
+	 *
+	 * @param string $query Search query string.
+	 * @return string|null Coordinates as "lat,lng" or null on failure.
 	 */
 	public static function query_nominatim( string $query ): ?string {
 		if ( empty( $query ) ) {
 			return null;
 		}
 
-		$url = add_query_arg(
-			array(
-				'format' => 'json',
-				'limit'  => 1,
-				'q'      => $query,
-			),
-			self::NOMINATIM_API
-		);
+		$result = NominatimClient::geocodeOne( $query );
 
-		$result = HttpClient::get(
-			$url,
-			array(
-				'timeout' => 10,
-				'headers' => array(
-					'User-Agent' => self::NOMINATIM_USER_AGENT,
-				),
-				'context' => 'Venue Geocoding',
-			)
-		);
+		if ( is_wp_error( $result ) ) {
+			$error_code = $result->get_error_code();
 
-		if ( ! $result['success'] ) {
-			do_action(
-				'datamachine_log',
-				'error',
-				'Geocoding request failed',
-				array(
-					'error' => $result['error'] ?? 'Unknown error',
-					'query' => $query,
-				)
-			);
+			// 'geocode_failed' is the no-results case — legacy contract
+			// surfaced that as a silent null. Other errors (transport,
+			// invalid response) keep the original log line.
+			if ( 'geocode_failed' !== $error_code ) {
+				do_action(
+					'datamachine_log',
+					'error',
+					'Geocoding request failed',
+					array(
+						'error' => $result->get_error_message(),
+						'query' => $query,
+					)
+				);
+			}
+
 			return null;
 		}
 
-		$body = $result['data'];
-		$data = json_decode( $body, true );
-
-		if ( empty( $data ) || ! is_array( $data ) || empty( $data[0] ) ) {
+		if ( empty( $result['lat'] ) || empty( $result['lng'] ) ) {
 			return null;
 		}
 
-		$nominatim_result = $data[0];
-
-		if ( isset( $nominatim_result['lat'] ) && isset( $nominatim_result['lon'] ) ) {
-			return $nominatim_result['lat'] . ',' . $nominatim_result['lon'];
-		}
-
-		return null;
+		return $result['lat'] . ',' . $result['lng'];
 	}
 
 	/**


### PR DESCRIPTION
Closes #303.

## Summary

Three callsites talked to Nominatim with three different levels of cache/rate-limit/user-agent discipline. This PR extracts a single `NominatimClient` helper that owns the HTTP plumbing, the user-agent constant, the 30-day cache key prefix + TTL, and the 2-second rate-limit sleep — and routes every existing callsite through it.

## Before / After call graph

### `GeocodingAbilities::executeGeocodeAddress()` (single-result, cached)

**Before**
```
executeGeocodeAddress()
  -> get_transient('dme_geocode_' . md5(query))      [GeocodingAbilities owns cache]
  -> Venue_Taxonomy::query_nominatim($query)         [HttpClient::get + own UA constant]
  -> explode(',', $coordinates)                      [stringly-typed contract]
  -> set_transient('dme_geocode_' . md5(query), …, 30d)
```

**After**
```
executeGeocodeAddress()
  -> NominatimClient::geocodeOne($query)
       -> get_transient('dme_geocode_' . md5(query))  [same key, same TTL]
       -> HttpClient::get(…, UA = NominatimClient::USER_AGENT)
       -> set_transient(…, 30d)
  -> override display_name with the user-supplied query (legacy contract)
```

### `GeocodingAbilities::executeGeocodeSearch()` (multi-result, autocomplete)

**Before**
```
executeGeocodeSearch()
  -> wp_remote_get(nominatim.org/search?…, UA = inline 'DataMachineEvents/1.0 (…)')
  -> no cache, no rate-limit awareness
```

**After**
```
executeGeocodeSearch()
  -> NominatimClient::searchAddress($query, $limit, $countrycodes)
       -> HttpClient::get(…, UA = NominatimClient::USER_AGENT)
```

### `Venue_Taxonomy::query_nominatim()` (back-compat shim)

**Before**
```
query_nominatim($query)
  -> HttpClient::get(nominatim.org/search?…)
  -> json_decode -> "lat,lon"
```

**After**
```
query_nominatim($query)   [@deprecated — kept as back-compat shim]
  -> NominatimClient::geocodeOne($query)
  -> "{lat},{lng}"   (preserves the legacy comma-joined string return contract
                      because external consumers may still depend on it)
```

### `CheckMissingVenueAddressesCommand::{reverse_geocode,places_lookup}()`

**Before**
```
reverse_geocode() -> HttpClient::get(nominatim.org/reverse?…) + own UA + own RATE_LIMIT_SECONDS + usleep
places_lookup()   -> HttpClient::get(nominatim.org/search?…)  + own UA + own RATE_LIMIT_SECONDS + usleep
```

**After**
```
reverse_geocode() -> NominatimClient::reverseGeocode($lat, $lng); NominatimClient::sleepForRateLimit()
places_lookup()   -> NominatimClient::searchAddress($query, 1);   NominatimClient::sleepForRateLimit()
```

## Public ability contract — unchanged

- `data-machine-events/geocode-address` input schema, output shape (`lat` / `lng` / `display_name` / `cached`), error codes (`invalid_query`, `geocode_failed`, `nominatim_request_failed`), and HTTP status codes are **identical**.
- `data-machine-events/geocode-search` input schema, output shape (`{success: true, results: [...]}`), and error codes are **identical**.
- `display_name` in `executeGeocodeAddress`'s response continues to be the user-supplied query, not Nominatim's longer response value (legacy behavior preserved explicitly).
- Cache key format (`dme_geocode_` + `md5(strtolower($query))`) and 30d TTL are **bit-identical** so warm transients from before the refactor remain readable.

## Back-compat shim

`Venue_Taxonomy::query_nominatim()` is **not removed**. It now delegates to `NominatimClient::geocodeOne()` and re-joins the result into the legacy `"lat,lng"` string contract. Marked `@deprecated 0.40.0` with a docblock pointing at `NominatimClient::geocodeOne()`. Kept as a shim because external consumers may still rely on the comma-string return value.

The private `Venue_Taxonomy::NOMINATIM_USER_AGENT` constant is preserved as a `@deprecated` alias of `NominatimClient::USER_AGENT` to avoid breaking any reflective consumer. `Venue_Taxonomy::NOMINATIM_API` was unused after the refactor and dropped.

`GeocodingAbilities::CACHE_TTL` / `CACHE_PREFIX` / `RATE_LIMIT_SECONDS` are likewise kept as `@deprecated` private const aliases of the `NominatimClient` constants.

## Validation

- `php -l` clean on all four touched files.
- `composer dump-autoload --no-dev` regenerated; PSR-4 picks up the new class with no plugin entry-file changes needed.
- Reflection load test confirmed `NominatimClient` resolves with the expected public surface and that all three downstream classes load cleanly via autoload (deprecated const aliases resolve to the canonical `NominatimClient` values at class-load time).
- No existing unit tests touch the geocoding surface — manual smoke via reflection only.

## Out of scope (per issue)

- Switching geocoding providers (still Nominatim).
- Geocoding cache invalidation policy (still 30d TTL).

## Constraints honored

- No `CHANGELOG.md` edits.
- No version-string bumps (homeboy owns those).
- Worktree workflow: all work in `/var/lib/datamachine/workspace/data-machine-events@fix-issue-303-nominatim-client`.
- Conventional commit (`refactor(geocoding): …`).