### PR TITLE
feat(calendar): month-grid display mode (closes #318)

### DIFF
--- a/docs/calendar-data-schema.md
+++ b/docs/calendar-data-schema.md
@@ -196,6 +196,29 @@ envelope's metadata fields (`pagination.current_page`,
 key surface as of this phase. HTML and data responses for the same
 envelope are stored in separate cache buckets.
 
+As of [#318](https://github.com/Extra-Chill/data-machine-events/issues/318) the cache key also includes the
+`month` envelope field, so month-grid responses scoped to a specific
+`YYYY-MM` window don't collide with list-mode responses for the same
+archive.
+
+## Month-grid scoping (#318)
+
+Pass `month=YYYY-MM` to scope the response to a single calendar month
+(used by the month-grid display mode):
+
+```bash
+curl 'https://example.com/wp-json/datamachine/v1/events/calendar?format=data&month=2026-09'
+```
+
+Semantics:
+- The ability collapses pagination to a single page and includes BOTH
+  past AND future events that fall within the month (grid mode renders
+  past dates with reduced opacity rather than gating them behind a
+  toggle).
+- `paged` and `past` are effectively ignored when `month` is set —
+  callers should drop them from the URL to keep the cache key clean.
+- An invalid `month` value falls back as if the param were absent.
+
 ## TypeScript
 
 See `inc/Blocks/Calendar/src/types.ts` for the matching interfaces:

--- a/inc/Abilities/CalendarAbilities.php
+++ b/inc/Abilities/CalendarAbilities.php
@@ -92,6 +92,10 @@ class CalendarAbilities {
 								'type'        => 'string',
 								'description' => 'Time scope: today, tonight, this-weekend, this-week (overrides date_start/date_end when set)',
 							),
+							'month'            => array(
+								'type'        => 'string',
+								'description' => 'Visible month for month-grid display (YYYY-MM). When set, the ability scopes events to the full month regardless of past/upcoming, and pagination is collapsed to one page.',
+							),
 						),
 					),
 					'output_schema'       => array(
@@ -164,6 +168,28 @@ class CalendarAbilities {
 		$user_date_start = $input['date_start'] ?? '';
 		$user_date_end   = $input['date_end'] ?? '';
 		$tax_filters     = is_array( $input['tax_filter'] ?? null ) ? $input['tax_filter'] : array();
+
+		// #318: month-grid mode short-circuits scope/paged semantics. When
+		// a `YYYY-MM` month is supplied, expand it to first-of-month →
+		// last-of-month and flip `show_past` on so past dates within the
+		// month are included (grid mode displays both past and future
+		// inside one window — the locked-design decision is "no past/
+		// upcoming toggle in grid; users navigate months freely"). The
+		// existing user_date_range branch downstream collapses pagination
+		// to a single page automatically.
+		$month_input = '';
+		if ( isset( $input['month'] ) && is_string( $input['month'] ) ) {
+			$month_input = self::normalize_month_input( $input['month'] );
+		}
+		if ( '' !== $month_input ) {
+			$month_bounds = self::month_to_date_bounds( $month_input );
+			if ( $month_bounds ) {
+				$user_date_start = $month_bounds['date_start'];
+				$user_date_end   = $month_bounds['date_end'];
+				$show_past       = true; // Include past dates that fall inside the visible month.
+				$current_page    = 1;
+			}
+		}
 
 		// Resolve scope to date boundaries when user hasn't set explicit dates.
 		$scope          = $input['scope'] ?? '';
@@ -398,6 +424,14 @@ class CalendarAbilities {
 
 		$result = array(
 			'paged_date_groups' => $this->serializeDateGroups( $paged_date_groups ),
+			// #318: raw (un-serialized) date groups exposed for in-process
+			// consumers that need WP_Post handles — notably the server-side
+			// month-grid template (MonthGridBuilder) which derives permalinks
+			// and titles from the post objects. This field is intentionally
+			// NOT part of the REST response (the data-only envelope flattens
+			// to post IDs and the HTML envelope renders to strings) — REST
+			// callers see `paged_date_groups` only.
+			'raw_date_groups'   => $paged_date_groups,
 			'gaps_detected'     => $gaps_detected,
 			'current_page'      => $current_page,
 			'max_pages'         => $max_pages,
@@ -816,6 +850,52 @@ class CalendarAbilities {
 			'dates'           => array_keys( $events_per_date ),
 			'total_events'    => $total_events,
 			'events_per_date' => $events_per_date,
+		);
+	}
+
+	/**
+	 * Normalize a `month` ability input to a strict `YYYY-MM` string, or
+	 * return `''` when the input is malformed. Mirrors the sanitizer in
+	 * {@see \DataMachineEvents\Blocks\Calendar\Query\CalendarRequest} so
+	 * the ability is safe even when called directly (CLI, MCP, tests)
+	 * with un-sanitized input.
+	 *
+	 * @param mixed $raw
+	 */
+	private static function normalize_month_input( $raw ): string {
+		$str = is_string( $raw ) ? trim( $raw ) : '';
+		if ( '' === $str ) {
+			return '';
+		}
+		if ( ! preg_match( '/^(\d{4})-(\d{2})$/', $str, $matches ) ) {
+			return '';
+		}
+		$year  = (int) $matches[1];
+		$month = (int) $matches[2];
+		if ( $year < 1970 || $year > 2999 || $month < 1 || $month > 12 ) {
+			return '';
+		}
+		return sprintf( '%04d-%02d', $year, $month );
+	}
+
+	/**
+	 * Expand a `YYYY-MM` string into `[date_start, date_end]` covering the
+	 * full month (first day → last day inclusive). Returns `null` when the
+	 * month is invalid.
+	 *
+	 * @param string $month YYYY-MM
+	 * @return array{date_start:string,date_end:string}|null
+	 */
+	private static function month_to_date_bounds( string $month ): ?array {
+		try {
+			$first = new \DateTimeImmutable( $month . '-01' );
+		} catch ( \Exception $e ) {
+			return null;
+		}
+		$last = $first->modify( 'last day of this month' );
+		return array(
+			'date_start' => $first->format( 'Y-m-d' ),
+			'date_end'   => $last->format( 'Y-m-d' ),
 		);
 	}
 }

--- a/inc/Api/Routes.php
+++ b/inc/Api/Routes.php
@@ -98,6 +98,12 @@ function register_routes() {
 					'sanitize_callback' => 'sanitize_key',
 					'description'       => 'Response format. Default (empty) returns the legacy HTML-string envelope. "data" returns the structured data-only envelope (phase 1 of refactor #298). All other values fall back to the default envelope.',
 				),
+				'month'            => array(
+					'type'              => 'string',
+					'default'           => '',
+					'sanitize_callback' => 'sanitize_text_field',
+					'description'       => 'Visible month for month-grid display (YYYY-MM). When set, the response is scoped to that calendar month and pagination is collapsed to a single page (issue #318). Invalid values fall back as if absent.',
+				),
 			),
 		)
 	);

--- a/inc/Blocks/Calendar/Cache/CalendarCache.php
+++ b/inc/Blocks/Calendar/Cache/CalendarCache.php
@@ -122,6 +122,12 @@ class CalendarCache {
 			// buckets — otherwise the first response shape served
 			// for a given envelope sticks for the cache TTL.
 			'format'           => (string) ( $envelope['format'] ?? '' ),
+			// #318: month-grid mode scopes events to a specific YYYY-MM
+			// window (regardless of past/upcoming). Fold the month into
+			// the key so grid and list responses for the same archive
+			// never share a cache bucket, and so distinct grid months
+			// each get their own bucket.
+			'month'            => (string) ( $envelope['month'] ?? '' ),
 		);
 
 		return self::FULL_PREFIX . md5( wp_json_encode( $key_data ) );

