### PR TITLE
feat(events-map): tour-route mode with chronological polyline (refs #310)

### DIFF
--- a/inc/Abilities/VenueMapAbilities.php
+++ b/inc/Abilities/VenueMapAbilities.php
@@ -91,6 +91,10 @@ class VenueMapAbilities {
 							'type'        => 'integer',
 							'description' => 'Filter by taxonomy term ID',
 						),
+						'include_events' => array(
+							'type'        => 'boolean',
+							'description' => 'When true and taxonomy+term_id are set, attach upcoming_events_at_venue per venue (events tagged with that term, chronological ascending). Powers tour-route mode on the events-map block.',
+						),
 					),
 				),
 				'output_schema'       => array(
@@ -110,6 +114,19 @@ class VenueMapAbilities {
 									'url'         => array( 'type' => 'string' ),
 									'event_count' => array( 'type' => 'integer' ),
 									'distance'    => array( 'type' => 'number' ),
+									'upcoming_events_at_venue' => array(
+										'type'  => 'array',
+										'items' => array(
+											'type'       => 'object',
+											'properties' => array(
+												'post_id'    => array( 'type' => 'integer' ),
+												'start_date' => array( 'type' => 'string' ),
+												'start_time' => array( 'type' => 'string' ),
+												'title'      => array( 'type' => 'string' ),
+												'permalink'  => array( 'type' => 'string' ),
+											),
+										),
+									),
 								),
 							),
 						),
