### PR TITLE
feat(events-map): add data_machine_events_map_query_args filter hook (refs Extra-Chill/extrachill-events#111)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,7 @@ Chat tools in `inc/Api/Chat/Tools` provide AI-driven venue and event management 
 ## Filters & Hooks
 
 - `data_machine_events_calendar_query_args`: Modify calendar WP_Query arguments before template rendering.
+- `data_machine_events_map_query_args`: Modify venue-map query args (`include_ids`, bounds, geo, taxonomy) before the database query runs. Generic extension point for host plugins to inject post-filter constraints.
 - `data_machine_events_excluded_taxonomies`: Control taxonomies excluded from badge lists or filter modals.
 - Badge/action filters: `data_machine_events_badge_wrapper_classes`, `data_machine_events_badge_classes`, `data_machine_events_more_info_button_classes`, `data_machine_events_ticket_button_classes`, and `data_machine_events_action_buttons` customize badge/CTA markup.
 - Pagination filters: `data_machine_events_pagination_wrapper_classes`, `data_machine_events_pagination_args` customize pagination markup.

--- a/docs/integration-api.md
+++ b/docs/integration-api.md
@@ -104,6 +104,7 @@ signatures are stable.
 | `data_machine_events_map_user_location` | `(?array $location, array $context)` | Provide a default user location override. |
 | `data_machine_events_map_show_location_search` | `(bool $show, array $context)` | Toggle the location search input. |
 | `data_machine_events_map_summary` | `(string $html, array $venues, array $context)` | Inject custom summary HTML above the map. |
+| `data_machine_events_map_query_args` | `(array $query_args, array $params)` | Modify the resolved venue-map query args before the database query runs. `$query_args['include_ids']` is the candidate venue term ID set (null = unrestricted, empty array = zero results, array of ints = intersected with existing filters). Mirrors `data_machine_events_calendar_query_args`. |
 
 ### Event Details / button-row actions
 

--- a/inc/Abilities/VenueMapAbilities.php
+++ b/inc/Abilities/VenueMapAbilities.php
@@ -217,32 +217,71 @@ class VenueMapAbilities {
 			}
 		}
 
+		// Combine geo and taxonomy filters (if both present) into a single
+		// candidate venue ID set. Null means "no restriction from this path".
+		$include_ids = null;
+		if ( null !== $geo_venue_ids && null !== $taxonomy_venue_ids ) {
+			$include_ids = array_values( array_intersect( $geo_venue_ids, $taxonomy_venue_ids ) );
+		} elseif ( null !== $geo_venue_ids ) {
+			$include_ids = $geo_venue_ids;
+		} elseif ( null !== $taxonomy_venue_ids ) {
+			$include_ids = $taxonomy_venue_ids;
+		}
+
+		/**
+		 * Filter the resolved venue-map query args before the database query runs.
+		 *
+		 * Generic extension point mirroring `data_machine_events_calendar_query_args`
+		 * for the events-map block. Consumers (e.g. an "only venues attended by the
+		 * current user" filter on a `/my-shows/` page) can inject post-filter
+		 * constraints here without referencing host-plugin tables from inside
+		 * data-machine-events.
+		 *
+		 * The `include_ids` key constrains the candidate venue set:
+		 *   - `null`        : no restriction (default when no geo/taxonomy filter).
+		 *   - empty array   : intentionally restrict to zero venues (no results).
+		 *   - array of ints : intersected with any existing geo/taxonomy filter.
+		 *
+		 * @since 1.x.x
+		 *
+		 * @param array $query_args {
+		 *     Resolved query args used by the events-map venue lookup.
+		 *
+		 *     @type array|null $include_ids   Candidate venue term IDs, or null for unrestricted.
+		 *     @type array|null $bounds        Parsed viewport bounds (sw_lat/sw_lng/ne_lat/ne_lng), or null.
+		 *     @type bool       $has_geo       Whether geo proximity filtering is active.
+		 *     @type float|null $lat           Center latitude, when geo filtering.
+		 *     @type float|null $lng           Center longitude, when geo filtering.
+		 *     @type int        $radius        Search radius, when geo filtering.
+		 *     @type string     $radius_unit   Radius unit ('mi' or 'km').
+		 *     @type string     $taxonomy      Taxonomy slug filter, or empty.
+		 *     @type int        $term_id       Taxonomy term ID filter, or 0.
+		 * }
+		 * @param array $params The original input envelope passed to executeListVenues().
+		 */
+		$query_args = apply_filters(
+			'data_machine_events_map_query_args',
+			array(
+				'include_ids' => $include_ids,
+				'bounds'      => $bounds_parsed,
+				'has_geo'     => $has_geo,
+				'lat'         => $has_geo ? $lat : null,
+				'lng'         => $has_geo ? $lng : null,
+				'radius'      => $radius,
+				'radius_unit' => $radius_unit,
+				'taxonomy'    => $taxonomy,
+				'term_id'     => $term_id,
+			),
+			$input
+		);
+
+		$include_ids   = $query_args['include_ids'] ?? null;
+		$bounds_parsed = $query_args['bounds'] ?? null;
+
 		// Bounds mode: query venues with coordinates in SQL.
 		if ( null !== $bounds_parsed ) {
-			$venue_ids_filter = null;
-
-			// Combine geo and taxonomy filters if both present.
-			if ( null !== $geo_venue_ids && null !== $taxonomy_venue_ids ) {
-				$venue_ids_filter = array_intersect( $geo_venue_ids, $taxonomy_venue_ids );
-			} elseif ( null !== $geo_venue_ids ) {
-				$venue_ids_filter = $geo_venue_ids;
-			} elseif ( null !== $taxonomy_venue_ids ) {
-				$venue_ids_filter = $taxonomy_venue_ids;
-			}
-
-			$venues = $this->queryVenuesByBounds( $bounds_parsed, $venue_ids_filter );
+			$venues = $this->queryVenuesByBounds( $bounds_parsed, $include_ids );
 		} else {
-			// Non-bounds mode: query all matching venues.
-			$include_ids = null;
-
-			if ( null !== $geo_venue_ids && null !== $taxonomy_venue_ids ) {
-				$include_ids = array_intersect( $geo_venue_ids, $taxonomy_venue_ids );
-			} elseif ( null !== $geo_venue_ids ) {
-				$include_ids = $geo_venue_ids;
-			} elseif ( null !== $taxonomy_venue_ids ) {
-				$include_ids = $taxonomy_venue_ids;
-			}
-
 			$venues = $this->queryVenuesWithCoordinates( $include_ids );
 		}
 


