### PR TITLE
fix(retention): tighten AS + jobs windows for high-volume events site

### DIFF
--- a/data-machine-events.php
+++ b/data-machine-events.php
@@ -88,6 +88,9 @@ if ( ! function_exists( 'datamachine_get_event_timing' ) ) {
 require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Core/performance.php';
 \DataMachineEvents\Core\cache_last_post_time();
 
+// Load retention policy overrides (tightens Data Machine core defaults for this site's volume).
+require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Core/retention.php';
+
 	// Load REST API routes (modular)
 if ( file_exists( DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Api/Routes.php' ) ) {
 	require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Api/Routes.php';

--- a/inc/Core/retention.php
+++ b/inc/Core/retention.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Retention policy overrides for events.extrachill.com.
+ *
+ * `data-machine-events` runs at high pipeline volume (~60K AS actions/day,
+ * with spikes of 285K/day observed on 2026-05-21). Data Machine core's
+ * default retention windows (7 days for AS actions/logs, 30 days for jobs)
+ * let the on-disk footprint balloon to multiple GB even when retention is
+ * "working" — the working set is just huge.
+ *
+ * These filters tighten the windows specifically for this plugin's
+ * deployment context. The plugin is only activated on events.extrachill.com
+ * (blog ID 7), so no blog-ID guard is needed — the filters scope themselves
+ * by virtue of the plugin not loading on other sites.
+ *
+ * Steady-state on-disk savings:
+ * - c8c_7_actionscheduler_actions: ~2.0 GB → ~600 MB
+ * - c8c_7_actionscheduler_logs:    ~470 MB → ~135 MB
+ * - c8c_7_datamachine_jobs:        ~900 MB → ~420 MB
+ *
+ * See: https://github.com/Extra-Chill/data-machine-events/issues/317
+ *
+ * @package DataMachineEvents\Core
+ */
+
+namespace DataMachineEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Tighten Action Scheduler completed/failed action retention to 2 days.
+ *
+ * Default in Data Machine core: 7 days.
+ */
+add_filter(
+	'datamachine_as_actions_max_age_days',
+	static function ( $days ) {
+		return 2;
+	},
+	10,
+	1
+);
+
+/**
+ * Tighten Action Scheduler log retention to 2 days.
+ *
+ * Default in Data Machine core: 7 days.
+ */
+add_filter(
+	'datamachine_log_max_age_days',
+	static function ( $days ) {
+		return 2;
+	},
+	10,
+	1
+);
+
+/**
+ * Tighten completed Data Machine job retention to 14 days.
+ *
+ * Default in Data Machine core: 30 days. Failed jobs use the same window
+ * via `datamachine_failed_jobs_max_age_days`.
+ */
+add_filter(
+	'datamachine_completed_jobs_max_age_days',
+	static function ( $days ) {
+		return 14;
+	},
+	10,
+	1
+);
+
+add_filter(
+	'datamachine_failed_jobs_max_age_days',
+	static function ( $days ) {
+		return 14;
+	},
+	10,
+	1
+);
+
+/**
+ * Tighten processed-items retention to 14 days.
+ *
+ * Default in Data Machine core: 30 days. Processed-items dedup table grows
+ * proportionally to pipeline throughput; 14 days is plenty to catch
+ * re-ingest loops without keeping a month of history on disk.
+ */
+add_filter(
+	'datamachine_processed_items_max_age_days',
+	static function ( $days ) {
+		return 14;
+	},
+	10,
+	1
+);


### PR DESCRIPTION
Closes #317

## Why

`data-machine-events` runs at high pipeline volume on events.extrachill.com — ~60K Action Scheduler actions/day, with a 285K spike observed on 2026-05-21. Data Machine core's default retention windows (7d for AS, 30d for jobs) let the on-disk footprint balloon to multiple GB even when retention is technically "working" — the working set is just huge.

Data Machine core **already exposes all these windows as filters**. No DM core changes needed; this is purely a per-site override.

## How

New file `inc/Core/retention.php` registers the filter hooks. Loaded from `data-machine-events.php` alongside the existing `performance.php` include.

Because this plugin is **only activated on events.extrachill.com (blog ID 7)**, the filters scope themselves to that site by virtue of the plugin not loading anywhere else. No `get_current_blog_id()` guard needed.

### Window changes

| Filter | Default (core) | New |
|---|---|---|
| `datamachine_as_actions_max_age_days` | 7d | **2d** |
| `datamachine_log_max_age_days` | 7d | **2d** |
| `datamachine_completed_jobs_max_age_days` | 30d | **14d** |
| `datamachine_failed_jobs_max_age_days` | 30d | **14d** |
| `datamachine_processed_items_max_age_days` | 30d | **14d** |

### Expected on-disk steady-state savings

| Table | Before | After |
|---|---|---|
| `c8c_7_actionscheduler_actions` | ~2.0 GB | ~600 MB |
| `c8c_7_actionscheduler_logs` | ~470 MB | ~135 MB |
| `c8c_7_datamachine_jobs` | ~900 MB | ~420 MB |

**Total: ~2 GB reclaimed steady-state on the VPS.**

## Validation

- `php -l` clean on both modified/new files
- Filters apply via `apply_filters()` in DM core's `RetentionCleanup` class — confirmed by grep
- Daily recurring action `datamachine_recurring_retention_as_actions` (and siblings) read the windows via these filters on each run, so this takes effect on the next scheduled retention pass without a manual trigger

## Follow-up (separate issue, not this PR)

Investigate **why** `datamachine_execute_step` fires 60K+ times/day on events.extrachill.com. Tighter retention is a band-aid; the structural question is whether some pipeline should batch instead of fanning out per-item.