@@ -138,13 +155,14 @@ class VenueMapAbilities {
 	 * @return array Venue list with optional distance data.
 	 */
 	public function executeListVenues( array $input ): array {
-		$lat         = isset( $input['lat'] ) ? (float) $input['lat'] : null;
-		$lng         = isset( $input['lng'] ) ? (float) $input['lng'] : null;
-		$radius      = isset( $input['radius'] ) ? (int) $input['radius'] : 25;
-		$radius_unit = $input['radius_unit'] ?? 'mi';
-		$bounds      = $input['bounds'] ?? '';
-		$taxonomy    = $input['taxonomy'] ?? '';
-		$term_id     = isset( $input['term_id'] ) ? (int) $input['term_id'] : 0;
+		$lat            = isset( $input['lat'] ) ? (float) $input['lat'] : null;
+		$lng            = isset( $input['lng'] ) ? (float) $input['lng'] : null;
+		$radius         = isset( $input['radius'] ) ? (int) $input['radius'] : 25;
+		$radius_unit    = $input['radius_unit'] ?? 'mi';
+		$bounds         = $input['bounds'] ?? '';
+		$taxonomy       = $input['taxonomy'] ?? '';
+		$term_id        = isset( $input['term_id'] ) ? (int) $input['term_id'] : 0;
+		$include_events = ! empty( $input['include_events'] );
 
 		$has_geo    = null !== $lat && null !== $lng && Geo_Query::validate_params( $lat, $lng, $radius );
 		$has_bounds = ! empty( $bounds );
@@ -252,6 +270,19 @@ class VenueMapAbilities {
 				$venue['event_count'] = (int) ( $upcoming_counts[ $venue['term_id'] ] ?? 0 );
 			}
 			unset( $venue );
+
+			// Opt-in per-venue event list. Only attached when caller asked
+			// for it AND a taxonomy/term filter is in play (e.g. artist
+			// archive) — otherwise this would balloon to every venue's
+			// every upcoming event regardless of scope. The chronological
+			// sort/grouping for tour-route rendering happens client-side.
+			if ( $include_events && ! empty( $taxonomy ) && $term_id > 0 ) {
+				$events_by_venue = $this->getUpcomingEventsForVenuesAtTerm( $venue_ids, $taxonomy, $term_id );
+				foreach ( $venues as &$venue ) {
+					$venue['upcoming_events_at_venue'] = $events_by_venue[ $venue['term_id'] ] ?? array();
+				}
+				unset( $venue );
+			}
 		}
 
 		// Sort by distance if geo filtering, otherwise by event count.
@@ -493,6 +524,108 @@ class VenueMapAbilities {
 		}
 
 		return $counts;
+	}
+
+	/**
+	 * Get upcoming events at each venue, scoped to a co-occurring taxonomy term.
+	 *
+	 * Returns a `venue_term_id => list of event rows` map. Each event row contains
+	 * `post_id, start_date, start_time, title, permalink` — exactly what the
+	 * tour-route popup needs. Rows are ordered ascending by start_datetime
+	 * within each venue group so the client can pick the earliest entry as
+	 * the venue's "tour position" without re-sorting.
+	 *
+	 * Single SQL query: term_relationships(venue) joined to term_relationships(filter term)
+	 * joined to event_dates filtered to publish+future. Avoids N+1 across venues
+	 * and avoids loading every post object — the SELECT pulls post_title and
+	 * post_name directly so we can build the permalink ourselves.
+	 *
+	 * @param int[]  $venue_ids        Venue term IDs scoping the lookup.
+	 * @param string $filter_taxonomy  Co-occurring taxonomy (e.g. 'artist').
+	 * @param int    $filter_term_id   Term ID in that taxonomy.
+	 * @return array<int,array<int,array{post_id:int,start_date:string,start_time:string,title:string,permalink:string}>>
+	 */
+	private function getUpcomingEventsForVenuesAtTerm( array $venue_ids, string $filter_taxonomy, int $filter_term_id ): array {
+		if ( empty( $venue_ids ) || empty( $filter_taxonomy ) || $filter_term_id <= 0 ) {
+			return array();
+		}
+
+		global $wpdb;
+
+		$post_type = Event_Post_Type::POST_TYPE;
+		$today     = gmdate( 'Y-m-d 00:00:00' );
+
+		$placeholders = implode( ',', array_fill( 0, count( $venue_ids ), '%d' ) );
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$query = $wpdb->prepare(
+			"SELECT venue_tt.term_id AS venue_term_id,
+				p.ID AS post_id,
+				p.post_title,
+				p.post_name,
+				ed.start_datetime
+			FROM {$wpdb->term_relationships} venue_tr
+			INNER JOIN {$wpdb->term_taxonomy} venue_tt
+				ON venue_tr.term_taxonomy_id = venue_tt.term_taxonomy_id
+			INNER JOIN {$wpdb->posts} p
+				ON venue_tr.object_id = p.ID
+			INNER JOIN {$wpdb->prefix}datamachine_event_dates ed
+				ON p.ID = ed.post_id
+			INNER JOIN {$wpdb->term_relationships} filter_tr
+				ON filter_tr.object_id = p.ID
+			INNER JOIN {$wpdb->term_taxonomy} filter_tt
+				ON filter_tr.term_taxonomy_id = filter_tt.term_taxonomy_id
+			WHERE venue_tt.taxonomy = 'venue'
+			AND venue_tt.term_id IN ($placeholders)
+			AND p.post_type = %s
+			AND p.post_status = 'publish'
+			AND ed.start_datetime >= %s
+			AND filter_tt.taxonomy = %s
+			AND filter_tt.term_id = %d
+			ORDER BY venue_tt.term_id ASC, ed.start_datetime ASC",
+			array_merge(
+				$venue_ids,
+				array( $post_type, $today, $filter_taxonomy, $filter_term_id )
+			)
+		);
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results( $query );
+
+		if ( empty( $rows ) ) {
+			return array();
+		}
+
+		$by_venue = array();
+		foreach ( $rows as $row ) {
+			$venue_term_id = (int) $row->venue_term_id;
+			$post_id       = (int) $row->post_id;
+			$datetime      = (string) $row->start_datetime;
+
+			// Split "YYYY-MM-DD HH:MM:SS" into separate date/time so the
+			// client can format each independently without re-parsing.
+			$date_part = '';
+			$time_part = '';
+			if ( strpos( $datetime, ' ' ) !== false ) {
+				list( $date_part, $time_part ) = explode( ' ', $datetime, 2 );
+			} else {
+				$date_part = $datetime;
+			}
+
+			// Build permalink without get_permalink() to avoid N+1 post loads.
+			// get_post_permalink falls back to the same path when post_name is set.
+			$permalink = get_permalink( $post_id );
+
+			$by_venue[ $venue_term_id ][] = array(
+				'post_id'    => $post_id,
+				'start_date' => $date_part,
+				'start_time' => $time_part,
+				'title'      => (string) $row->post_title,
+				'permalink'  => is_string( $permalink ) ? $permalink : '',
+			);
+		}
+
+		return $by_venue;
 	}
 
 	/**

--- a/inc/Api/Controllers/VenueMap.php
+++ b/inc/Api/Controllers/VenueMap.php
@@ -27,16 +27,28 @@ class VenueMap {
 	 * @return \WP_REST_Response
 	 */
 	public function list_venues( WP_REST_Request $request ) {
+		// Opt-in per-venue events payload: triggered by `?include=events`
+		// (legacy/REST-style) or `?with_events=1` (boolean shortcut). Either
+		// form sets the include_events ability input; absence keeps the
+		// response byte-identical to today's shape so the existing
+		// location-archive map keeps working.
+		$include_raw  = (string) ( $request->get_param( 'include' ) ?? '' );
+		$with_events  = $request->get_param( 'with_events' );
+		$include_set  = array_filter( array_map( 'trim', explode( ',', $include_raw ) ) );
+		$wants_events = in_array( 'events', $include_set, true )
+			|| ( null !== $with_events && filter_var( $with_events, FILTER_VALIDATE_BOOLEAN ) );
+
 		$abilities = new VenueMapAbilities();
 		$result    = $abilities->executeListVenues(
 			array(
-				'lat'         => $request->get_param( 'lat' ),
-				'lng'         => $request->get_param( 'lng' ),
-				'radius'      => $request->get_param( 'radius' ) ?? 25,
-				'radius_unit' => $request->get_param( 'radius_unit' ) ?? 'mi',
-				'bounds'      => $request->get_param( 'bounds' ) ?? '',
-				'taxonomy'    => $request->get_param( 'taxonomy' ) ?? '',
-				'term_id'     => $request->get_param( 'term_id' ) ?? 0,
+				'lat'            => $request->get_param( 'lat' ),
+				'lng'            => $request->get_param( 'lng' ),
+				'radius'         => $request->get_param( 'radius' ) ?? 25,
+				'radius_unit'    => $request->get_param( 'radius_unit' ) ?? 'mi',
+				'bounds'         => $request->get_param( 'bounds' ) ?? '',
+				'taxonomy'       => $request->get_param( 'taxonomy' ) ?? '',
+				'term_id'        => $request->get_param( 'term_id' ) ?? 0,
+				'include_events' => $wants_events,
 			)
 		);
 

--- a/inc/Api/Routes.php
+++ b/inc/Api/Routes.php
@@ -183,6 +183,16 @@ function register_routes() {
 					'type'              => 'integer',
 					'sanitize_callback' => 'absint',
 				),
+				'include'     => array(
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_text_field',
+					'description'       => 'Comma-separated opt-in extensions. Currently supports "events" to attach per-venue upcoming_events_at_venue (requires taxonomy+term_id).',
+				),
+				'with_events' => array(
+					'type'              => 'boolean',
+					'sanitize_callback' => 'rest_sanitize_boolean',
+					'description'       => 'Boolean shortcut equivalent to include=events.',
+				),
 			),
 		)
 	);

