### PR TITLE
fix(events-map): rename tourRouteMode → chronologicalRouteMode (closes #326)

### DIFF
--- a/inc/Abilities/VenueMapAbilities.php
+++ b/inc/Abilities/VenueMapAbilities.php
@@ -93,7 +93,7 @@ class VenueMapAbilities {
 						),
 						'include_events' => array(
 							'type'        => 'boolean',
-							'description' => 'When true and taxonomy+term_id are set, attach upcoming_events_at_venue per venue (events tagged with that term, chronological ascending). Powers tour-route mode on the events-map block.',
+							'description' => 'When true and taxonomy+term_id are set, attach upcoming_events_at_venue per venue (events tagged with that term, chronological ascending). Powers chronological-route mode on the events-map block.',
 						),
 					),
 				),
@@ -311,10 +311,10 @@ class VenueMapAbilities {
 			unset( $venue );
 
 			// Opt-in per-venue event list. Only attached when caller asked
-			// for it AND a taxonomy/term filter is in play (e.g. artist
-			// archive) — otherwise this would balloon to every venue's
-			// every upcoming event regardless of scope. The chronological
-			// sort/grouping for tour-route rendering happens client-side.
+			// for it AND a taxonomy/term filter is in play — otherwise this
+			// would balloon to every venue's every upcoming event regardless
+			// of scope. The chronological sort/grouping for route rendering
+			// happens client-side.
 			if ( $include_events && ! empty( $taxonomy ) && $term_id > 0 ) {
 				$events_by_venue = $this->getUpcomingEventsForVenuesAtTerm( $venue_ids, $taxonomy, $term_id );
 				foreach ( $venues as &$venue ) {
@@ -570,9 +570,9 @@ class VenueMapAbilities {
 	 *
 	 * Returns a `venue_term_id => list of event rows` map. Each event row contains
 	 * `post_id, start_date, start_time, title, permalink` — exactly what the
-	 * tour-route popup needs. Rows are ordered ascending by start_datetime
-	 * within each venue group so the client can pick the earliest entry as
-	 * the venue's "tour position" without re-sorting.
+	 * chronological-route popup needs. Rows are ordered ascending by
+	 * start_datetime within each venue group so the client can pick the
+	 * earliest entry as the venue's route position without re-sorting.
 	 *
 	 * Single SQL query: term_relationships(venue) joined to term_relationships(filter term)
 	 * joined to event_dates filtered to publish+future. Avoids N+1 across venues
@@ -580,7 +580,7 @@ class VenueMapAbilities {
 	 * post_name directly so we can build the permalink ourselves.
 	 *
 	 * @param int[]  $venue_ids        Venue term IDs scoping the lookup.
-	 * @param string $filter_taxonomy  Co-occurring taxonomy (e.g. 'artist').
+	 * @param string $filter_taxonomy  Co-occurring taxonomy slug.
 	 * @param int    $filter_term_id   Term ID in that taxonomy.
 	 * @return array<int,array<int,array{post_id:int,start_date:string,start_time:string,title:string,permalink:string}>>
 	 */

--- a/inc/Blocks/EventsMap/block.json
+++ b/inc/Blocks/EventsMap/block.json
@@ -26,7 +26,7 @@
             "type": "boolean",
             "default": false
         },
-        "tourRouteMode": {
+        "chronologicalRouteMode": {
             "type": "boolean",
             "default": false
         }

--- a/inc/Blocks/EventsMap/render.php
+++ b/inc/Blocks/EventsMap/render.php
@@ -89,23 +89,25 @@ $geocode_rest_url = $show_location_search ? rest_url( 'datamachine/v1/events/geo
 // Summary (plugins can filter to show venue/event counts).
 $summary = apply_filters( 'data_machine_events_map_summary', '', array(), $context );
 
-// Tour-route mode: artist archives can render the same block with a chronological
-// polyline connecting venues by date. Either the block attribute (set when the
-// host emits the block with {"tourRouteMode":true}) or the filter can flip it on.
-$tour_route_mode = (bool) ( $attributes['tourRouteMode'] ?? false );
+// Chronological-route mode: render the venues as a chronologically-ordered
+// route (polyline through venue markers with distinguished first/last stops).
+// Generic display mode for any consumer that needs to draw a route through
+// venues by event date. Either the block attribute or the filter can flip
+// it on.
+$chronological_route_mode = (bool) ( $attributes['chronologicalRouteMode'] ?? false );
 
 /**
- * Filter whether the events map renders in tour-route mode.
+ * Filter whether the events map renders in chronological-route mode.
  *
- * Tour-route mode draws a chronological polyline between venue markers and
- * distinguishes the first/last venues. Intended for artist taxonomy archives
- * where a venue corresponds to a tour stop. Only meaningful when the block
- * also has a taxonomy/term context.
+ * Chronological-route mode draws a polyline between venue markers ordered by
+ * event date and distinguishes the first/last venues. Generic display mode
+ * for any consumer that needs a chronological route through venues. Only
+ * meaningful when the block also has a taxonomy/term context.
  *
- * @param bool  $tour_route_mode Current value.
- * @param array $context         Map context with taxonomy/term info.
+ * @param bool  $chronological_route_mode Current value.
+ * @param array $context                  Map context with taxonomy/term info.
  */
-$tour_route_mode = (bool) apply_filters( 'data_machine_events_map_tour_route', $tour_route_mode, $context );
+$chronological_route_mode = (bool) apply_filters( 'data_machine_events_map_chronological_route', $chronological_route_mode, $context );
 
 ?>
 <div <?php echo $wrapper; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
@@ -128,8 +130,8 @@ $tour_route_mode = (bool) apply_filters( 'data_machine_events_map_tour_route', $
 		data-show-location-search="1"
 		data-geocode-url="<?php echo esc_attr( $geocode_rest_url ); ?>"
 		<?php endif; ?>
-		<?php if ( $tour_route_mode ) : ?>
-		data-tour-route-mode="1"
+		<?php if ( $chronological_route_mode ) : ?>
+		data-chronological-route-mode="1"
 		<?php endif; ?>
 	></div>
 	<?php if ( ! empty( $summary ) ) : ?>

--- a/inc/Blocks/EventsMap/src/api-client.ts
+++ b/inc/Blocks/EventsMap/src/api-client.ts
@@ -20,7 +20,7 @@ interface FetchVenuesParams {
 	/**
 	 * When true, request the opt-in `upcoming_events_at_venue` payload by
 	 * appending `include=events`. Only meaningful in combination with a
-	 * taxonomy/term filter (e.g. tour-route mode on an artist archive).
+	 * taxonomy/term filter (e.g. chronological-route mode).
 	 */
 	includeEvents?: boolean;
 }

--- a/inc/Blocks/EventsMap/src/frontend.css
+++ b/inc/Blocks/EventsMap/src/frontend.css
@@ -280,14 +280,14 @@ a.venue-popup-name:hover {
 	font-size: 1rem;
 }
 
-/* Tour-route mode — chronological polyline + first/last marker styling.
-   Used on artist taxonomy archives via the tourRouteMode block attribute. */
-.data-machine-events-map .tour-route-marker {
+/* Chronological-route mode — polyline ordered by event date with first/last
+   marker styling. Activated via the chronologicalRouteMode block attribute. */
+.data-machine-events-map .chronological-route-marker {
 	background: none;
 	border: none;
 }
 
-.data-machine-events-map .tour-route-pin {
+.data-machine-events-map .chronological-route-pin {
 	display: block;
 	width: 18px;
 	height: 18px;
@@ -298,18 +298,18 @@ a.venue-popup-name:hover {
 	margin-left: 2px;
 }
 
-.data-machine-events-map .tour-route-pin--first {
+.data-machine-events-map .chronological-route-pin--first {
 	width: 22px;
 	height: 22px;
 }
 
-.data-machine-events-map .tour-route-pin--last {
+.data-machine-events-map .chronological-route-pin--last {
 	width: 22px;
 	height: 22px;
 }
 
-/* Tour-route popup — multi-date show list under venue name */
-.data-machine-events-map .venue-popup--tour-route {
+/* Chronological-route popup — multi-date show list under venue name */
+.data-machine-events-map .venue-popup--chronological-route {
 	min-width: 220px;
 	max-width: 280px;
 }

--- a/inc/Blocks/EventsMap/src/frontend.tsx
+++ b/inc/Blocks/EventsMap/src/frontend.tsx
@@ -110,12 +110,12 @@ function formatEventDateTime( date: string, time: string ): string {
 }
 
 /**
- * Tour-route popup. Lists every upcoming show at this venue for the
- * scoped artist, chronologically. The same shape is used for first, last,
- * and middle markers — only the marker icon differs by tour position.
+ * Chronological-route popup. Lists every upcoming show at this venue for the
+ * scoped taxonomy term, chronologically. The same shape is used for first,
+ * last, and middle markers — only the marker icon differs by route position.
  */
-function buildTourRoutePopupHtml( venue: Venue ): string {
-	let html = '<div class="venue-popup venue-popup--tour-route">';
+function buildChronologicalRoutePopupHtml( venue: Venue ): string {
+	let html = '<div class="venue-popup venue-popup--chronological-route">';
 
 	if ( venue.url ) {
 		html += `<a href="${ escapeHtml( venue.url ) }" class="venue-popup-name">${ escapeHtml( venue.name ) }</a>`;
@@ -161,9 +161,9 @@ function createVenueIcon(): L.DivIcon {
 }
 
 /**
- * Tour-route marker. `position` flags first/last for distinct color
- * treatment; middle stops fall through to the default pin look but in
- * the tour-route className so site CSS can theme them as a set.
+ * Chronological-route marker. `position` flags first/last for distinct color
+ * treatment; middle stops fall through to the default pin look but in the
+ * chronological-route className so site CSS can theme them as a set.
  *
  * Colors picked for high contrast against OSM tiles:
  *   - first = green  (#22c55e)
@@ -173,7 +173,7 @@ function createVenueIcon(): L.DivIcon {
  * v1 keeps numbered badges out of scope (per #310 design notes); revisit
  * once Chris weighs in on the live render.
  */
-function createTourRouteIcon( position: 'first' | 'last' | 'middle' ): L.DivIcon {
+function createChronologicalRouteIcon( position: 'first' | 'last' | 'middle' ): L.DivIcon {
 	const color =
 		position === 'first'
 			? '#22c55e'
@@ -181,11 +181,11 @@ function createTourRouteIcon( position: 'first' | 'last' | 'middle' ): L.DivIcon
 				? '#ef4444'
 				: '#475569';
 
-	const html = `<span class="tour-route-pin tour-route-pin--${ position }" style="background:${ color };"></span>`;
+	const html = `<span class="chronological-route-pin chronological-route-pin--${ position }" style="background:${ color };"></span>`;
 
 	return L.divIcon( {
 		html,
-		className: `tour-route-marker tour-route-marker--${ position }`,
+		className: `chronological-route-marker chronological-route-marker--${ position }`,
 		iconSize: [ 22, 22 ],
 		iconAnchor: [ 11, 22 ],
 		popupAnchor: [ 0, -22 ],
@@ -195,8 +195,8 @@ function createTourRouteIcon( position: 'first' | 'last' | 'middle' ): L.DivIcon
 /**
  * Earliest start_datetime (date + time) for a venue, as a sortable
  * "YYYY-MM-DD HH:MM:SS" string. Used to order venues chronologically when
- * drawing the tour-route polyline. Returns null when no events were
- * attached (which means we should skip the venue from the route).
+ * drawing the chronological-route polyline. Returns null when no events
+ * were attached (which means we should skip the venue from the route).
  */
 function earliestEventKey( venue: Venue ): string | null {
 	const shows = venue.upcoming_events_at_venue ?? [];
@@ -400,21 +400,21 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 		nonce,
 		showLocationSearch,
 		geocodeUrl,
-		tourRouteMode,
+		chronologicalRouteMode,
 	} = props;
 
 	const mapRef = useRef<L.Map | null>( null );
 	const clusterGroupRef = useRef<L.MarkerClusterGroup | null>( null );
 	const markerMapRef = useRef<Map<number, L.Marker>>( new Map() );
 	const userMarkerRef = useRef<L.Marker | null>( null );
-	// Single L.polyline holding the chronological tour route. Recreated
-	// from scratch whenever venues change so we don't manage segment-level
+	// Single L.polyline holding the chronological route. Recreated from
+	// scratch whenever venues change so we don't manage segment-level
 	// diffing — the route is at most a few dozen points.
-	const tourPolylineRef = useRef<L.Polyline | null>( null );
-	// Tracks whether the tour-route effect has already fit bounds once.
-	// Without this we'd re-fit on every bounds-change refetch and trap
-	// the user inside the route.
-	const tourFitOnceRef = useRef<boolean>( false );
+	const chronologicalRoutePolylineRef = useRef<L.Polyline | null>( null );
+	// Tracks whether the chronological-route effect has already fit bounds
+	// once. Without this we'd re-fit on every bounds-change refetch and
+	// trap the user inside the route.
+	const chronologicalRouteFitOnceRef = useRef<boolean>( false );
 	const containerRef = useRef<HTMLDivElement | null>( null );
 	const gestureOverlayRef = useRef<HTMLDivElement | null>( null );
 	const gestureTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
@@ -438,10 +438,10 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 					bounds,
 					taxonomy: taxonomy || undefined,
 					termId: termId || undefined,
-					// Tour-route popups and ordering need the per-venue
-					// upcoming events array. Other contexts stay on the
-					// lean default response shape.
-					includeEvents: tourRouteMode || undefined,
+					// Chronological-route popups and ordering need the
+					// per-venue upcoming events array. Other contexts stay
+					// on the lean default response shape.
+					includeEvents: chronologicalRouteMode || undefined,
 				} );
 				setVenues( result.venues );
 			} catch ( err ) {
@@ -451,7 +451,7 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 				setLoading( false );
 			}
 		},
-		[ restUrl, nonce, taxonomy, termId, tourRouteMode ],
+		[ restUrl, nonce, taxonomy, termId, chronologicalRouteMode ],
 	);
 
 	/* --- debounced bounds handler --- */
@@ -561,10 +561,11 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 		mapRef.current = map;
 
 		// Fetch venues on pan/zoom and dispatch bounds-changed events.
-		// Tour-route mode is artist-scoped: the full set is already small
-		// and refetching by viewport would drop venues that the user just
-		// panned away from, mid-route. Skip the moveend refetch for it.
-		if ( ! tourRouteMode ) {
+		// Chronological-route mode operates on a bounded set (one taxonomy
+		// term's events) — the full set is already small and refetching by
+		// viewport would drop venues that the user just panned away from,
+		// mid-route. Skip the moveend refetch for it.
+		if ( ! chronologicalRouteMode ) {
 			map.on( 'moveend', () => debouncedFetch( map ) );
 		}
 
@@ -575,11 +576,11 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 		if ( initialVenues.length === 0 ) {
 			// Small delay so map is fully sized first.
 			setTimeout( () => {
-				// Tour-route mode wants the full set of artist venues
+				// Chronological-route mode wants the full bounded set
 				// regardless of the default viewport, then it auto-fits
 				// to those points. Passing bounds here would clip the
 				// route on first paint.
-				const bounds = tourRouteMode ? undefined : getBoundsFromMap( map );
+				const bounds = chronologicalRouteMode ? undefined : getBoundsFromMap( map );
 				loadVenues( bounds );
 				dispatchBoundsChanged( map );
 			}, 200 );
@@ -589,8 +590,8 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 			map.remove();
 			mapRef.current = null;
 			clusterGroupRef.current = null;
-			tourPolylineRef.current = null;
-			tourFitOnceRef.current = false;
+			chronologicalRoutePolylineRef.current = null;
+			chronologicalRouteFitOnceRef.current = false;
 			markerMapRef.current.clear();
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -668,23 +669,23 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 		const clusterGroup = clusterGroupRef.current;
 		if ( ! map || ! clusterGroup ) return;
 
-		// Always tear down any previously-drawn tour polyline first. Whether
-		// or not this redraw ends up creating a new one, the stale one must
-		// not linger across filter changes / bounds refetches.
-		if ( tourPolylineRef.current ) {
-			map.removeLayer( tourPolylineRef.current );
-			tourPolylineRef.current = null;
+		// Always tear down any previously-drawn route polyline first.
+		// Whether or not this redraw ends up creating a new one, the stale
+		// one must not linger across filter changes / bounds refetches.
+		if ( chronologicalRoutePolylineRef.current ) {
+			map.removeLayer( chronologicalRoutePolylineRef.current );
+			chronologicalRoutePolylineRef.current = null;
 		}
 
 		// ============================================================
-		// Tour-route mode: chronological polyline + first/last styling.
-		// Simpler than the diffing path — every redraw clears markers and
-		// re-creates them because tour position (first/last/middle) is a
-		// function of the whole set, not the individual venue. The route
-		// is bounded by upcoming events for a single artist, so cardinality
-		// is small (typically <30).
+		// Chronological-route mode: polyline ordered by event date with
+		// first/last styling. Simpler than the diffing path — every redraw
+		// clears markers and re-creates them because route position (first/
+		// last/middle) is a function of the whole set, not the individual
+		// venue. The route is bounded by upcoming events for a single
+		// taxonomy term, so cardinality is small (typically <30).
 		// ============================================================
-		if ( tourRouteMode ) {
+		if ( chronologicalRouteMode ) {
 			const currentMarkers = markerMapRef.current;
 			if ( currentMarkers.size > 0 ) {
 				clusterGroup.clearLayers();
@@ -701,10 +702,9 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 				.sort( ( a, b ) => ( a.key < b.key ? -1 : a.key > b.key ? 1 : 0 ) )
 				.map( ( entry ) => entry.venue );
 
-			// Per #310: <2 distinct venues = no route. The host plugin
-			// (extrachill-events artist-map.php) also gates this server-side,
-			// but enforce it here too so the block stays self-contained when
-			// rendered directly via shortcode/REST.
+			// Per #310: <2 distinct venues = no route. Host plugins also
+			// gate this server-side, but enforce it here too so the block
+			// stays self-contained when rendered directly via shortcode/REST.
 			if ( routeVenues.length < 2 ) {
 				return;
 			}
@@ -730,10 +730,10 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 					color: '#2563eb',
 					weight: 3,
 					opacity: 0.7,
-					className: 'tour-route-polyline',
+					className: 'chronological-route-polyline',
 				} );
 				polyline.addTo( map );
-				tourPolylineRef.current = polyline;
+				chronologicalRoutePolylineRef.current = polyline;
 			}
 
 			// Build markers with position-aware icons + multi-date popups.
@@ -747,8 +747,8 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 							: 'middle';
 
 				const marker = L.marker( [ venue.lat, venue.lon ], {
-					icon: createTourRouteIcon( position ),
-				} ).bindPopup( buildTourRoutePopupHtml( venue ) );
+					icon: createChronologicalRouteIcon( position ),
+				} ).bindPopup( buildChronologicalRoutePopupHtml( venue ) );
 
 				currentMarkers.set( venue.term_id, marker );
 				markersToAdd.push( marker );
@@ -761,14 +761,14 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 			// Fit bounds to the full route on the FIRST successful render.
 			// Subsequent refetches (filter changes, bounds events) keep
 			// the current viewport so the user isn't yanked around.
-			if ( ! tourFitOnceRef.current ) {
+			if ( ! chronologicalRouteFitOnceRef.current ) {
 				const latlngs = orderedLatLngs.length > 0
 					? orderedLatLngs
 					: routeVenues.map( ( v ) => [ v.lat, v.lon ] as L.LatLngExpression );
 				if ( latlngs.length > 0 ) {
 					const bounds = L.latLngBounds( latlngs );
 					map.fitBounds( bounds.pad( 0.15 ) );
-					tourFitOnceRef.current = true;
+					chronologicalRouteFitOnceRef.current = true;
 				}
 			}
 
@@ -776,7 +776,7 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 		}
 
 		// ============================================================
-		// Default (non-tour-route) mode — preserved verbatim.
+		// Default (non-chronological-route) mode — preserved verbatim.
 		// ============================================================
 		const icon = createVenueIcon();
 		const currentMarkers = markerMapRef.current;
@@ -942,7 +942,7 @@ function parseMapProps( container: HTMLElement ): MapProps {
 		nonce: data.nonce || '',
 		showLocationSearch: data.showLocationSearch === '1',
 		geocodeUrl: data.geocodeUrl || '',
-		tourRouteMode: data.tourRouteMode === '1',
+		chronologicalRouteMode: data.chronologicalRouteMode === '1',
 	};
 }
 

--- a/inc/Blocks/EventsMap/src/types.ts
+++ b/inc/Blocks/EventsMap/src/types.ts
@@ -10,7 +10,7 @@
 /**
  * Per-venue upcoming event row attached when the REST endpoint is called
  * with `include=events` and a taxonomy/term filter. Used to drive
- * tour-route popups and chronological ordering.
+ * chronological-route popups and chronological ordering.
  */
 export interface VenueUpcomingEvent {
 	post_id: number;
@@ -63,7 +63,7 @@ export interface MapAttributes {
 	height: number;
 	zoom: number;
 	mapType: MapType;
-	tourRouteMode?: boolean;
+	chronologicalRouteMode?: boolean;
 }
 
 /**
@@ -85,7 +85,7 @@ export interface MapProps {
 	nonce: string;
 	showLocationSearch: boolean;
 	geocodeUrl: string;
-	tourRouteMode: boolean;
+	chronologicalRouteMode: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

Hard cutover rename of the chronological-polyline display mode on the events-map block. Removes a layer-purity violation introduced by PR #311 — `tour` is a music-industry concept owned by consumer plugins, not the generic data-machine-events layer. The functionality (draw a polyline through venues in chronological event order, distinguish first/last markers, support multi-event popups) is genuinely generic; only the names encoded a consumer.

**No backward-compat aliases.** Per the revised brief, this is a hard cutover — deprecated names are deleted, no `_doing_it_wrong()` shims, no fallback readers. The in-flight Roadie #111 minion and any extrachill-events consumer update to the new name in a follow-up.

Closes #326.

## Naming map

| Old | New |
|---|---|
| Block attribute `tourRouteMode` | `chronologicalRouteMode` |
| Data attribute `data-tour-route-mode` | `data-chronological-route-mode` |
| Filter hook `data_machine_events_map_tour_route` | `data_machine_events_map_chronological_route` |
| TS `tourRouteMode` prop / field | `chronologicalRouteMode` |
| `createTourRouteIcon()` | `createChronologicalRouteIcon()` |
| `buildTourRoutePopupHtml()` | `buildChronologicalRoutePopupHtml()` |
| `tourPolylineRef`, `tourFitOnceRef` | `chronologicalRoutePolylineRef`, `chronologicalRouteFitOnceRef` |
| CSS `.tour-route-marker`, `.tour-route-pin{,--first,--last}`, `.tour-route-polyline`, `.venue-popup--tour-route` | `.chronological-route-*`, `.venue-popup--chronological-route` |
| Docblock comments referencing 'artist taxonomy archives' / 'artist tour' / 'tour stops' / 'tour position' | Rewritten generically (e.g. "any consumer that needs a chronological route through venues", "route position") |

## Files changed

- `inc/Blocks/EventsMap/block.json` — replace `tourRouteMode` attribute with `chronologicalRouteMode`.
- `inc/Blocks/EventsMap/render.php` — only read `$attributes['chronologicalRouteMode']`; only apply_filters() on `data_machine_events_map_chronological_route`; only emit `data-chronological-route-mode`.
- `inc/Blocks/EventsMap/src/frontend.tsx` — rename all props, function names, ref names, and docblock comments.
- `inc/Blocks/EventsMap/src/types.ts` — rename `tourRouteMode` field on `MapAttributes` and `MapProps`; update related docblock.
- `inc/Blocks/EventsMap/src/api-client.ts` — update docblock example from "tour-route mode on an artist archive" to "chronological-route mode".
- `inc/Blocks/EventsMap/src/frontend.css` — rename `.tour-route-*` / `.venue-popup--tour-route` classes; rewrite section comment.
- `inc/Abilities/VenueMapAbilities.php` — clean up related ability docblocks (description, code comments, function docblock) that referenced "tour-route mode" or "artist archive" as the only example consumer.

`build/` is gitignored — homeboy rebuilds on release. Verified `npm install && npm run build` runs clean locally (webpack compiled successfully in 3548ms).

## Grep verification

Strict gate on the events-map block tree:

\`\`\`bash
$ grep -riE 'tour|extrachill|artist' inc/Blocks/EventsMap/ \\
    --include='*.php' --include='*.ts' --include='*.tsx' --include='*.css' --include='*.json' \\
    | grep -v build | grep -v vendor | grep -v package-lock
(no output)
\`\`\`

Stricter "just tour" gate:

\`\`\`bash
$ grep -riE 'tour' inc/Blocks/EventsMap/ \\
    --include='*.php' --include='*.ts' --include='*.tsx' --include='*.css' --include='*.json' \\
    | grep -v build | grep -v vendor | grep -v package-lock
(no output)
\`\`\`

And on the related ability:

\`\`\`bash
$ grep -riE 'tour|artist' inc/Abilities/VenueMapAbilities.php
(no output)
\`\`\`

Pre-existing layer violations elsewhere in `inc/Abilities/` (e.g. `ArtistUrlImportAbilities.php`, `MergedBillDetectAbilities.php`) are real and should be filed as separate issues, but are out of scope for #326.

## What this PR does NOT do

- No behavior changes — pure rename.
- No backward-compat shims.
- No changes outside the events-map block + its supporting ability.
- No changes to `extrachill-events` (separate follow-up will update the consumer to emit `chronologicalRouteMode`).
- No version bumps or CHANGELOG edits (homeboy owns those at release time via conventional commits).

mention @chubes when ready for review.