### PR TITLE
feat(abilities): scope UpcomingCountAbilities by a filter taxonomy/term pair

### DIFF
--- a/inc/Abilities/UpcomingCountAbilities.php
+++ b/inc/Abilities/UpcomingCountAbilities.php
@@ -41,14 +41,22 @@ class UpcomingCountAbilities {
 						'type'       => 'object',
 						'required'   => array( 'taxonomy' ),
 						'properties' => array(
-							'taxonomy'      => array(
+							'taxonomy'        => array(
 								'type'        => 'string',
 								'enum'        => array( 'venue', 'location', 'artist', 'festival' ),
 								'description' => __( 'Taxonomy to count events for.', 'data-machine-events' ),
 							),
-							'exclude_roots' => array(
+							'exclude_roots'   => array(
 								'type'        => 'boolean',
 								'description' => __( 'Exclude root-level terms (parent = 0). Default true for hierarchical taxonomies like location.', 'data-machine-events' ),
+							),
+							'filter_taxonomy' => array(
+								'type'        => 'string',
+								'description' => __( 'Optional. When paired with filter_term_id, restrict counts to upcoming events also tagged with that term in this taxonomy (e.g. taxonomy=venue + filter_taxonomy=artist + filter_term_id=N counts distinct venues of upcoming events tagged with artist N).', 'data-machine-events' ),
+							),
+							'filter_term_id'  => array(
+								'type'        => 'integer',
+								'description' => __( 'Optional. Term ID to scope by. Must be paired with filter_taxonomy; provided alone is an error.', 'data-machine-events' ),
 							),
 						),
 					),
@@ -106,6 +114,43 @@ class UpcomingCountAbilities {
 		$taxonomy      = $input['taxonomy'];
 		$exclude_roots = $input['exclude_roots'] ?? ( is_taxonomy_hierarchical( $taxonomy ) );
 
+		// Optional co-occurrence filter. Both keys must be set together;
+		// providing only one is misuse and returns an error so callers
+		// catch the wiring bug instead of silently getting unfiltered results.
+		$filter_taxonomy_raw = $input['filter_taxonomy'] ?? null;
+		$filter_term_id_raw  = $input['filter_term_id'] ?? null;
+		$filter_taxonomy     = null;
+		$filter_term_id      = 0;
+		$has_filter          = false;
+
+		if ( null !== $filter_taxonomy_raw || null !== $filter_term_id_raw ) {
+			if ( null === $filter_taxonomy_raw || null === $filter_term_id_raw ) {
+				return new \WP_Error(
+					'invalid_filter_pair',
+					'filter_taxonomy and filter_term_id must be provided together.',
+					array( 'status' => 400 )
+				);
+			}
+			$filter_taxonomy = sanitize_key( (string) $filter_taxonomy_raw );
+			$filter_term_id  = absint( $filter_term_id_raw );
+
+			if ( '' === $filter_taxonomy || 0 === $filter_term_id ) {
+				return new \WP_Error(
+					'invalid_filter_pair',
+					'filter_taxonomy and filter_term_id must both be non-empty.',
+					array( 'status' => 400 )
+				);
+			}
+			if ( ! taxonomy_exists( $filter_taxonomy ) ) {
+				return new \WP_Error(
+					'invalid_filter_taxonomy',
+					"Filter taxonomy '{$filter_taxonomy}' does not exist.",
+					array( 'status' => 400 )
+				);
+			}
+			$has_filter = true;
+		}
+
 		if ( ! taxonomy_exists( $taxonomy ) ) {
 			return new \WP_Error( 'invalid_taxonomy', "Taxonomy '{$taxonomy}' does not exist.", array( 'status' => 400 ) );
 		}
@@ -117,25 +162,55 @@ class UpcomingCountAbilities {
 
 		$parent_clause = $exclude_roots ? 'AND tt.parent != 0' : '';
 
-		// Uses ed.post_status to avoid joining the posts table (3s → <100ms).
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		$rows = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT t.term_id, t.name, t.slug, COUNT(DISTINCT tr.object_id) AS event_count
-				FROM {$wpdb->term_relationships} tr
-				INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
-				INNER JOIN {$wpdb->terms} t ON tt.term_id = t.term_id
-				INNER JOIN {$ed_table} ed ON tr.object_id = ed.post_id
-				WHERE tt.taxonomy = %s
-				AND ed.post_status = 'publish'
-				AND ed.start_datetime >= %s
-				{$parent_clause}
-				GROUP BY t.term_id
-				ORDER BY event_count DESC",
-				$taxonomy,
-				$today
-			)
-		);
+		if ( $has_filter ) {
+			// Co-occurrence join: require each counted post to ALSO be tagged
+			// with $filter_term_id in $filter_taxonomy. Aliases f_tr / f_tt
+			// keep the filter join distinct from the primary tr / tt aliases.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$rows = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT t.term_id, t.name, t.slug, COUNT(DISTINCT tr.object_id) AS event_count
+					FROM {$wpdb->term_relationships} tr
+					INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
+					INNER JOIN {$wpdb->terms} t ON tt.term_id = t.term_id
+					INNER JOIN {$ed_table} ed ON tr.object_id = ed.post_id
+					INNER JOIN {$wpdb->term_relationships} f_tr ON f_tr.object_id = tr.object_id
+					INNER JOIN {$wpdb->term_taxonomy} f_tt ON f_tr.term_taxonomy_id = f_tt.term_taxonomy_id
+					WHERE tt.taxonomy = %s
+					AND ed.post_status = 'publish'
+					AND ed.start_datetime >= %s
+					AND f_tt.taxonomy = %s
+					AND f_tt.term_id = %d
+					{$parent_clause}
+					GROUP BY t.term_id
+					ORDER BY event_count DESC",
+					$taxonomy,
+					$today,
+					$filter_taxonomy,
+					$filter_term_id
+				)
+			);
+		} else {
+			// Uses ed.post_status to avoid joining the posts table (3s → <100ms).
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$rows = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT t.term_id, t.name, t.slug, COUNT(DISTINCT tr.object_id) AS event_count
+					FROM {$wpdb->term_relationships} tr
+					INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
+					INNER JOIN {$wpdb->terms} t ON tt.term_id = t.term_id
+					INNER JOIN {$ed_table} ed ON tr.object_id = ed.post_id
+					WHERE tt.taxonomy = %s
+					AND ed.post_status = 'publish'
+					AND ed.start_datetime >= %s
+					{$parent_clause}
+					GROUP BY t.term_id
+					ORDER BY event_count DESC",
+					$taxonomy,
+					$today
+				)
+			);
+		}
 
 		if ( empty( $rows ) ) {
 			return array(

--- a/tests/Unit/UpcomingCountAbilitiesTest.php
+++ b/tests/Unit/UpcomingCountAbilitiesTest.php
@@ -1,0 +1,264 @@
+<?php
+/**
+ * UpcomingCountAbilities Tests
+ *
+ * Covers the `data-machine-events/get-upcoming-counts` ability and the
+ * optional co-occurrence filter pair (filter_taxonomy + filter_term_id)
+ * used by per-archive upcoming-events stats lines on the consuming sites.
+ *
+ * Calls the ability's execute method directly (matching the
+ * VenueStatsAbilitiesTest pattern) rather than going through the Abilities
+ * API runner. The shape returned here is the contract the downstream
+ * extrachill-events block keys on.
+ *
+ * @package DataMachineEvents\Tests\Unit
+ * @since   0.39.2
+ */
+
+namespace DataMachineEvents\Tests\Unit;
+
+use WP_UnitTestCase;
+use DataMachineEvents\Abilities\UpcomingCountAbilities;
+use DataMachineEvents\Core\Event_Post_Type;
+use DataMachineEvents\Core\Venue_Taxonomy;
+use DataMachineEvents\Core\EventDatesTable;
+
+class UpcomingCountAbilitiesTest extends WP_UnitTestCase {
+
+	private UpcomingCountAbilities $abilities;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		if ( ! post_type_exists( 'data_machine_events' ) ) {
+			Event_Post_Type::register();
+		}
+		if ( ! taxonomy_exists( 'venue' ) ) {
+			Venue_Taxonomy::register();
+		}
+		// `artist` is registered by extrachill-events in production. For the
+		// unit test we just need *a* second taxonomy attached to the event CPT
+		// so we can exercise the co-occurrence filter join.
+		if ( ! taxonomy_exists( 'artist' ) ) {
+			register_taxonomy(
+				'artist',
+				array( 'data_machine_events' ),
+				array(
+					'public'       => true,
+					'hierarchical' => false,
+					'rewrite'      => array( 'slug' => 'artist' ),
+				)
+			);
+		} else {
+			register_taxonomy_for_object_type( 'artist', 'data_machine_events' );
+		}
+
+		if ( ! EventDatesTable::table_exists() ) {
+			EventDatesTable::create_table();
+		}
+
+		$this->abilities = new UpcomingCountAbilities();
+	}
+
+	/**
+	 * Insert a published event, attach it to venue + (optional) artist terms,
+	 * and seed the event_dates table with a future datetime so it counts as
+	 * "upcoming".
+	 *
+	 * @param int      $venue_term_id  Venue term ID to attach.
+	 * @param int|null $artist_term_id Artist term ID to attach (optional).
+	 * @param string   $start_datetime MySQL datetime; defaults to far-future.
+	 * @return int Inserted post ID.
+	 */
+	private function seed_upcoming_event(
+		int $venue_term_id,
+		?int $artist_term_id = null,
+		string $start_datetime = '2099-01-01 20:00:00'
+	): int {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Event ' . uniqid(),
+				'post_type'   => 'data_machine_events',
+				'post_status' => 'publish',
+			)
+		);
+		$this->assertGreaterThan( 0, $post_id );
+
+		wp_set_object_terms( $post_id, array( $venue_term_id ), 'venue' );
+		if ( null !== $artist_term_id ) {
+			wp_set_object_terms( $post_id, array( $artist_term_id ), 'artist' );
+		}
+
+		EventDatesTable::upsert( $post_id, $start_datetime, null, 'publish' );
+
+		return $post_id;
+	}
+
+	private function make_venue( string $name ): int {
+		$term = wp_insert_term( $name . ' ' . uniqid(), 'venue' );
+		$this->assertNotWPError( $term );
+		return (int) $term['term_id'];
+	}
+
+	private function make_artist( string $name ): int {
+		$term = wp_insert_term( $name . ' ' . uniqid(), 'artist' );
+		$this->assertNotWPError( $term );
+		return (int) $term['term_id'];
+	}
+
+	/**
+	 * Regression: the unfiltered call must continue returning ALL venues
+	 * with any upcoming event. The pre-existing contract must not narrow.
+	 */
+	public function test_unfiltered_returns_all_venues_with_upcoming_events(): void {
+		$venue_a = $this->make_venue( 'Venue A' );
+		$venue_b = $this->make_venue( 'Venue B' );
+
+		$artist_one = $this->make_artist( 'Artist One' );
+
+		// 2 events at Venue A (both tagged Artist One).
+		$this->seed_upcoming_event( $venue_a, $artist_one );
+		$this->seed_upcoming_event( $venue_a, $artist_one );
+		// 1 event at Venue B (no artist tag).
+		$this->seed_upcoming_event( $venue_b, null );
+
+		$result = $this->abilities->executeGetUpcomingCounts(
+			array( 'taxonomy' => 'venue' )
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'venue', $result['taxonomy'] );
+		$this->assertSame( 2, $result['total'] );
+
+		$by_id = array();
+		foreach ( $result['terms'] as $row ) {
+			$by_id[ $row['term_id'] ] = $row['count'];
+		}
+		$this->assertArrayHasKey( $venue_a, $by_id );
+		$this->assertArrayHasKey( $venue_b, $by_id );
+		$this->assertSame( 2, $by_id[ $venue_a ] );
+		$this->assertSame( 1, $by_id[ $venue_b ] );
+	}
+
+	/**
+	 * Filtered call: scoping `taxonomy=venue` by `filter_taxonomy=artist` +
+	 * `filter_term_id=N` must return only venues that co-occur with that
+	 * artist on at least one upcoming event.
+	 */
+	public function test_filtered_returns_only_venues_cooccurring_with_filter_term(): void {
+		$venue_a = $this->make_venue( 'Venue A' );
+		$venue_b = $this->make_venue( 'Venue B' );
+		$venue_c = $this->make_venue( 'Venue C' );
+
+		$artist_target = $this->make_artist( 'Target Artist' );
+		$artist_other  = $this->make_artist( 'Other Artist' );
+
+		// 2 upcoming events at Venue A tagged Target Artist.
+		$this->seed_upcoming_event( $venue_a, $artist_target );
+		$this->seed_upcoming_event( $venue_a, $artist_target );
+		// 1 upcoming event at Venue B tagged Target Artist.
+		$this->seed_upcoming_event( $venue_b, $artist_target );
+		// 1 upcoming event at Venue C tagged ONLY Other Artist — must be excluded.
+		$this->seed_upcoming_event( $venue_c, $artist_other );
+
+		$result = $this->abilities->executeGetUpcomingCounts(
+			array(
+				'taxonomy'        => 'venue',
+				'filter_taxonomy' => 'artist',
+				'filter_term_id'  => $artist_target,
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 2, $result['total'] );
+
+		$by_id = array();
+		foreach ( $result['terms'] as $row ) {
+			$by_id[ $row['term_id'] ] = $row['count'];
+		}
+		$this->assertArrayHasKey( $venue_a, $by_id );
+		$this->assertArrayHasKey( $venue_b, $by_id );
+		$this->assertArrayNotHasKey( $venue_c, $by_id );
+		$this->assertSame( 2, $by_id[ $venue_a ] );
+		$this->assertSame( 1, $by_id[ $venue_b ] );
+	}
+
+	/**
+	 * Filter for a term that has no upcoming events at all must return
+	 * an empty terms array (not a WP_Error, not the unfiltered set).
+	 */
+	public function test_filter_with_no_cooccurrences_returns_empty_terms(): void {
+		$venue_a = $this->make_venue( 'Venue A' );
+
+		$artist_one      = $this->make_artist( 'Artist One' );
+		$artist_isolated = $this->make_artist( 'Isolated Artist' );
+
+		// All upcoming events are tagged Artist One only.
+		$this->seed_upcoming_event( $venue_a, $artist_one );
+		$this->seed_upcoming_event( $venue_a, $artist_one );
+
+		$result = $this->abilities->executeGetUpcomingCounts(
+			array(
+				'taxonomy'        => 'venue',
+				'filter_taxonomy' => 'artist',
+				'filter_term_id'  => $artist_isolated,
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 0, $result['total'] );
+		$this->assertSame( array(), $result['terms'] );
+	}
+
+	/**
+	 * Documented contract: providing only one of the filter pair is misuse
+	 * and returns a WP_Error('invalid_filter_pair'). This prevents callers
+	 * from silently getting unfiltered results when they thought they were
+	 * filtering.
+	 */
+	public function test_partial_filter_pair_returns_wp_error(): void {
+		$venue_a = $this->make_venue( 'Venue A' );
+		$this->seed_upcoming_event( $venue_a, null );
+
+		$only_taxonomy = $this->abilities->executeGetUpcomingCounts(
+			array(
+				'taxonomy'        => 'venue',
+				'filter_taxonomy' => 'artist',
+			)
+		);
+		$this->assertInstanceOf( \WP_Error::class, $only_taxonomy );
+		$this->assertSame( 'invalid_filter_pair', $only_taxonomy->get_error_code() );
+
+		$only_term = $this->abilities->executeGetUpcomingCounts(
+			array(
+				'taxonomy'       => 'venue',
+				'filter_term_id' => 42,
+			)
+		);
+		$this->assertInstanceOf( \WP_Error::class, $only_term );
+		$this->assertSame( 'invalid_filter_pair', $only_term->get_error_code() );
+	}
+
+	/**
+	 * A nonexistent filter taxonomy returns a distinct error code so
+	 * callers can differentiate a wiring bug from a usage bug.
+	 */
+	public function test_unknown_filter_taxonomy_returns_wp_error(): void {
+		$venue_a = $this->make_venue( 'Venue A' );
+		$this->seed_upcoming_event( $venue_a, null );
+
+		$result = $this->abilities->executeGetUpcomingCounts(
+			array(
+				'taxonomy'        => 'venue',
+				'filter_taxonomy' => 'no_such_taxonomy_exists',
+				'filter_term_id'  => 1,
+			)
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'invalid_filter_taxonomy', $result->get_error_code() );
+	}
+}


### PR DESCRIPTION
Refs Extra-Chill/extrachill-events#107.

## Summary

Extends `UpcomingCountAbilities::executeGetUpcomingCounts()` with an optional **co-occurrence filter pair** so callers can count terms in one taxonomy scoped to events that are *also* tagged with a specific term in another taxonomy.

This unlocks per-archive upcoming-events stats lines on the consuming sites, e.g.:

- **Artist archive:** `N upcoming events at N venues in N locations`
  - `taxonomy=venue + filter_taxonomy=artist + filter_term_id=N`
  - `taxonomy=location + filter_taxonomy=artist + filter_term_id=N`
- **Location archive:** `N upcoming events at N venues`
  - `taxonomy=venue + filter_taxonomy=location + filter_term_id=N`

## New input params

| Key | Type | Required | Notes |
|---|---|---|---|
| `filter_taxonomy` | string | with `filter_term_id` | `sanitize_key()` applied. Must be a registered taxonomy. |
| `filter_term_id` | integer | with `filter_taxonomy` | `absint()` applied. Must be > 0. |

Both must be provided together. **Misuse contract:** providing only one returns `WP_Error('invalid_filter_pair')` (HTTP 400) rather than silently falling back to the unfiltered query — wiring bugs surface immediately instead of hiding as 'no filter applied' results.

A nonexistent `filter_taxonomy` returns the distinct code `invalid_filter_taxonomy` so callers can differentiate usage bugs from registration bugs.

## SQL extension

When both filter params are provided, the query gains two additional INNER JOINs scoped with `f_tr` / `f_tt` aliases:

```sql
INNER JOIN {term_relationships} f_tr ON f_tr.object_id = tr.object_id
INNER JOIN {term_taxonomy}      f_tt ON f_tr.term_taxonomy_id = f_tt.term_taxonomy_id
WHERE ...
  AND f_tt.taxonomy = %s
  AND f_tt.term_id  = %d
```

All values flow through `$wpdb->prepare()` — no interpolation of caller-supplied data. Table prefixes use `$wpdb->term_relationships` / `$wpdb->term_taxonomy` (multisite-safe).

## Backward-compatibility guarantee

When `filter_taxonomy` / `filter_term_id` are not provided, the unfiltered SQL branch is **byte-identical** to the pre-existing query. Existing callers (VenueMapAbilities, calendar-stats consumers, etc.) keep working unchanged. No widening of the existing contract.

The ability has no internal cache, so no cache-key updates were needed; consumers that wrap this ability with their own cache (e.g. extrachill-events follow-up PR) must include the new params in their key.

## Before / after

Suppose Venue A has 2 upcoming events (both tagged Artist X), Venue B has 1 upcoming event (Artist X), Venue C has 1 upcoming event (Artist Y).

**Unfiltered** (existing behavior, unchanged):
```php
executeGetUpcomingCounts([ 'taxonomy' => 'venue' ])
// → total: 3, terms: [A=2, B=1, C=1]
```

**Filtered to Artist X**:
```php
executeGetUpcomingCounts([
    'taxonomy'        => 'venue',
    'filter_taxonomy' => 'artist',
    'filter_term_id'  => $artist_x_id,
])
// → total: 2, terms: [A=2, B=1]   // Venue C dropped — never co-occurs with Artist X
```

## Tests

`tests/Unit/UpcomingCountAbilitiesTest.php` covers:

- **Regression:** unfiltered call returns all venues with upcoming events and the existing shape.
- **Filtered call:** returns only venues co-occurring with the filter term, with correct per-term counts.
- **Empty co-occurrence:** filter for a term with zero upcoming events returns `success: true, total: 0, terms: []` (not WP_Error, not unfiltered set).
- **Partial filter pair:** providing only `filter_taxonomy` or only `filter_term_id` returns `WP_Error('invalid_filter_pair')`.
- **Unknown filter taxonomy:** returns `WP_Error('invalid_filter_taxonomy')`.

Mirrors the existing `VenueStatsAbilitiesTest` direct-execute pattern.

## Out of scope

- No new ability, no public function wrapper, no REST controller changes, no caching infra changes.
- The extrachill-events follow-up PR (per-archive stats block) consumes this directly via `new UpcomingCountAbilities()->executeGetUpcomingCounts(...)`, same pattern as `calendar-stats.php`.

mention <@532385681268408341> when ready for review