### PR TITLE
style(calendar): tighten date-group + time-gap chrome on sparse archives

### DIFF
--- a/inc/Blocks/Calendar/style.css
+++ b/inc/Blocks/Calendar/style.css
@@ -839,12 +839,12 @@
 /* Date Group Container */
 .data-machine-events-calendar .data-machine-date-group {
     display: block;
-    margin-bottom: 1.25rem;
+    margin-bottom: 0.5rem;
     border-radius: var(--data-machine-border-radius);
     border: 1px solid var(--data-machine-border-light);
     position: relative;
-    padding-top: 40px;
-    padding-bottom: 2.5rem;
+    padding-top: 24px;
+    padding-bottom: 1rem;
 }
 
 /* Day-specific border colors for date groups */
@@ -861,7 +861,7 @@
     display: flex;
     flex-wrap: nowrap;
     gap: var(--data-machine-grid-gap);
-    padding: 1.5rem;
+    padding: 0.75rem;
     overflow-x: auto;
     scroll-behavior: smooth;
     -webkit-overflow-scrolling: touch;
@@ -905,7 +905,7 @@
     content: 'More';
     position: absolute;
     right: 0;
-    top: 40px;
+    top: 24px;
     bottom: 0;
     width: 60px;
     background: linear-gradient(to right, transparent, var(--data-machine-scroll-gradient-color) 70%);
@@ -1191,7 +1191,7 @@
 .data-machine-time-gap-separator {
     display: flex;
     align-items: center;
-    margin: 2rem 0;
+    margin: 1rem 0;
     opacity: 0.7;
     position: relative;
 }