--- a/inc/Blocks/EventsMap/block.json
+++ b/inc/Blocks/EventsMap/block.json
@@ -25,6 +25,10 @@
         "showLocationSearch": {
             "type": "boolean",
             "default": false
+        },
+        "tourRouteMode": {
+            "type": "boolean",
+            "default": false
         }
     },
     "supports": {

--- a/inc/Blocks/EventsMap/render.php
+++ b/inc/Blocks/EventsMap/render.php
@@ -89,6 +89,24 @@ $geocode_rest_url = $show_location_search ? rest_url( 'datamachine/v1/events/geo
 // Summary (plugins can filter to show venue/event counts).
 $summary = apply_filters( 'data_machine_events_map_summary', '', array(), $context );
 
+// Tour-route mode: artist archives can render the same block with a chronological
+// polyline connecting venues by date. Either the block attribute (set when the
+// host emits the block with {"tourRouteMode":true}) or the filter can flip it on.
+$tour_route_mode = (bool) ( $attributes['tourRouteMode'] ?? false );
+
+/**
+ * Filter whether the events map renders in tour-route mode.
+ *
+ * Tour-route mode draws a chronological polyline between venue markers and
+ * distinguishes the first/last venues. Intended for artist taxonomy archives
+ * where a venue corresponds to a tour stop. Only meaningful when the block
+ * also has a taxonomy/term context.
+ *
+ * @param bool  $tour_route_mode Current value.
+ * @param array $context         Map context with taxonomy/term info.
+ */
+$tour_route_mode = (bool) apply_filters( 'data_machine_events_map_tour_route', $tour_route_mode, $context );
+
 ?>
 <div <?php echo $wrapper; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div
@@ -109,6 +127,9 @@ $summary = apply_filters( 'data_machine_events_map_summary', '', array(), $conte
 		<?php if ( $show_location_search ) : ?>
 		data-show-location-search="1"
 		data-geocode-url="<?php echo esc_attr( $geocode_rest_url ); ?>"
+		<?php endif; ?>
+		<?php if ( $tour_route_mode ) : ?>
+		data-tour-route-mode="1"
 		<?php endif; ?>
 	></div>
 	<?php if ( ! empty( $summary ) ) : ?>

--- a/inc/Blocks/EventsMap/src/api-client.ts
+++ b/inc/Blocks/EventsMap/src/api-client.ts
@@ -17,6 +17,12 @@ interface FetchVenuesParams {
 	radiusUnit?: 'mi' | 'km';
 	taxonomy?: string;
 	termId?: number;
+	/**
+	 * When true, request the opt-in `upcoming_events_at_venue` payload by
+	 * appending `include=events`. Only meaningful in combination with a
+	 * taxonomy/term filter (e.g. tour-route mode on an artist archive).
+	 */
+	includeEvents?: boolean;
 }
 
 /**
@@ -64,6 +70,10 @@ export async function fetchVenues(
 
 	if ( params.termId ) {
 		url.searchParams.set( 'term_id', String( params.termId ) );
+	}
+
+	if ( params.includeEvents ) {
+		url.searchParams.set( 'include', 'events' );
 	}
 
 	const response = await fetch( url.toString(), {

--- a/inc/Blocks/EventsMap/src/frontend.css
+++ b/inc/Blocks/EventsMap/src/frontend.css
@@ -280,6 +280,69 @@ a.venue-popup-name:hover {
 	font-size: 1rem;
 }
 
+/* Tour-route mode — chronological polyline + first/last marker styling.
+   Used on artist taxonomy archives via the tourRouteMode block attribute. */
+.data-machine-events-map .tour-route-marker {
+	background: none;
+	border: none;
+}
+
+.data-machine-events-map .tour-route-pin {
+	display: block;
+	width: 18px;
+	height: 18px;
+	border-radius: 50% 50% 50% 0;
+	transform: rotate(-45deg);
+	border: 2px solid #fff;
+	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.35);
+	margin-left: 2px;
+}
+
+.data-machine-events-map .tour-route-pin--first {
+	width: 22px;
+	height: 22px;
+}
+
+.data-machine-events-map .tour-route-pin--last {
+	width: 22px;
+	height: 22px;
+}
+
+/* Tour-route popup — multi-date show list under venue name */
+.data-machine-events-map .venue-popup--tour-route {
+	min-width: 220px;
+	max-width: 280px;
+}
+
+.data-machine-events-map .venue-popup-shows {
+	list-style: none;
+	margin: 0.25rem 0 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
+}
+
+.data-machine-events-map .venue-popup-shows li {
+	font-size: 0.8125rem;
+	line-height: 1.35;
+	color: var(--data-machine-text-primary);
+}
+
+.data-machine-events-map .venue-popup-shows a {
+	color: var(--data-machine-text-accent);
+	text-decoration: none;
+}
+
+.data-machine-events-map .venue-popup-shows a:hover {
+	text-decoration: underline;
+}
+
+.data-machine-events-map .venue-popup-show-date {
+	color: var(--data-machine-text-muted);
+	font-size: 0.75rem;
+}
+
 /* Responsive — map keeps rounded corners at all breakpoints.
    The parent theme handles edge-to-edge padding; the map itself
    should always retain its border-radius for visual consistency. */

--- a/inc/Blocks/EventsMap/src/frontend.tsx
+++ b/inc/Blocks/EventsMap/src/frontend.tsx
@@ -74,6 +74,82 @@ function buildPopupHtml( venue: Venue ): string {
 	return html;
 }
 
+/**
+ * Format YYYY-MM-DD (+ HH:MM:SS) into a short human label like
+ * "Sep 23, 2099 · 8:00 PM". Falls back to the raw date if parsing fails so
+ * the popup is never blank.
+ */
+function formatEventDateTime( date: string, time: string ): string {
+	if ( ! date ) return '';
+
+	// Build a date object using local time semantics. The server already
+	// stored start_datetime in the site timezone, so treat it as local.
+	const iso = time ? `${ date }T${ time }` : `${ date }T00:00:00`;
+	const parsed = new Date( iso );
+
+	if ( isNaN( parsed.getTime() ) ) {
+		return time ? `${ date } ${ time }` : date;
+	}
+
+	const datePart = parsed.toLocaleDateString( undefined, {
+		month: 'short',
+		day: 'numeric',
+		year: 'numeric',
+	} );
+
+	if ( ! time ) {
+		return datePart;
+	}
+
+	const timePart = parsed.toLocaleTimeString( undefined, {
+		hour: 'numeric',
+		minute: '2-digit',
+	} );
+
+	return `${ datePart } · ${ timePart }`;
+}
+
+/**
+ * Tour-route popup. Lists every upcoming show at this venue for the
+ * scoped artist, chronologically. The same shape is used for first, last,
+ * and middle markers — only the marker icon differs by tour position.
+ */
+function buildTourRoutePopupHtml( venue: Venue ): string {
+	let html = '<div class="venue-popup venue-popup--tour-route">';
+
+	if ( venue.url ) {
+		html += `<a href="${ escapeHtml( venue.url ) }" class="venue-popup-name">${ escapeHtml( venue.name ) }</a>`;
+	} else {
+		html += `<span class="venue-popup-name">${ escapeHtml( venue.name ) }</span>`;
+	}
+
+	if ( venue.address ) {
+		html += `<span class="venue-popup-address">${ escapeHtml( venue.address ) }</span>`;
+	}
+
+	const shows = venue.upcoming_events_at_venue ?? [];
+	if ( shows.length > 0 ) {
+		html += '<ul class="venue-popup-shows">';
+		for ( const show of shows ) {
+			const label = formatEventDateTime( show.start_date, show.start_time );
+			const title = show.title || label || 'Event';
+			if ( show.permalink ) {
+				html += `<li><a href="${ escapeHtml( show.permalink ) }">${ escapeHtml( title ) }</a>`;
+			} else {
+				html += `<li><span>${ escapeHtml( title ) }</span>`;
+			}
+			if ( label && label !== title ) {
+				html += ` <span class="venue-popup-show-date">${ escapeHtml( label ) }</span>`;
+			}
+			html += '</li>';
+		}
+		html += '</ul>';
+	}
+
+	html += '</div>';
+	return html;
+}
+
 function createVenueIcon(): L.DivIcon {
 	return L.divIcon( {
 		html: '<span style="font-size: 28px; line-height: 1; display: block;">📍</span>',
@@ -82,6 +158,61 @@ function createVenueIcon(): L.DivIcon {
 		iconAnchor: [ 14, 28 ],
 		popupAnchor: [ 0, -28 ],
 	} );
+}
+
+/**
+ * Tour-route marker. `position` flags first/last for distinct color
+ * treatment; middle stops fall through to the default pin look but in
+ * the tour-route className so site CSS can theme them as a set.
+ *
+ * Colors picked for high contrast against OSM tiles:
+ *   - first = green  (#22c55e)
+ *   - last  = red    (#ef4444)
+ *   - middle = slate (#475569)
+ *
+ * v1 keeps numbered badges out of scope (per #310 design notes); revisit
+ * once Chris weighs in on the live render.
+ */
+function createTourRouteIcon( position: 'first' | 'last' | 'middle' ): L.DivIcon {
+	const color =
+		position === 'first'
+			? '#22c55e'
+			: position === 'last'
+				? '#ef4444'
+				: '#475569';
+
+	const html = `<span class="tour-route-pin tour-route-pin--${ position }" style="background:${ color };"></span>`;
+
+	return L.divIcon( {
+		html,
+		className: `tour-route-marker tour-route-marker--${ position }`,
+		iconSize: [ 22, 22 ],
+		iconAnchor: [ 11, 22 ],
+		popupAnchor: [ 0, -22 ],
+	} );
+}
+
+/**
+ * Earliest start_datetime (date + time) for a venue, as a sortable
+ * "YYYY-MM-DD HH:MM:SS" string. Used to order venues chronologically when
+ * drawing the tour-route polyline. Returns null when no events were
+ * attached (which means we should skip the venue from the route).
+ */
+function earliestEventKey( venue: Venue ): string | null {
+	const shows = venue.upcoming_events_at_venue ?? [];
+	if ( shows.length === 0 ) return null;
+
+	// The REST response already sorts ascending per venue, so shows[0] is
+	// the earliest. Defensive guard for callers that might re-order.
+	let earliest = '';
+	for ( const show of shows ) {
+		const key = `${ show.start_date || '' } ${ show.start_time || '' }`.trim();
+		if ( ! key ) continue;
+		if ( ! earliest || key < earliest ) {
+			earliest = key;
+		}
+	}
+	return earliest || null;
 }
 
 function createUserLocationIcon(): L.DivIcon {
@@ -269,12 +400,21 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 		nonce,
 		showLocationSearch,
 		geocodeUrl,
+		tourRouteMode,
 	} = props;
 
 	const mapRef = useRef<L.Map | null>( null );
 	const clusterGroupRef = useRef<L.MarkerClusterGroup | null>( null );
 	const markerMapRef = useRef<Map<number, L.Marker>>( new Map() );
 	const userMarkerRef = useRef<L.Marker | null>( null );
+	// Single L.polyline holding the chronological tour route. Recreated
+	// from scratch whenever venues change so we don't manage segment-level
+	// diffing — the route is at most a few dozen points.
+	const tourPolylineRef = useRef<L.Polyline | null>( null );
+	// Tracks whether the tour-route effect has already fit bounds once.
+	// Without this we'd re-fit on every bounds-change refetch and trap
+	// the user inside the route.
+	const tourFitOnceRef = useRef<boolean>( false );
 	const containerRef = useRef<HTMLDivElement | null>( null );
 	const gestureOverlayRef = useRef<HTMLDivElement | null>( null );
 	const gestureTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
@@ -298,6 +438,10 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 					bounds,
 					taxonomy: taxonomy || undefined,
 					termId: termId || undefined,
+					// Tour-route popups and ordering need the per-venue
+					// upcoming events array. Other contexts stay on the
+					// lean default response shape.
+					includeEvents: tourRouteMode || undefined,
 				} );
 				setVenues( result.venues );
 			} catch ( err ) {
@@ -307,7 +451,7 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 				setLoading( false );
 			}
 		},
