### PR TITLE
feat(event-details): add-to-calendar dropdown (Google / Outlook.com / .ics)

### DIFF
--- a/data-machine-events.php
+++ b/data-machine-events.php
@@ -55,6 +55,9 @@ if ( ! function_exists( 'data_machine_events_sanitize_query_params' ) ) {
 // See docs/integration-api.md.
 require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/public-api.php';
 
+// Add-to-Calendar button + dropdown for single-event pages (issue #312).
+require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Blocks/EventDetails/add-to-calendar-button.php';
+
 // Load event dates sync (monitors Event Details block saves → datamachine_event_dates table).
 require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Core/event-dates-sync.php';
 require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Core/EventDatesTable.php';

--- a/inc/Api/Controllers/EventIcs.php
+++ b/inc/Api/Controllers/EventIcs.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * EventIcs REST controller.
+ *
+ * Serves a single event as an iCalendar (.ics) download. This endpoint
+ * EXPECTS to be hit as a top-level browser navigation (the "Apple Calendar /
+ * Download (.ics)" item in the Add-to-Calendar dropdown is a plain `<a download>`
+ * link). The BrowserNavigationGuard pattern used by /events/calendar does
+ * NOT apply here.
+ *
+ * Returns raw `text/calendar` (not JSON), so we short-circuit the REST
+ * serializer via `rest_pre_serve_request`.
+ *
+ * @package DataMachineEvents\Api\Controllers
+ * @since   0.40.0
+ */
+
+namespace DataMachineEvents\Api\Controllers;
+
+defined( 'ABSPATH' ) || exit;
+
+use DataMachineEvents\EventActions\IcsBuilder;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_Error;
+
+class EventIcs {
+
+	/**
+	 * GET /datamachine/v1/events/{id}/ics
+	 *
+	 * @param WP_REST_Request $request
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function download( WP_REST_Request $request ) {
+		$post_id = (int) $request->get_param( 'id' );
+		if ( $post_id <= 0 ) {
+			return new WP_Error(
+				'invalid_event_id',
+				__( 'Invalid event ID.', 'data-machine-events' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$post = get_post( $post_id );
+		if ( ! $post || 'publish' !== $post->post_status ) {
+			return new WP_Error(
+				'event_not_found',
+				__( 'Event not found.', 'data-machine-events' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( defined( 'DATA_MACHINE_EVENTS_POST_TYPE' ) && DATA_MACHINE_EVENTS_POST_TYPE !== $post->post_type ) {
+			return new WP_Error(
+				'event_not_found',
+				__( 'Event not found.', 'data-machine-events' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( ! class_exists( IcsBuilder::class ) ) {
+			require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/EventActions/IcsBuilder.php';
+		}
+
+		$body = IcsBuilder::build( $post_id );
+		if ( '' === $body ) {
+			return new WP_Error(
+				'event_ics_unavailable',
+				__( 'Could not build .ics for this event.', 'data-machine-events' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$slug     = $post->post_name ? $post->post_name : ( 'event-' . $post_id );
+		$filename = sanitize_file_name( $slug . '.ics' );
+
+		// Short-circuit the JSON serializer: emit text/calendar directly.
+		add_filter(
+			'rest_pre_serve_request',
+			static function ( $served, $response ) use ( $body, $filename ) {
+				if ( $served ) {
+					return $served;
+				}
+				if ( ! headers_sent() ) {
+					header( 'Content-Type: text/calendar; charset=utf-8' );
+					header( 'Content-Disposition: attachment; filename="' . $filename . '"' );
+					header( 'Cache-Control: public, max-age=300' );
+				}
+				echo $body; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				return true;
+			},
+			10,
+			2
+		);
+
+		// The body of this response is ignored because the filter above
+		// already echoed the real payload; it just needs to be a 200.
+		return new WP_REST_Response( null, 200 );
+	}
+}

--- a/inc/Api/Routes.php
+++ b/inc/Api/Routes.php
@@ -12,9 +12,12 @@ if ( defined( 'DATA_MACHINE_EVENTS_PLUGIN_DIR' ) ) {
 		DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Api/Controllers/Calendar.php',
 		DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Api/Controllers/Venues.php',
 		DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Api/Controllers/Events.php',
+		DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Api/Controllers/EventIcs.php',
 		DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Api/Controllers/Filters.php',
 		DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Api/Controllers/Geocoding.php',
 		DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Api/Controllers/VenueMap.php',
+		DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/EventActions/CalendarUrlBuilder.php',
+		DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/EventActions/IcsBuilder.php',
 	);
 	foreach ( $controllers as $file ) {
 		if ( file_exists( $file ) ) {
@@ -25,6 +28,7 @@ if ( defined( 'DATA_MACHINE_EVENTS_PLUGIN_DIR' ) ) {
 
 use DataMachineEvents\Api\Controllers\Calendar;
 use DataMachineEvents\Api\Controllers\Venues;
+use DataMachineEvents\Api\Controllers\EventIcs;
 use DataMachineEvents\Api\Controllers\Filters;
 use DataMachineEvents\Api\Controllers\Geocoding;
 use DataMachineEvents\Api\Controllers\VenueMap;
@@ -228,6 +232,28 @@ function register_routes() {
 				'past'       => array(
 					'type'              => 'string',
 					'sanitize_callback' => 'sanitize_text_field',
+				),
+			),
+		)
+	);
+
+	$event_ics = new EventIcs();
+
+	register_rest_route(
+		API_NAMESPACE,
+		'/events/(?P<id>\d+)/ics',
+		array(
+			'methods'             => 'GET',
+			'callback'            => array( $event_ics, 'download' ),
+			'permission_callback' => '__return_true',
+			'args'                => array(
+				'id' => array(
+					'type'              => 'integer',
+					'required'          => true,
+					'sanitize_callback' => 'absint',
+					'validate_callback' => function ( $param ) {
+						return is_numeric( $param ) && (int) $param > 0;
+					},
 				),
 			),
 		)

--- a/inc/Blocks/EventDetails/add-to-calendar-button.php
+++ b/inc/Blocks/EventDetails/add-to-calendar-button.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Add to Calendar button + dropdown for single-event pages.
+ *
+ * Hooks onto `data_machine_events_action_buttons` (fired inside the
+ * EventDetails block render) and emits a button that opens a dropdown
+ * with three calendar destinations: Google Calendar, Outlook.com, and
+ * a downloadable .ics file (for Apple Calendar / Thunderbird / etc.).
+ *
+ * Hook priority 7: this puts the button between the existing attendance
+ * button (priority 5, from extrachill-events) and the share button
+ * (priority 10, from extrachill-events). Order on a page that has all
+ * three: Ticket → Attendance → Add to Calendar → Share.
+ *
+ * @package DataMachineEvents\Blocks\EventDetails
+ * @since   0.40.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( '\\DataMachineEvents\\EventActions\\CalendarUrlBuilder' ) ) {
+	require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/EventActions/CalendarUrlBuilder.php';
+}
+
+add_action(
+	'data_machine_events_action_buttons',
+	'data_machine_events_render_add_to_calendar_button',
+	7,
+	2
+);
+
+if ( ! function_exists( 'data_machine_events_render_add_to_calendar_button' ) ) {
+	/**
+	 * Emit the Add-to-Calendar button + dropdown HTML.
+	 *
+	 * @param int    $post_id    Event post ID.
+	 * @param string $ticket_url Ticket URL (unused here, present for hook signature parity).
+	 */
+	function data_machine_events_render_add_to_calendar_button( $post_id, $ticket_url ) {
+		unset( $ticket_url );
+
+		$post_id = (int) $post_id;
+		if ( $post_id <= 0 ) {
+			return;
+		}
+
+		$post = get_post( $post_id );
+		if ( ! $post ) {
+			return;
+		}
+
+		if ( ! function_exists( 'data_machine_events_parse_event_data' ) ) {
+			return;
+		}
+
+		$event = \data_machine_events_parse_event_data( $post );
+		if ( ! $event ) {
+			return;
+		}
+
+		// Inject post_id so URL builders can resolve title + permalink.
+		$event['post_id'] = $post_id;
+
+		$google_url  = \DataMachineEvents\EventActions\CalendarUrlBuilder::google( $event );
+		$outlook_url = \DataMachineEvents\EventActions\CalendarUrlBuilder::outlook( $event );
+		$ics_url     = \DataMachineEvents\EventActions\CalendarUrlBuilder::ics_url( $post_id );
+
+		if ( ! $google_url && ! $outlook_url && ! $ics_url ) {
+			return;
+		}
+
+		$menu_id = 'dm-atc-menu-' . $post_id;
+		?>
+		<div class="dm-events-add-to-calendar" data-dm-add-to-calendar>
+			<button
+				type="button"
+				class="dm-events-action-btn dm-events-add-to-calendar-toggle ticket-button"
+				aria-haspopup="true"
+				aria-expanded="false"
+				aria-controls="<?php echo esc_attr( $menu_id ); ?>"
+			>
+				<span class="dashicons dashicons-calendar-alt" aria-hidden="true"></span>
+				<?php esc_html_e( 'Add to Calendar', 'data-machine-events' ); ?>
+			</button>
+			<ul
+				id="<?php echo esc_attr( $menu_id ); ?>"
+				class="dm-events-add-to-calendar-menu"
+				role="menu"
+				hidden
+			>
+				<?php if ( $google_url ) : ?>
+					<li role="none">
+						<a
+							role="menuitem"
+							href="<?php echo esc_url( $google_url ); ?>"
+							target="_blank"
+							rel="noopener noreferrer"
+						><?php esc_html_e( 'Google Calendar', 'data-machine-events' ); ?></a>
+					</li>
+				<?php endif; ?>
+				<?php if ( $outlook_url ) : ?>
+					<li role="none">
+						<a
+							role="menuitem"
+							href="<?php echo esc_url( $outlook_url ); ?>"
+							target="_blank"
+							rel="noopener noreferrer"
+						><?php esc_html_e( 'Outlook.com', 'data-machine-events' ); ?></a>
+					</li>
+				<?php endif; ?>
+				<?php if ( $ics_url ) : ?>
+					<li role="none">
+						<a
+							role="menuitem"
+							href="<?php echo esc_url( $ics_url ); ?>"
+							download
+						><?php esc_html_e( 'Apple Calendar / Download (.ics)', 'data-machine-events' ); ?></a>
+					</li>
+				<?php endif; ?>
+			</ul>
+		</div>
+		<?php
+	}
+}

--- a/inc/Blocks/EventDetails/block.json
+++ b/inc/Blocks/EventDetails/block.json
@@ -11,6 +11,7 @@
     "style": ["data-machine-events-root", "leaflet"],
     "editorStyle": "file:./style.css",
     "viewStyle": "file:./build/frontend.css",
+    "viewScript": "file:./build/frontend.js",
     "attributes": {
         "startDate": {
             "type": "string",

--- a/inc/Blocks/EventDetails/src/add-to-calendar.js
+++ b/inc/Blocks/EventDetails/src/add-to-calendar.js
@@ -1,0 +1,244 @@
+/**
+ * Add to Calendar dropdown — vanilla JS (no jQuery, no React).
+ *
+ * Implements the WAI-ARIA menu button pattern for the `.dm-events-add-to-calendar`
+ * widget rendered server-side by inc/Blocks/EventDetails/add-to-calendar-button.php.
+ *
+ * - Toggle button opens/closes the dropdown (toggles `hidden` + `aria-expanded`).
+ * - Click outside closes the menu.
+ * - Escape closes the menu and returns focus to the toggle.
+ * - Arrow Down / Up navigate menu items; Home / End jump to first/last.
+ * - Tab through items works via native tab order.
+ * - Enter / Space on a menu item activates the link via the browser default.
+ *
+ * Bound via event delegation on `document` so dynamically inserted widgets
+ * keep working (e.g. server-rendered HTML swapped into the page).
+ *
+ * @package DataMachineEvents
+ * @since   0.40.0
+ */
+
+(function () {
+	'use strict';
+
+	if ( typeof document === 'undefined' ) {
+		return;
+	}
+
+	var WIDGET_SELECTOR = '[data-dm-add-to-calendar]';
+	var TOGGLE_SELECTOR = '.dm-events-add-to-calendar-toggle';
+	var MENU_SELECTOR = '.dm-events-add-to-calendar-menu';
+	var ITEM_SELECTOR = '[role="menuitem"]';
+	var RIGHT_ALIGN_CLASS = 'is-right-aligned';
+
+	/**
+	 * Resolve the menu element for a given toggle.
+	 */
+	function getMenu( toggle ) {
+		var widget = toggle.closest( WIDGET_SELECTOR );
+		if ( ! widget ) {
+			return null;
+		}
+		return widget.querySelector( MENU_SELECTOR );
+	}
+
+	function getItems( menu ) {
+		return Array.prototype.slice.call( menu.querySelectorAll( ITEM_SELECTOR ) );
+	}
+
+	function isOpen( toggle ) {
+		return toggle.getAttribute( 'aria-expanded' ) === 'true';
+	}
+
+	function openMenu( toggle ) {
+		var menu = getMenu( toggle );
+		if ( ! menu ) {
+			return;
+		}
+
+		// Close any other open menus on the page first.
+		closeAllMenus( toggle );
+
+		toggle.setAttribute( 'aria-expanded', 'true' );
+		menu.hidden = false;
+
+		// Decide whether to right-align to keep within viewport.
+		applyEdgeAlignment( toggle, menu );
+	}
+
+	function closeMenu( toggle, opts ) {
+		var menu = getMenu( toggle );
+		if ( ! menu ) {
+			return;
+		}
+		toggle.setAttribute( 'aria-expanded', 'false' );
+		menu.hidden = true;
+		menu.classList.remove( RIGHT_ALIGN_CLASS );
+		if ( opts && opts.focusToggle ) {
+			toggle.focus();
+		}
+	}
+
+	function closeAllMenus( exceptToggle ) {
+		var toggles = document.querySelectorAll( TOGGLE_SELECTOR );
+		for ( var i = 0; i < toggles.length; i++ ) {
+			if ( toggles[ i ] !== exceptToggle && isOpen( toggles[ i ] ) ) {
+				closeMenu( toggles[ i ] );
+			}
+		}
+	}
+
+	/**
+	 * Position the menu so it stays within the viewport.
+	 * Default anchor is left-aligned (CSS `left: 0`). When the menu would
+	 * overflow the right edge, add `.is-right-aligned` so CSS can flip it.
+	 */
+	function applyEdgeAlignment( toggle, menu ) {
+		// Defer measurement until layout is done.
+		requestAnimationFrame( function () {
+			var menuRect = menu.getBoundingClientRect();
+			var viewportWidth = document.documentElement.clientWidth || window.innerWidth;
+			if ( menuRect.right > viewportWidth - 8 ) {
+				menu.classList.add( RIGHT_ALIGN_CLASS );
+			} else {
+				menu.classList.remove( RIGHT_ALIGN_CLASS );
+			}
+		} );
+	}
+
+	function focusItemAt( menu, index ) {
+		var items = getItems( menu );
+		if ( ! items.length ) {
+			return;
+		}
+		var bounded = ( ( index % items.length ) + items.length ) % items.length;
+		items[ bounded ].focus();
+	}
+
+	// Toggle click — open/close.
+	document.addEventListener( 'click', function ( event ) {
+		var target = event.target;
+		if ( ! ( target instanceof Element ) ) {
+			return;
+		}
+
+		var toggle = target.closest( TOGGLE_SELECTOR );
+		if ( toggle ) {
+			event.preventDefault();
+			event.stopPropagation();
+			if ( isOpen( toggle ) ) {
+				closeMenu( toggle );
+			} else {
+				openMenu( toggle );
+			}
+			return;
+		}
+
+		// Click outside any open menu → close it.
+		var widget = target.closest( WIDGET_SELECTOR );
+		if ( ! widget ) {
+			closeAllMenus( null );
+		}
+	} );
+
+	// Keyboard handling.
+	document.addEventListener( 'keydown', function ( event ) {
+		var target = event.target;
+		if ( ! ( target instanceof Element ) ) {
+			return;
+		}
+
+		// Escape: close any open menu, return focus to its toggle.
+		if ( event.key === 'Escape' || event.key === 'Esc' ) {
+			var openToggle = document.querySelector(
+				TOGGLE_SELECTOR + '[aria-expanded="true"]'
+			);
+			if ( openToggle ) {
+				event.preventDefault();
+				closeMenu( openToggle, { focusToggle: true } );
+			}
+			return;
+		}
+
+		// Arrow keys on the toggle: open the menu and focus the first item.
+		var toggle = target.closest( TOGGLE_SELECTOR );
+		if ( toggle ) {
+			if ( event.key === 'ArrowDown' || event.key === 'Down' ) {
+				event.preventDefault();
+				if ( ! isOpen( toggle ) ) {
+					openMenu( toggle );
+				}
+				var menuDown = getMenu( toggle );
+				if ( menuDown ) {
+					focusItemAt( menuDown, 0 );
+				}
+				return;
+			}
+			if ( event.key === 'ArrowUp' || event.key === 'Up' ) {
+				event.preventDefault();
+				if ( ! isOpen( toggle ) ) {
+					openMenu( toggle );
+				}
+				var menuUp = getMenu( toggle );
+				if ( menuUp ) {
+					var items = getItems( menuUp );
+					focusItemAt( menuUp, items.length - 1 );
+				}
+				return;
+			}
+			return;
+		}
+
+		// Keys on a menu item: arrows + Home/End.
+		var item = target.closest( ITEM_SELECTOR );
+		if ( ! item ) {
+			return;
+		}
+		var menu = item.closest( MENU_SELECTOR );
+		if ( ! menu ) {
+			return;
+		}
+		var menuItems = getItems( menu );
+		var currentIndex = menuItems.indexOf( item );
+
+		switch ( event.key ) {
+			case 'ArrowDown':
+			case 'Down':
+				event.preventDefault();
+				focusItemAt( menu, currentIndex + 1 );
+				break;
+			case 'ArrowUp':
+			case 'Up':
+				event.preventDefault();
+				focusItemAt( menu, currentIndex - 1 );
+				break;
+			case 'Home':
+				event.preventDefault();
+				focusItemAt( menu, 0 );
+				break;
+			case 'End':
+				event.preventDefault();
+				focusItemAt( menu, menuItems.length - 1 );
+				break;
+			default:
+				break;
+		}
+	} );
+
+	// Close menus when focus leaves the widget entirely (Tab past last item).
+	document.addEventListener(
+		'focusin',
+		function ( event ) {
+			var target = event.target;
+			if ( ! ( target instanceof Element ) ) {
+				return;
+			}
+			var widget = target.closest( WIDGET_SELECTOR );
+			if ( widget ) {
+				return;
+			}
+			closeAllMenus( null );
+		},
+		true
+	);
+} )();

--- a/inc/Blocks/EventDetails/src/frontend.css
+++ b/inc/Blocks/EventDetails/src/frontend.css
@@ -267,3 +267,105 @@
         background: var(--data-machine-background-secondary);
     }
 }
+
+/* -----------------------------------------------------------------------
+ * Add to Calendar dropdown
+ *
+ * Server-rendered button + menu (see add-to-calendar-button.php). Vanilla
+ * JS (src/add-to-calendar.js) toggles `[hidden]` and `aria-expanded`.
+ * ----------------------------------------------------------------------- */
+
+.dm-events-add-to-calendar {
+    position: relative;
+    display: inline-block;
+}
+
+.dm-events-add-to-calendar-toggle {
+    /* Inherit ticket-button styling so the three action buttons match.
+       Consumers may override `.ticket-button` to restyle all action buttons
+       at once. */
+    cursor: pointer;
+    border: 0;
+    font: inherit;
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+.dm-events-add-to-calendar-toggle .dashicons {
+    line-height: 1;
+}
+
+.dm-events-add-to-calendar-toggle[aria-expanded="true"] {
+    /* Slight visual cue when open. */
+    filter: brightness(0.95);
+}
+
+.dm-events-add-to-calendar-menu {
+    position: absolute;
+    top: calc(100% + 0.25rem);
+    left: 0;
+    z-index: 50;
+    min-width: 220px;
+    margin: 0;
+    padding: 0.25rem 0;
+    list-style: none;
+    background: var(--data-machine-background-light, #fff);
+    border: 1px solid var(--data-machine-border-color, rgba(0, 0, 0, 0.12));
+    border-radius: var(--data-machine-border-radius, 4px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+}
+
+.dm-events-add-to-calendar-menu[hidden] {
+    display: none;
+}
+
+.dm-events-add-to-calendar-menu.is-right-aligned {
+    left: auto;
+    right: 0;
+}
+
+.dm-events-add-to-calendar-menu li {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.dm-events-add-to-calendar-menu a {
+    display: block;
+    padding: 0.6rem 1rem;
+    color: var(--data-machine-text-primary, inherit);
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.dm-events-add-to-calendar-menu a:hover,
+.dm-events-add-to-calendar-menu a:focus {
+    background: var(--data-machine-background-secondary, rgba(0, 0, 0, 0.05));
+    color: var(--data-machine-text-accent, inherit);
+    outline: none;
+}
+
+.dm-events-add-to-calendar-menu a:focus-visible {
+    box-shadow: inset 0 0 0 2px var(--data-machine-text-accent, #2271b1);
+}
+
+@media (max-width: 480px) {
+    .dm-events-add-to-calendar-menu {
+        min-width: 200px;
+    }
+}
+
+@media (prefers-color-scheme: dark) {
+    .dm-events-add-to-calendar-menu {
+        background: var(--data-machine-background-secondary, #1f2937);
+        border-color: rgba(255, 255, 255, 0.12);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+    }
+
+    .dm-events-add-to-calendar-menu a:hover,
+    .dm-events-add-to-calendar-menu a:focus {
+        background: rgba(255, 255, 255, 0.08);
+    }
+}

--- a/inc/Blocks/EventDetails/src/frontend.js
+++ b/inc/Blocks/EventDetails/src/frontend.js
@@ -12,3 +12,4 @@
  * Internal dependencies
  */
 import './frontend.css';
+import './add-to-calendar.js';

--- a/inc/EventActions/CalendarUrlBuilder.php
+++ b/inc/EventActions/CalendarUrlBuilder.php
@@ -1,0 +1,287 @@
+<?php
+/**
+ * Calendar URL Builder
+ *
+ * Pure functions that build add-to-calendar deep-link URLs for the
+ * single-event "Add to Calendar" dropdown.
+ *
+ * Three destinations:
+ *   - Google Calendar (https://calendar.google.com/calendar/render)
+ *   - Outlook.com (https://outlook.live.com/calendar/0/deeplink/compose)
+ *   - .ics file download (REST route /datamachine/v1/events/{id}/ics)
+ *
+ * Input is the structured `$event_data` array produced by
+ * `data_machine_events_parse_event_data( $post )` (see public-api.php).
+ *
+ * Timezone handling notes:
+ *   - Google Calendar expects `dates=YYYYMMDDTHHmmSSZ/YYYYMMDDTHHmmSSZ`
+ *     in UTC. We convert the event's local start/end (interpreted in
+ *     `venueTimezone`, falling back to site timezone) into UTC.
+ *   - Outlook.com accepts ISO 8601 with offset. We emit the local time
+ *     with the event's timezone offset, e.g. `2026-09-23T20:00:00-04:00`.
+ *
+ * Default end time: when `endTime` is empty we assume a 3-hour event.
+ *
+ * @package DataMachineEvents\EventActions
+ * @since   0.40.0
+ */
+
+namespace DataMachineEvents\EventActions;
+
+defined( 'ABSPATH' ) || exit;
+
+class CalendarUrlBuilder {
+
+	/**
+	 * Default event duration when no endTime is provided, in seconds.
+	 */
+	const DEFAULT_DURATION_SECONDS = 3 * HOUR_IN_SECONDS;
+
+	/**
+	 * Google Calendar deep-link base.
+	 */
+	const GOOGLE_BASE = 'https://calendar.google.com/calendar/render';
+
+	/**
+	 * Outlook.com deep-link base.
+	 */
+	const OUTLOOK_BASE = 'https://outlook.live.com/calendar/0/deeplink/compose';
+
+	/**
+	 * Build a Google Calendar "create event" URL.
+	 *
+	 * @param array $event Event data from `data_machine_events_parse_event_data()`.
+	 *                     Must include `post_id` (added by callers) plus the standard
+	 *                     EventDetails attributes (startDate, startTime, endDate,
+	 *                     endTime, venueTimezone, venue, address, etc.).
+	 * @return string Absolute Google Calendar URL, or empty string when event lacks
+	 *                a start date.
+	 */
+	public static function google( array $event ): string {
+		$range = self::resolve_datetime_range( $event );
+		if ( null === $range ) {
+			return '';
+		}
+
+		$post_id = isset( $event['post_id'] ) ? (int) $event['post_id'] : 0;
+		$title   = self::event_title( $event, $post_id );
+
+		// Google expects UTC dates with a literal Z suffix.
+		$start_utc = $range['start']->setTimezone( new \DateTimeZone( 'UTC' ) )->format( 'Ymd\THis\Z' );
+		$end_utc   = $range['end']->setTimezone( new \DateTimeZone( 'UTC' ) )->format( 'Ymd\THis\Z' );
+
+		$params = array(
+			'action'   => 'TEMPLATE',
+			'text'     => $title,
+			'dates'    => $start_utc . '/' . $end_utc,
+			'details'  => self::build_description( $event, $post_id ),
+			'location' => self::build_location( $event ),
+		);
+
+		// Google accepts a `ctz` (calendar timezone) hint — useful so the
+		// imported event remembers its origin timezone even though `dates`
+		// is in UTC.
+		if ( ! empty( $event['venueTimezone'] ) ) {
+			$params['ctz'] = (string) $event['venueTimezone'];
+		}
+
+		return self::GOOGLE_BASE . '?' . self::build_query( $params );
+	}
+
+	/**
+	 * Build an Outlook.com "create event" URL.
+	 *
+	 * @param array $event Event data (see google()).
+	 * @return string Absolute Outlook.com URL, or empty string when event lacks
+	 *                a start date.
+	 */
+	public static function outlook( array $event ): string {
+		$range = self::resolve_datetime_range( $event );
+		if ( null === $range ) {
+			return '';
+		}
+
+		$post_id = isset( $event['post_id'] ) ? (int) $event['post_id'] : 0;
+		$title   = self::event_title( $event, $post_id );
+
+		// Outlook accepts ISO 8601 with offset, e.g. 2026-09-23T20:00:00-04:00.
+		$start_iso = $range['start']->format( \DateTimeInterface::ATOM );
+		$end_iso   = $range['end']->format( \DateTimeInterface::ATOM );
+
+		$params = array(
+			'path'     => '/calendar/action/compose',
+			'rru'      => 'addevent',
+			'subject'  => $title,
+			'startdt'  => $start_iso,
+			'enddt'    => $end_iso,
+			'body'     => self::build_description( $event, $post_id ),
+			'location' => self::build_location( $event ),
+		);
+
+		return self::OUTLOOK_BASE . '?' . self::build_query( $params );
+	}
+
+	/**
+	 * Build the public URL of the .ics endpoint for a given event.
+	 *
+	 * @param int $post_id Event post ID.
+	 * @return string Absolute URL of the .ics endpoint.
+	 */
+	public static function ics_url( int $post_id ): string {
+		return rest_url( 'datamachine/v1/events/' . $post_id . '/ics' );
+	}
+
+	/**
+	 * Resolve the start + end DateTimeImmutable for an event.
+	 *
+	 * Honors `venueTimezone` when present; falls back to the site timezone.
+	 * When `endTime` is empty the end defaults to start + 3 hours.
+	 *
+	 * @param array $event Event data.
+	 * @return array|null { start: \DateTimeImmutable, end: \DateTimeImmutable } or null.
+	 */
+	private static function resolve_datetime_range( array $event ): ?array {
+		if ( empty( $event['startDate'] ) ) {
+			return null;
+		}
+
+		$tz_name = ! empty( $event['venueTimezone'] ) ? (string) $event['venueTimezone'] : wp_timezone_string();
+		try {
+			$tz = new \DateTimeZone( $tz_name );
+		} catch ( \Exception $e ) {
+			$tz = new \DateTimeZone( 'UTC' );
+		}
+
+		$start_time = ! empty( $event['startTime'] ) ? (string) $event['startTime'] : '00:00:00';
+		try {
+			$start = new \DateTimeImmutable( $event['startDate'] . ' ' . $start_time, $tz );
+		} catch ( \Exception $e ) {
+			return null;
+		}
+
+		$end_date = ! empty( $event['endDate'] ) ? (string) $event['endDate'] : (string) $event['startDate'];
+		if ( ! empty( $event['endTime'] ) ) {
+			try {
+				$end = new \DateTimeImmutable( $end_date . ' ' . $event['endTime'], $tz );
+			} catch ( \Exception $e ) {
+				$end = $start->add( new \DateInterval( 'PT3H' ) );
+			}
+		} else {
+			// Default duration: 3 hours.
+			$end = $start->add( new \DateInterval( 'PT3H' ) );
+		}
+
+		// Defensive: end must be >= start.
+		if ( $end < $start ) {
+			$end = $start->add( new \DateInterval( 'PT3H' ) );
+		}
+
+		return array(
+			'start' => $start,
+			'end'   => $end,
+		);
+	}
+
+	/**
+	 * Get the event title, preferring `get_the_title()` when a post ID is available.
+	 *
+	 * @param array $event   Event data.
+	 * @param int   $post_id Event post ID (0 if unknown).
+	 * @return string
+	 */
+	private static function event_title( array $event, int $post_id ): string {
+		if ( $post_id > 0 ) {
+			$title = get_the_title( $post_id );
+			if ( $title ) {
+				return wp_strip_all_tags( $title );
+			}
+		}
+		return isset( $event['title'] ) ? wp_strip_all_tags( (string) $event['title'] ) : '';
+	}
+
+	/**
+	 * Build the description body shared between Google and Outlook.
+	 *
+	 * Includes performer (when present), the permalink, and the ticket URL
+	 * (when present). Plain text only — no HTML.
+	 *
+	 * @param array $event   Event data.
+	 * @param int   $post_id Event post ID.
+	 * @return string
+	 */
+	private static function build_description( array $event, int $post_id ): string {
+		$parts = array();
+
+		$performer = '';
+		if ( ! empty( $event['performer'] ) ) {
+			$performer = (string) $event['performer'];
+		} elseif ( ! empty( $event['performerName'] ) ) {
+			$performer = (string) $event['performerName'];
+		}
+		if ( $performer ) {
+			$parts[] = sprintf( __( 'Performer: %s', 'data-machine-events' ), wp_strip_all_tags( $performer ) );
+		}
+
+		if ( $post_id > 0 ) {
+			$permalink = get_permalink( $post_id );
+			if ( $permalink ) {
+				$parts[] = __( 'More info:', 'data-machine-events' ) . ' ' . $permalink;
+			}
+		}
+
+		if ( ! empty( $event['ticketUrl'] ) ) {
+			$parts[] = __( 'Tickets:', 'data-machine-events' ) . ' ' . (string) $event['ticketUrl'];
+		}
+
+		/**
+		 * Filter the Add-to-Calendar description body.
+		 *
+		 * @param string $description Joined description lines (newline-separated).
+		 * @param array  $event       Event data.
+		 * @param int    $post_id     Event post ID.
+		 */
+		return (string) apply_filters(
+			'data_machine_events_add_to_calendar_description',
+			implode( "\n", $parts ),
+			$event,
+			$post_id
+		);
+	}
+
+	/**
+	 * Build the location string shared between Google and Outlook.
+	 *
+	 * @param array $event Event data.
+	 * @return string
+	 */
+	private static function build_location( array $event ): string {
+		$venue   = isset( $event['venue'] ) ? wp_strip_all_tags( (string) $event['venue'] ) : '';
+		$address = isset( $event['address'] ) ? wp_strip_all_tags( (string) $event['address'] ) : '';
+
+		if ( $venue && $address ) {
+			return $venue . ', ' . $address;
+		}
+		return $venue ?: $address;
+	}
+
+	/**
+	 * URL-encode an associative array using rawurlencode, joined with `&`.
+	 *
+	 * `http_build_query()` uses urlencode (spaces -> `+`); we prefer
+	 * rawurlencode (spaces -> `%20`) for consistency with calendar URL
+	 * conventions in the wild.
+	 *
+	 * @param array $params
+	 * @return string
+	 */
+	private static function build_query( array $params ): string {
+		$pairs = array();
+		foreach ( $params as $key => $value ) {
+			if ( '' === $value || null === $value ) {
+				continue;
+			}
+			$pairs[] = rawurlencode( (string) $key ) . '=' . rawurlencode( (string) $value );
+		}
+		return implode( '&', $pairs );
+	}
+}

--- a/inc/EventActions/IcsBuilder.php
+++ b/inc/EventActions/IcsBuilder.php
@@ -1,0 +1,391 @@
+<?php
+/**
+ * .ics (iCalendar / RFC 5545) Builder
+ *
+ * Hand-rolled VCALENDAR/VEVENT/VTIMEZONE generator for the single-event
+ * "Add to Calendar" / "Apple Calendar / Download .ics" link.
+ *
+ * Why hand-rolled? The plugin already ships `johngrogg/ics-parser` for
+ * INBOUND parsing, but it has no writer. A single VEVENT with an optional
+ * VTIMEZONE block is ~80 lines of `sprintf()` — a dependency is overkill.
+ *
+ * RFC 5545 details implemented here:
+ *   - CRLF line endings.
+ *   - Long-line folding at 75 octets (continuation lines start with a space).
+ *   - Text escaping for `\`, `;`, `,`, and newlines in TEXT-typed fields.
+ *   - VTIMEZONE block with one STANDARD + one DAYLIGHT sub-component built
+ *     from `DateTimeZone::getTransitions()` (skipped entirely when the
+ *     event timezone is UTC or has no DST transitions in the relevant window).
+ *
+ * @package DataMachineEvents\EventActions
+ * @since   0.40.0
+ */
+
+namespace DataMachineEvents\EventActions;
+
+defined( 'ABSPATH' ) || exit;
+
+class IcsBuilder {
+
+	/**
+	 * Default event duration when no end time is provided, in seconds.
+	 */
+	const DEFAULT_DURATION_SECONDS = 3 * HOUR_IN_SECONDS;
+
+	/**
+	 * Maximum octet width per RFC 5545 §3.1 (lines must be folded above this).
+	 */
+	const FOLD_LIMIT = 75;
+
+	/**
+	 * Build a VCALENDAR blob for a single event post.
+	 *
+	 * @param int $post_id Event post ID.
+	 * @return string The .ics body (CRLF-terminated lines, UTF-8).
+	 */
+	public static function build( int $post_id ): string {
+		$post = get_post( $post_id );
+		if ( ! $post ) {
+			return '';
+		}
+
+		if ( ! function_exists( 'data_machine_events_parse_event_data' ) ) {
+			return '';
+		}
+
+		$event = \data_machine_events_parse_event_data( $post );
+		if ( ! $event ) {
+			return '';
+		}
+
+		// Resolve timezone.
+		$tz_name = ! empty( $event['venueTimezone'] ) ? (string) $event['venueTimezone'] : wp_timezone_string();
+		try {
+			$tz = new \DateTimeZone( $tz_name );
+		} catch ( \Exception $e ) {
+			$tz      = new \DateTimeZone( 'UTC' );
+			$tz_name = 'UTC';
+		}
+
+		// Resolve start/end.
+		$start_time = ! empty( $event['startTime'] ) ? (string) $event['startTime'] : '00:00:00';
+		try {
+			$start = new \DateTimeImmutable( $event['startDate'] . ' ' . $start_time, $tz );
+		} catch ( \Exception $e ) {
+			return '';
+		}
+
+		$end_date = ! empty( $event['endDate'] ) ? (string) $event['endDate'] : (string) $event['startDate'];
+		if ( ! empty( $event['endTime'] ) ) {
+			try {
+				$end = new \DateTimeImmutable( $end_date . ' ' . $event['endTime'], $tz );
+			} catch ( \Exception $e ) {
+				$end = $start->add( new \DateInterval( 'PT3H' ) );
+			}
+		} else {
+			$end = $start->add( new \DateInterval( 'PT3H' ) );
+		}
+		if ( $end < $start ) {
+			$end = $start->add( new \DateInterval( 'PT3H' ) );
+		}
+
+		$title       = wp_strip_all_tags( (string) get_the_title( $post_id ) );
+		$permalink   = (string) get_permalink( $post_id );
+		$description = self::build_description( $event, $post_id );
+		$location    = self::build_location( $event );
+
+		$is_utc = 'UTC' === $tz_name;
+
+		// Build VTIMEZONE only when non-UTC.
+		$vtimezone_lines = $is_utc ? array() : self::build_vtimezone( $tz, $tz_name, $start, $end );
+
+		// DTSTART/DTEND formatting differs between UTC and local-with-TZID.
+		if ( $is_utc || empty( $vtimezone_lines ) ) {
+			$dtstart_line = 'DTSTART:' . $start->setTimezone( new \DateTimeZone( 'UTC' ) )->format( 'Ymd\THis\Z' );
+			$dtend_line   = 'DTEND:' . $end->setTimezone( new \DateTimeZone( 'UTC' ) )->format( 'Ymd\THis\Z' );
+		} else {
+			$dtstart_line = 'DTSTART;TZID=' . $tz_name . ':' . $start->format( 'Ymd\THis' );
+			$dtend_line   = 'DTEND;TZID=' . $tz_name . ':' . $end->format( 'Ymd\THis' );
+		}
+
+		$dtstamp = ( new \DateTimeImmutable( 'now', new \DateTimeZone( 'UTC' ) ) )->format( 'Ymd\THis\Z' );
+
+		$uid_seed = $permalink ?: ( 'event-' . $post_id . '@' . wp_parse_url( home_url(), PHP_URL_HOST ) );
+
+		$lines = array();
+		$lines[] = 'BEGIN:VCALENDAR';
+		$lines[] = 'VERSION:2.0';
+		$lines[] = 'PRODID:-//Data Machine Events//EN';
+		$lines[] = 'CALSCALE:GREGORIAN';
+		$lines[] = 'METHOD:PUBLISH';
+
+		foreach ( $vtimezone_lines as $vtz_line ) {
+			$lines[] = $vtz_line;
+		}
+
+		$lines[] = 'BEGIN:VEVENT';
+		$lines[] = 'UID:' . self::escape_text( $uid_seed );
+		$lines[] = 'DTSTAMP:' . $dtstamp;
+		$lines[] = $dtstart_line;
+		$lines[] = $dtend_line;
+		$lines[] = 'SUMMARY:' . self::escape_text( $title );
+		if ( $description ) {
+			$lines[] = 'DESCRIPTION:' . self::escape_text( $description );
+		}
+		if ( $location ) {
+			$lines[] = 'LOCATION:' . self::escape_text( $location );
+		}
+		if ( $permalink ) {
+			// URL is a URI-type field; do NOT TEXT-escape the colons/commas.
+			$lines[] = 'URL:' . $permalink;
+		}
+		$lines[] = 'END:VEVENT';
+		$lines[] = 'END:VCALENDAR';
+
+		// Fold long lines and join with CRLF.
+		$folded = array_map( array( __CLASS__, 'fold_line' ), $lines );
+
+		return implode( "\r\n", $folded ) . "\r\n";
+	}
+
+	/**
+	 * Build the VTIMEZONE block for the given timezone.
+	 *
+	 * Walks `DateTimeZone::getTransitions()` over the year containing the event
+	 * to find the most-recent STANDARD and DAYLIGHT transitions, then emits
+	 * RRULE-less sub-components describing them. This produces an iCalendar-
+	 * valid block that's accepted by Google, Apple, and Outlook.
+	 *
+	 * Returns an empty array when the timezone has no DST in the relevant
+	 * window (in which case the caller falls back to plain UTC DTSTART/DTEND).
+	 *
+	 * @param \DateTimeZone        $tz      The timezone object.
+	 * @param string               $tz_name The timezone identifier (e.g. "America/New_York").
+	 * @param \DateTimeImmutable   $start   Event start (used to scope transitions).
+	 * @param \DateTimeImmutable   $end     Event end.
+	 * @return string[] VTIMEZONE block lines (BEGIN...END), or [] when not needed.
+	 */
+	private static function build_vtimezone( \DateTimeZone $tz, string $tz_name, \DateTimeImmutable $start, \DateTimeImmutable $end ): array {
+		// Look one year before/after the event for transition data.
+		$window_start = $start->modify( '-1 year' )->getTimestamp();
+		$window_end   = $end->modify( '+1 year' )->getTimestamp();
+
+		$transitions = $tz->getTransitions( $window_start, $window_end );
+		if ( ! is_array( $transitions ) || count( $transitions ) < 2 ) {
+			// `getTransitions()` always returns at least a synthetic "window
+			// start" snapshot entry as element 0. We need at least one real
+			// transition AFTER it to build a meaningful VTIMEZONE.
+			return array();
+		}
+
+		// Element 0 is the window-start snapshot (current state at $window_start)
+		// — not a real transition. Skip it. Real transitions follow.
+		$real = array_slice( $transitions, 1 );
+		if ( empty( $real ) ) {
+			return array();
+		}
+
+		// Find the first real daylight and the first real standard transition.
+		$daylight = null;
+		$standard = null;
+		foreach ( $real as $t ) {
+			if ( ! empty( $t['isdst'] ) && null === $daylight ) {
+				$daylight = $t;
+			} elseif ( empty( $t['isdst'] ) && null === $standard ) {
+				$standard = $t;
+			}
+			if ( $daylight && $standard ) {
+				break;
+			}
+		}
+
+		// If neither sub-component is available (e.g. timezone with no DST
+		// in the window), fall back to plain UTC formatting in the caller.
+		if ( ! $daylight && ! $standard ) {
+			return array();
+		}
+
+		// For each real transition, the predecessor is the entry immediately
+		// before it in the full transitions array (including element 0,
+		// because that snapshot accurately represents the offset at $window_start).
+		$find_prev_offset = static function ( $target ) use ( $transitions ) {
+			$prev = null;
+			foreach ( $transitions as $t ) {
+				if ( $t['ts'] === $target['ts'] ) {
+					return $prev ? (int) $prev['offset'] : (int) $target['offset'];
+				}
+				$prev = $t;
+			}
+			return $prev ? (int) $prev['offset'] : (int) $target['offset'];
+		};
+
+		$lines = array();
+		$lines[] = 'BEGIN:VTIMEZONE';
+		$lines[] = 'TZID:' . $tz_name;
+
+		if ( $daylight ) {
+			$prev_offset = $find_prev_offset( $daylight );
+			$lines[]     = 'BEGIN:DAYLIGHT';
+			$lines[]     = 'DTSTART:' . gmdate( 'Ymd\THis', (int) $daylight['ts'] );
+			$lines[]     = 'TZOFFSETFROM:' . self::format_offset( $prev_offset );
+			$lines[]     = 'TZOFFSETTO:' . self::format_offset( (int) $daylight['offset'] );
+			if ( ! empty( $daylight['abbr'] ) ) {
+				$lines[] = 'TZNAME:' . self::escape_text( (string) $daylight['abbr'] );
+			}
+			$lines[] = 'END:DAYLIGHT';
+		}
+
+		if ( $standard ) {
+			$prev_offset = $find_prev_offset( $standard );
+			$lines[]     = 'BEGIN:STANDARD';
+			$lines[]     = 'DTSTART:' . gmdate( 'Ymd\THis', (int) $standard['ts'] );
+			$lines[]     = 'TZOFFSETFROM:' . self::format_offset( $prev_offset );
+			$lines[]     = 'TZOFFSETTO:' . self::format_offset( (int) $standard['offset'] );
+			if ( ! empty( $standard['abbr'] ) ) {
+				$lines[] = 'TZNAME:' . self::escape_text( (string) $standard['abbr'] );
+			}
+			$lines[] = 'END:STANDARD';
+		}
+
+		$lines[] = 'END:VTIMEZONE';
+
+		return $lines;
+	}
+
+	/**
+	 * Format a UTC offset in seconds as +HHMM / -HHMM (iCalendar UTC-OFFSET).
+	 *
+	 * @param int $offset_seconds
+	 * @return string
+	 */
+	private static function format_offset( int $offset_seconds ): string {
+		$sign     = $offset_seconds >= 0 ? '+' : '-';
+		$abs      = abs( $offset_seconds );
+		$hours    = (int) floor( $abs / 3600 );
+		$minutes  = (int) floor( ( $abs % 3600 ) / 60 );
+		return sprintf( '%s%02d%02d', $sign, $hours, $minutes );
+	}
+
+	/**
+	 * Escape a TEXT-typed value per RFC 5545 §3.3.11.
+	 *
+	 * @param string $value
+	 * @return string
+	 */
+	private static function escape_text( string $value ): string {
+		// Order matters: backslash first.
+		$value = str_replace( '\\', '\\\\', $value );
+		$value = str_replace( array( "\r\n", "\r", "\n" ), '\\n', $value );
+		$value = str_replace( ';', '\\;', $value );
+		$value = str_replace( ',', '\\,', $value );
+		return $value;
+	}
+
+	/**
+	 * Fold a single content line to 75 octets per RFC 5545 §3.1.
+	 *
+	 * Continuation lines start with a single space (CRLF + SP).
+	 *
+	 * @param string $line
+	 * @return string Possibly multi-line string joined by CRLF.
+	 */
+	private static function fold_line( string $line ): string {
+		if ( strlen( $line ) <= self::FOLD_LIMIT ) {
+			return $line;
+		}
+
+		$out    = '';
+		$first  = true;
+		$remain = $line;
+
+		while ( strlen( $remain ) > 0 ) {
+			$chunk_size = $first ? self::FOLD_LIMIT : self::FOLD_LIMIT - 1;
+			$chunk      = self::utf8_safe_substr( $remain, $chunk_size );
+			$remain     = (string) substr( $remain, strlen( $chunk ) );
+
+			if ( $first ) {
+				$out  .= $chunk;
+				$first = false;
+			} else {
+				$out .= "\r\n " . $chunk;
+			}
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Take up to $bytes octets from a UTF-8 string without splitting a multibyte char.
+	 *
+	 * @param string $str
+	 * @param int    $bytes
+	 * @return string
+	 */
+	private static function utf8_safe_substr( string $str, int $bytes ): string {
+		if ( strlen( $str ) <= $bytes ) {
+			return $str;
+		}
+		$chunk = substr( $str, 0, $bytes );
+		// Walk back to a UTF-8 boundary.
+		while ( strlen( $chunk ) > 0 && ( ord( $chunk[ strlen( $chunk ) - 1 ] ) & 0xC0 ) === 0x80 ) {
+			$chunk = substr( $chunk, 0, -1 );
+		}
+		return $chunk;
+	}
+
+	/**
+	 * Build the description body shared with the Google/Outlook URL builders.
+	 *
+	 * @param array $event
+	 * @param int   $post_id
+	 * @return string
+	 */
+	private static function build_description( array $event, int $post_id ): string {
+		$parts = array();
+
+		$performer = '';
+		if ( ! empty( $event['performer'] ) ) {
+			$performer = (string) $event['performer'];
+		} elseif ( ! empty( $event['performerName'] ) ) {
+			$performer = (string) $event['performerName'];
+		}
+		if ( $performer ) {
+			$parts[] = sprintf( __( 'Performer: %s', 'data-machine-events' ), wp_strip_all_tags( $performer ) );
+		}
+
+		if ( $post_id > 0 ) {
+			$permalink = get_permalink( $post_id );
+			if ( $permalink ) {
+				$parts[] = __( 'More info:', 'data-machine-events' ) . ' ' . $permalink;
+			}
+		}
+
+		if ( ! empty( $event['ticketUrl'] ) ) {
+			$parts[] = __( 'Tickets:', 'data-machine-events' ) . ' ' . (string) $event['ticketUrl'];
+		}
+
+		/** This filter is documented in inc/EventActions/CalendarUrlBuilder.php */
+		return (string) apply_filters(
+			'data_machine_events_add_to_calendar_description',
+			implode( "\n", $parts ),
+			$event,
+			$post_id
+		);
+	}
+
+	/**
+	 * Build the location string.
+	 *
+	 * @param array $event
+	 * @return string
+	 */
+	private static function build_location( array $event ): string {
+		$venue   = isset( $event['venue'] ) ? wp_strip_all_tags( (string) $event['venue'] ) : '';
+		$address = isset( $event['address'] ) ? wp_strip_all_tags( (string) $event['address'] ) : '';
+
+		if ( $venue && $address ) {
+			return $venue . ', ' . $address;
+		}
+		return $venue ?: $address;
+	}
+}


### PR DESCRIPTION
Closes #312.

## Summary

Adds an **Add to Calendar** button on single-event pages with a dropdown menu offering three destinations:

- **Google Calendar** — `calendar.google.com/calendar/render` deep link with `dates=` in UTC and a `ctz` hint
- **Outlook.com** — `outlook.live.com/calendar/0/deeplink/compose` deep link with ISO 8601 + offset
- **Apple Calendar / Download (.ics)** — public REST endpoint that streams a valid VCALENDAR file

The button hooks `data_machine_events_action_buttons` at **priority 7** so it renders between the existing attendance button (priority 5, from extrachill-events) and the share button (priority 10, from extrachill-events). Final order on a fully-loaded EC event page: **Ticket → Attendance → Add to Calendar → Share**.

## Files

| File | Purpose |
|---|---|
| `inc/EventActions/CalendarUrlBuilder.php` | Pure PHP URL builders for Google + Outlook (TZ-aware), plus the .ics endpoint URL |
| `inc/EventActions/IcsBuilder.php` | Hand-rolled VCALENDAR/VEVENT/VTIMEZONE generator (RFC 5545) |
| `inc/Api/Controllers/EventIcs.php` | REST controller, public, bypasses JSON serialization via `rest_pre_serve_request` |
| `inc/Api/Routes.php` | Registers `GET /datamachine/v1/events/(?P<id>\d+)/ics` |
| `inc/Blocks/EventDetails/add-to-calendar-button.php` | Hook callback that emits button + dropdown HTML |
| `inc/Blocks/EventDetails/src/add-to-calendar.js` | Vanilla JS WAI-ARIA menu button pattern |
| `inc/Blocks/EventDetails/src/frontend.css` | Dropdown styling using existing `--data-machine-*` tokens |
| `inc/Blocks/EventDetails/block.json` | Adds `viewScript` so the frontend bundle is enqueued |
| `data-machine-events.php` | Loads the button registration file |

## Timezone handling

- **Google URL** emits `dates=YYYYMMDDTHHmmSSZ/YYYYMMDDTHHmmSSZ` in UTC (converted from local time via `venueTimezone`), plus a `ctz=America/New_York` hint so Google's UI shows the imported event in the venue's timezone.
- **Outlook URL** emits `startdt=2026-06-06T19:00:00-04:00` (local time + offset, `DateTimeInterface::ATOM` format).
- **.ics** uses `DTSTART;TZID=America/New_York:20260606T190000` with a VTIMEZONE block built from `DateTimeZone::getTransitions()`. The first entry is the synthetic "window-start" snapshot — we skip it and use the first **real** DAYLIGHT and STANDARD transition. Predecessor offsets come from the immediately-prior entry in the full transitions array.

If `venueTimezone` is missing, falls back to `wp_timezone_string()`. Invalid timezone strings fall back to UTC.

**Default duration:** when `endTime` is empty, builders default to **start + 3 hours**.

## RFC 5545 details

- CRLF line endings
- 75-octet line folding (continuation lines start with a space)
- TEXT escaping for `\`, `;`, `,`, and CRLF→`\n` in TEXT-typed fields
- UTF-8 boundary-safe folding (won't split multi-byte chars)
- UID is the event permalink → re-imports are idempotent

## Manual import sanity-check matrix

Smoke-tested via WP-CLI against real events on `events.extrachill.com`:

**Event 236482** (`cancerslug, Trunk, Seeing Snakes` — 2026-06-06 19:00 America/New_York, no endTime):

Google URL: `dates=20260606T230000Z/20260607T020000Z` (verified UTC: 19:00 EDT = 23:00 UTC, +3h default duration = 02:00 next-day UTC).

Outlook URL: `startdt=2026-06-06T19:00:00-04:00&enddt=2026-06-06T22:00:00-04:00`.

`.ics` body:
```
BEGIN:VCALENDAR
VERSION:2.0
PRODID:-//Data Machine Events//EN
CALSCALE:GREGORIAN
METHOD:PUBLISH
BEGIN:VTIMEZONE
TZID:America/New_York
BEGIN:DAYLIGHT
DTSTART:20260308T070000
TZOFFSETFROM:-0500
TZOFFSETTO:-0400
TZNAME:EDT
END:DAYLIGHT
BEGIN:STANDARD
DTSTART:20251102T060000
TZOFFSETFROM:-0400
TZOFFSETTO:-0500
TZNAME:EST
END:STANDARD
END:VTIMEZONE
BEGIN:VEVENT
UID:https://events.extrachill.com/events/cancerslug-trunk-seeing-snakes
DTSTAMP:20260527T002217Z
DTSTART;TZID=America/New_York:20260606T190000
DTEND;TZID=America/New_York:20260606T220000
SUMMARY:cancerslug\, Trunk\, Seeing Snakes
DESCRIPTION:Performer: cancerslug\nMore info: https://events.extrachill.com
 /events/cancerslug-trunk-seeing-snakes\nTickets: ...
LOCATION:Nikki Lopez Philly\, 304 South St\, Philadelphia\, PA\, 10147
URL:https://events.extrachill.com/events/cancerslug-trunk-seeing-snakes
END:VEVENT
END:VCALENDAR
```

Round-trip parsed cleanly via the bundled `johngrogg/ics-parser`:
```
Parser found 1 event(s)
  summary: cancerslug, Trunk, Seeing Snakes
  dtstart: 20260606T190000
  dtend: 20260606T220000
  location: Nikki Lopez Philly, 304 South St, Philadelphia, PA, 10147
  uid: https://events.extrachill.com/events/cancerslug-trunk-seeing-snakes
Success: ICS parses cleanly
```

**Reviewer verification once deployed** (after merge + release + deploy):
1. `curl -sSL https://events.extrachill.com/wp-json/datamachine/v1/events/236482/ics` → should return `text/calendar` body matching the above shape, with a fresh `DTSTAMP`.
2. Save the response to `event.ics`, double-click on macOS → Apple Calendar should import as `cancerslug, Trunk, Seeing Snakes` on 2026-06-06 from 19:00–22:00 ET.
3. Click the Google Calendar item in the dropdown on a single-event page → Google's "create event" UI should open pre-filled with the venue, title, description (containing performer + permalink + ticket link), and the venue timezone.
4. Click the Outlook item → analogous flow at outlook.live.com.
5. On mobile, position the button near the right edge of the viewport — menu should add `.is-right-aligned` (CSS flips to `right: 0`) and stay within the viewport.

## Accessibility

WAI-ARIA menu button pattern:
- `aria-haspopup="true"`, `aria-expanded` flips on toggle
- `role="menu"` / `role="menuitem"` on the list + items
- Escape closes + returns focus to toggle
- ArrowDown/Up on the toggle opens and focuses first/last item
- ArrowDown/Up on items navigate, Home/End jump to first/last
- Focus leaving the widget closes the menu (Tab past last item)
- `:focus-visible` outline on menu items

## Out-of-scope / NOT changed

- No Yahoo / Office 365 deep link / Android intent (per locked scope)
- No JS library (no `add-to-calendar-button.js`, no `atcb`)
- No jQuery, no admin-ajax, no React for this dropdown
- No analytics on button clicks
- Endpoint does NOT use `BrowserNavigationGuard` — this one *is* meant to be a top-level navigation
- No button on event cards in calendar listings (single-event page only)

cc @chubes — ready for review.