@@ -1210,9 +1210,9 @@
 
 .data-machine-gap-text {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     align-items: center;
-    gap: 0.25rem;
+    gap: 0.75rem;
     padding: 0 1.5rem;
     background: var(--data-machine-background-primary);
     position: relative;
@@ -1238,7 +1238,7 @@
 /* Responsive adjustments */
 @media (max-width: 768px) {
     .data-machine-time-gap-separator {
-        margin: 1.5rem 0;
+        margin: 0.75rem 0;
     }
 
     .data-machine-gap-text {

--- a/inc/Blocks/Calendar/templates/time-gap-separator.php
+++ b/inc/Blocks/Calendar/templates/time-gap-separator.php
@@ -23,8 +23,9 @@ if ( 2 == $gap_days ) {
 <div class="data-machine-time-gap-separator">
 	<div class="data-machine-gap-line"></div>
 	<div class="data-machine-gap-text">
-		<span class="data-machine-gap-indicator">• • •</span>
+		<span class="data-machine-gap-indicator" aria-hidden="true">• • •</span>
 		<span class="data-machine-gap-label"><?php echo esc_html( $gap_text ); ?></span>
+		<span class="data-machine-gap-indicator" aria-hidden="true">• • •</span>
 	</div>
 	<div class="data-machine-gap-line"></div>
 </div>


### PR DESCRIPTION
Closes #308.

## Summary

Density pass on the calendar's date-group chrome + time-gap chip so sparse archives (artists/venues with 1–2 events spread across a week) stop burning ~100px between date groups. Pure CSS + one PHP template rewrite — no PHP logic changes, no JS, no build.

## Changes

### `inc/Blocks/Calendar/style.css`

**`.data-machine-date-group` (date-group container):**
- `padding-top`: 40px → **24px**
- `padding-bottom`: 2.5rem → **1rem**
- `margin-bottom`: 1.25rem → **0.5rem**

**`.data-machine-date-group .data-machine-events-wrapper` (inner carousel wrapper):**
- `padding`: 1.5rem → **0.75rem**
- `flex-wrap: nowrap`, `overflow-x: auto`, `scroll-behavior: smooth` untouched — multi-event horizontal carousels still scroll.

**`.data-machine-date-group::after` ("More" overflow indicator):**
- `top`: 40px → **24px** (moves in lockstep with date-group padding-top so the indicator stays aligned with the wrapper).
- Mobile override at `top: 36px` deliberately **not** changed — that value is anchored to mobile `.data-machine-day-header { top: 10px }` + badge height (~26px), not the desktop padding-top.

**`.data-machine-time-gap-separator` (gap chip outer):**
- `margin`: 2rem 0 → **1rem 0** (halved breathing room around the chip).

**`.data-machine-gap-text` (gap chip inner flex):**
- `flex-direction`: column → **row** (matches new inline template).
- `gap`: 0.25rem → **0.75rem** (tuned for horizontal spacing between the two dot spans and the label; old 0.25rem was vertical-spacing tuned).
- `padding: 0 1.5rem` and `background: var(--data-machine-background-primary)` preserved — chip stays readable against the gradient line behind it.

**Mobile media query (`@media (max-width: 768px)`):**
- `.data-machine-time-gap-separator { margin: 1.5rem 0 }` → **`0.75rem 0`** (proportional reduction matching desktop).
- `.data-machine-gap-text { padding: 0 1rem }` left as-is (inline layout fits mobile widths).
- `.data-machine-gap-indicator { font-size: 1rem; letter-spacing: 0.3rem }` left as-is.

### `inc/Blocks/Calendar/templates/time-gap-separator.php`

Markup change from STACKED (one dot span above label) to INLINE (two dot spans flanking the label):

```html
<div class="data-machine-time-gap-separator">
  <div class="data-machine-gap-line"></div>
  <div class="data-machine-gap-text">
    <span class="data-machine-gap-indicator" aria-hidden="true">• • •</span>
    <span class="data-machine-gap-label">2 DAYS LATER</span>
    <span class="data-machine-gap-indicator" aria-hidden="true">• • •</span>
  </div>
  <div class="data-machine-gap-line"></div>
</div>
```

- `aria-hidden="true"` on both decorative dot spans so screen readers only announce the label ("2 days later").
- `gap_text` PHP branching (`2 == $gap_days` → "1 day later", else `"%d days later"`) preserved verbatim.

## Day-badge clipping verification

The day badge is `position: absolute; top: 14px` per `.data-machine-events-calendar .data-machine-day-header`. Reading the badge tokens in `inc/Blocks/root.css`:

- `--data-machine-badge-font-size: 0.75rem` (12px)
- `--data-machine-badge-padding-y: 0.25rem` (4px top + 4px bottom = 8px)
- Default line-height ~1.4 → text line box ~17px

**Computed badge height: ~25–26px.** Badge top edge at 14px → bottom edge at ~39–40px.

With new `padding-top: 24px`, the badge's lower ~15px overlaps the events-wrapper start. Because `.data-machine-day-header` is `z-index: 2` and the new `.data-machine-events-wrapper` has `padding: 0.75rem` (12px), the badge bottom (~40px) sits on top of the wrapper but largely within the wrapper's top padding zone (24px padding + 12px wrapper-padding = 36px clean before cards start; badge overlaps ~4px into card region).

**Spot-check ask for the reviewer:** confirm visually on `https://events.extrachill.com/artist/theo-katzman/` that the day badge does not visually clash with event card tops. If it clips, bump `.data-machine-date-group { padding-top: 24px → 28px }` and `.data-machine-date-group::after { top: 24px → 28px }` in lockstep, as the issue spec calls out.

## Acceptance criteria checklist

- [x] Date-group chrome reduced across all four levers (padding-top, padding-bottom, margin-bottom, inner wrapper padding).
- [x] Gap chip renders on a single line: `• • •   2 DAYS LATER   • • •` (template + CSS both flipped to inline).
- [x] `flex-wrap`, `overflow-x`, `scroll-behavior` on `.data-machine-events-wrapper` untouched — multi-event carousels still scroll.
- [x] Day-specific border colors, multi-day continuation, event-item card styling, `DateGrouper.php` all untouched.
- [x] `.data-machine-date-group::after` `top` moved in lockstep with `padding-top` so "More" indicator stays aligned.
- [x] Mobile media query gap-margin reduced proportionally (1.5rem → 0.75rem).
- [x] No new utility classes or selectors added beyond the second `.data-machine-gap-indicator` span.
- [ ] **Reviewer:** verify on a real sparse archive that both date groups + gap chip fit on a 13-inch laptop above the fold.
- [ ] **Reviewer:** verify day badge does not visually clip against the new 24px padding-top (math suggests ~4px overlap into card region — looks fine in theory, needs eyeballs).

mention <@532385681268408341> when complete and ready for review