### PR TITLE
feat(events-map): add data_machine_events_map_venues filter on the final venue array

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,7 @@ Chat tools in `inc/Api/Chat/Tools` provide AI-driven venue and event management 
 
 - `data_machine_events_calendar_query_args`: Modify calendar WP_Query arguments before template rendering.
 - `data_machine_events_map_query_args`: Modify venue-map query args (`include_ids`, bounds, geo, taxonomy) before the database query runs. Generic extension point for host plugins to inject post-filter constraints.
+- `data_machine_events_map_venues`: Modify the final venue array before it is returned. Runs after sort + cap. Lets consumers inject per-venue payloads (e.g. `upcoming_events_at_venue` from custom sources), re-order, or further filter the set.
 - `data_machine_events_excluded_taxonomies`: Control taxonomies excluded from badge lists or filter modals.
 - Badge/action filters: `data_machine_events_badge_wrapper_classes`, `data_machine_events_badge_classes`, `data_machine_events_more_info_button_classes`, `data_machine_events_ticket_button_classes`, and `data_machine_events_action_buttons` customize badge/CTA markup.
 - Pagination filters: `data_machine_events_pagination_wrapper_classes`, `data_machine_events_pagination_args` customize pagination markup.

--- a/docs/integration-api.md
+++ b/docs/integration-api.md
@@ -105,6 +105,7 @@ signatures are stable.
 | `data_machine_events_map_show_location_search` | `(bool $show, array $context)` | Toggle the location search input. |
 | `data_machine_events_map_summary` | `(string $html, array $venues, array $context)` | Inject custom summary HTML above the map. |
 | `data_machine_events_map_query_args` | `(array $query_args, array $params)` | Modify the resolved venue-map query args before the database query runs. `$query_args['include_ids']` is the candidate venue term ID set (null = unrestricted, empty array = zero results, array of ints = intersected with existing filters). Mirrors `data_machine_events_calendar_query_args`. |
+| `data_machine_events_map_venues` | `(array $venues, array $params)` | Modify the final venue array before it is returned to the caller. Runs after sort + cap. Consumers may mutate per-venue fields, inject `upcoming_events_at_venue` payloads from custom sources (when the built-in `include_events` + taxonomy/term gating does not apply), re-order, or remove venues. Cannot expand beyond `MAX_VENUES`. |
 
 ### Event Details / button-row actions
 

--- a/inc/Abilities/VenueMapAbilities.php
+++ b/inc/Abilities/VenueMapAbilities.php
@@ -339,6 +339,40 @@ class VenueMapAbilities {
 		$total  = count( $venues );
 		$venues = array_slice( $venues, 0, self::MAX_VENUES );
 
+		/**
+		 * Filter the final venue array before it is returned to the caller.
+		 *
+		 * Runs after sort + cap, so consumers see exactly the venue set that
+		 * will be rendered. Consumers may:
+		 *
+		 *   - Mutate per-venue fields (e.g. override `event_count`, rewrite
+		 *     `address`, attach extra metadata).
+		 *   - Inject the `upcoming_events_at_venue` payload from a custom
+		 *     source when the built-in attachment path (which requires both
+		 *     `taxonomy` and `term_id` plus `include_events=true`) does not
+		 *     apply — e.g. a host plugin that wants to drive the
+		 *     events-map block from a non-taxonomy-archive page and supply
+		 *     its own per-venue event list.
+		 *   - Re-order the array (e.g. chronological order keyed on the
+		 *     injected per-venue payload, replacing the default
+		 *     event-count / distance sort).
+		 *   - Remove venues (filter to a stricter subset).
+		 *
+		 * Consumers should not expand the array beyond `MAX_VENUES` — the
+		 * cap is a safety valve enforced before this filter runs.
+		 *
+		 * @since 1.x.x
+		 *
+		 * @param array $venues The final venue array (already sorted and capped).
+		 *                      Each entry has term_id, name, slug, lat, lon,
+		 *                      address, url, event_count, and optionally
+		 *                      distance / upcoming_events_at_venue.
+		 * @param array $params The original input envelope passed to
+		 *                      executeListVenues() (lat, lng, radius, bounds,
+		 *                      taxonomy, term_id, include_events, etc.).
+		 */
+		$venues = apply_filters( 'data_machine_events_map_venues', $venues, $input );
+
 		return array(
 			'venues' => $venues,
 			'total'  => $total,


### PR DESCRIPTION
## Why

`data_machine_events_map_query_args` (added in #324) lets host plugins decide **which** venues come back from the events-map block. But the route-mode rendering path (`chronologicalRouteMode`) requires `upcoming_events_at_venue` to be populated per venue — and the built-in attachment is gated on `include_events=true` **plus** `taxonomy` and `term_id` being set on the request. Hosts that drive the events-map block from a non-taxonomy-archive page (e.g. a regular `wp_page`) can't satisfy that gating, so their venues come back without the per-venue event arrays and the route-mode frontend silently filters them out.

This PR adds the complementary extension point: a generic filter on the final venue array that lets a host inject its own per-venue payload (or mutate / re-order / further filter the set) without referencing host-specific concerns from inside data-machine-events.

## What

`VenueMapAbilities::executeListVenues` applies a new filter immediately before `return`:

```php
$venues = apply_filters( 'data_machine_events_map_venues', $venues, $input );
```

- Runs **after** sort + cap, so consumers see exactly the venue set that will be returned.
- Consumers may mutate per-venue fields, inject `upcoming_events_at_venue` from custom sources, re-order, or remove venues.
- Consumers cannot expand the set beyond `MAX_VENUES` — the cap is a safety valve enforced before this filter runs.

Pairs with `data_machine_events_map_query_args`: that filter controls **which** venues come back; this one controls **what** each venue carries on the way out.

## Files

- `inc/Abilities/VenueMapAbilities.php` — new filter + docblock (+34 lines).
- `docs/integration-api.md` — document the filter in the Events Map block filter table.
- `CLAUDE.md` — note the filter in the Filters & Hooks section.

## Backward compatibility

Pure addition. With no callbacks registered the filter is a no-op and the venue lookup returns byte-identical to today.

## Verification

- `php -l inc/Abilities/VenueMapAbilities.php` clean.
- Filter signature `(array \$venues, array \$params)` mirrors the other map filters.
- Position: after the conditional `include_events` attachment block, after sort + cap, before `return`. This is the only point where the post-attachment / post-sort / post-cap shape of the venue array is fully resolved.

## Scope

- One filter, one extension point. No new abilities, no new REST params, no behavior changes when the filter is unused.
- Generic naming + generic docblock — describes WHAT consumers can do, does NOT name any specific consumer.

Do not merge before review.