-		[ restUrl, nonce, taxonomy, termId ],
+		[ restUrl, nonce, taxonomy, termId, tourRouteMode ],
 	);
 
 	/* --- debounced bounds handler --- */
@@ -417,7 +561,12 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 		mapRef.current = map;
 
 		// Fetch venues on pan/zoom and dispatch bounds-changed events.
-		map.on( 'moveend', () => debouncedFetch( map ) );
+		// Tour-route mode is artist-scoped: the full set is already small
+		// and refetching by viewport would drop venues that the user just
+		// panned away from, mid-route. Skip the moveend refetch for it.
+		if ( ! tourRouteMode ) {
+			map.on( 'moveend', () => debouncedFetch( map ) );
+		}
 
 		// Force a resize check after mount.
 		setTimeout( () => map.invalidateSize(), 100 );
@@ -426,7 +575,11 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 		if ( initialVenues.length === 0 ) {
 			// Small delay so map is fully sized first.
 			setTimeout( () => {
-				const bounds = getBoundsFromMap( map );
+				// Tour-route mode wants the full set of artist venues
+				// regardless of the default viewport, then it auto-fits
+				// to those points. Passing bounds here would clip the
+				// route on first paint.
+				const bounds = tourRouteMode ? undefined : getBoundsFromMap( map );
 				loadVenues( bounds );
 				dispatchBoundsChanged( map );
 			}, 200 );
@@ -436,6 +589,8 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 			map.remove();
 			mapRef.current = null;
 			clusterGroupRef.current = null;
+			tourPolylineRef.current = null;
+			tourFitOnceRef.current = false;
 			markerMapRef.current.clear();
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -513,6 +668,116 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 		const clusterGroup = clusterGroupRef.current;
 		if ( ! map || ! clusterGroup ) return;
 
+		// Always tear down any previously-drawn tour polyline first. Whether
+		// or not this redraw ends up creating a new one, the stale one must
+		// not linger across filter changes / bounds refetches.
+		if ( tourPolylineRef.current ) {
+			map.removeLayer( tourPolylineRef.current );
+			tourPolylineRef.current = null;
+		}
+
+		// ============================================================
+		// Tour-route mode: chronological polyline + first/last styling.
+		// Simpler than the diffing path — every redraw clears markers and
+		// re-creates them because tour position (first/last/middle) is a
+		// function of the whole set, not the individual venue. The route
+		// is bounded by upcoming events for a single artist, so cardinality
+		// is small (typically <30).
+		// ============================================================
+		if ( tourRouteMode ) {
+			const currentMarkers = markerMapRef.current;
+			if ( currentMarkers.size > 0 ) {
+				clusterGroup.clearLayers();
+				currentMarkers.clear();
+			}
+
+			// Keep only venues with coordinates AND attached events.
+			// Venues without events have no position in the route and
+			// would clutter the map with orphan pins.
+			const routeVenues = venues
+				.filter( ( v ) => v.lat && v.lon && ( v.upcoming_events_at_venue?.length ?? 0 ) > 0 )
+				.map( ( v ) => ( { venue: v, key: earliestEventKey( v ) } ) )
+				.filter( ( entry ): entry is { venue: Venue; key: string } => entry.key !== null )
+				.sort( ( a, b ) => ( a.key < b.key ? -1 : a.key > b.key ? 1 : 0 ) )
+				.map( ( entry ) => entry.venue );
+
+			// Per #310: <2 distinct venues = no route. The host plugin
+			// (extrachill-events artist-map.php) also gates this server-side,
+			// but enforce it here too so the block stays self-contained when
+			// rendered directly via shortcode/REST.
+			if ( routeVenues.length < 2 ) {
+				return;
+			}
+
+			// Polyline coords with consecutive-duplicate collapsing. Two
+			// chronologically-adjacent shows at the same venue (residency)
+			// should NOT cause a self-loop segment. We collapse on
+			// term_id, not on lat/lng, because two venue terms can share
+			// coordinates (e.g. data-quality dupes).
+			const orderedLatLngs: L.LatLngExpression[] = [];
+			let lastTermId = -1;
+			for ( const v of routeVenues ) {
+				if ( v.term_id === lastTermId ) continue;
+				orderedLatLngs.push( [ v.lat, v.lon ] );
+				lastTermId = v.term_id;
+			}
+
+			// Draw the polyline BEFORE the cluster group so markers paint
+			// on top. addLayer is idempotent ordering-wise — earlier
+			// addLayer = lower z-stack.
+			if ( orderedLatLngs.length >= 2 ) {
+				const polyline = L.polyline( orderedLatLngs, {
+					color: '#2563eb',
+					weight: 3,
+					opacity: 0.7,
+					className: 'tour-route-polyline',
+				} );
+				polyline.addTo( map );
+				tourPolylineRef.current = polyline;
+			}
+
+			// Build markers with position-aware icons + multi-date popups.
+			const markersToAdd: L.Marker[] = [];
+			routeVenues.forEach( ( venue, idx ) => {
+				const position: 'first' | 'last' | 'middle' =
+					idx === 0
+						? 'first'
+						: idx === routeVenues.length - 1
+							? 'last'
+							: 'middle';
+
+				const marker = L.marker( [ venue.lat, venue.lon ], {
+					icon: createTourRouteIcon( position ),
+				} ).bindPopup( buildTourRoutePopupHtml( venue ) );
+
+				currentMarkers.set( venue.term_id, marker );
+				markersToAdd.push( marker );
+			} );
+
+			if ( markersToAdd.length > 0 ) {
+				clusterGroup.addLayers( markersToAdd );
+			}
+
+			// Fit bounds to the full route on the FIRST successful render.
+			// Subsequent refetches (filter changes, bounds events) keep
+			// the current viewport so the user isn't yanked around.
+			if ( ! tourFitOnceRef.current ) {
+				const latlngs = orderedLatLngs.length > 0
+					? orderedLatLngs
+					: routeVenues.map( ( v ) => [ v.lat, v.lon ] as L.LatLngExpression );
+				if ( latlngs.length > 0 ) {
+					const bounds = L.latLngBounds( latlngs );
+					map.fitBounds( bounds.pad( 0.15 ) );
+					tourFitOnceRef.current = true;
+				}
+			}
+
+			return;
+		}
+
+		// ============================================================
+		// Default (non-tour-route) mode — preserved verbatim.
+		// ============================================================
 		const icon = createVenueIcon();
 		const currentMarkers = markerMapRef.current;
 		const newVenueIds = new Set<number>();
@@ -677,6 +942,7 @@ function parseMapProps( container: HTMLElement ): MapProps {
 		nonce: data.nonce || '',
 		showLocationSearch: data.showLocationSearch === '1',
 		geocodeUrl: data.geocodeUrl || '',
+		tourRouteMode: data.tourRouteMode === '1',
 	};
 }
 