### PR DESCRIPTION
## Why

The events-map block needs an extension point analogous to the calendar block's `data_machine_events_calendar_query_args` filter so host plugins can inject post-filter constraints on the venue set without referencing host-plugin tables from inside data-machine-events.

First consumer: Extra-Chill/extrachill-events#111 (My Shows map view tab) — needs to restrict the events-map block to venues of events the current user has marked attended. The constraint lives in `c8c_ec_concert_tracking` on the host site; reaching into that table from DME would be a layer violation. This filter lets the host register a callback that resolves the user's tracked venue term IDs and injects them as `include_ids`.

## What

`VenueMapAbilities::executeListVenues` now folds the geo/taxonomy include-ID logic into a single `$include_ids` variable before running the venue queries, then applies a new filter:

```php
$query_args = apply_filters( 'data_machine_events_map_query_args', $query_args, $params );
```

`$query_args` carries the resolved query inputs (`include_ids`, `bounds`, `has_geo`, `lat`, `lng`, `radius`, `radius_unit`, `taxonomy`, `term_id`); `$params` is the original input envelope. Consumers mutate `include_ids` to constrain the candidate venue set:

- `null` — no restriction (default when no geo/taxonomy filter).
- empty array — intentionally restrict to zero venues (no results).
- array of ints — intersected with any existing geo/taxonomy filter.

The bounds-mode and non-bounds-mode branches now both consume the (potentially filter-modified) `$include_ids` the same way, removing the duplicate intersection logic that previously lived in each branch.

## Files

- `inc/Abilities/VenueMapAbilities.php` — refactor + new filter (+59 / -22).
- `docs/integration-api.md` — document the filter in the Events Map block filter table.
- `CLAUDE.md` — note the filter in the Filters & Hooks section.

## Backward compatibility

Pure addition. With no callbacks registered the filter is a no-op and the venue lookup behaves byte-identical to today. The refactor that folds geo+taxonomy filters into a single `$include_ids` is semantically equivalent to the previous per-branch intersection.

## Verification

- `php -l inc/Abilities/VenueMapAbilities.php` clean.
- Filter signature mirrors `data_machine_events_calendar_query_args` (`(array $args, array $params)`).

## Scope

- One filter, one extension point. No new abilities, no new REST params, no behavior changes when the filter is unused.
- Follow-up PR in extrachill-events depends on this merging first.

Do not merge before review.