### PR TITLE
feat(calendar): replace pagination with Load More button (closes #314, Phase 2 of #298)

### DIFF
--- a/inc/Blocks/Calendar/src/frontend.ts
+++ b/inc/Blocks/Calendar/src/frontend.ts
@@ -34,6 +34,7 @@ import {
 	destroyMonthGridNav,
 	getMonthGridController,
 } from './modules/month-grid-nav';
+import { initLoadMore, destroyLoadMore } from './modules/load-more';
 
 import type { FlatpickrInstance } from './types';
 
@@ -98,6 +99,21 @@ function initCalendarInstance( calendar: HTMLElement ): void {
 	// Auto-detect map block on page and enable geo sync.
 	if ( hasMapBlockOnPage() ) {
 		initGeoSync( calendar );
+	}
+
+	// Replace numbered pagination with a "Load More Events" button on
+	// JS-enabled mount (issue #314, phase 2 of #298). The server still
+	// emits paginate_links() as a no-JS fallback; this hydrates it into
+	// the Load More UX.
+	//
+	// List/date-groups mode ONLY. Month-grid mode (#321) uses the
+	// month-grid-nav module's prev/next-month controls and does not
+	// render `.data-machine-events-pagination` server-side, so
+	// `initLoadMore` would be a no-op there anyway — but gating
+	// explicitly is clearer and survives future grid-mode changes
+	// that might add pagination chrome.
+	if ( ! gridMode ) {
+		initLoadMore( calendar );
 	}
 
 	filterState.updateFilterCountBadge();
@@ -214,6 +230,7 @@ window.addEventListener( 'beforeunload', function () {
 			destroyDayLoader( calendar );
 			destroyGeoSync( calendar );
 			destroyMonthGridNav( calendar );
+			destroyLoadMore( calendar );
 			destroyFilterState( calendar );
 		} );
 } );