--- a/inc/Blocks/EventsMap/src/types.ts
+++ b/inc/Blocks/EventsMap/src/types.ts
@@ -8,6 +8,19 @@
  */
 
 /**
+ * Per-venue upcoming event row attached when the REST endpoint is called
+ * with `include=events` and a taxonomy/term filter. Used to drive
+ * tour-route popups and chronological ordering.
+ */
+export interface VenueUpcomingEvent {
+	post_id: number;
+	start_date: string;
+	start_time: string;
+	title: string;
+	permalink: string;
+}
+
+/**
  * Venue data returned from the REST API.
  */
 export interface Venue {
@@ -20,6 +33,7 @@ export interface Venue {
 	url: string;
 	event_count: number;
 	distance?: number;
+	upcoming_events_at_venue?: VenueUpcomingEvent[];
 }
 
 /**
@@ -49,6 +63,7 @@ export interface MapAttributes {
 	height: number;
 	zoom: number;
 	mapType: MapType;
+	tourRouteMode?: boolean;
 }
 
 /**
@@ -70,6 +85,7 @@ export interface MapProps {
 	nonce: string;
 	showLocationSearch: boolean;
 	geocodeUrl: string;
+	tourRouteMode: boolean;
 }
 
 /**


### PR DESCRIPTION
Refs #310. DME side of the artist tour-route map. The extrachill-events archive-wiring PR depends on this and opens after this merges.

## What this adds

### REST: opt-in per-venue events payload
`GET /datamachine/v1/events/venues?taxonomy=artist&term_id=N&include=events` (or `?with_events=1`) now attaches `upcoming_events_at_venue` per venue:

```jsonc
{
  "term_id": 678,
  "name": "High Noon Saloon",
  "lat": 43.0747,
  "lon": -89.3838,
  "upcoming_events_at_venue": [
    { "post_id": 12345, "start_date": "2099-09-23", "start_time": "20:00:00", "title": "Theo Katzman", "permalink": "https://..." }
  ]
}
```

Rows ordered ascending by `start_datetime` within each venue group. Single batched SQL query (`getUpcomingEventsForVenuesAtTerm`) — no N+1 across venues. Only attached when the caller asked for it **and** `taxonomy`+`term_id` are set; absence keeps the response shape byte-identical to today.

### Block: tour-route mode
- `block.json` → new `tourRouteMode` boolean attribute (default false).
- `render.php` → emits `data-tour-route-mode="1"` when attribute true OR new `data_machine_events_map_tour_route` filter returns true.
- `src/api-client.ts` → adds `includeEvents` param → `&include=events`.
- `src/frontend.tsx`:
  - Reads `tourRouteMode` from the root data attribute.
  - Sorts venues by earliest `start_date+start_time`.
  - Collapses consecutive same-venue entries → residencies render as one marker, polyline does **not** self-loop.
  - Draws `L.polyline([...], { color: '#2563eb', weight: 3, opacity: 0.7 })` **before** the cluster group so markers paint on top.
  - First/last/middle pins via `createTourRouteIcon()` — green (`#22c55e`) / red (`#ef4444`) / slate (`#475569`). Simple v1 treatment; numbered badges out of scope.
  - Multi-date popup: venue name + address + every upcoming show for the scoped artist at that venue (linked title + formatted date/time).
  - Tear-down: polyline removed at the top of every marker-update effect so it's always rebuilt cleanly.
  - Tour-route mode skips the `moveend` refetch and the initial bounds filter — the dataset is artist-scoped, the route auto-fits the viewport once, and viewport refetching would otherwise drop venues outside the visible area mid-route.

### CSS
Tour-route pin shapes + popup show-list styling, using existing `--data-machine-*` tokens.

## Backward compatibility

`GET /datamachine/v1/events/venues?taxonomy=location&term_id=N` and the bounds-mode location-archive map response are unchanged.

Verified against production today (before this PR lands):

```
$ curl -sS 'https://events.extrachill.com/wp-json/datamachine/v1/events/venues?taxonomy=artist&term_id=15008'
{"venues":[{"term_id":1905,"name":"C-Boy's Heart & Soul",...,"event_count":51}],"total":1,"center":null,"radius":25}
```

That exact URL will produce the exact same payload after merge. Only adding `&include=events` (with a `taxonomy`+`term_id` scope) flips on the new field.

## Build

`build/` is gitignored in this repo. Rebuild before release:

```
cd inc/Blocks/EventsMap && npm install && npm run build
```

I built locally and confirmed the bundle contains `tour-route-pin`, `tour-route-marker`, `tour-route-polyline`, and the `include=events` API call. PHP files lint clean.

## Scope locked from the issue

- Upcoming events only. No past route, no toggle.
- Straight `L.polyline()` — no curves, no routing API.
- Residencies = one marker, no self-loop; popup lists all dates.
- Empty-route handling enforced both server-side (host plugin) and client-side (`<2` distinct venues = no polyline drawn).
- Marker styling = simple first/last color treatment.
- Location-archive map untouched.

## Follow-up

The extrachill-events PR (artist-archive hook → `inc/core/artist-map.php`) opens after this PR merges. It will emit `<!-- wp:data-machine-events/events-map {"tourRouteMode":true} /-->` from `extrachill_archive_below_description` gated to `is_tax('artist')`.

Do **not** merge before review. Print the PR URL.