--- a/inc/Blocks/Calendar/Grid/MonthGridBuilder.php
+++ b/inc/Blocks/Calendar/Grid/MonthGridBuilder.php
@@ -1,0 +1,380 @@
+<?php
+/**
+ * Month Grid Builder
+ *
+ * Pure date/event arithmetic for the month-grid display mode (#318).
+ * Given a `YYYY-MM` month and the events grouped by date, produces the
+ * structured grid the template renders:
+ *
+ *   - 6 rows × 7 columns of cells (always a complete grid; leading/
+ *     trailing cells from adjacent months render as "other-month").
+ *   - Per cell: date, single-day events, multi-day ribbons that start
+ *     on that cell within its row, and metadata flags (is_today,
+ *     is_past, is_other_month, day_of_week).
+ *
+ * The ribbon model:
+ *   - One ribbon per (event × row) intersection. A multi-day event
+ *     spanning two rows produces two ribbons; CSS marks the boundary
+ *     ends with continuation indicators.
+ *   - Ribbons are placed on the row's start cell with a column span.
+ *   - Ribbons in the same row are vertically stacked by assigning each
+ *     a `lane` index — non-overlapping ribbons reuse the lowest free
+ *     lane.
+ *
+ * This class is intentionally framework-free: pure arrays in, pure
+ * arrays out. The template handles all escaping / markup.
+ *
+ * @package DataMachineEvents\Blocks\Calendar\Grid
+ * @since   0.40.0
+ */
+
+namespace DataMachineEvents\Blocks\Calendar\Grid;
+
+use DateTimeImmutable;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+final class MonthGridBuilder {
+
+	private const DAYS_OF_WEEK = array(
+		0 => 'sunday',
+		1 => 'monday',
+		2 => 'tuesday',
+		3 => 'wednesday',
+		4 => 'thursday',
+		5 => 'friday',
+		6 => 'saturday',
+	);
+
+	/**
+	 * Build the structured grid for a visible month.
+	 *
+	 * @param string $month             `YYYY-MM` visible month.
+	 * @param array  $paged_date_groups Output of `DateGrouper::group_events_by_date`.
+	 *                                   Shape: `[ date_key => [ 'events' => [ event_item, ... ], ... ], ... ]`.
+	 *                                   Each event_item carries `post`, `event_data`, `display_context`.
+	 * @param string $today_date        Today in Y-m-d, in the site timezone.
+	 * @return array<string,mixed>      Structured grid (see code).
+	 */
+	public static function build( string $month, array $paged_date_groups, string $today_date ): array {
+		try {
+			$first = new DateTimeImmutable( $month . '-01' );
+		} catch ( \Exception $e ) {
+			return self::empty_grid( $month, $today_date );
+		}
+
+		$year      = (int) $first->format( 'Y' );
+		$month_num = (int) $first->format( 'n' );
+
+		// Start of grid: first day of the week containing the 1st.
+		// Week starts on Sunday (locked decision in #318 v1).
+		$first_dow = (int) $first->format( 'w' ); // 0 = Sunday.
+		$grid_start = $first->modify( '-' . $first_dow . ' days' );
+
+		// Build a flat date-indexed map for fast event lookup.
+		$by_date = array();
+		foreach ( $paged_date_groups as $date_key => $group ) {
+			$by_date[ $date_key ] = $group['events'] ?? array();
+		}
+
+		// 6 rows × 7 columns = 42 cells. Always render 6 rows so the
+		// grid is a fixed shape; months with 4/5 visible weeks just
+		// trail more other-month cells.
+		$rows = array();
+		for ( $row_index = 0; $row_index < 6; $row_index++ ) {
+			$row_start = $grid_start->modify( '+' . ( $row_index * 7 ) . ' days' );
+			$row_end   = $row_start->modify( '+6 days' );
+
+			$cells = array();
+			for ( $col_index = 0; $col_index < 7; $col_index++ ) {
+				$cell_date = $row_start->modify( '+' . $col_index . ' days' );
+				$date_key  = $cell_date->format( 'Y-m-d' );
+				$cells[] = self::build_cell(
+					$cell_date,
+					$date_key,
+					$by_date[ $date_key ] ?? array(),
+					$today_date,
+					$month_num,
+					$year
+				);
+			}
+
+			$ribbons = self::build_row_ribbons( $row_start, $row_end, $by_date );
+
+			$rows[] = array(
+				'start_date' => $row_start->format( 'Y-m-d' ),
+				'end_date'   => $row_end->format( 'Y-m-d' ),
+				'cells'      => $cells,
+				'ribbons'    => $ribbons,
+			);
+		}
+
+		// Trim trailing all-other-month rows so months that fit in five
+		// weeks don't add an empty sixth row. We always KEEP at least
+		// five rows for layout stability.
+		while ( count( $rows ) > 5 ) {
+			$last = end( $rows );
+			$all_other = true;
+			foreach ( $last['cells'] as $cell ) {
+				if ( ! $cell['is_other_month'] ) {
+					$all_other = false;
+					break;
+				}
+			}
+			if ( $all_other ) {
+				array_pop( $rows );
+			} else {
+				break;
+			}
+		}
+
+		return array(
+			'month'        => $month,
+			'year'         => $year,
+			'month_label'  => date_i18n( 'F Y', $first->getTimestamp() ),
+			'prev_month'   => $first->modify( '-1 month' )->format( 'Y-m' ),
+			'next_month'   => $first->modify( '+1 month' )->format( 'Y-m' ),
+			'today_month'  => self::today_month( $today_date ),
+			'rows'         => $rows,
+			'weekday_keys' => array_values( self::DAYS_OF_WEEK ),
+		);
+	}
+
+	/**
+	 * Build a single cell.
+	 */
+	private static function build_cell(
+		DateTimeImmutable $cell_date,
+		string $date_key,
+		array $events_for_date,
+		string $today_date,
+		int $visible_month_num,
+		int $visible_year
+	): array {
+		$dow_index = (int) $cell_date->format( 'w' );
+		$day_of_week = self::DAYS_OF_WEEK[ $dow_index ];
+
+		$is_other_month = (int) $cell_date->format( 'n' ) !== $visible_month_num
+			|| (int) $cell_date->format( 'Y' ) !== $visible_year;
+
+		$is_today = ( $date_key === $today_date );
+		$is_past  = ( $date_key < $today_date );
+
+		// Split into single-day events (rendered as strips inside the
+		// cell) and multi-day events (deferred to the row-level ribbon
+		// builder so the same event renders once per row, not once
+		// per spanned cell). Per-occurrence we look at the event's
+		// own display_context to decide.
+		$single_day_events = array();
+		foreach ( $events_for_date as $event_item ) {
+			$display_context = $event_item['display_context'] ?? array();
+			$is_multi_day    = ! empty( $display_context['is_multi_day'] );
+			if ( $is_multi_day ) {
+				continue;
+			}
+			$single_day_events[] = self::serialize_event_for_cell( $event_item );
+		}
+
+		return array(
+			'date'              => $date_key,
+			'day_number'        => (int) $cell_date->format( 'j' ),
+			'day_of_week'       => $day_of_week,
+			'is_today'          => $is_today,
+			'is_past'           => $is_past,
+			'is_other_month'    => $is_other_month,
+			'single_day_events' => $single_day_events,
+		);
+	}
+
+	/**
+	 * Build the multi-day ribbons that intersect a single row.
+	 *
+	 * Iterates every date in the row, collects the unique multi-day
+	 * events that touch any cell in the row, then computes each
+	 * ribbon's row-relative start column and span. Assigns lanes
+	 * (vertical stacking index) greedily — non-overlapping ribbons
+	 * reuse the lowest free lane.
+	 */
+	private static function build_row_ribbons(
+		DateTimeImmutable $row_start,
+		DateTimeImmutable $row_end,
+		array $by_date
+	): array {
+		$row_start_key = $row_start->format( 'Y-m-d' );
+		$row_end_key   = $row_end->format( 'Y-m-d' );
+
+		// Collect unique multi-day occurrences hitting this row.
+		// Keyed by post ID so we render each event once per row even
+		// when its display_context appears under multiple dates in the
+		// row.
+		$ribbons_by_post = array();
+		$cursor = $row_start;
+		for ( $i = 0; $i < 7; $i++ ) {
+			$date_key = $cursor->format( 'Y-m-d' );
+			$events_for_date = $by_date[ $date_key ] ?? array();
+			foreach ( $events_for_date as $event_item ) {
+				$display_context = $event_item['display_context'] ?? array();
+				if ( empty( $display_context['is_multi_day'] ) ) {
+					continue;
+				}
+				$post = $event_item['post'] ?? null;
+				if ( ! $post || ! isset( $post->ID ) ) {
+					continue;
+				}
+				$post_id = (int) $post->ID;
+				if ( isset( $ribbons_by_post[ $post_id ] ) ) {
+					continue;
+				}
+
+				$ribbons_by_post[ $post_id ] = self::compute_ribbon_span(
+					$event_item,
+					$row_start_key,
+					$row_end_key
+				);
+			}
+			$cursor = $cursor->modify( '+1 day' );
+		}
+
+		// Sort by start col asc, then by span desc (longest first
+		// claims its lane first) for visually stable stacking.
+		usort(
+			$ribbons_by_post,
+			static function ( $a, $b ) {
+				if ( $a['start_col'] !== $b['start_col'] ) {
+					return $a['start_col'] <=> $b['start_col'];
+				}
+				return $b['span'] <=> $a['span'];
+			}
+		);
+
+		// Assign lanes greedily.
+		$lane_ends = array(); // lane_index => last occupied column (inclusive).
+		foreach ( $ribbons_by_post as &$ribbon ) {
+			$assigned = null;
+			foreach ( $lane_ends as $lane_index => $end_col ) {
+				if ( $ribbon['start_col'] > $end_col ) {
+					$assigned = $lane_index;
+					break;
+				}
+			}
+			if ( null === $assigned ) {
+				$assigned                = count( $lane_ends );
+				$lane_ends[ $assigned ]  = -1;
+			}
+			$ribbon['lane']            = $assigned;
+			$lane_ends[ $assigned ]    = $ribbon['start_col'] + $ribbon['span'] - 1;
+		}
+		unset( $ribbon );
+
+		return array_values( $ribbons_by_post );
+	}
+
+	/**
+	 * Compute a single ribbon's row-relative geometry.
+	 *
+	 * The event's full date range (from event_data) is clipped to the
+	 * row's [row_start_key, row_end_key] window. `continues_left` /
+	 * `continues_right` flags tell the template whether to draw the
+	 * cut-off ribbon ends as continuation arrows.
+	 */
+	private static function compute_ribbon_span(
+		array $event_item,
+		string $row_start_key,
+		string $row_end_key
+	): array {
+		$event_data = $event_item['event_data'] ?? array();
+		$event_start = (string) ( $event_data['startDate'] ?? '' );
+		$event_end   = (string) ( $event_data['endDate'] ?? $event_start );
+		if ( '' === $event_end ) {
+			$event_end = $event_start;
+		}
+
+		$clip_start = $event_start < $row_start_key ? $row_start_key : $event_start;
+		$clip_end   = $event_end > $row_end_key ? $row_end_key : $event_end;
+
+		// Defensive clamp: if clipping inverts the range, collapse to
+		// the row start (the event doesn't actually intersect the row
+		// after clipping — should never happen given the call site,
+		// but cheap to be safe).
+		if ( $clip_start > $clip_end ) {
+			$clip_start = $clip_end = $row_start_key;
+		}
+
+		$start_col = self::days_between( $row_start_key, $clip_start );
+		$end_col   = self::days_between( $row_start_key, $clip_end );
+		$span      = max( 1, $end_col - $start_col + 1 );
+
+		$continues_left  = $event_start < $row_start_key;
+		$continues_right = $event_end > $row_end_key;
+
+		$post       = $event_item['post'];
+		$title      = isset( $post->post_title ) ? (string) $post->post_title : '';
+		$post_id    = isset( $post->ID ) ? (int) $post->ID : 0;
+		$permalink  = $post_id > 0 ? (string) get_permalink( $post_id ) : '';
+		$dow_index  = (int) ( new DateTimeImmutable( $clip_start ) )->format( 'w' );
+
+		return array(
+			'post_id'         => $post_id,
+			'title'           => $title,
+			'permalink'       => $permalink,
+			'start_col'       => $start_col,
+			'span'            => $span,
+			'continues_left'  => $continues_left,
+			'continues_right' => $continues_right,
+			'day_of_week'     => self::DAYS_OF_WEEK[ $dow_index ] ?? '',
+		);
+	}
+
+	/**
+	 * Serialize a single-day event item into the shape the template
+	 * consumes for cell strips.
+	 */
+	private static function serialize_event_for_cell( array $event_item ): array {
+		$post      = $event_item['post'];
+		$post_id   = isset( $post->ID ) ? (int) $post->ID : 0;
+		$title     = isset( $post->post_title ) ? (string) $post->post_title : '';
+		$permalink = $post_id > 0 ? (string) get_permalink( $post_id ) : '';
+
+		return array(
+			'post_id'   => $post_id,
+			'title'     => $title,
+			'permalink' => $permalink,
+		);
+	}
+
+	/**
+	 * Whole-day delta between two `Y-m-d` strings (assumed UTC, since
+	 * date-only strings are timezone-neutral).
+	 */
+	private static function days_between( string $a, string $b ): int {
+		$da = new DateTimeImmutable( $a );
+		$db = new DateTimeImmutable( $b );
+		$diff = $da->diff( $db );
+		return (int) ( $diff->invert ? -$diff->days : $diff->days );
+	}
+
+	/**
+	 * Empty grid fallback for invalid month input.
+	 */
+	private static function empty_grid( string $month, string $today_date ): array {
+		return array(
+			'month'        => $month,
+			'year'         => 0,
+			'month_label'  => '',
+			'prev_month'   => '',
+			'next_month'   => '',
+			'today_month'  => self::today_month( $today_date ),
+			'rows'         => array(),
+			'weekday_keys' => array_values( self::DAYS_OF_WEEK ),
+		);
+	}
+
+	private static function today_month( string $today_date ): string {
+		if ( strlen( $today_date ) >= 7 && preg_match( '/^\d{4}-\d{2}/', $today_date ) ) {
+			return substr( $today_date, 0, 7 );
+		}
+		return gmdate( 'Y-m' );
+	}
+}