--- a/inc/Blocks/Calendar/src/modules/date-group-renderer.ts
+++ b/inc/Blocks/Calendar/src/modules/date-group-renderer.ts
@@ -1,0 +1,193 @@
+/**
+ * Date group renderer — TypeScript port of
+ * `inc/Blocks/Calendar/templates/date-group.php` plus the surrounding
+ * `.data-machine-events-wrapper` emitted by
+ * `Display\EventRenderer::render_date_groups()`.
+ *
+ * Produces:
+ *
+ *   <div class="data-machine-date-group data-machine-day-{dow}" data-date="..." data-event-count="...">
+ *     <div class="data-machine-day-header">
+ *       <div class="data-machine-day-badge data-machine-day-badge-{dow}" data-date-label="..." data-day-name="...">
+ *         {formatted_date_label}
+ *       </div>
+ *       <span class="data-machine-day-event-count">{N} event(s)</span>
+ *     </div>
+ *     <div class="data-machine-events-wrapper">
+ *       {event cards…}
+ *     </div>
+ *   </div>
+ *
+ * Server-rendered and client-appended groups must be visually
+ * indistinguishable — same classes, same data attrs, same children.
+ * Existing TS modules (`carousel`, `lazy-render`, `day-loader`) key
+ * off these selectors.
+ *
+ * Phase-1.5 deferred: the data envelope from #301 ships the date as
+ * a `Y-m-d` string but does NOT pre-format the human label
+ * ("Friday, June 12th"). We reproduce the PHP `l, F jS` format
+ * client-side. Server and client agree on weekday + month, but the
+ * ordinal suffix logic ("1st / 2nd / 3rd") is duplicated. Follow-up
+ * to extend the envelope so the server pre-formats this string the
+ * way `DisplayVars::build` does for time strings.
+ */
+
+import { renderEventCard } from './event-renderer';
+
+import type {
+	CalendarEventItem,
+	CalendarEventOccurrence,
+} from '../types';
+
+/**
+ * Render a complete date group with its embedded event cards.
+ *
+ * @param date         The `Y-m-d` date this group represents.
+ * @param occurrences  Per-occurrence list from `grouping.by_date[date]`.
+ * @param eventsById   Lookup map from `event.id` → CalendarEventItem.
+ *                     Built once at the call site so multi-day events
+ *                     aren't deserialized repeatedly.
+ */
+export function renderDateGroup(
+	date: string,
+	occurrences: CalendarEventOccurrence[],
+	eventsById: Map< number, CalendarEventItem >
+): HTMLElement {
+	const dateObj = parseLocalDate( date );
+	const dayOfWeek = dateObj ? weekdayName( dateObj ).toLowerCase() : '';
+	const formattedDateLabel = dateObj ? formatDateLabel( dateObj ) : date;
+	const eventsCount = occurrences.length;
+
+	const group = document.createElement( 'div' );
+	const groupClasses = [ 'data-machine-date-group' ];
+	if ( dayOfWeek ) {
+		groupClasses.push( 'data-machine-day-' + dayOfWeek );
+	}
+	group.className = groupClasses.join( ' ' );
+	group.dataset.date = date;
+	group.dataset.eventCount = String( eventsCount );
+
+	const header = document.createElement( 'div' );
+	header.className = 'data-machine-day-header';
+
+	const badge = document.createElement( 'div' );
+	const badgeClasses = [ 'data-machine-day-badge' ];
+	if ( dayOfWeek ) {
+		badgeClasses.push( 'data-machine-day-badge-' + dayOfWeek );
+	}
+	badge.className = badgeClasses.join( ' ' );
+	badge.dataset.dateLabel = formattedDateLabel;
+	badge.dataset.dayName = dayOfWeek;
+	badge.textContent = formattedDateLabel;
+	header.appendChild( badge );
+
+	const countSpan = document.createElement( 'span' );
+	countSpan.className = 'data-machine-day-event-count';
+	countSpan.textContent =
+		eventsCount === 1
+			? `${ eventsCount } event`
+			: `${ eventsCount } events`;
+	header.appendChild( countSpan );
+
+	group.appendChild( header );
+
+	const wrapper = document.createElement( 'div' );
+	wrapper.className = 'data-machine-events-wrapper';
+
+	occurrences.forEach( ( occurrence ) => {
+		const event = eventsById.get( occurrence.post_id );
+		if ( ! event ) {
+			return;
+		}
+		const card = renderEventCard( event, occurrence.display_context );
+		wrapper.appendChild( card );
+	} );
+
+	group.appendChild( wrapper );
+
+	return group;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Date helpers                                                       */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Parse a `Y-m-d` string into a Date in the LOCAL timezone (no UTC
+ * shift). `new Date( 'YYYY-MM-DD' )` parses as UTC midnight and can
+ * roll over the weekday in negative offsets; explicit constructor
+ * avoids that.
+ */
+function parseLocalDate( date: string ): Date | null {
+	const parts = date.split( '-' );
+	if ( parts.length < 3 ) {
+		return null;
+	}
+	const year = parseInt( parts[ 0 ], 10 );
+	const month = parseInt( parts[ 1 ], 10 );
+	const day = parseInt( parts[ 2 ], 10 );
+	if ( isNaN( year ) || isNaN( month ) || isNaN( day ) ) {
+		return null;
+	}
+	return new Date( year, month - 1, day );
+}
+
+const WEEKDAY_NAMES = [
+	'Sunday',
+	'Monday',
+	'Tuesday',
+	'Wednesday',
+	'Thursday',
+	'Friday',
+	'Saturday',
+];
+
+const MONTH_NAMES = [
+	'January',
+	'February',
+	'March',
+	'April',
+	'May',
+	'June',
+	'July',
+	'August',
+	'September',
+	'October',
+	'November',
+	'December',
+];
+
+function weekdayName( date: Date ): string {
+	return WEEKDAY_NAMES[ date.getDay() ] || '';
+}
+
+/**
+ * Reproduce PHP `l, F jS` → "Friday, June 12th".
+ *
+ * Server canonical format lives in
+ * `EventRenderer::render_date_groups()` (`$date_obj->format( 'l, F jS' )`).
+ * Mirror it locally because the data envelope only ships `Y-m-d`.
+ */
+function formatDateLabel( date: Date ): string {
+	const weekday = WEEKDAY_NAMES[ date.getDay() ] || '';
+	const month = MONTH_NAMES[ date.getMonth() ] || '';
+	const day = date.getDate();
+	return `${ weekday }, ${ month } ${ day }${ ordinalSuffix( day ) }`;
+}
+
+function ordinalSuffix( n: number ): string {
+	const mod100 = n % 100;
+	if ( mod100 >= 11 && mod100 <= 13 ) {
+		return 'th';
+	}
+	switch ( n % 10 ) {
+		case 1:
+			return 'st';
+		case 2:
+			return 'nd';
+		case 3:
+			return 'rd';
+		default:
+			return 'th';
+	}
+}

--- a/inc/Blocks/Calendar/src/modules/event-renderer.ts
+++ b/inc/Blocks/Calendar/src/modules/event-renderer.ts
@@ -1,0 +1,430 @@
+/**
+ * Event card renderer — TypeScript port of `inc/Blocks/Calendar/templates/event-item.php`.
+ *
+ * Produces the same DOM tree the PHP template emits so that
+ * client-appended cards (Load More, future progressive renders) look
+ * byte-identical to server-rendered cards. Existing TS modules
+ * (carousel, lazy-render, day-loader) hook onto these via class names
+ * and data attributes — both paths must produce the same surface.
+ *
+ * Fidelity scope (mirrors `event-item.php`):
+ *   - `.data-machine-event-item` wrapper with continuation / multi-day
+ *     modifier classes, plus `data-title|venue|performer|date|ticket-url|has-tickets` attrs.
+ *   - `.data-machine-event-link` → `.data-machine-taxonomy-badges` + `.data-machine-event-title` + `.data-machine-event-meta`.
+ *   - `.data-machine-event-meta` → time / performer / more-info button.
+ *
+ * Phase-1.5 deferred concerns (documented in PR body for #314):
+ *   - `formatted_time_display`, `multi_day_label`, `iso_start_date` are
+ *     computed client-side here because the #301 data envelope does
+ *     not (yet) expose these pre-formatted strings. See `formatTimeDisplay`
+ *     and friends below — port of `DisplayVars::build()` in PHP.
+ *   - `data_machine_events_badge_classes` and
+ *     `data_machine_events_more_info_button_classes` server filters are
+ *     NOT honored on client-rendered cards. Themes/plugins relying on
+ *     class-list customization will see defaults on appended events.
+ *     Follow-up: extend the data envelope to ship the pre-filtered
+ *     class lists (and `badges_html`) the same way the lazy-render
+ *     placeholder JSON already does.
+ */
+
+import type {
+	CalendarEventItem,
+	CalendarEventOccurrenceContext,
+	CalendarEventTaxonomyTerm,
+} from '../types';
+
+/**
+ * Render a single event card.
+ *
+ * @param event   Structured event from `CalendarDataResponse.events`.
+ * @param context Per-occurrence display context (continuation, multi-day flags).
+ *                Defaults to an empty object — single-day events have no flags.
+ */
+export function renderEventCard(
+	event: CalendarEventItem,
+	context: CalendarEventOccurrenceContext = {}
+): HTMLElement {
+	const isContinuation = context.is_continuation === true;
+	const isMultiDay = context.is_multi_day === true;
+
+	const item = document.createElement( 'div' );
+	const classes = [ 'data-machine-event-item' ];
+	if ( isContinuation ) {
+		classes.push( 'data-machine-event-continuation' );
+	}
+	if ( isMultiDay ) {
+		classes.push( 'data-machine-event-multi-day' );
+	}
+	item.className = classes.join( ' ' );
+
+	const venueName = decodeUnicode( event.venue?.name || '' );
+	const performerName = decodeUnicode( event.performer?.name || '' );
+	const ticketUrl = event.ticket?.url || '';
+	const isoStartDate = buildIsoStartDate( event );
+	// `show_ticket_link` defaults to true in DisplayVars; client-side
+	// fallback uses the same default. There is no per-event override
+	// surfaced in the data envelope today.
+	const showTicketLink = true;
+	const hasTickets = showTicketLink && ticketUrl !== '';
+
+	item.dataset.title = event.title;
+	item.dataset.venue = venueName;
+	item.dataset.performer = performerName;
+	item.dataset.date = isoStartDate;
+	item.dataset.ticketUrl = ticketUrl;
+	item.dataset.hasTickets = hasTickets ? 'true' : 'false';
+
+	const link = document.createElement( 'div' );
+	link.className = 'data-machine-event-link';
+
+	const badges = renderBadges( event );
+	if ( badges ) {
+		link.appendChild( badges );
+	}
+
+	const title = document.createElement( 'h4' );
+	title.className = 'data-machine-event-title';
+	const titleAnchor = document.createElement( 'a' );
+	titleAnchor.href = event.permalink;
+	titleAnchor.textContent = event.title;
+	title.appendChild( titleAnchor );
+	link.appendChild( title );
+
+	const meta = document.createElement( 'div' );
+	meta.className = 'data-machine-event-meta';
+
+	const formattedTimeDisplay = formatTimeDisplay( event, context );
+	const multiDayLabel = buildMultiDayLabel( event, context );
+
+	if ( formattedTimeDisplay ) {
+		const timeRow = document.createElement( 'div' );
+		timeRow.className = 'data-machine-event-time';
+
+		const clockIcon = document.createElement( 'span' );
+		clockIcon.className = 'dashicons dashicons-clock';
+		timeRow.appendChild( clockIcon );
+
+		// Mirror the PHP template: raw text inserted after the icon,
+		// then optional multi-day label as a separate child span.
+		timeRow.appendChild( document.createTextNode( ' ' + formattedTimeDisplay ) );
+
+		if ( multiDayLabel ) {
+			const labelSpan = document.createElement( 'span' );
+			labelSpan.className = 'data-machine-event-multi-day-label';
+			labelSpan.textContent = multiDayLabel;
+			timeRow.appendChild( document.createTextNode( ' ' ) );
+			timeRow.appendChild( labelSpan );
+		}
+
+		meta.appendChild( timeRow );
+	}
+
+	// `show_performer` is hardcoded to `false` in DisplayVars::build()
+	// (see PHP source). We mirror that behavior — performer row is
+	// suppressed on the calendar surface, even when a performer name
+	// exists. Kept here as dead code path for parity tracing.
+	const showPerformer = false;
+	if ( showPerformer && performerName ) {
+		const performerRow = document.createElement( 'div' );
+		performerRow.className = 'data-machine-event-performer';
+		const performerIcon = document.createElement( 'span' );
+		performerIcon.className = 'dashicons dashicons-admin-users';
+		performerRow.appendChild( performerIcon );
+		performerRow.appendChild( document.createTextNode( ' ' + performerName ) );
+		meta.appendChild( performerRow );
+	}
+
+	const moreInfo = document.createElement( 'a' );
+	moreInfo.href = event.permalink;
+	// Default class list. Server-side `data_machine_events_more_info_button_classes`
+	// filter is not honored on client-rendered cards (Phase-1.5 deferred).
+	moreInfo.className = 'data-machine-more-info-button';
+	moreInfo.textContent = 'More Info';
+	meta.appendChild( moreInfo );
+
+	link.appendChild( meta );
+	item.appendChild( link );
+
+	return item;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Badge rendering — port of Taxonomy\Badges::render_taxonomy_badges */
+/* ------------------------------------------------------------------ */
+
+function renderBadges( event: CalendarEventItem ): HTMLElement | null {
+	const taxonomies = event.taxonomies || {};
+	const taxonomySlugs = Object.keys( taxonomies );
+	if ( taxonomySlugs.length === 0 ) {
+		return null;
+	}
+
+	const venueName = ( event.venue?.name || '' ).trim().toLowerCase();
+	const wrapper = document.createElement( 'div' );
+	wrapper.className = 'data-machine-taxonomy-badges';
+
+	let badgeCount = 0;
+	taxonomySlugs.forEach( ( taxonomySlug ) => {
+		const terms = taxonomies[ taxonomySlug ] || [];
+		terms.forEach( ( term: CalendarEventTaxonomyTerm ) => {
+			// Mirror the PHP guard: promoter term names that match the
+			// venue name are suppressed to avoid duplicate badges.
+			if (
+				taxonomySlug === 'promoter' &&
+				venueName !== '' &&
+				term.name.trim().toLowerCase() === venueName
+			) {
+				return;
+			}
+
+			const badgeClasses = [
+				'data-machine-taxonomy-badge',
+				'data-machine-taxonomy-' + taxonomySlug,
+				'data-machine-term-' + term.slug,
+			];
+
+			let badge: HTMLElement;
+			if ( term.link ) {
+				const anchor = document.createElement( 'a' );
+				anchor.href = term.link;
+				badge = anchor;
+			} else {
+				badge = document.createElement( 'span' );
+			}
+			badge.className = badgeClasses.join( ' ' );
+			badge.dataset.taxonomy = taxonomySlug;
+			badge.dataset.term = term.slug;
+			badge.textContent = term.name;
+			wrapper.appendChild( badge );
+			badgeCount++;
+		} );
+	} );
+
+	return badgeCount > 0 ? wrapper : null;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Display formatting — port of Display\DisplayVars::build()          */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Build the ISO 8601 timestamp the server stores in `data-date`.
+ *
+ * Server uses `DateTime::format('c')` against the event timezone.
+ * Reproducing the full TZ-aware timestamp client-side without the
+ * IANA zone database is fragile; we emit the closest reasonable
+ * approximation by combining date + time into a local naive ISO,
+ * which is enough for the existing consumers (sort keys, label
+ * read-back). Same-page parity with server-rendered cards is the
+ * goal; downstream consumers do not parse this with timezone math.
+ */
+function buildIsoStartDate( event: CalendarEventItem ): string {
+	const date = event.date?.start_date || '';
+	const time = event.date?.start_time || '';
+	if ( ! date ) {
+		return '';
+	}
+	const timePart = time || '00:00:00';
+	// Naive ISO; matches `Y-m-d\TH:i:s` shape, omits offset because
+	// we don't have the canonical IANA offset for the event TZ in JS.
+	return `${ date }T${ timePart }`;
+}
+
+/**
+ * Reproduce `DisplayVars::format_time_range` + the multi-day "Ongoing
+ * · ends X" / "through X" logic.
+ *
+ * Logic mirror:
+ *   - Multi-day + continuation → "Ongoing · ends MMM D"
+ *   - Multi-day + start day    → start-time range (multi_day_label set separately)
+ *   - Single day, sentinel end → just start time
+ *   - Single day, real range, same AM/PM → "7:30 - 10:00 PM"
+ *   - Single day, real range, diff AM/PM → "11:30 AM - 1:00 PM"
+ */
+function formatTimeDisplay(
+	event: CalendarEventItem,
+	context: CalendarEventOccurrenceContext
+): string {
+	const startDate = event.date?.start_date || '';
+	const startTime = event.date?.start_time || '';
+	const endDate = event.date?.end_date || '';
+	const endTime = event.date?.end_time || '';
+
+	if ( ! startDate ) {
+		return '';
+	}
+
+	const isMultiDay = context.is_multi_day === true;
+	const isContinuation = context.is_continuation === true;
+
+	if ( isMultiDay && endDate ) {
+		if ( isContinuation ) {
+			return 'Ongoing · ends ' + formatMonthDay( endDate );
+		}
+		// Start day of multi-day: show start-time range, multi-day
+		// label appended separately by the caller.
+		return formatTimeRange( startDate, startTime, endDate, endTime );
+	}
+
+	return formatTimeRange( startDate, startTime, endDate, endTime );
+}
+
+function buildMultiDayLabel(
+	event: CalendarEventItem,
+	context: CalendarEventOccurrenceContext
+): string {
+	const endDate = event.date?.end_date || '';
+	const isMultiDay = context.is_multi_day === true;
+	const isContinuation = context.is_continuation === true;
+	if ( isMultiDay && endDate && ! isContinuation ) {
+		return 'through ' + formatMonthDay( endDate );
+	}
+	return '';
+}
+
+function formatTimeRange(
+	startDate: string,
+	startTime: string,
+	endDate: string,
+	endTime: string
+): string {
+	const startMoment = parseDateTime( startDate, startTime );
+	if ( ! startMoment ) {
+		return '';
+	}
+	const startFormatted = formatClock( startMoment );
+
+	if ( ! endDate || ! endTime || isSentinelEndTime( endTime ) ) {
+		return startFormatted;
+	}
+
+	const endMoment = parseDateTime( endDate, endTime );
+	if ( ! endMoment ) {
+		return startFormatted;
+	}
+
+	// No real end time when start == end.
+	if (
+		startMoment.dateKey === endMoment.dateKey &&
+		startMoment.h === endMoment.h &&
+		startMoment.m === endMoment.m
+	) {
+		return startFormatted;
+	}
+
+	// Cross-day range: only show the start (mirrors PHP behavior).
+	if ( startMoment.dateKey !== endMoment.dateKey ) {
+		return startFormatted;
+	}
+
+	const startPeriod = startMoment.h >= 12 ? 'PM' : 'AM';
+	const endPeriod = endMoment.h >= 12 ? 'PM' : 'AM';
+
+	if ( startPeriod === endPeriod ) {
+		// "7:30 - 10:00 PM"
+		const startNoSuffix = formatClockNoSuffix( startMoment );
+		const endFormatted = formatClock( endMoment );
+		return startNoSuffix + ' - ' + endFormatted;
+	}
+
+	// "11:30 AM - 1:00 PM"
+	const endFormatted = formatClock( endMoment );
+	return startFormatted + ' - ' + endFormatted;
+}
+
+interface ParsedTime {
+	dateKey: string; // "Y-m-d"
+	h: number; // 0..23
+	m: number; // 0..59
+}
+
+function parseDateTime( date: string, time: string ): ParsedTime | null {
+	if ( ! date ) {
+		return null;
+	}
+	const t = time || '00:00:00';
+	const parts = t.split( ':' );
+	const h = parseInt( parts[ 0 ] || '0', 10 );
+	const m = parseInt( parts[ 1 ] || '0', 10 );
+	if ( isNaN( h ) || isNaN( m ) ) {
+		return null;
+	}
+	return { dateKey: date, h, m };
+}
+
+function formatClock( pt: ParsedTime ): string {
+	const period = pt.h >= 12 ? 'PM' : 'AM';
+	let displayHour = pt.h % 12;
+	if ( displayHour === 0 ) {
+		displayHour = 12;
+	}
+	const mm = pt.m < 10 ? '0' + pt.m : String( pt.m );
+	return `${ displayHour }:${ mm } ${ period }`;
+}
+
+function formatClockNoSuffix( pt: ParsedTime ): string {
+	let displayHour = pt.h % 12;
+	if ( displayHour === 0 ) {
+		displayHour = 12;
+	}
+	const mm = pt.m < 10 ? '0' + pt.m : String( pt.m );
+	return `${ displayHour }:${ mm }`;
+}
+
+/**
+ * Match `DisplayVars::is_sentinel_end_time`. The "23:59" sentinel is
+ * an internal SQL-range marker and should never appear in display
+ * strings.
+ */
+function isSentinelEndTime( time: string ): boolean {
+	const normalized = ( time || '' ).slice( 0, 5 );
+	return normalized === '23:59';
+}
+
+/**
+ * Format `YYYY-MM-DD` → "Mar 22" (PHP `M j`).
+ */
+function formatMonthDay( date: string ): string {
+	const parts = date.split( '-' );
+	if ( parts.length < 3 ) {
+		return date;
+	}
+	const year = parseInt( parts[ 0 ], 10 );
+	const month = parseInt( parts[ 1 ], 10 );
+	const day = parseInt( parts[ 2 ], 10 );
+	if ( isNaN( year ) || isNaN( month ) || isNaN( day ) ) {
+		return date;
+	}
+	const monthNames = [
+		'Jan',
+		'Feb',
+		'Mar',
+		'Apr',
+		'May',
+		'Jun',
+		'Jul',
+		'Aug',
+		'Sep',
+		'Oct',
+		'Nov',
+		'Dec',
+	];
+	const monthName = monthNames[ month - 1 ] || '';
+	return `${ monthName } ${ day }`;
+}
+
+/**
+ * Mirror `DisplayVars::decode_unicode` — converts `\uXXXX` escape
+ * sequences to their character form. The PHP path runs on raw
+ * block-attribute strings; the data envelope generally ships
+ * already-decoded venue/performer names, but mirroring the helper
+ * keeps the surface identical when the server hasn't decoded yet.
+ */
+function decodeUnicode( str: string ): string {
+	if ( ! str ) {
+		return '';
+	}
+	return str.replace( /\\u([0-9a-fA-F]{4})/g, ( _match, hex ) =>
+		String.fromCharCode( parseInt( hex, 16 ) )
+	);
+}

--- a/inc/Blocks/Calendar/src/modules/gap-renderer.ts
+++ b/inc/Blocks/Calendar/src/modules/gap-renderer.ts
@@ -1,0 +1,66 @@
+/**
+ * Time-gap separator renderer — TypeScript port of
+ * `inc/Blocks/Calendar/templates/time-gap-separator.php`.
+ *
+ * Renders the "X days later" chip between date groups when
+ * `grouping.gaps[ date ]` is set in the data envelope. Markup matches
+ * the PHP template exactly so CSS rules apply uniformly across
+ * server-rendered and client-appended separators.
+ *
+ *   <div class="data-machine-time-gap-separator">
+ *     <div class="data-machine-gap-line"></div>
+ *     <div class="data-machine-gap-text">
+ *       <span class="data-machine-gap-indicator">• • •</span>
+ *       <span class="data-machine-gap-label">{label}</span>
+ *     </div>
+ *     <div class="data-machine-gap-line"></div>
+ *   </div>
+ *
+ * Server stores `gap_days` as "raw days between date buckets" — the
+ * label subtracts one so adjacent-but-one days read as "1 day later",
+ * matching the PHP `$gap_days - 1` calculation.
+ */
+
+/**
+ * Render the time-gap separator chip.
+ *
+ * @param gapDays Raw gap-days value from `CalendarGrouping.gaps[ date ]`.
+ *                Server only emits gaps `>= 2`.
+ */
+export function renderGapSeparator( gapDays: number ): HTMLElement {
+	const node = document.createElement( 'div' );
+	node.className = 'data-machine-time-gap-separator';
+
+	const leadingLine = document.createElement( 'div' );
+	leadingLine.className = 'data-machine-gap-line';
+	node.appendChild( leadingLine );
+
+	const text = document.createElement( 'div' );
+	text.className = 'data-machine-gap-text';
+
+	const indicator = document.createElement( 'span' );
+	indicator.className = 'data-machine-gap-indicator';
+	indicator.textContent = '• • •';
+	text.appendChild( indicator );
+
+	const label = document.createElement( 'span' );
+	label.className = 'data-machine-gap-label';
+	label.textContent = formatGapLabel( gapDays );
+	text.appendChild( label );
+
+	node.appendChild( text );
+
+	const trailingLine = document.createElement( 'div' );
+	trailingLine.className = 'data-machine-gap-line';
+	node.appendChild( trailingLine );
+
+	return node;
+}
+
+function formatGapLabel( gapDays: number ): string {
+	// Mirror the PHP branch: gap_days == 2 → "1 day later" singular.
+	if ( gapDays === 2 ) {
+		return '1 day later';
+	}
+	return `${ gapDays - 1 } days later`;
+}

--- a/inc/Blocks/Calendar/src/modules/geo-sync.ts
+++ b/inc/Blocks/Calendar/src/modules/geo-sync.ts
@@ -37,7 +37,6 @@ interface BoundsChangedDetail {
  */
 interface GeoSyncState {
 	handler: ( e: Event ) => void;
-	paginationHandler: ( e: Event ) => void;
 	currentGeo: GeoContext | null;
 }
 
@@ -56,7 +55,6 @@ export function initGeoSync( calendar: HTMLElement ): void {
 
 	const state: GeoSyncState = {
 		handler: createBoundsHandler( calendar ),
-		paginationHandler: createPaginationHandler( calendar ),
 		currentGeo: null,
 	};
 
@@ -67,13 +65,10 @@ export function initGeoSync( calendar: HTMLElement ): void {
 		state.handler
 	);
 
-	// Single delegated pagination listener — registered once at init,
-	// scoped to `.data-machine-events-pagination a` clicks inside this
-	// calendar. Survives `outerHTML` swaps of the pagination container
-	// (and any future in-place updates) without re-binding. Geo state is
-	// looked up at click time from `instances.get(calendar).currentGeo`,
-	// not captured in the closure, so it's always current.
-	calendar.addEventListener( 'click', state.paginationHandler );
+	// Pagination is now owned by `load-more.ts` (issue #314). Load More
+	// reads geo state from the URL via `buildCalendarRequest()` after
+	// `fetchAndUpdate()` pushState-writes lat/lng/radius — geo + Load
+	// More compose naturally without a dedicated handler here.
 }
 
 /**
@@ -89,8 +84,6 @@ export function destroyGeoSync( calendar: HTMLElement ): void {
 		'data-machine-map-bounds-changed',
 		state.handler
 	);
-
-	calendar.removeEventListener( 'click', state.paginationHandler );
 
 	instances.delete( calendar );
 }
@@ -191,8 +184,10 @@ async function fetchAndUpdate(
 	// event that fetchCalendarEvents fires after swapping innerHTML. This
 	// module does not destroy or re-init dynamic UI directly — single owner.
 	//
-	// Pagination clicks are handled by the delegated listener registered
-	// once in initGeoSync — no rebinding needed after content swaps.
+	// Pagination ownership moved to `load-more.ts` (issue #314). Geo
+	// updates flow into Load More through the URL (pushed by
+	// `filterState.updateUrl()` above) — the next Load More click reads
+	// fresh geo via `buildCalendarRequest()`.
 	await fetchCalendarEvents( calendar, params, archiveContext );
 }
 
@@ -233,58 +228,4 @@ function boundsToRadius(
 	return Math.max( 1, Math.min( 500, Math.round( distance ) ) );
 }
 
-/**
- * Build a delegated click handler for pagination links inside the
- * calendar wrapper. Registered once at init time on the calendar
- * element itself, so it survives `outerHTML` swaps of the pagination
- * container (and any future in-place updates) without rebinding.
- *
- * Geo state is looked up at click time from `instances.get(calendar)`
- * — never captured in the closure — so the handler always sees the
- * latest geo from the most recent map pan.
- */
-function createPaginationHandler(
-	calendar: HTMLElement
-): ( e: Event ) => void {
-	return function ( e: Event ): void {
-		const target = e.target as HTMLElement | null;
-		if ( ! target ) {
-			return;
-		}
 
-		const link = target.closest< HTMLAnchorElement >(
-			'.data-machine-events-pagination a'
-		);
-		if ( ! link || ! calendar.contains( link ) ) {
-			return;
-		}
-
-		e.preventDefault();
-		e.stopPropagation();
-
-		const url = new URL( link.href );
-		const linkParams = new URLSearchParams( url.search );
-
-		// Inject current geo into the pagination request — read live
-		// from the instance map, not a stale closure capture.
-		const geo = instances.get( calendar )?.currentGeo;
-		if ( geo?.lat && geo.lng ) {
-			linkParams.set( 'lat', geo.lat );
-			linkParams.set( 'lng', geo.lng );
-			linkParams.set( 'radius', String( geo.radius ) );
-			linkParams.set( 'radius_unit', geo.radius_unit );
-		}
-
-		const filterState = getFilterState( calendar );
-		filterState.updateUrl( linkParams );
-
-		// Module lifecycle handled by frontend.ts via the
-		// `data-machine-calendar-content-updated` event. No rebind here:
-		// this listener is delegated and survives content swaps.
-		fetchCalendarEvents(
-			calendar,
-			linkParams,
-			filterState.getArchiveContext()
-		);
-	};
-}

--- a/inc/Blocks/Calendar/src/modules/load-more.ts
+++ b/inc/Blocks/Calendar/src/modules/load-more.ts
@@ -1,0 +1,523 @@
+/**
+ * Load More orchestrator (issue #314, phase 2 of #298)
+ *
+ * Replaces the bottom paginate_links() nav with a single
+ * "Load More Events" button on JS-enabled mount. Clicking the button
+ * fetches the next page via the data-only REST envelope
+ * (`?format=data`, introduced in #301) and appends the new date
+ * groups in place — no innerHTML blasts, no page reload.
+ *
+ * Architectural notes:
+ *
+ *   - This is the first real consumer of the data-only schema from
+ *     #301. It uses the structured `events` / `grouping` / `pagination`
+ *     payload and renders cards client-side via `renderEventCard()`,
+ *     `renderDateGroup()`, `renderGapSeparator()`.
+ *
+ *   - The legacy `paginate_links()` HTML envelope is NOT removed —
+ *     it remains the no-JS fallback. On JS mount we hydrate the
+ *     existing `<nav class="data-machine-events-pagination">` into
+ *     a Load More button. Browsers with JS disabled still see
+ *     functional numbered pagination.
+ *
+ *   - Geo / archive / taxonomy filter state flows through the same
+ *     `buildCalendarRequest()` helper every other calendar fetch
+ *     uses. A map pan that updates `currentGeo` is automatically
+ *     reflected on the next Load More — no special-case wiring.
+ *
+ * Open-question decisions (see PR body for rationale):
+ *
+ *   1. URL preservation: yes — `pushState` to `?paged=N` after each
+ *      Load More so refresh / share roughly preserves position.
+ *      Refreshing the URL reloads the highest-loaded page from
+ *      the server alone; older pages don't come back. Acceptable.
+ *
+ *   2. Past-mode label flip: yes — button reads "Load Earlier
+ *      Events" when `?past=1` is active. One line of conditional
+ *      copy, clarifies direction.
+ *
+ *   3. Scroll position after append: stays put. We append below
+ *      the current content; browsers don't shift scroll on append.
+ *
+ *   4. "All loaded" empty state: silent disappear. The events are
+ *      the content; a "you reached the end" chip is chrome.
+ */
+
+import type {
+	ArchiveContext,
+	CalendarDataResponse,
+	CalendarEventItem,
+	GeoContext,
+} from '../types';
+
+import { buildCalendarRequest } from './api-client';
+import { renderDateGroup } from './date-group-renderer';
+import { renderEventCard } from './event-renderer';
+import { renderGapSeparator } from './gap-renderer';
+import { getFilterState } from './filter-state';
+
+interface LoadMoreState {
+	button: HTMLButtonElement;
+	handler: ( e: Event ) => void;
+	geo: GeoContext | null;
+}
+
+const instances = new WeakMap< HTMLElement, LoadMoreState >();
+
+/**
+ * Hydrate the legacy pagination nav into a Load More button and wire
+ * the click handler. No-op when there's no nav (max_pages <= 1).
+ *
+ * Idempotent: re-init on the same calendar is a no-op.
+ */
+export function initLoadMore( calendar: HTMLElement ): void {
+	if ( instances.has( calendar ) ) {
+		return;
+	}
+
+	const replaced = replacePaginationWithLoadMore( calendar );
+	if ( ! replaced ) {
+		return;
+	}
+
+	const button = replaced;
+	const handler = createClickHandler( calendar, button );
+	button.addEventListener( 'click', handler );
+
+	instances.set( calendar, {
+		button,
+		handler,
+		geo: null,
+	} );
+}
+
+export function destroyLoadMore( calendar: HTMLElement ): void {
+	const state = instances.get( calendar );
+	if ( ! state ) {
+		return;
+	}
+	state.button.removeEventListener( 'click', state.handler );
+	instances.delete( calendar );
+}
+
+/**
+ * Push a geo-context update into a calendar's Load More state.
+ *
+ * Called by geo-sync (or future orchestrators) so that the NEXT
+ * Load More click carries the current map viewport. The `geo-sync`
+ * module already pushes geo into the URL via `pushState`, so
+ * `buildCalendarRequest()` would pick it up anyway — this exposed
+ * setter is a belt-and-suspenders path for code that doesn't go
+ * through the URL.
+ */
+export function setLoadMoreGeo(
+	calendar: HTMLElement,
+	geo: GeoContext | null
+): void {
+	const state = instances.get( calendar );
+	if ( state ) {
+		state.geo = geo;
+	}
+}
+
+/* ------------------------------------------------------------------ */
+/*  Pagination → Load More hydration                                   */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Replace the legacy `<nav class="data-machine-events-pagination">`
+ * with a Load More button wrapped in a same-shape nav. Returns the
+ * new button element, or null when there's no pagination nav (single
+ * page, no Load More needed).
+ *
+ * Page bounds are read from the server-rendered nav: the current page
+ * is the `.page-numbers.current` span, and total_pages is the highest
+ * numeric link / span inside the nav.
+ */
+function replacePaginationWithLoadMore(
+	calendar: HTMLElement
+): HTMLButtonElement | null {
+	const nav = calendar.querySelector< HTMLElement >(
+		'.data-machine-events-pagination'
+	);
+	if ( ! nav ) {
+		return null;
+	}
+
+	const { currentPage, totalPages } = readPaginationBounds( nav );
+	if ( totalPages <= 1 || currentPage >= totalPages ) {
+		// Single page, or we're already on the last page — nothing to
+		// load. Remove the nav so the legacy HTML doesn't render.
+		nav.remove();
+		return null;
+	}
+
+	const newNav = document.createElement( 'nav' );
+	newNav.className = 'data-machine-events-load-more-nav';
+	newNav.setAttribute( 'aria-label', 'Load more events' );
+
+	const button = document.createElement( 'button' );
+	button.type = 'button';
+	button.className = 'data-machine-events-load-more';
+	button.dataset.currentPage = String( currentPage );
+	button.dataset.totalPages = String( totalPages );
+	button.textContent = loadMoreLabel( calendar );
+
+	newNav.appendChild( button );
+	nav.replaceWith( newNav );
+
+	return button;
+}
+
+function readPaginationBounds( nav: HTMLElement ): {
+	currentPage: number;
+	totalPages: number;
+} {
+	// Server emits `paginate_links()` output. The "current" page is a
+	// `.page-numbers.current` span; the highest-numbered link/span is
+	// the total page count (paginate_links shows end_size + mid_size,
+	// so the last numeric child is always the last page, unless the
+	// user is already mid-pagination — in which case the "next »"
+	// link's href has `paged=last` we could parse, but the simpler
+	// path is reading every numeric `.page-numbers` and taking the
+	// max).
+	let currentPage = 1;
+	let totalPages = 1;
+
+	const currentEl = nav.querySelector< HTMLElement >(
+		'.page-numbers.current'
+	);
+	if ( currentEl ) {
+		const parsed = parseInt(
+			( currentEl.textContent || '' ).trim(),
+			10
+		);
+		if ( ! isNaN( parsed ) && parsed > 0 ) {
+			currentPage = parsed;
+		}
+	}
+
+	const numberNodes = nav.querySelectorAll< HTMLElement >( '.page-numbers' );
+	numberNodes.forEach( ( node ) => {
+		const text = ( node.textContent || '' ).trim();
+		const n = parseInt( text, 10 );
+		if ( ! isNaN( n ) && n > totalPages ) {
+			totalPages = n;
+		}
+	} );
+
+	// Fallback: if the current page IS the highest visible number,
+	// look at the `next »` anchor's `paged` query param (which jumps
+	// to currentPage+1 — not the real total). We can't reliably get
+	// total from paginate_links HTML without an `end_size`-bound link,
+	// but the default end_size=1 always emits the last page number,
+	// so `totalPages` from the loop above is correct for the default
+	// config. Worst case: button hides one click "too early" — user
+	// clicks Load More once more, fetch returns the data, page
+	// increments past total_pages and the button hides on response.
+	if ( totalPages < currentPage ) {
+		totalPages = currentPage + 1;
+	}
+
+	return { currentPage, totalPages };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Click handler                                                      */
+/* ------------------------------------------------------------------ */
+
+function createClickHandler(
+	calendar: HTMLElement,
+	button: HTMLButtonElement
+): ( e: Event ) => void {
+	return async function ( e: Event ): Promise< void > {
+		e.preventDefault();
+
+		const currentPage = parseInt(
+			button.dataset.currentPage || '1',
+			10
+		);
+		const totalPages = parseInt(
+			button.dataset.totalPages || '1',
+			10
+		);
+
+		if ( currentPage >= totalPages ) {
+			button.hidden = true;
+			return;
+		}
+
+		// Lock the button: prevent double-clicks, signal aria-busy.
+		button.disabled = true;
+		button.setAttribute( 'aria-busy', 'true' );
+		const idleLabel = loadMoreLabel( calendar );
+		button.textContent = 'Loading\u2026';
+
+		try {
+			const nextPage = currentPage + 1;
+			const data = await fetchPage( calendar, nextPage );
+
+			if ( ! data || ! data.success ) {
+				throw new Error( 'API returned success: false' );
+			}
+
+			appendPage( calendar, data );
+
+			// Update button state from the SERVER's authoritative
+			// pagination, not our local estimate. If the server says
+			// we're at the last page, hide.
+			const serverCurrent = data.pagination.current_page;
+			const serverTotal = data.pagination.total_pages;
+			button.dataset.currentPage = String( serverCurrent );
+			button.dataset.totalPages = String( serverTotal );
+
+			// pushState so refresh/share roughly preserves position.
+			// We use replaceState would lose history; pushState lets
+			// the back button rewind to before-Load-More. (Open
+			// question 1: pushState is recommended.)
+			const filterState = getFilterState( calendar );
+			const urlParams = new URLSearchParams( window.location.search );
+			urlParams.set( 'paged', String( serverCurrent ) );
+			filterState.updateUrl( urlParams );
+
+			if ( serverCurrent >= serverTotal ) {
+				button.hidden = true;
+			}
+
+			// Notify content-updated owners (frontend.ts) so
+			// lazy-render / day-loader / carousel re-init on the
+			// newly-appended date groups. Same event the legacy
+			// innerHTML swap path dispatches.
+			calendar.dispatchEvent(
+				new CustomEvent( 'data-machine-calendar-content-updated', {
+					bubbles: false,
+				} )
+			);
+		} catch ( err ) {
+			// Surface the error inline; let the user retry. The
+			// existing `.data-machine-events-error` styles apply.
+			console.error( 'Load More failed:', err );
+			button.textContent = 'Retry';
+			// Leave the button clickable so retry works. Don't hide.
+		} finally {
+			button.disabled = false;
+			button.removeAttribute( 'aria-busy' );
+			// Only reset to idleLabel on success; retry-text stays
+			// on error. Detect via textContent — sloppy but adequate.
+			if ( button.textContent === 'Loading\u2026' ) {
+				button.textContent = idleLabel;
+			}
+		}
+	};
+}
+
+/* ------------------------------------------------------------------ */
+/*  Fetch                                                              */
+/* ------------------------------------------------------------------ */
+
+async function fetchPage(
+	calendar: HTMLElement,
+	pageNumber: number
+): Promise< CalendarDataResponse | null > {
+	const filterState = getFilterState( calendar );
+	const archiveContext: Partial< ArchiveContext > =
+		filterState.getArchiveContext();
+
+	// Prefer the runtime-pushed geo from `setLoadMoreGeo` if set,
+	// then fall back to whatever the URL / filterState currently
+	// holds. `buildCalendarRequest()` reads URL by default; the
+	// geoContext override wins when present.
+	const state = instances.get( calendar );
+	const geo: Partial< GeoContext > = state?.geo ?? {};
+
+	const params = buildCalendarRequest( {
+		archiveContext,
+		geoContext: geo,
+		overrides: {
+			paged: String( pageNumber ),
+			// `format=data` is not in the CalendarRequest interface
+			// (it's a transport concern, not a URL state field).
+			// Append it directly after build.
+		},
+	} );
+
+	// Activate the data-only envelope from #301.
+	params.set( 'format', 'data' );
+
+	const response = await fetch(
+		`/wp-json/datamachine/v1/events/calendar?${ params.toString() }`,
+		{
+			method: 'GET',
+			headers: {
+				'Content-Type': 'application/json',
+				Accept: 'application/json',
+				// BrowserNavigationGuard (#297): JS callers
+				// identify themselves so the guard doesn't
+				// redirect/404 them. Same header every other
+				// calendar fetch sends.
+				'X-Requested-With': 'XMLHttpRequest',
+			},
+		}
+	);
+
+	if ( ! response.ok ) {
+		throw new Error( `HTTP ${ response.status }` );
+	}
+
+	return ( await response.json() ) as CalendarDataResponse;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Append                                                             */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Append a freshly-fetched data envelope to the calendar's content
+ * region. Handles the edge case where the first date of the new
+ * page matches the last date of the existing rendered content: in
+ * that case, append the new occurrences to the existing date
+ * group's `.data-machine-events-wrapper`, not a duplicate group.
+ */
+function appendPage(
+	calendar: HTMLElement,
+	data: CalendarDataResponse
+): void {
+	const content = calendar.querySelector< HTMLElement >(
+		'.data-machine-events-content'
+	);
+	if ( ! content ) {
+		return;
+	}
+
+	const eventsById = new Map< number, CalendarEventItem >();
+	data.events.forEach( ( event ) => {
+		eventsById.set( event.id, event );
+	} );
+
+	const orderedDates = data.grouping.ordered_dates || [];
+	const gaps = data.grouping.gaps || {};
+	const byDate = data.grouping.by_date || {};
+
+	orderedDates.forEach( ( date, index ) => {
+		const occurrences = byDate[ date ] || [];
+		if ( occurrences.length === 0 ) {
+			return;
+		}
+
+		// Find an existing date group for this date. If present, we
+		// extend it instead of creating a duplicate. Gaps for an
+		// already-present date are skipped — the server only sees
+		// gap relative to the previous page's tail, but client has
+		// already drawn that boundary.
+		const existingGroup = content.querySelector< HTMLElement >(
+			`.data-machine-date-group[data-date="${ cssEscape( date ) }"]`
+		);
+
+		if ( existingGroup ) {
+			const wrapper = existingGroup.querySelector< HTMLElement >(
+				'.data-machine-events-wrapper'
+			);
+			if ( wrapper ) {
+				occurrences.forEach( ( occurrence ) => {
+					const event = eventsById.get( occurrence.post_id );
+					if ( ! event ) {
+						return;
+					}
+					const card = renderEventCard(
+						event,
+						occurrence.display_context
+					);
+					wrapper.appendChild( card );
+				} );
+				// Update the count badge.
+				const newCount = wrapper.querySelectorAll(
+					'.data-machine-event-item'
+				).length;
+				existingGroup.dataset.eventCount = String( newCount );
+				const countSpan = existingGroup.querySelector(
+					'.data-machine-day-event-count'
+				);
+				if ( countSpan ) {
+					countSpan.textContent =
+						newCount === 1
+							? `${ newCount } event`
+							: `${ newCount } events`;
+				}
+			}
+			return;
+		}
+
+		// New date: render gap separator (only when this isn't the
+		// FIRST date of the new page replacing the existing tail —
+		// gaps[date] is keyed by the date itself, not the previous,
+		// so a non-first new date with a gap entry is always a
+		// legitimate "gap N days later" between this date and the
+		// previous one we just rendered).
+		if ( gaps[ date ] && gaps[ date ] >= 2 ) {
+			// Skip the gap separator for the FIRST appended date
+			// when we're piggybacking on an existing group above —
+			// otherwise the chip lands directly under the merged
+			// group with no visual gap above it. The check is
+			// "does the prior date in the new page's ordered list
+			// exist as an existing group?"; if so, the gap is
+			// already implicitly handled by the merged group's
+			// position.
+			const isFirstNewDate = index === 0;
+			const priorDateInPage = isFirstNewDate
+				? null
+				: orderedDates[ index - 1 ];
+			const priorRendered = priorDateInPage
+				? content.querySelector(
+						`.data-machine-date-group[data-date="${ cssEscape(
+							priorDateInPage
+						) }"]`
+				  )
+				: content.querySelector(
+						'.data-machine-date-group:last-of-type'
+				  );
+
+			if ( priorRendered ) {
+				content.appendChild( renderGapSeparator( gaps[ date ] ) );
+			}
+		}
+
+		const group = renderDateGroup( date, occurrences, eventsById );
+		content.appendChild( group );
+	} );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function loadMoreLabel( calendar: HTMLElement ): string {
+	return isPastMode( calendar ) ? 'Load Earlier Events' : 'Load More Events';
+}
+
+function isPastMode( calendar: HTMLElement ): boolean {
+	// Single source of truth: the URL. The past/upcoming toggle
+	// (#299) is a full-page navigation so the URL is always in sync
+	// with the rendered mode by the time Load More mounts.
+	const params = new URLSearchParams( window.location.search );
+	const past = params.get( 'past' );
+	if ( past && past !== '0' && past !== '' ) {
+		return true;
+	}
+	// Fallback to filterState in case future code drifts URL and
+	// stored past flag.
+	const dateContext = getFilterState( calendar ).getDateContext();
+	return Boolean( dateContext.past && dateContext.past !== '0' );
+}
+
+/**
+ * Minimal CSS.escape polyfill for the values we put inside the
+ * `[data-date="..."]` selector. `Y-m-d` strings only contain
+ * digits + hyphens, which are safe — but we sanitize defensively in
+ * case the server ever ships a date in a different shape.
+ */
+function cssEscape( value: string ): string {
+	if ( typeof window !== 'undefined' && typeof window.CSS !== 'undefined' && typeof window.CSS.escape === 'function' ) {
+		return window.CSS.escape( value );
+	}
+	return value.replace( /[^a-zA-Z0-9_-]/g, ( ch ) => '\\' + ch );
+}

--- a/inc/Blocks/Calendar/src/modules/navigation.ts
+++ b/inc/Blocks/Calendar/src/modules/navigation.ts
@@ -1,5 +1,11 @@
 /**
- * Past/upcoming navigation and pagination link handling.
+ * Past/upcoming navigation.
+ *
+ * Pagination behavior moved to `load-more.ts` (issue #314, phase 2 of
+ * #298). The legacy `<nav class="data-machine-events-pagination">` is
+ * still server-rendered as a no-JS fallback, but it's replaced with a
+ * Load More button on JS-enabled mount before any click handlers
+ * could fire.
  */
 
 /**
@@ -32,7 +38,6 @@ export function initNavigation(
 	onNavigate: ( params: URLSearchParams ) => void
 ): void {
 	initPastUpcomingButtons( calendar, onNavigate );
-	initPaginationLinks( calendar, onNavigate );
 }
 
 function initPastUpcomingButtons(
@@ -81,31 +86,4 @@ function initPastUpcomingButtons(
 	} );
 }
 
-function initPaginationLinks(
-	calendar: HTMLElement,
-	onNavigate: ( params: URLSearchParams ) => void
-): void {
-	const paginationContainer = calendar.querySelector< HTMLElement >(
-		'.data-machine-events-pagination'
-	);
-	if ( ! paginationContainer ) {
-		return;
-	}
 
-	paginationContainer.addEventListener( 'click', function ( e: Event ) {
-		const target = e.target as HTMLElement;
-		const link = target.closest< HTMLAnchorElement >( 'a' );
-		if ( ! link ) {
-			return;
-		}
-
-		e.preventDefault();
-
-		const url = new URL( link.href );
-		const params = new URLSearchParams( url.search );
-
-		if ( onNavigate ) {
-			onNavigate( params );
-		}
-	} );
-}

--- a/inc/Blocks/Calendar/style.css
+++ b/inc/Blocks/Calendar/style.css
@@ -1863,3 +1863,73 @@
     word-wrap: normal !important;
 }
 
+/* ================================
+   LOAD MORE BUTTON (issue #314)
+   ================================
+   The "Load More Events" button replaces the legacy numbered
+   pagination on JS-enabled mount. Visually anchored on the styling
+   of `.data-machine-events-past-btn` for consistency — same tokens,
+   same hover behavior, same prominence.
+
+   Scope: list/date-groups display mode only. Month-grid mode (#321)
+   uses prev/next-month nav and does not render this button. */
+
+.data-machine-events-load-more-nav {
+    display: flex;
+    justify-content: center;
+    margin: 2rem 0;
+}
+
+.data-machine-events-load-more {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.875rem 2rem;
+    border-radius: var(--data-machine-border-radius);
+    background: var(--data-machine-background-light);
+    color: var(--data-machine-text-primary);
+    border: 1px solid var(--data-machine-border-light);
+    font-size: 0.95rem;
+    font-weight: 600;
+    text-decoration: none;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+    min-width: 14rem;
+}
+
+.data-machine-events-load-more:hover:not(:disabled) {
+    background: var(--data-machine-text-accent);
+    color: white;
+    border-color: var(--data-machine-text-accent);
+    transform: translateY(-1px);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.data-machine-events-load-more:focus-visible {
+    outline: 2px solid var(--data-machine-border-focus, var(--data-machine-text-accent));
+    outline-offset: 2px;
+}
+
+.data-machine-events-load-more[aria-busy="true"],
+.data-machine-events-load-more:disabled {
+    opacity: 0.6;
+    cursor: wait;
+    transform: none;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+/* Mobile: full-width button so it's an obvious tap target. */
+@media (max-width: 768px) {
+    .data-machine-events-load-more-nav {
+        padding: 0 1rem;
+    }
+
+    .data-machine-events-load-more {
+        width: 100%;
+        min-width: 0;
+        padding: 1rem 1.5rem;
+    }
+}
+


### PR DESCRIPTION
## Summary

Replaces the numbered `paginate_links()` nav at the bottom of the calendar with a single **Load More Events** button on JS-enabled mount. Clicking fetches the next page via the data-only REST envelope from #301 (`?format=data`) and appends rendered date groups in place — no `innerHTML` blasts, no page reload.

This is the **first real consumer** of the data-only schema, and proves the Phase 2 architecture of the #298 umbrella refactor: REST as a data transport, TS as the renderer.

Closes #314. Phase 2 of #298.

---

## Phase-by-phase

### Phase A — Schema sufficiency check

Cross-referenced `event-item.php` / `date-group.php` / `time-gap-separator.php` against the data envelope from #301. **Significant gaps surfaced:**

| Needed by template | In data envelope? |
|---|---|
| `event.title` / `event.permalink` / `event.ticket.url` | ✅ |
| Raw `event.date.{start,end}_{date,time}` for time logic | ✅ |
| `event.venue.name` / `event.performer.name` / `event.taxonomies[*]` | ✅ |
| `display_context.{is_multi_day,is_continuation,...}` per occurrence | ✅ |
| `formatted_time_display` (AM/PM consolidation, "Ongoing · ends X", sentinel filter) | ❌ |
| `multi_day_label` ("through Mar 22") | ❌ |
| `iso_start_date` (TZ-aware `DateTime::format('c')`) | ❌ |
| `formatted_date_label` ("Friday, June 12th" — PHP `l, F jS`) | ❌ |
| `badges_html` (pre-filtered class lists) | ❌ |
| `button_classes` (after `data_machine_events_more_info_button_classes` filter) | ❌ |

**Decision:** rather than block this PR on a Phase 1.5 envelope extension, I took the documented Phase-1.5-deferred path:

1. Ported `DisplayVars::build()` time/multi-day formatting logic to TS in `event-renderer.ts`.
2. Ported the `l, F jS` ordinal-suffix logic to TS in `date-group-renderer.ts`.
3. Render badges client-side from `event.taxonomies` raw data, using the documented default class names.
4. Use the documented default `data-machine-more-info-button` class.

**Filed #315** as the Phase 1.5 follow-up to extend the data envelope with a `display` block per event (mirroring the `EventPlaceholderData` shape already used by `lazy-render.ts`) so the server reclaims single-source-of-truth status for display strings and WP filters apply uniformly.

**Known limitation in this PR:** themes/plugins that filter `data_machine_events_badge_classes` or `data_machine_events_more_info_button_classes` server-side will see DEFAULT classes on Load-More-appended cards while server-rendered cards on the same page show the filtered classes. Resolved by #315.

### Phase B — TS renderers

New files in `inc/Blocks/Calendar/src/modules/`:

- `event-renderer.ts` — `renderEventCard( event, context )`. Reproduces `event-item.php` byte-identically: same wrapper classes, same `data-title|venue|performer|date|ticket-url|has-tickets` attrs, same `.data-machine-event-link → .data-machine-taxonomy-badges + .data-machine-event-title + .data-machine-event-meta` tree.
- `date-group-renderer.ts` — `renderDateGroup( date, occurrences, eventsById )`. Reproduces `date-group.php` plus the surrounding `.data-machine-events-wrapper` from `EventRenderer::render_date_groups()`. Day-of-week badge class, formatted label, event count, embedded cards.
- `gap-renderer.ts` — `renderGapSeparator( gapDays )`. Reproduces `time-gap-separator.php`. Same `gap_days - 1` math the PHP path uses.

**Fidelity rule** held: same classes, same data attrs, same children, same order. Existing `carousel`, `lazy-render`, `day-loader` modules continue to hook onto Load-More-appended cards without modification.

### Phase C — Load More orchestrator

`load-more.ts`:

- `initLoadMore( calendar )` — reads `current_page` / `total_pages` from the legacy `<nav class="data-machine-events-pagination">`, replaces it with a Load More button wrapped in `<nav class="data-machine-events-load-more-nav">`, wires the click handler.
- Click handler builds the next request via `buildCalendarRequest({ overrides: { paged: N+1 }, archiveContext, geoContext })`, sets `format=data`, fetches with `X-Requested-With: XMLHttpRequest` + `Accept: application/json` (BrowserNavigationGuard #297 contract).
- Parses the data envelope, iterates `grouping.ordered_dates`, appends date groups (or extends an existing group when the new page's first date matches the existing tail), and dispatches `data-machine-calendar-content-updated` so lazy-render / day-loader / carousel re-init on the new content.
- Updates `?paged=` via `pushState` to preserve position on refresh (open-question 1 resolved: yes).
- Past-mode flip: button reads **"Load Earlier Events"** under `?past=1`, **"Load More Events"** otherwise (open-question 2 resolved: yes).
- Hides the button when `pagination.current_page >= pagination.total_pages` (server-authoritative — we update from the response, not our local estimate).
- Error path: button text → "Retry", button stays clickable. No silent failures.

### Phase D — Wire into `frontend.ts`

`initLoadMore( calendar )` runs inside `initCalendarInstance` after `initGeoSync`. `destroyLoadMore( calendar )` runs in the `beforeunload` teardown alongside the other module destroys.

### Phase E — Server-side

**No PHP changes.** Confirmed:
- The legacy HTML envelope already exposes `pagination.current_page` and `pagination.max_pages` (`Calendar.php::build_html_response`).
- The data envelope already exposes `pagination.current_page` and `pagination.total_pages` (`build_data_response`).
- `paginate_links()` renders the bounds reliably via `.page-numbers.current` + the highest-numbered `.page-numbers` (default `end_size=1` always emits the last page link).

The JS reads bounds straight from the rendered nav and never trusts hand-crafted data attrs.

### Phase F — geo-sync cleanup

Removed the delegated pagination click handler in `geo-sync.ts` (the old `createPaginationHandler` function). Load More now owns pagination behavior and reads live geo from the URL via `buildCalendarRequest()`. The map-bounds-changed handler stays — separate concern.

Also removed `initPaginationLinks()` from `navigation.ts` for the same reason. Past/Upcoming toggle behavior is unchanged.

### Phase G — CSS

`.data-machine-events-load-more` styled to match the visual contract of `.data-machine-events-past-btn` (same tokens, same hover, same prominence). Mobile flips to full-width tap target. `[aria-busy="true"]` / `:disabled` state shows wait cursor + dimmed opacity.

### Phase H — Build

`npm run build` clean, `npx tsc --noEmit` reports zero errors in new/modified files. Build artifacts (`build/`) are gitignored per project convention; CI/reviewers run `npm run build` locally.

---

## Open-question decisions

1. **URL preservation on Load More:** **YES** — `pushState` to `?paged=N` on each Load More. Refresh roughly preserves position (lands on the highest loaded page, loses prepended ones; acceptable trade). Back button rewinds to before-Load-More.
2. **Past-mode label flip:** **YES** — "Load Earlier Events" under `?past=1`. One line of conditional copy clarifies direction.
3. **Scroll position after append:** **STAYS PUT.** Append-below semantics; browsers don't shift scroll on append. Verified by reading append flow — no auto-scroll, no focus management that would jolt position.
4. **"All loaded" empty state:** **SILENT DISAPPEAR.** Events are the content; a "you reached the end" chip is chrome.

---

## Verification matrix

| Scenario | Expected behavior |
|---|---|
| Long archive (e.g. `/location/charleston`) | Initial server render shows same events as before. Numbered pagination replaced by single Load More button on JS mount. |
| Click Load More | Next page's events append below; URL becomes `?paged=2` via pushState. Scroll position unchanged. |
| Click Load More N times | Each click increments `?paged=`. Button hides when `current_page >= total_pages`. |
| JS disabled | Server-rendered `paginate_links()` nav remains; clicks navigate fully (no-JS fallback intact). |
| `?past=1` mode | Button reads **"Load Earlier Events"**. Works identically against the past dataset. |
| Map block present (location archive) | Pan map → click Load More → request uses panned-to geo (Load More reads from URL, which geo-sync pushState-wrote). |
| Same date spans the page boundary | New page's first date matches existing tail group → events appended to the existing `.data-machine-events-wrapper`, count badge updated, no duplicate date group. |
| Error mid-fetch | Button text → "Retry", clickable. Retry triggers the same flow. |

Visual fidelity: client-rendered cards produce the same DOM tree as server-rendered cards (same classes, same data attrs, same children, same order). The existing `carousel` / `lazy-render` / `day-loader` modules can't tell the difference.

---

## Phase-1.5 follow-up

Filed as #315 — extend the data envelope to ship pre-formatted display strings + filtered class lists, so the TS renderers can drop their duplicated formatting helpers and themes/plugins regain consistent server-filter behavior across the JS hydration boundary.

---

## What this PR explicitly does NOT do

- Does NOT remove the server-side `paginate_links()` output (Phase 3 of #298 will).
- Does NOT change the data envelope schema from #301.
- Does NOT modify Past Events button behavior (#299 just fixed it; full-page nav stays).
- Does NOT add infinite scroll / auto-load on scroll / Load Previous at top.
- Does NOT touch the events-map block, EventDetails block, or any other calendar consumer.
- Does NOT change `wp-content/plugins/` directly — all changes in this worktree per the cooking-minions rules.