### PR TITLE
feat(query): apply data_machine_events_calendar_query_args filter in active code path

### DIFF
--- a/inc/Abilities/EventDateQueryAbilities.php
+++ b/inc/Abilities/EventDateQueryAbilities.php
@@ -268,6 +268,28 @@ class EventDateQueryAbilities {
 			$query_args['no_found_rows'] = false; // Need found_posts for count mode.
 		}
 
+		/**
+		 * Filter the final WP_Query args before the events query runs.
+		 *
+		 * Extension point for platform-specific plugins to inject additional
+		 * constraints (e.g. `post__in` to scope a calendar to events a
+		 * specific user has attended). Replaces the dead-code filter of the
+		 * same name on the deprecated EventQueryBuilder — the active code
+		 * path is now EventDateQueryAbilities::executeQueryEvents, so the
+		 * extension point lives here.
+		 *
+		 * Keeps data-machine-events generic (no platform-specific JOINs
+		 * inside this plugin) by letting consumers add WP_Query-level
+		 * constraints. The second argument is the raw ability input so
+		 * callbacks can branch on scope, tax_filters, search, geo, etc.
+		 *
+		 * @since 0.40.0
+		 *
+		 * @param array $query_args WP_Query arguments about to be executed.
+		 * @param array $input      The full ability input array.
+		 */
+		$query_args = (array) apply_filters( 'data_machine_events_calendar_query_args', $query_args, $input );
+
 		// Execute query.
 		$query = new WP_Query( $query_args );
 


### PR DESCRIPTION
## Summary

- The `data_machine_events_calendar_query_args` filter only existed on the **deprecated** `EventQueryBuilder::build_query_args()`. The class is unreferenced in live code — `CalendarAbilities::executeGetCalendarPage()` calls `EventDateQueryAbilities::executeQueryEvents()` directly. The filter has been dead since the EventDateQueryAbilities refactor.
- Move the extension point into the live path. Apply the same-named filter inside `EventDateQueryAbilities::executeQueryEvents()` right before the `WP_Query` is executed, so existing/intended callbacks fire on the real query path without consumers having to know which internal primitive is active.

## Why

Extra-Chill/extrachill-events#110 needs to inject `post__in` from the `c8c_ec_concert_tracking` table to scope a calendar embed to the events the current user has marked attended. The clean / layer-pure path is for `data-machine-events` to expose an extension point and `extrachill-events` to register a callback — but the documented extension point is currently a no-op.

Keeps `data-machine-events` generic (no platform-specific JOINs inside this plugin) by letting consumers add `WP_Query`-level constraints (`post__in`, additional `meta_query`, etc.).

## Hook signature

```php
/**
 * @param array \$query_args WP_Query arguments about to be executed.
 * @param array \$input      The full ability input array.
 */
\$query_args = (array) apply_filters( 'data_machine_events_calendar_query_args', \$query_args, \$input );
```

The second arg is the raw ability `\$input` (scope, tax_filters, search, geo, date_start, date_end, …) so callbacks can branch by context. Hook name is unchanged from the deprecated location to keep wire-compat with any consumers that already wired against it.

## Risk

- **Cast to array** before assignment defends against a misbehaving callback returning non-array (filter returns the original on type mismatch).
- Single-line addition just above `new WP_Query()`. No behavior change for callers that don't register a callback.
- The deprecated `EventQueryBuilder` still apply_filters() the same hook — fine; nothing calls it, so no double-fire.

## Test

- Existing `EventQueryBuilderGeoSkipTest.php` covers the deprecated path; no test added for the new filter location yet. Followup if wanted: assert the filter fires once per `executeQueryEvents` call and that returned `query_args` is honored. Not blocking ship.

## Scope

- One-line filter addition + docblock. No schema change, no API surface change, no template change, no cache change.

cc <@532385681268408341>