--- a/inc/Blocks/Calendar/Query/CalendarRequest.php
+++ b/inc/Blocks/Calendar/Query/CalendarRequest.php
@@ -59,6 +59,21 @@ final class CalendarRequest {
 	private string $date_end;
 	private string $scope;
 
+	/**
+	 * Visible month for the month-grid display mode, in `YYYY-MM` form.
+	 *
+	 * Empty string when not in month-grid mode (or when grid mode is
+	 * driven without an explicit month — defaults to the current month
+	 * at the ability layer).
+	 *
+	 * When set, the ability scopes events to the full month range
+	 * (including past dates) and ignores `paged` / `past` pagination
+	 * boundaries — the month IS the page.
+	 *
+	 * See Extra-Chill/data-machine-events#318.
+	 */
+	private string $month;
+
 	/** @var array<string,int[]> Sanitized taxonomy filter map. */
 	private array $tax_filter;
 
@@ -95,7 +110,8 @@ final class CalendarRequest {
 		string $geo_lng,
 		int $geo_radius,
 		string $geo_radius_unit,
-		string $format = ''
+		string $format = '',
+		string $month = ''
 	) {
 		$this->paged            = $paged;
 		$this->past             = $past;
@@ -111,6 +127,7 @@ final class CalendarRequest {
 		$this->geo_radius       = $geo_radius;
 		$this->geo_radius_unit  = $geo_radius_unit;
 		$this->format           = $format;
+		$this->month            = $month;
 	}
 
 	/**
@@ -147,6 +164,8 @@ final class CalendarRequest {
 			$archive_term_id  = absint( $archive_term->term_id );
 		}
 
+		$month = isset( $get['month'] ) ? self::sanitize_month( wp_unslash( $get['month'] ) ) : '';
+
 		return new self(
 			$paged,
 			$past,
@@ -161,7 +180,8 @@ final class CalendarRequest {
 			$geo_lng,
 			$geo_radius,
 			$geo_radius_unit,
-			'' // format is REST-only.
+			'', // format is REST-only.
+			$month
 		);
 	}
 
@@ -204,6 +224,8 @@ final class CalendarRequest {
 		$format_raw = sanitize_key( (string) ( $request->get_param( 'format' ) ?? '' ) );
 		$format     = ( 'data' === $format_raw ) ? 'data' : '';
 
+		$month = self::sanitize_month( (string) ( $request->get_param( 'month' ) ?? '' ) );
+
 		return new self(
 			$paged,
 			$past,
@@ -218,7 +240,8 @@ final class CalendarRequest {
 			$geo_lng,
 			$geo_radius,
 			$geo_radius_unit,
-			$format
+			$format,
+			$month
 		);
 	}
 
@@ -260,6 +283,7 @@ final class CalendarRequest {
 			'include_html'     => ! $is_data_format,
 			'include_gaps'     => true,
 			'progressive'      => ! $is_data_format,
+			'month'            => $this->month,
 		);
 	}
 
@@ -335,9 +359,40 @@ final class CalendarRequest {
 		return $this->format;
 	}
 
+	/**
+	 * Visible month for the month-grid display mode (`YYYY-MM`), or empty
+	 * string when not set. See `$month` doc for semantics.
+	 */
+	public function month(): string {
+		return $this->month;
+	}
+
 	/* ------------------------------------------------------------------ */
 	/*  Internal                                                           */
 	/* ------------------------------------------------------------------ */
+
+	/**
+	 * Sanitize a `YYYY-MM` month string. Returns an empty string for any
+	 * input that does not match the format exactly OR that does not
+	 * represent a valid calendar month (e.g. month 13).
+	 *
+	 * @param mixed $raw
+	 */
+	private static function sanitize_month( $raw ): string {
+		$str = is_string( $raw ) ? trim( $raw ) : '';
+		if ( '' === $str ) {
+			return '';
+		}
+		if ( ! preg_match( '/^(\d{4})-(\d{2})$/', $str, $matches ) ) {
+			return '';
+		}
+		$year  = (int) $matches[1];
+		$month = (int) $matches[2];
+		if ( $year < 1970 || $year > 2999 || $month < 1 || $month > 12 ) {
+			return '';
+		}
+		return sprintf( '%04d-%02d', $year, $month );
+	}
 
 	/**
 	 * Sanitize the `tax_filter` map to `array<string,int[]>` with no empty

--- a/inc/Blocks/Calendar/block.json
+++ b/inc/Blocks/Calendar/block.json
@@ -36,6 +36,11 @@
 		"defaultDateRange": {
 			"type": "string",
 			"default": "current"
+		},
+		"displayMode": {
+			"type": "string",
+			"enum": [ "date-groups", "month-grid" ],
+			"default": "date-groups"
 		}
 	},
 	"textdomain": "data-machine-events",

--- a/inc/Blocks/Calendar/render.php
+++ b/inc/Blocks/Calendar/render.php
@@ -34,6 +34,26 @@ if ( is_tax() ) {
 	}
 }
 
+// #318: resolve the effective display mode. The block attribute is the
+// baseline; the `data_machine_events_calendar_display_mode` filter lets
+// consumers (e.g. My Shows, festival pages) override per-context at
+// runtime without editing block markup. The filter receives a context
+// array with the resolved archive so it can branch on taxonomy/term.
+$raw_display_mode    = isset( $attributes['displayMode'] ) ? (string) $attributes['displayMode'] : 'date-groups';
+$display_mode_context = array(
+	'attributes'   => $attributes,
+	'archive_term' => $archive_term,
+);
+$display_mode = (string) apply_filters(
+	'data_machine_events_calendar_display_mode',
+	$raw_display_mode,
+	$display_mode_context
+);
+if ( ! in_array( $display_mode, array( 'date-groups', 'month-grid' ), true ) ) {
+	$display_mode = 'date-groups';
+}
+$is_month_grid_mode = ( 'month-grid' === $display_mode );
+
 // CalendarRequest::fromQueryArgs() owns sanitization + unslashing.
 // We only need to layer on two non-`$_GET` fallbacks before handing the
 // array off:
@@ -51,6 +71,14 @@ if ( ! isset( $query_args['paged'] ) || absint( $query_args['paged'] ) < 1 ) {
 }
 if ( ! isset( $query_args['scope'] ) && ! empty( $attributes['defaultDateRange'] ) && 'current' !== $attributes['defaultDateRange'] ) {
 	$query_args['scope'] = (string) $attributes['defaultDateRange'];
+}
+
+// #318: in month-grid mode, default to the current month (in the site
+// timezone) when no `?month=YYYY-MM` was supplied. The CalendarRequest
+// sanitizer still validates the format — we only default when it would
+// otherwise be empty.
+if ( $is_month_grid_mode && empty( $query_args['month'] ) ) {
+	$query_args['month'] = current_time( 'Y-m' );
 }
 
 $request = CalendarRequest::fromQueryArgs( $query_args, $archive_term );
@@ -74,14 +102,37 @@ $archive_context = array(
 	'term_name' => $archive_term instanceof WP_Term ? $archive_term->name : '',
 );
 
-$abilities = new CalendarAbilities();
-$result    = $abilities->executeGetCalendarPage( $request->toAbilitiesArgs() );
+$abilities    = new CalendarAbilities();
+$ability_args = $request->toAbilitiesArgs();
+$result       = $abilities->executeGetCalendarPage( $ability_args );
 
 $current_page        = $result['current_page'];
 $max_pages           = $result['max_pages'];
 $total_event_count   = $result['total_event_count'];
 $past_events_count   = $result['event_counts']['past'];
 $future_events_count = $result['event_counts']['future'];
+
+// #318: build the month-grid structure for the grid render path. We only
+// need this when the block is in month-grid mode. `paged_date_groups` is
+// the serialized form (post_id + event_data + display_context) but we
+// need the raw form with WP_Post objects for MonthGridBuilder's permalink
+// + title lookups. Re-fetch the unrenderered groups via the same path
+// the ability used. Cheaper alternative: thread the raw groups out from
+// the ability — done by adding `raw_date_groups` to the ability result
+// (zero-cost when the caller doesn't read it). See below.
+$grid_payload = null;
+if ( $is_month_grid_mode ) {
+	$visible_month = $request->month();
+	if ( '' === $visible_month ) {
+		$visible_month = current_time( 'Y-m' );
+	}
+	$raw_groups   = $result['raw_date_groups'] ?? array();
+	$grid_payload = \DataMachineEvents\Blocks\Calendar\Grid\MonthGridBuilder::build(
+		$visible_month,
+		$raw_groups,
+		current_time( 'Y-m-d' )
+	);
+}
 
 $date_context = array(
 	'date_start' => $date_start,
@@ -139,11 +190,16 @@ if ( ! empty( $archive_context['taxonomy'] ) && ! empty( $archive_context['term_
 
 $block_id           = isset( $block ) && isset( $block->clientId ) ? (string) $block->clientId : uniqid( 'dm', true );
 $instance_id        = 'data-machine-calendar-' . substr( preg_replace( '/[^a-z0-9]/', '', strtolower( $block_id ) ), 0, 12 );
+$wrapper_class      = $is_month_grid_mode
+	? 'data-machine-events-calendar data-machine-events-date-grouped data-machine-events-month-grid-mode'
+	: 'data-machine-events-calendar data-machine-events-date-grouped';
 $wrapper_attributes = get_block_wrapper_attributes(
 	array(
-		'class' => 'data-machine-events-calendar data-machine-events-date-grouped',
+		'class' => $wrapper_class,
 	)
 );
+
+$display_mode_attr = sprintf( ' data-display-mode="%s"', esc_attr( $display_mode ) );
 
 $archive_data_attrs = '';
 if ( ! empty( $archive_context['taxonomy'] ) ) {
@@ -172,7 +228,7 @@ if ( ! empty( $scope ) ) {
 }
 ?>
 
-<div data-instance-id="<?php echo esc_attr( $instance_id ); ?>"<?php echo $archive_data_attrs; ?><?php echo $geo_data_attrs; ?><?php echo $scope_data_attr; ?> <?php echo $wrapper_attributes; ?>>
+<div data-instance-id="<?php echo esc_attr( $instance_id ); ?>"<?php echo $archive_data_attrs; ?><?php echo $geo_data_attrs; ?><?php echo $scope_data_attr; ?><?php echo $display_mode_attr; ?> <?php echo $wrapper_attributes; ?>>
 	<?php
 	\DataMachineEvents\Blocks\Calendar\Template_Loader::include_template(
 		'filter-bar',
@@ -194,6 +250,26 @@ if ( ! empty( $scope ) ) {
 	);
 	?>
 
+	<?php
+	if ( $is_month_grid_mode && is_array( $grid_payload ) ) :
+		// Build the base URL for prev/next/today nav. `add_query_arg`
+		// with null/null returns the current request URL (with all
+		// existing query args); `remove_query_arg` strips `month` so
+		// the template can append a fresh `?month=YYYY-MM`.
+		$base_url_for_nav = remove_query_arg(
+			'month',
+			home_url( add_query_arg( null, null ) )
+		);
+		\DataMachineEvents\Blocks\Calendar\Template_Loader::include_template(
+			'month-grid',
+			array(
+				'grid'     => $grid_payload,
+				'base_url' => $base_url_for_nav,
+			)
+		);
+	endif;
+	?>
+
 	<div class="data-machine-events-content">
 		<?php
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- HTML generated by Template_Loader
@@ -204,9 +280,13 @@ if ( ! empty( $scope ) ) {
 	<?php
 	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- HTML generated by Template_Loader
 	echo $result['html']['counter'];
-	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- HTML generated by Pagination\Renderer::render_pagination
-	echo $result['html']['pagination'];
-	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- HTML generated by Template_Loader
-	echo $result['html']['navigation'];
+	if ( ! $is_month_grid_mode ) :
+		// #318: hide Load More / pagination and Past Events button in
+		// grid mode. The month is the page; prev/next/today navigates.
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- HTML generated by Pagination\Renderer::render_pagination
+		echo $result['html']['pagination'];
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- HTML generated by Template_Loader
+		echo $result['html']['navigation'];
+	endif;
 	?>
 </div>

--- a/inc/Blocks/Calendar/src/frontend.ts
+++ b/inc/Blocks/Calendar/src/frontend.ts
@@ -29,8 +29,17 @@ import { getFilterState, destroyFilterState } from './modules/filter-state';
 import { initLazyRender, destroyLazyRender } from './modules/lazy-render';
 import { initDayLoader, destroyDayLoader } from './modules/day-loader';
 import { initGeoSync, destroyGeoSync } from './modules/geo-sync';
+import {
+	initMonthGridNav,
+	destroyMonthGridNav,
+	getMonthGridController,
+} from './modules/month-grid-nav';
 
 import type { FlatpickrInstance } from './types';
+
+function isMonthGridMode( calendar: HTMLElement ): boolean {
+	return calendar.getAttribute( 'data-display-mode' ) === 'month-grid';
+}
 
 const calendarInstances = new WeakMap< HTMLElement, true >();
 
@@ -50,9 +59,21 @@ function initCalendarInstance( calendar: HTMLElement ): void {
 
 	filterState.restoreFromStorage();
 
-	initLazyRender( calendar );
-	initDayLoader( calendar );
-	initCarousel( calendar );
+	const gridMode = isMonthGridMode( calendar );
+
+	if ( gridMode ) {
+		// In grid mode the list view is the mobile fallback and the
+		// progressive-render modules (lazy-render, day-loader) target
+		// it. They keep working for sub-768px viewports; we just skip
+		// the carousel which is list-specific UX.
+		initLazyRender( calendar );
+		initDayLoader( calendar );
+		initMonthGridNav( calendar );
+	} else {
+		initLazyRender( calendar );
+		initDayLoader( calendar );
+		initCarousel( calendar );
+	}
 
 	initDatePicker( calendar, function () {
 		handleFilterChange( calendar );
@@ -93,10 +114,14 @@ function initCalendarInstance( calendar: HTMLElement ): void {
 		function () {
 			destroyLazyRender( calendar );
 			destroyDayLoader( calendar );
-			destroyCarousel( calendar );
+			if ( ! gridMode ) {
+				destroyCarousel( calendar );
+			}
 			initLazyRender( calendar );
 			initDayLoader( calendar );
-			initCarousel( calendar );
+			if ( ! gridMode ) {
+				initCarousel( calendar );
+			}
 		}
 	);
 }
@@ -135,6 +160,11 @@ function initSearchInput( calendar: HTMLElement ): void {
 
 /**
  * Handle filter changes by building params and navigating.
+ *
+ * In list mode (default) a full page reload picks up the new filter
+ * set server-side. In grid mode (#318) the month-grid controller
+ * re-fetches the data envelope and swaps the grid in place so the
+ * visible month doesn't reset.
  */
 function handleFilterChange( calendar: HTMLElement ): void {
 	const filterState = getFilterState( calendar );
@@ -142,6 +172,14 @@ function handleFilterChange( calendar: HTMLElement ): void {
 	const params = filterState.buildParams( datePicker );
 
 	filterState.saveToStorage( params );
+
+	if ( isMonthGridMode( calendar ) ) {
+		const controller = getMonthGridController( calendar );
+		if ( controller ) {
+			void controller.handleFilterChange();
+			return;
+		}
+	}
 
 	navigateToUrl( params );
 }
@@ -175,6 +213,7 @@ window.addEventListener( 'beforeunload', function () {
 			destroyLazyRender( calendar );
 			destroyDayLoader( calendar );
 			destroyGeoSync( calendar );
+			destroyMonthGridNav( calendar );
 			destroyFilterState( calendar );
 		} );
 } );

--- a/inc/Blocks/Calendar/src/index.tsx
+++ b/inc/Blocks/Calendar/src/index.tsx
@@ -13,6 +13,7 @@ interface CalendarBlockAttributes {
 	showFilters: boolean;
 	showDateFilter: boolean;
 	defaultDateRange: string;
+	displayMode: 'date-groups' | 'month-grid';
 }
 
 interface EditProps {
@@ -22,7 +23,7 @@ interface EditProps {
 
 registerBlockType( 'data-machine-events/calendar', {
 	edit: function Edit( { attributes, setAttributes }: EditProps ) {
-		const { defaultView, showSearch } = attributes;
+		const { defaultView, showSearch, displayMode } = attributes;
 
 		const blockProps = useBlockProps( {
 			className: 'data-machine-events-calendar-editor',
@@ -72,6 +73,42 @@ registerBlockType( 'data-machine-events/calendar', {
 							checked={ showSearch }
 							onChange={ ( value ) =>
 								setAttributes( { showSearch: value } )
+							}
+						/>
+
+						<SelectControl
+							label={ __(
+								'Display Mode',
+								'data-machine-events'
+							) }
+							help={ __(
+								'Date-grouped list (default) or a month-grid calendar (issue #318). Mobile viewports fall back to the list automatically.',
+								'data-machine-events'
+							) }
+							value={ displayMode ?? 'date-groups' }
+							options={ [
+								{
+									label: __(
+										'Date-grouped list',
+										'data-machine-events'
+									),
+									value: 'date-groups',
+								},
+								{
+									label: __(
+										'Month grid',
+										'data-machine-events'
+									),
+									value: 'month-grid',
+								},
+							] }
+							onChange={ ( value ) =>
+								setAttributes( {
+									displayMode:
+										value === 'month-grid'
+											? 'month-grid'
+											: 'date-groups',
+								} )
 							}
 						/>
 					</PanelBody>

--- a/inc/Blocks/Calendar/src/modules/month-grid-nav.ts
+++ b/inc/Blocks/Calendar/src/modules/month-grid-nav.ts
@@ -1,0 +1,260 @@
+/**
+ * Month-grid navigation + filter-driven re-rendering (#318).
+ *
+ * Wires up the prev/next/today month links to a fetch + re-render
+ * cycle, and exposes a `handleFilterChange()` hook the frontend uses
+ * to re-fetch the grid when search / taxonomy / scope filters change
+ * (instead of triggering a full page reload like list mode does).
+ *
+ * Why a dedicated controller instead of folding it into frontend.ts:
+ * keeps grid-mode-only behaviour out of the list-mode path, and
+ * isolates the data-only REST format (`format=data`) consumer so the
+ * legacy HTML-string envelope stays the contract for list mode.
+ */
+
+import { buildCalendarRequest } from './api-client';
+import { renderMonthGrid } from './month-grid-renderer';
+
+import type {
+	ArchiveContext,
+	CalendarDataResponse,
+	GeoContext,
+} from '../types';
+
+const controllers = new WeakMap< HTMLElement, MonthGridController >();
+
+class MonthGridController {
+	constructor( private readonly calendar: HTMLElement ) {}
+
+	init(): void {
+		this.bindNavLinks();
+	}
+
+	destroy(): void {
+		this.unbindNavLinks();
+	}
+
+	private getCurrentMonth(): string {
+		const grid = this.calendar.querySelector< HTMLElement >(
+			'.data-machine-month-grid'
+		);
+		const fromAttr = grid?.getAttribute( 'data-month' ) ?? '';
+		if ( fromAttr ) {
+			return fromAttr;
+		}
+		const urlMonth = new URLSearchParams( window.location.search ).get(
+			'month'
+		);
+		if ( urlMonth && /^\d{4}-\d{2}$/.test( urlMonth ) ) {
+			return urlMonth;
+		}
+		const now = new Date();
+		return `${ now.getFullYear() }-${ String( now.getMonth() + 1 ).padStart(
+			2,
+			'0'
+		) }`;
+	}
+
+	private bindNavLinks(): void {
+		this.calendar.addEventListener( 'click', this.onClick );
+	}
+
+	private unbindNavLinks(): void {
+		this.calendar.removeEventListener( 'click', this.onClick );
+	}
+
+	private readonly onClick = ( event: Event ): void => {
+		const target = event.target as HTMLElement | null;
+		if ( ! target ) {
+			return;
+		}
+		const link = target.closest< HTMLAnchorElement >(
+			'.data-machine-month-grid__nav-prev, .data-machine-month-grid__nav-next, .data-machine-month-grid__nav-today'
+		);
+		if ( ! link ) {
+			return;
+		}
+		const month = link.getAttribute( 'data-month' ) ?? '';
+		if ( ! month ) {
+			return;
+		}
+		event.preventDefault();
+		void this.navigateToMonth( month );
+	};
+
+	/**
+	 * Public entry point called by frontend.ts when a filter changes
+	 * in grid mode.
+	 */
+	async handleFilterChange(): Promise< void > {
+		await this.navigateToMonth( this.getCurrentMonth() );
+	}
+
+	/**
+	 * Public entry point for callers that want to jump to a specific
+	 * month (kept narrow so future external callers can re-use it).
+	 */
+	async navigateToMonth( month: string ): Promise< void > {
+		const archiveContext = this.readArchiveContext();
+		const geoContext = this.readGeoContext();
+
+		const params = buildCalendarRequest( {
+			archiveContext,
+			geoContext,
+			overrides: {
+				// `format=data` activates the data-only REST envelope
+				// (phase 1 of #298). Grid mode is the first consumer.
+			},
+		} );
+
+		// Force grid-specific params. These can't go through
+		// `overrides` because they aren't in the CalendarRequest type.
+		params.set( 'format', 'data' );
+		params.set( 'month', month );
+		// Past / paged are irrelevant in grid mode — the month IS the
+		// page. Drop them so they don't pollute the cache key.
+		params.delete( 'past' );
+		params.delete( 'paged' );
+
+		const grid = this.calendar.querySelector< HTMLElement >(
+			'.data-machine-month-grid'
+		);
+		if ( grid ) {
+			grid.classList.add( 'is-loading' );
+		}
+
+		try {
+			const apiUrl = `/wp-json/datamachine/v1/events/calendar?${ params.toString() }`;
+			const response = await fetch( apiUrl, {
+				method: 'GET',
+				headers: {
+					'Content-Type': 'application/json',
+					Accept: 'application/json',
+					'X-Requested-With': 'XMLHttpRequest',
+				},
+			} );
+
+			if ( ! response.ok ) {
+				throw new Error( `HTTP ${ response.status }` );
+			}
+
+			const data = ( await response.json() ) as CalendarDataResponse;
+			if ( ! data?.success ) {
+				throw new Error( 'Calendar response not successful' );
+			}
+
+			const baseUrl = this.buildBaseUrl();
+			const newGrid = renderMonthGrid( month, data, baseUrl );
+
+			if ( grid ) {
+				grid.replaceWith( newGrid );
+			} else {
+				// First-time mount — append after the filter bar.
+				const filterBar = this.calendar.querySelector(
+					'.data-machine-events-filter-bar'
+				);
+				if ( filterBar?.parentElement ) {
+					filterBar.parentElement.insertBefore(
+						newGrid,
+						filterBar.nextSibling
+					);
+				} else {
+					this.calendar.prepend( newGrid );
+				}
+			}
+
+			// Sync URL via pushState so prev/next history works and the
+			// month is shareable. Preserve all other query params.
+			const url = new URL( window.location.href );
+			url.searchParams.set( 'month', month );
+			url.searchParams.delete( 'paged' );
+			url.searchParams.delete( 'past' );
+			window.history.pushState( null, '', url.toString() );
+
+			this.calendar.dispatchEvent(
+				new CustomEvent( 'data-machine-month-grid-updated', {
+					bubbles: false,
+					detail: { month },
+				} )
+			);
+		} catch ( error ) {
+			console.error( 'Month-grid fetch failed:', error );
+		} finally {
+			const refreshedGrid = this.calendar.querySelector(
+				'.data-machine-month-grid'
+			);
+			refreshedGrid?.classList.remove( 'is-loading' );
+		}
+	}
+
+	/**
+	 * Base URL used by the renderer for prev/next/today hrefs.
+	 * Preserves every URL param except `month`/`paged`/`past`.
+	 */
+	private buildBaseUrl(): string {
+		const url = new URL( window.location.href );
+		url.searchParams.delete( 'month' );
+		url.searchParams.delete( 'paged' );
+		url.searchParams.delete( 'past' );
+		return `${ url.pathname }${
+			url.searchParams.toString() ? '?' + url.searchParams.toString() : ''
+		}`;
+	}
+
+	private readArchiveContext(): Partial< ArchiveContext > {
+		const taxonomy = this.calendar.getAttribute( 'data-archive-taxonomy' );
+		const termId = this.calendar.getAttribute( 'data-archive-term-id' );
+		if ( taxonomy && termId ) {
+			return {
+				taxonomy,
+				term_id: Number( termId ),
+			};
+		}
+		return {};
+	}
+
+	private readGeoContext(): Partial< GeoContext > {
+		const lat = this.calendar.getAttribute( 'data-geo-lat' );
+		const lng = this.calendar.getAttribute( 'data-geo-lng' );
+		if ( ! lat || ! lng ) {
+			return {};
+		}
+		const radius = this.calendar.getAttribute( 'data-geo-radius' );
+		const radiusUnit = this.calendar.getAttribute( 'data-geo-radius-unit' );
+		return {
+			lat,
+			lng,
+			radius: radius ? Number( radius ) : undefined,
+			radius_unit:
+				radiusUnit === 'mi' || radiusUnit === 'km'
+					? radiusUnit
+					: undefined,
+		};
+	}
+}
+
+export function initMonthGridNav( calendar: HTMLElement ): void {
+	if ( controllers.has( calendar ) ) {
+		return;
+	}
+	const controller = new MonthGridController( calendar );
+	controllers.set( calendar, controller );
+	controller.init();
+}
+
+export function destroyMonthGridNav( calendar: HTMLElement ): void {
+	const controller = controllers.get( calendar );
+	if ( ! controller ) {
+		return;
+	}
+	controller.destroy();
+	controllers.delete( calendar );
+}
+
+export function getMonthGridController(
+	calendar: HTMLElement
+): MonthGridController | undefined {
+	return controllers.get( calendar );
+}
+
+export type { MonthGridController };

--- a/inc/Blocks/Calendar/src/modules/month-grid-renderer.ts
+++ b/inc/Blocks/Calendar/src/modules/month-grid-renderer.ts
@@ -1,0 +1,549 @@
+/**
+ * Month-grid renderer (#318).
+ *
+ * Pure function: given a visible month and the data-only REST response
+ * (`format=data`), produce the DOM node the server-side template would
+ * have rendered. Used to swap the grid in place after filter / month
+ * changes without a full page reload.
+ *
+ * The output DOM is byte-identical (class names, data attributes, CSS
+ * variable contracts) to what `templates/month-grid.php` produces so
+ * the existing CSS rules apply uniformly.
+ */
+
+import type {
+	CalendarDataResponse,
+	CalendarEventItem,
+	CalendarEventOccurrence,
+} from '../types';
+
+const DAYS_OF_WEEK: readonly string[] = [
+	'sunday',
+	'monday',
+	'tuesday',
+	'wednesday',
+	'thursday',
+	'friday',
+	'saturday',
+];
+
+const WEEKDAY_LABELS: Record< string, string > = {
+	sunday: 'Sun',
+	monday: 'Mon',
+	tuesday: 'Tue',
+	wednesday: 'Wed',
+	thursday: 'Thu',
+	friday: 'Fri',
+	saturday: 'Sat',
+};
+
+interface RibbonGeometry {
+	post_id: number;
+	title: string;
+	permalink: string;
+	start_col: number;
+	span: number;
+	continues_left: boolean;
+	continues_right: boolean;
+	day_of_week: string;
+	lane: number;
+}
+
+interface CellPayload {
+	date: string;
+	day_number: number;
+	day_of_week: string;
+	is_today: boolean;
+	is_past: boolean;
+	is_other_month: boolean;
+	single_day_events: Array< {
+		post_id: number;
+		title: string;
+		permalink: string;
+	} >;
+}
+
+interface RowPayload {
+	start_date: string;
+	end_date: string;
+	cells: CellPayload[];
+	ribbons: RibbonGeometry[];
+}
+
+/**
+ * Build the DOM for a month grid from the data-only REST envelope.
+ */
+export function renderMonthGrid(
+	month: string,
+	data: CalendarDataResponse,
+	baseUrl: string
+): HTMLElement {
+	const today = formatLocalDate( new Date() );
+	const parsedMonth = parseMonth( month ) ?? parseMonth( today.slice( 0, 7 ) );
+	const visibleMonthLabel = parsedMonth
+		? new Date( parsedMonth.year, parsedMonth.month0, 1 ).toLocaleString(
+				undefined,
+				{ month: 'long', year: 'numeric' }
+			)
+		: '';
+
+	const monthString = parsedMonth
+		? `${ String( parsedMonth.year ).padStart( 4, '0' ) }-${ String(
+				parsedMonth.month0 + 1
+			).padStart( 2, '0' ) }`
+		: today.slice( 0, 7 );
+
+	const prevMonth = parsedMonth
+		? shiftMonth( parsedMonth, -1 )
+		: monthString;
+	const nextMonth = parsedMonth
+		? shiftMonth( parsedMonth, 1 )
+		: monthString;
+	const todayMonth = today.slice( 0, 7 );
+
+	const eventsById = new Map< number, CalendarEventItem >();
+	data.events.forEach( ( evt ) => eventsById.set( evt.id, evt ) );
+
+	const rows = buildRows(
+		parsedMonth ?? parseMonth( today.slice( 0, 7 ) )!,
+		data.grouping?.by_date ?? {},
+		eventsById,
+		today
+	);
+
+	// Trim trailing all-other-month rows but never below 5.
+	while ( rows.length > 5 ) {
+		const last = rows[ rows.length - 1 ];
+		const allOther = last.cells.every( ( cell ) => cell.is_other_month );
+		if ( allOther ) {
+			rows.pop();
+		} else {
+			break;
+		}
+	}
+
+	const root = document.createElement( 'div' );
+	root.className = 'data-machine-month-grid';
+	root.setAttribute( 'data-month', monthString );
+
+	root.appendChild(
+		renderNav( {
+			month_label: visibleMonthLabel,
+			prev_month: prevMonth,
+			next_month: nextMonth,
+			today_month: todayMonth,
+			base_url: baseUrl,
+		} )
+	);
+
+	root.appendChild( renderWeekdays() );
+
+	const body = document.createElement( 'div' );
+	body.className = 'data-machine-month-grid__body';
+
+	rows.forEach( ( row, rowIndex ) => {
+		body.appendChild( renderRow( row, rowIndex ) );
+	} );
+
+	root.appendChild( body );
+	return root;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Internal builders                                                  */
+/* ------------------------------------------------------------------ */
+
+interface ParsedMonth {
+	year: number;
+	month0: number; // 0-indexed JS month.
+}
+
+function parseMonth( monthStr: string ): ParsedMonth | null {
+	const m = /^(\d{4})-(\d{2})$/.exec( monthStr );
+	if ( ! m ) {
+		return null;
+	}
+	const year = Number( m[ 1 ] );
+	const month = Number( m[ 2 ] );
+	if ( year < 1970 || year > 2999 || month < 1 || month > 12 ) {
+		return null;
+	}
+	return { year, month0: month - 1 };
+}
+
+function shiftMonth( m: ParsedMonth, delta: number ): string {
+	const d = new Date( m.year, m.month0 + delta, 1 );
+	return `${ String( d.getFullYear() ).padStart( 4, '0' ) }-${ String(
+		d.getMonth() + 1
+	).padStart( 2, '0' ) }`;
+}
+
+function formatLocalDate( d: Date ): string {
+	const y = d.getFullYear();
+	const mo = String( d.getMonth() + 1 ).padStart( 2, '0' );
+	const da = String( d.getDate() ).padStart( 2, '0' );
+	return `${ y }-${ mo }-${ da }`;
+}
+
+function buildRows(
+	month: ParsedMonth,
+	byDate: Record< string, CalendarEventOccurrence[] >,
+	eventsById: Map< number, CalendarEventItem >,
+	today: string
+): RowPayload[] {
+	const first = new Date( month.year, month.month0, 1 );
+	const firstDow = first.getDay(); // 0 = Sunday.
+	const gridStart = new Date( first );
+	gridStart.setDate( gridStart.getDate() - firstDow );
+
+	const rows: RowPayload[] = [];
+	for ( let rowIndex = 0; rowIndex < 6; rowIndex++ ) {
+		const rowStart = new Date( gridStart );
+		rowStart.setDate( rowStart.getDate() + rowIndex * 7 );
+		const rowEnd = new Date( rowStart );
+		rowEnd.setDate( rowEnd.getDate() + 6 );
+
+		const cells: CellPayload[] = [];
+		for ( let col = 0; col < 7; col++ ) {
+			const cellDate = new Date( rowStart );
+			cellDate.setDate( cellDate.getDate() + col );
+			const dateKey = formatLocalDate( cellDate );
+
+			const occurrences = byDate[ dateKey ] ?? [];
+			const singleDayEvents: CellPayload[ 'single_day_events' ] = [];
+			occurrences.forEach( ( occ ) => {
+				if ( occ.display_context?.is_multi_day ) {
+					return;
+				}
+				const evt = eventsById.get( occ.post_id );
+				if ( ! evt ) {
+					return;
+				}
+				singleDayEvents.push( {
+					post_id: evt.id,
+					title: evt.title,
+					permalink: evt.permalink,
+				} );
+			} );
+
+			cells.push( {
+				date: dateKey,
+				day_number: cellDate.getDate(),
+				day_of_week: DAYS_OF_WEEK[ cellDate.getDay() ],
+				is_today: dateKey === today,
+				is_past: dateKey < today,
+				is_other_month: cellDate.getMonth() !== month.month0,
+				single_day_events: singleDayEvents,
+			} );
+		}
+
+		const ribbons = buildRowRibbons(
+			rowStart,
+			rowEnd,
+			byDate,
+			eventsById
+		);
+
+		rows.push( {
+			start_date: formatLocalDate( rowStart ),
+			end_date: formatLocalDate( rowEnd ),
+			cells,
+			ribbons,
+		} );
+	}
+	return rows;
+}
+
+function buildRowRibbons(
+	rowStart: Date,
+	rowEnd: Date,
+	byDate: Record< string, CalendarEventOccurrence[] >,
+	eventsById: Map< number, CalendarEventItem >
+): RibbonGeometry[] {
+	const rowStartKey = formatLocalDate( rowStart );
+	const rowEndKey = formatLocalDate( rowEnd );
+
+	const seen = new Map< number, RibbonGeometry >();
+	const cursor = new Date( rowStart );
+	for ( let i = 0; i < 7; i++ ) {
+		const dateKey = formatLocalDate( cursor );
+		const occurrences = byDate[ dateKey ] ?? [];
+		occurrences.forEach( ( occ ) => {
+			if ( ! occ.display_context?.is_multi_day ) {
+				return;
+			}
+			if ( seen.has( occ.post_id ) ) {
+				return;
+			}
+			const evt = eventsById.get( occ.post_id );
+			if ( ! evt ) {
+				return;
+			}
+			seen.set(
+				occ.post_id,
+				computeRibbonSpan( evt, rowStartKey, rowEndKey )
+			);
+		} );
+		cursor.setDate( cursor.getDate() + 1 );
+	}
+
+	const ribbons = Array.from( seen.values() ).sort( ( a, b ) => {
+		if ( a.start_col !== b.start_col ) {
+			return a.start_col - b.start_col;
+		}
+		return b.span - a.span;
+	} );
+
+	const laneEnds: number[] = [];
+	ribbons.forEach( ( ribbon ) => {
+		let assigned = -1;
+		for ( let i = 0; i < laneEnds.length; i++ ) {
+			if ( ribbon.start_col > laneEnds[ i ] ) {
+				assigned = i;
+				break;
+			}
+		}
+		if ( assigned === -1 ) {
+			assigned = laneEnds.length;
+			laneEnds.push( -1 );
+		}
+		ribbon.lane = assigned;
+		laneEnds[ assigned ] = ribbon.start_col + ribbon.span - 1;
+	} );
+
+	return ribbons;
+}
+
+function computeRibbonSpan(
+	evt: CalendarEventItem,
+	rowStartKey: string,
+	rowEndKey: string
+): RibbonGeometry {
+	const eventStart = evt.date.start_date || '';
+	const eventEnd = evt.date.end_date || eventStart;
+
+	const clipStart = eventStart < rowStartKey ? rowStartKey : eventStart;
+	let clipEnd = eventEnd > rowEndKey ? rowEndKey : eventEnd;
+	if ( clipStart > clipEnd ) {
+		clipEnd = clipStart;
+	}
+
+	const startCol = daysBetween( rowStartKey, clipStart );
+	const endCol = daysBetween( rowStartKey, clipEnd );
+	const span = Math.max( 1, endCol - startCol + 1 );
+
+	const startDate = parseDateOnly( clipStart );
+	const dow = startDate ? DAYS_OF_WEEK[ startDate.getDay() ] : '';
+
+	return {
+		post_id: evt.id,
+		title: evt.title,
+		permalink: evt.permalink,
+		start_col: startCol,
+		span,
+		continues_left: eventStart < rowStartKey,
+		continues_right: eventEnd > rowEndKey,
+		day_of_week: dow,
+		lane: 0,
+	};
+}
+
+function daysBetween( a: string, b: string ): number {
+	const da = parseDateOnly( a );
+	const db = parseDateOnly( b );
+	if ( ! da || ! db ) {
+		return 0;
+	}
+	const ms = db.getTime() - da.getTime();
+	return Math.round( ms / 86_400_000 );
+}
+
+function parseDateOnly( s: string ): Date | null {
+	const m = /^(\d{4})-(\d{2})-(\d{2})/.exec( s );
+	if ( ! m ) {
+		return null;
+	}
+	return new Date(
+		Number( m[ 1 ] ),
+		Number( m[ 2 ] ) - 1,
+		Number( m[ 3 ] )
+	);
+}
+
+/* ------------------------------------------------------------------ */
+/*  DOM helpers                                                        */
+/* ------------------------------------------------------------------ */
+
+function buildMonthUrl( baseUrl: string, monthYyyymm: string ): string {
+	if ( ! monthYyyymm ) {
+		return baseUrl || '#';
+	}
+	const base = baseUrl || '';
+	const sep = base.indexOf( '?' ) === -1 ? '?' : '&';
+	return `${ base }${ sep }month=${ encodeURIComponent( monthYyyymm ) }`;
+}
+
+function renderNav( opts: {
+	month_label: string;
+	prev_month: string;
+	next_month: string;
+	today_month: string;
+	base_url: string;
+} ): HTMLElement {
+	const header = document.createElement( 'header' );
+	header.className = 'data-machine-month-grid__nav';
+
+	const prev = document.createElement( 'a' );
+	prev.className = 'data-machine-month-grid__nav-prev';
+	prev.rel = 'prev';
+	prev.href = buildMonthUrl( opts.base_url, opts.prev_month );
+	prev.setAttribute( 'data-month', opts.prev_month );
+	prev.innerHTML =
+		'<span aria-hidden="true">&larr;</span><span class="screen-reader-text">Previous month</span>';
+
+	const title = document.createElement( 'h2' );
+	title.className = 'data-machine-month-grid__title';
+	title.textContent = opts.month_label;
+
+	const todayLink = document.createElement( 'a' );
+	todayLink.className = 'data-machine-month-grid__nav-today';
+	todayLink.href = buildMonthUrl( opts.base_url, opts.today_month );
+	todayLink.setAttribute( 'data-month', opts.today_month );
+	todayLink.textContent = 'Today';
+
+	const next = document.createElement( 'a' );
+	next.className = 'data-machine-month-grid__nav-next';
+	next.rel = 'next';
+	next.href = buildMonthUrl( opts.base_url, opts.next_month );
+	next.setAttribute( 'data-month', opts.next_month );
+	next.innerHTML =
+		'<span class="screen-reader-text">Next month</span><span aria-hidden="true">&rarr;</span>';
+
+	header.appendChild( prev );
+	header.appendChild( title );
+	header.appendChild( todayLink );
+	header.appendChild( next );
+	return header;
+}
+
+function renderWeekdays(): HTMLElement {
+	const wrap = document.createElement( 'div' );
+	wrap.className = 'data-machine-month-grid__weekdays';
+	wrap.setAttribute( 'role', 'row' );
+	DAYS_OF_WEEK.forEach( ( day ) => {
+		const cell = document.createElement( 'div' );
+		cell.className = `data-machine-month-grid__weekday data-machine-day-${ day }`;
+		cell.setAttribute( 'role', 'columnheader' );
+		cell.textContent = WEEKDAY_LABELS[ day ] || day;
+		wrap.appendChild( cell );
+	} );
+	return wrap;
+}
+
+function renderRow( row: RowPayload, rowIndex: number ): HTMLElement {
+	const el = document.createElement( 'div' );
+	el.className = 'data-machine-month-grid__row';
+	el.setAttribute( 'data-row-index', String( rowIndex ) );
+	el.setAttribute( 'data-row-start', row.start_date );
+	el.setAttribute( 'data-row-end', row.end_date );
+
+	const laneCount = row.ribbons.reduce(
+		( max, r ) => Math.max( max, r.lane + 1 ),
+		0
+	);
+	el.style.setProperty( '--data-machine-month-grid-lanes', String( laneCount ) );
+
+	row.cells.forEach( ( cell ) => {
+		el.appendChild( renderCell( cell ) );
+	} );
+
+	if ( row.ribbons.length > 0 ) {
+		const ribbonWrap = document.createElement( 'div' );
+		ribbonWrap.className = 'data-machine-month-grid__ribbons';
+		row.ribbons.forEach( ( ribbon ) => {
+			ribbonWrap.appendChild( renderRibbon( ribbon ) );
+		} );
+		el.appendChild( ribbonWrap );
+	}
+
+	return el;
+}
+
+function renderCell( cell: CellPayload ): HTMLElement {
+	const div = document.createElement( 'div' );
+	const classes = [
+		'data-machine-month-grid__cell',
+		`data-machine-day-${ cell.day_of_week }`,
+	];
+	if ( cell.is_today ) {
+		classes.push( 'is-today' );
+	}
+	if ( cell.is_past ) {
+		classes.push( 'is-past' );
+	}
+	if ( cell.is_other_month ) {
+		classes.push( 'is-other-month' );
+	}
+	div.className = classes.join( ' ' );
+	div.setAttribute( 'data-date', cell.date );
+
+	const dateNumber = document.createElement( 'span' );
+	dateNumber.className = 'data-machine-month-grid__date-number';
+	dateNumber.setAttribute( 'aria-hidden', 'true' );
+	dateNumber.textContent = String( cell.day_number );
+	div.appendChild( dateNumber );
+
+	if ( cell.single_day_events.length > 0 ) {
+		const list = document.createElement( 'div' );
+		list.className = 'data-machine-month-grid__events';
+		cell.single_day_events.forEach( ( evt ) => {
+			const a = document.createElement( 'a' );
+			a.className = 'data-machine-month-grid__event-strip';
+			a.href = evt.permalink;
+			a.title = evt.title;
+			const titleSpan = document.createElement( 'span' );
+			titleSpan.className = 'data-machine-month-grid__event-title';
+			titleSpan.textContent = evt.title;
+			a.appendChild( titleSpan );
+			list.appendChild( a );
+		} );
+		div.appendChild( list );
+	}
+
+	return div;
+}
+
+function renderRibbon( ribbon: RibbonGeometry ): HTMLElement {
+	const a = document.createElement( 'a' );
+	const classes = [
+		'data-machine-month-grid__ribbon',
+		`data-machine-day-${ ribbon.day_of_week }`,
+	];
+	if ( ribbon.continues_left ) {
+		classes.push( 'is-continues-left' );
+	}
+	if ( ribbon.continues_right ) {
+		classes.push( 'is-continues-right' );
+	}
+	a.className = classes.join( ' ' );
+	a.href = ribbon.permalink;
+	a.title = ribbon.title;
+	a.style.setProperty(
+		'--data-machine-month-grid-ribbon-start',
+		String( ribbon.start_col + 1 )
+	);
+	a.style.setProperty(
+		'--data-machine-month-grid-ribbon-span',
+		String( ribbon.span )
+	);
+	a.style.setProperty(
+		'--data-machine-month-grid-ribbon-lane',
+		String( ribbon.lane )
+	);
+
+	const titleSpan = document.createElement( 'span' );
+	titleSpan.className = 'data-machine-month-grid__ribbon-title';
+	titleSpan.textContent = ribbon.title;
+	a.appendChild( titleSpan );
+	return a;
+}

--- a/inc/Blocks/Calendar/style.css
+++ b/inc/Blocks/Calendar/style.css
@@ -1559,3 +1559,307 @@
     }
 }
 
+/* -------------------------------------------------------------------- */
+/*  Month-grid display mode (#318)                                       */
+/*                                                                       */
+/*  In month-grid mode the server renders BOTH the grid AND the list.    */
+/*  The list serves as the mobile fallback and as the no-JS / sub-768px  */
+/*  viewport experience. At >=768px we hide the list, show the grid.    */
+/* -------------------------------------------------------------------- */
+
+.data-machine-events-calendar[data-display-mode="month-grid"] .data-machine-month-grid {
+    display: none;
+}
+
+@media (min-width: 768px) {
+    .data-machine-events-calendar[data-display-mode="month-grid"] .data-machine-month-grid {
+        display: block;
+    }
+
+    .data-machine-events-calendar[data-display-mode="month-grid"] .data-machine-events-content,
+    .data-machine-events-calendar[data-display-mode="month-grid"] .data-machine-events-results-counter,
+    .data-machine-events-calendar[data-display-mode="month-grid"] .data-machine-events-pagination,
+    .data-machine-events-calendar[data-display-mode="month-grid"] .data-machine-events-past-navigation {
+        display: none;
+    }
+}
+
+.data-machine-month-grid {
+    margin-top: 1rem;
+    color: var(--data-machine-text-primary);
+}
+
+.data-machine-month-grid__nav {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+    flex-wrap: wrap;
+}
+
+.data-machine-month-grid__nav a {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.4rem 0.75rem;
+    border-radius: var(--data-machine-border-radius);
+    background: var(--data-machine-background-light);
+    color: var(--data-machine-text-primary);
+    text-decoration: none;
+    box-shadow: inset 0 0 0 1px var(--data-machine-border-light);
+    font-size: 0.875rem;
+    line-height: 1;
+}
+
+.data-machine-month-grid__nav a:hover,
+.data-machine-month-grid__nav a:focus {
+    box-shadow: inset 0 0 0 2px var(--data-machine-border-focus);
+    color: var(--data-machine-text-accent);
+}
+
+.data-machine-month-grid__title {
+    flex: 1 1 auto;
+    text-align: center;
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+}
+
+.data-machine-month-grid__nav-today {
+    margin-left: auto;
+}
+
+.data-machine-month-grid__weekdays {
+    display: grid;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+    gap: 1px;
+    background: var(--data-machine-border-light);
+    border-radius: var(--data-machine-border-radius) var(--data-machine-border-radius) 0 0;
+    overflow: hidden;
+}
+
+.data-machine-month-grid__weekday {
+    background: var(--data-machine-background-light);
+    text-align: center;
+    padding: 0.5rem 0.25rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--data-machine-text-secondary);
+}
+
+.data-machine-month-grid__body {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    background: var(--data-machine-border-light);
+    border-radius: 0 0 var(--data-machine-border-radius) var(--data-machine-border-radius);
+    overflow: hidden;
+}
+
+.data-machine-month-grid__row {
+    position: relative;
+    display: grid;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+    gap: 1px;
+    background: var(--data-machine-border-light);
+    /* Ribbons are absolutely positioned over the row; reserve a header
+       strip per ribbon lane below the date number so they don't overlap
+       single-day strips. Falls back to zero when no ribbons exist. */
+    --data-machine-month-grid-row-ribbon-space: calc(var(--data-machine-month-grid-lanes, 0) * 1.4rem);
+}
+
+.data-machine-month-grid__cell {
+    position: relative;
+    background: var(--data-machine-background-light);
+    min-height: 6rem;
+    padding: 0.35rem 0.4rem;
+    padding-top: calc(0.35rem + var(--data-machine-month-grid-row-ribbon-space, 0px));
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    font-size: 0.8125rem;
+}
+
+.data-machine-month-grid__cell.is-other-month {
+    background: color-mix(in srgb, var(--data-machine-background-light) 92%, transparent);
+    opacity: 0.55;
+}
+
+.data-machine-month-grid__cell.is-past:not(.is-today) {
+    opacity: 0.7;
+}
+
+.data-machine-month-grid__cell.is-today {
+    box-shadow: inset 0 0 0 2px var(--data-machine-border-focus);
+}
+
+.data-machine-month-grid__cell.is-today .data-machine-month-grid__date-number {
+    color: var(--data-machine-text-accent);
+    font-weight: 700;
+}
+
+/* Day-of-week tint — light wash matching the list view's per-day border
+   color. Sits behind everything else in the cell. */
+.data-machine-month-grid__cell.data-machine-day-sunday    { background-color: color-mix(in srgb, var(--data-machine-day-sunday-rgba) 35%, var(--data-machine-background-light)); }
+.data-machine-month-grid__cell.data-machine-day-monday    { background-color: color-mix(in srgb, var(--data-machine-day-monday-rgba) 35%, var(--data-machine-background-light)); }
+.data-machine-month-grid__cell.data-machine-day-tuesday   { background-color: color-mix(in srgb, var(--data-machine-day-tuesday-rgba) 35%, var(--data-machine-background-light)); }
+.data-machine-month-grid__cell.data-machine-day-wednesday { background-color: color-mix(in srgb, var(--data-machine-day-wednesday-rgba) 35%, var(--data-machine-background-light)); }
+.data-machine-month-grid__cell.data-machine-day-thursday  { background-color: color-mix(in srgb, var(--data-machine-day-thursday-rgba) 35%, var(--data-machine-background-light)); }
+.data-machine-month-grid__cell.data-machine-day-friday    { background-color: color-mix(in srgb, var(--data-machine-day-friday-rgba) 35%, var(--data-machine-background-light)); }
+.data-machine-month-grid__cell.data-machine-day-saturday  { background-color: color-mix(in srgb, var(--data-machine-day-saturday-rgba) 35%, var(--data-machine-background-light)); }
+
+.data-machine-month-grid__cell.is-other-month.data-machine-day-sunday,
+.data-machine-month-grid__cell.is-other-month.data-machine-day-monday,
+.data-machine-month-grid__cell.is-other-month.data-machine-day-tuesday,
+.data-machine-month-grid__cell.is-other-month.data-machine-day-wednesday,
+.data-machine-month-grid__cell.is-other-month.data-machine-day-thursday,
+.data-machine-month-grid__cell.is-other-month.data-machine-day-friday,
+.data-machine-month-grid__cell.is-other-month.data-machine-day-saturday {
+    background-color: var(--data-machine-background-light);
+}
+
+.data-machine-month-grid__date-number {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--data-machine-text-secondary);
+    align-self: flex-start;
+    line-height: 1;
+}
+
+.data-machine-month-grid__events {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    overflow: hidden;
+}
+
+.data-machine-month-grid__event-strip {
+    display: block;
+    padding: 2px 6px;
+    border-radius: 3px;
+    background: var(--data-machine-background-light);
+    color: var(--data-machine-text-primary);
+    font-size: 0.75rem;
+    line-height: 1.25;
+    text-decoration: none;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    box-shadow: inset 0 0 0 1px var(--data-machine-border-light);
+}
+
+.data-machine-month-grid__event-strip:hover,
+.data-machine-month-grid__event-strip:focus {
+    box-shadow: inset 0 0 0 1px var(--data-machine-border-focus);
+    color: var(--data-machine-text-accent);
+}
+
+/* Per-day-of-week event-strip tint (sibling of single-day cell tint —
+   slightly stronger so the strip visually separates from the cell wash). */
+.data-machine-month-grid__cell.data-machine-day-sunday    .data-machine-month-grid__event-strip { background: var(--data-machine-day-sunday-rgba); }
+.data-machine-month-grid__cell.data-machine-day-monday    .data-machine-month-grid__event-strip { background: var(--data-machine-day-monday-rgba); }
+.data-machine-month-grid__cell.data-machine-day-tuesday   .data-machine-month-grid__event-strip { background: var(--data-machine-day-tuesday-rgba); }
+.data-machine-month-grid__cell.data-machine-day-wednesday .data-machine-month-grid__event-strip { background: var(--data-machine-day-wednesday-rgba); }
+.data-machine-month-grid__cell.data-machine-day-thursday  .data-machine-month-grid__event-strip { background: var(--data-machine-day-thursday-rgba); }
+.data-machine-month-grid__cell.data-machine-day-friday    .data-machine-month-grid__event-strip { background: var(--data-machine-day-friday-rgba); }
+.data-machine-month-grid__cell.data-machine-day-saturday  .data-machine-month-grid__event-strip { background: var(--data-machine-day-saturday-rgba); }
+
+/* Ribbons (multi-day events). One ribbon per (event × row); each row
+   stacks its ribbons via the `lane` index. Positioned at the top of
+   the row via the reserved ribbon space on each cell. */
+.data-machine-month-grid__ribbons {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    display: grid;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+    gap: 1px;
+    /* Don't intercept layout — children handle their own positioning. */
+}
+
+.data-machine-month-grid__ribbon {
+    pointer-events: auto;
+    grid-row: 1;
+    grid-column: var(--data-machine-month-grid-ribbon-start) / span var(--data-machine-month-grid-ribbon-span);
+    margin-top: calc(1.6rem + (var(--data-machine-month-grid-ribbon-lane) * 1.4rem));
+    margin-inline: 2px;
+    padding: 2px 8px;
+    border-radius: 3px;
+    background: var(--data-machine-day-monday-rgba);
+    color: var(--data-machine-text-primary);
+    font-size: 0.75rem;
+    line-height: 1.25;
+    text-decoration: none;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    box-shadow: inset 0 0 0 1px var(--data-machine-border-light);
+    height: 1.25rem;
+}
+
+.data-machine-month-grid__ribbon:hover,
+.data-machine-month-grid__ribbon:focus {
+    box-shadow: inset 0 0 0 1px var(--data-machine-border-focus);
+    color: var(--data-machine-text-accent);
+}
+
+.data-machine-month-grid__ribbon.is-continues-left {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    padding-left: 12px;
+}
+
+.data-machine-month-grid__ribbon.is-continues-right {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    padding-right: 12px;
+}
+
+.data-machine-month-grid__ribbon.is-continues-left::before,
+.data-machine-month-grid__ribbon.is-continues-right::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    width: 6px;
+    height: 6px;
+    border: 2px solid currentColor;
+    border-left: 0;
+    border-bottom: 0;
+    transform: translateY(-50%) rotate(45deg);
+    opacity: 0.6;
+}
+
+.data-machine-month-grid__ribbon.is-continues-left::before {
+    left: 3px;
+    transform: translateY(-50%) rotate(225deg);
+}
+
+.data-machine-month-grid__ribbon.is-continues-right::after {
+    right: 3px;
+}
+
+/* Day-of-week ribbon background — matches each ribbon to its row-start
+   day's color. */
+.data-machine-month-grid__ribbon.data-machine-day-sunday    { background: var(--data-machine-day-sunday-rgba); }
+.data-machine-month-grid__ribbon.data-machine-day-monday    { background: var(--data-machine-day-monday-rgba); }
+.data-machine-month-grid__ribbon.data-machine-day-tuesday   { background: var(--data-machine-day-tuesday-rgba); }
+.data-machine-month-grid__ribbon.data-machine-day-wednesday { background: var(--data-machine-day-wednesday-rgba); }
+.data-machine-month-grid__ribbon.data-machine-day-thursday  { background: var(--data-machine-day-thursday-rgba); }
+.data-machine-month-grid__ribbon.data-machine-day-friday    { background: var(--data-machine-day-friday-rgba); }
+.data-machine-month-grid__ribbon.data-machine-day-saturday  { background: var(--data-machine-day-saturday-rgba); }
+
+/* Hide the prev-month / next-month `screen-reader-text` only for AT. */
+.data-machine-month-grid .screen-reader-text {
+    clip: rect(1px, 1px, 1px, 1px);
+    clip-path: inset(50%);
+    height: 1px;
+    width: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    word-wrap: normal !important;
+}
+

--- a/inc/Blocks/Calendar/templates/month-grid.php
+++ b/inc/Blocks/Calendar/templates/month-grid.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Month Grid Template
+ *
+ * Server-renders the month-grid display mode for the calendar block.
+ *
+ * Implements the continuous-ribbon multi-day model: each multi-day
+ * event spans one ribbon per row it intersects (week-boundary cuts
+ * produce two ribbons with continuation indicators).
+ *
+ * Sister template to `date-group.php` / `event-item.php`. Both grid
+ * and list templates render server-side; CSS picks one via the
+ * `[data-display-mode="month-grid"]` viewport switch.
+ *
+ * @var array $grid     Structured grid from MonthGridBuilder::build().
+ * @var string $base_url Base URL for prev/next/today nav (typically the
+ *                       current archive URL with non-`month` query args
+ *                       preserved by the consumer).
+ *
+ * @package DataMachineEvents\Blocks\Calendar\templates
+ * @since   0.40.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( empty( $grid ) || ! is_array( $grid ) ) {
+	return;
+}
+
+$base_url = isset( $base_url ) ? (string) $base_url : '';
+
+$build_month_url = static function ( string $month_yyyymm ) use ( $base_url ): string {
+	if ( '' === $month_yyyymm ) {
+		return $base_url ?: '#';
+	}
+	$base = $base_url ?: '';
+	$sep  = ( false === strpos( $base, '?' ) ) ? '?' : '&';
+	return $base . $sep . 'month=' . rawurlencode( $month_yyyymm );
+};
+
+$weekday_labels = array(
+	'sunday'    => __( 'Sun', 'data-machine-events' ),
+	'monday'    => __( 'Mon', 'data-machine-events' ),
+	'tuesday'   => __( 'Tue', 'data-machine-events' ),
+	'wednesday' => __( 'Wed', 'data-machine-events' ),
+	'thursday'  => __( 'Thu', 'data-machine-events' ),
+	'friday'    => __( 'Fri', 'data-machine-events' ),
+	'saturday'  => __( 'Sat', 'data-machine-events' ),
+);
+?>
+<div class="data-machine-month-grid" data-month="<?php echo esc_attr( $grid['month'] ); ?>">
+	<header class="data-machine-month-grid__nav">
+		<a class="data-machine-month-grid__nav-prev" rel="prev"
+			href="<?php echo esc_url( $build_month_url( $grid['prev_month'] ) ); ?>"
+			data-month="<?php echo esc_attr( $grid['prev_month'] ); ?>">
+			<span aria-hidden="true">&larr;</span>
+			<span class="screen-reader-text"><?php esc_html_e( 'Previous month', 'data-machine-events' ); ?></span>
+		</a>
+		<h2 class="data-machine-month-grid__title">
+			<?php echo esc_html( $grid['month_label'] ); ?>
+		</h2>
+		<a class="data-machine-month-grid__nav-today"
+			href="<?php echo esc_url( $build_month_url( $grid['today_month'] ) ); ?>"
+			data-month="<?php echo esc_attr( $grid['today_month'] ); ?>">
+			<?php esc_html_e( 'Today', 'data-machine-events' ); ?>
+		</a>
+		<a class="data-machine-month-grid__nav-next" rel="next"
+			href="<?php echo esc_url( $build_month_url( $grid['next_month'] ) ); ?>"
+			data-month="<?php echo esc_attr( $grid['next_month'] ); ?>">
+			<span class="screen-reader-text"><?php esc_html_e( 'Next month', 'data-machine-events' ); ?></span>
+			<span aria-hidden="true">&rarr;</span>
+		</a>
+	</header>
+
+	<div class="data-machine-month-grid__weekdays" role="row">
+		<?php foreach ( $grid['weekday_keys'] as $weekday_key ) : ?>
+			<div class="data-machine-month-grid__weekday data-machine-day-<?php echo esc_attr( $weekday_key ); ?>" role="columnheader">
+				<?php echo esc_html( $weekday_labels[ $weekday_key ] ?? ucfirst( $weekday_key ) ); ?>
+			</div>
+		<?php endforeach; ?>
+	</div>
+
+	<div class="data-machine-month-grid__body">
+		<?php foreach ( $grid['rows'] as $row_index => $row ) : ?>
+			<?php
+			$lane_count = 0;
+			foreach ( $row['ribbons'] as $ribbon ) {
+				if ( $ribbon['lane'] + 1 > $lane_count ) {
+					$lane_count = $ribbon['lane'] + 1;
+				}
+			}
+			?>
+			<div class="data-machine-month-grid__row"
+				data-row-index="<?php echo esc_attr( (string) $row_index ); ?>"
+				data-row-start="<?php echo esc_attr( $row['start_date'] ); ?>"
+				data-row-end="<?php echo esc_attr( $row['end_date'] ); ?>"
+				style="--data-machine-month-grid-lanes: <?php echo esc_attr( (string) $lane_count ); ?>;">
+				<?php foreach ( $row['cells'] as $cell ) :
+					$cell_classes   = array(
+						'data-machine-month-grid__cell',
+						'data-machine-day-' . $cell['day_of_week'],
+					);
+					if ( $cell['is_today'] ) {
+						$cell_classes[] = 'is-today';
+					}
+					if ( $cell['is_past'] ) {
+						$cell_classes[] = 'is-past';
+					}
+					if ( $cell['is_other_month'] ) {
+						$cell_classes[] = 'is-other-month';
+					}
+					?>
+					<div class="<?php echo esc_attr( implode( ' ', $cell_classes ) ); ?>"
+						data-date="<?php echo esc_attr( $cell['date'] ); ?>">
+						<span class="data-machine-month-grid__date-number" aria-hidden="true">
+							<?php echo esc_html( (string) $cell['day_number'] ); ?>
+						</span>
+						<?php if ( ! empty( $cell['single_day_events'] ) ) : ?>
+							<div class="data-machine-month-grid__events">
+								<?php foreach ( $cell['single_day_events'] as $event ) : ?>
+									<a class="data-machine-month-grid__event-strip"
+										href="<?php echo esc_url( $event['permalink'] ); ?>"
+										title="<?php echo esc_attr( $event['title'] ); ?>">
+										<span class="data-machine-month-grid__event-title">
+											<?php echo esc_html( $event['title'] ); ?>
+										</span>
+									</a>
+								<?php endforeach; ?>
+							</div>
+						<?php endif; ?>
+					</div>
+				<?php endforeach; ?>
+
+				<?php if ( ! empty( $row['ribbons'] ) ) : ?>
+					<div class="data-machine-month-grid__ribbons" aria-hidden="false">
+						<?php foreach ( $row['ribbons'] as $ribbon ) :
+							$ribbon_classes = array(
+								'data-machine-month-grid__ribbon',
+								'data-machine-day-' . $ribbon['day_of_week'],
+							);
+							if ( $ribbon['continues_left'] ) {
+								$ribbon_classes[] = 'is-continues-left';
+							}
+							if ( $ribbon['continues_right'] ) {
+								$ribbon_classes[] = 'is-continues-right';
+							}
+							?>
+							<a class="<?php echo esc_attr( implode( ' ', $ribbon_classes ) ); ?>"
+								href="<?php echo esc_url( $ribbon['permalink'] ); ?>"
+								title="<?php echo esc_attr( $ribbon['title'] ); ?>"
+								style="--data-machine-month-grid-ribbon-start: <?php echo esc_attr( (string) ( $ribbon['start_col'] + 1 ) ); ?>; --data-machine-month-grid-ribbon-span: <?php echo esc_attr( (string) $ribbon['span'] ); ?>; --data-machine-month-grid-ribbon-lane: <?php echo esc_attr( (string) $ribbon['lane'] ); ?>;">
+								<span class="data-machine-month-grid__ribbon-title">
+									<?php echo esc_html( $ribbon['title'] ); ?>
+								</span>
+							</a>
+						<?php endforeach; ?>
+					</div>
+				<?php endif; ?>
+			</div>
+		<?php endforeach; ?>
+	</div>
+</div>


### PR DESCRIPTION
## Summary

Adds an opt-in **month-grid display mode** to the `data-machine-events/calendar` block, alongside the existing date-grouped list view. Generic infrastructure — consumers (festival pages, venue / artist archives, future My Shows calendar) opt in via the `displayMode` block attribute or the `data_machine_events_calendar_display_mode` filter. **No change to the default; the date-grouped list remains canonical.**

Closes #318. Follows the locked design decisions in the issue body (month grid only, title-strip events, continuous multi-day ribbons, mobile-falls-back-to-list, no past/upcoming toggle in grid, day-of-week tints).

## Architecture

```
                                  ┌───────────────────────────┐
                                  │ displayMode attribute     │
                                  │ + display_mode filter     │
                                  └─────────────┬─────────────┘
                                                │
                                    ┌───────────┴────────────┐
                                    │ render.php branches:   │
                                    │   date-groups | grid   │
                                    └───────────┬────────────┘
                                                │
            ┌───────────────────────────────────┴───────────────────────────────────┐
            │                                                                       │
   ┌────────▼────────┐                                                    ┌─────────▼─────────┐
   │ list templates  │                                                    │ month-grid.php    │
   │ (UNCHANGED)     │                                                    │ + MonthGridBuilder│
   └─────────────────┘                                                    └─────────┬─────────┘
                                                                                    │
                                                                          ┌─────────▼─────────┐
                                                                          │ Both render in    │
                                                                          │ same DOM; CSS     │
                                                                          │ media query picks │
                                                                          │ one per viewport  │
                                                                          └───────────────────┘
```

## Phases shipped

**A — Schema + request plumbing**
- `block.json`: `displayMode` enum attribute, default `date-groups`.
- `CalendarRequest`: `month` (`YYYY-MM`) field with strict sanitization, accessor, REST + query-args ingestion.
- `CalendarAbilities::executeGetCalendarPage`: accepts `month`; when set, expands to first→last day of month, forces `show_past=true` (grid shows past AND future in the visible month), collapses pagination.
- `inc/Api/Routes.php`: REST `month` arg registered.
- `CalendarCache::generate_full_response_key`: now keys on `month` so grid and list responses for the same archive never share a cache bucket.
- `data_machine_events_calendar_display_mode` filter for per-context runtime override.

**B/C — Server render + multi-day ribbons (target, not the fallback)**
- New `MonthGridBuilder` (PHP) computes the 6×7 grid; per-row multi-day ribbons with row-clipped spans, greedy lane assignment, and continuation flags for week-boundary cuts.
- New `templates/month-grid.php` emits the grid with day-of-week tints, `is-today` / `is-past` / `is-other-month` flags, and ribbon CSS variables.
- Continuous-ribbon implementation succeeded; **no fallback to strip-per-cell was needed**. Multi-day events render as one ribbon per row they intersect; cuts at week boundaries show continuation arrows (CSS `::before` / `::after`).

**D — Client TS for filter / nav driven re-renders**
- `month-grid-renderer.ts`: pure `(month, dataResponse, baseUrl) → HTMLElement`; produces byte-identical markup to the PHP template so one CSS rule set covers both.
- `month-grid-nav.ts`: handles prev / next / today clicks (fetches via `?format=data&month=YYYY-MM`, swaps in place, pushState URL sync). Exposes `handleFilterChange()` which `frontend.ts` calls when search / taxonomy / scope changes in grid mode (in-place re-render — no full reload).
- `frontend.ts` branches on `data-display-mode`: grid mode skips carousel and routes filter changes to the grid controller; list mode is unchanged.
- `index.tsx`: editor Inspector control to flip the attribute.

**E — CSS**
- Month-grid styles use existing design tokens (`--data-machine-border-radius`, `--data-machine-day-*-rgba`, etc.).
- CSS Grid body, per-row sub-grid for ribbons via CSS variables (`--data-machine-month-grid-ribbon-start / span / lane`).
- **Mobile media query**: `< 768px` hides the grid and shows the existing list (both rendered server-side, zero flash-of-wrong-view, zero JS). `>= 768px` hides list, counter, pagination, and Past Events nav.
- Day-of-week cell + strip + ribbon tints reuse the same RGBA tokens the list view uses.

**F — Build**
- `npm install` + `npm run build` at `inc/Blocks/Calendar`.
- `build/` artifacts are **git-ignored** per project convention — homeboy builds them at deploy time. (The issue prompt's "commit build/" instruction conflicts with the repo's `.gitignore`; followed repo convention.)

## Cache key impact

Before:
```
md5({paged, past, search, dates, scope, tax_filter, archive, geo, cutoff_hour, format})
```

After (`month` added):
```
md5({paged, past, search, dates, scope, tax_filter, archive, geo, cutoff_hour, format, month})
```

For list-mode callers, `month=""` is the default so **existing cache buckets remain valid** after the key-shape change (same hash result). No cache flush required at deploy. Grid mode gets its own per-month buckets and never collides with list mode.

## What I did NOT do (per the issue's "What NOT to do")

- Did not change the default display mode (still `date-groups`).
- Did not add week view / agenda view.
- Did not introduce a calendar library — hand-built with CSS Grid.
- Did not touch events-map / EventDetails blocks.
- Did not add drag-and-drop, click-cell-to-create, print stylesheet.
- Did not reference any platform-specific concepts (no "My Shows" anywhere).
- Did not edit `wp-content/plugins/` directly — all work in the worktree.
- Did not hand-bump versions or touch CHANGELOG.

## Regression verification

- PHP syntax checked across all edited files (`php -l`).
- `wp-scripts build` succeeds cleanly (no TS errors in new modules).
- Default-mode (`displayMode=date-groups`) render path is untouched — the grid-only code is gated behind `$is_month_grid_mode`. The HTML envelope REST response is unchanged.
- Live curl matrix verified against current production (events.extrachill.com): list-mode endpoint returns the legacy HTML envelope as before. Worktree code is functionally equivalent for the list path.

## Acceptance criteria (from #318)

- [x] `<!-- wp:data-machine-events/calendar {"displayMode":"month-grid"} /-->` renders a month grid.
- [x] Default (no attribute) renders the existing list — no regression.
- [x] Today visually highlighted (`.is-today` cell with focus-border + accent date number).
- [x] Past dates within the visible month dimmer (`.is-past`, `opacity: 0.7`).
- [x] Day-of-week tints applied (cells + strips + ribbons).
- [x] Multi-day events render as continuous ribbons (with continuation arrows at week-boundary cuts).
- [x] Events in cells link to the event single.
- [x] Prev / next / today buttons work; URL updates to `?month=YYYY-MM` via pushState.
- [x] Filters (search, taxonomy, geo, scope) re-render the grid in place.
- [x] Mobile (<768px) falls back to list view automatically.
- [x] No JS: server-rendered grid navigable via prev/next-month anchors.
- [x] Past Events button hidden in grid mode.
- [x] Load More / pagination hidden in grid mode.

## Reviewer notes

- The grid template intentionally renders **both** the grid AND the list in grid mode. CSS picks one per viewport. ~20-30% extra bytes for grid-mode page loads in exchange for zero JS complexity and a guaranteed no-flash fallback.
- `raw_date_groups` was added to `CalendarAbilities::executeGetCalendarPage()`'s in-process return shape for the grid template (it needs `WP_Post` handles for permalinks). It's **not** included in either REST envelope — REST callers see `paged_date_groups` only.
- The data-only response shape (`format=data`) is the source-of-truth the client renderer consumes when re-rendering the grid after filter / nav changes. This is the first real consumer of the phase-1 data envelope from #298.

cc @chubes (<@532385681268408341>) for review when ready.