### PR TITLE
fix(calendar): revert #309 chrome density pass, keep single-row + gap-chip (closes #329)

### DIFF
--- a/inc/Blocks/Calendar/style.css
+++ b/inc/Blocks/Calendar/style.css
@@ -839,12 +839,12 @@
 /* Date Group Container */
 .data-machine-events-calendar .data-machine-date-group {
     display: block;
-    margin-bottom: 0.5rem;
+    margin-bottom: 1.25rem;
     border-radius: var(--data-machine-border-radius);
     border: 1px solid var(--data-machine-border-light);
     position: relative;
-    padding-top: 24px;
-    padding-bottom: 1rem;
+    padding-top: 40px;
+    padding-bottom: 2.5rem;
 }
 
 /* Day-specific border colors for date groups */
@@ -861,7 +861,7 @@
     display: flex;
     flex-wrap: nowrap;
     gap: var(--data-machine-grid-gap);
-    padding: 0.75rem;
+    padding: 1.5rem;
     overflow-x: auto;
     scroll-behavior: smooth;
     -webkit-overflow-scrolling: touch;
@@ -905,7 +905,7 @@
     content: 'More';
     position: absolute;
     right: 0;
-    top: 24px;
+    top: 40px;
     bottom: 0;
     width: 60px;
     background: linear-gradient(to right, transparent, var(--data-machine-scroll-gradient-color) 70%);


### PR DESCRIPTION
PR #309 bundled three things:

1. **Chrome tightening** on `.data-machine-date-group` (padding/margin) — applied globally, made busy and sparse days both look cramped on production after v0.40.0.
2. **Time-gap-separator** inline chip layout + tighter outer margin + `aria-hidden` on decorative dots + trailing-newline fix on `time-gap-separator.php` — correct everywhere.
3. The pre-existing **single-row card layout for 1/2-event days** from #275 was untouched by #309 and continues to work.

This PR reverts only the chrome tightening from (1). The base `.data-machine-date-group` rule returns to its v0.39.1 values so every day group breathes again:

| Selector | Property | Restored to |
|---|---|---|
| `.data-machine-date-group` | `margin-bottom` | `1.25rem` |
| `.data-machine-date-group` | `padding-top` | `40px` |
| `.data-machine-date-group` | `padding-bottom` | `2.5rem` |
| `.data-machine-date-group .data-machine-events-wrapper` | `padding` | `1.5rem` |
| `.data-machine-date-group::after` | `top` | `40px` |

The time-gap chip changes from #309 (2) stay as shipped, and the single-row sparse-day layout from #275 (3) stays as shipped — sparse days still get their compact inline card format, they just sit inside a properly-padded date-group container again.

Pure CSS-only change; no JS/template/rebuild needed.

Closes #329.