### PR TITLE
fix(calendar): re-hydrate Load More after dynamic content swaps

### DIFF
--- a/inc/Blocks/Calendar/src/frontend.ts
+++ b/inc/Blocks/Calendar/src/frontend.ts
@@ -138,6 +138,23 @@ function initCalendarInstance( calendar: HTMLElement ): void {
 			if ( ! gridMode ) {
 				initCarousel( calendar );
 			}
+
+			// Re-hydrate Load More after a content swap (issue #314).
+			// Every dynamic re-fetch path (geo-sync, scope tabs,
+			// filters) re-renders the server's `paginate_links()`
+			// nav into the DOM as the no-JS fallback. Without this,
+			// that fresh `.data-machine-events-pagination` nav stays
+			// numbered — the initial-mount `initLoadMore` already ran
+			// and its WeakMap guard makes a bare re-init a no-op,
+			// leaving a Load More button stranded ABOVE the
+			// re-injected numbered pagination on archive pages. Tear
+			// down the stale binding and re-hydrate so the freshly
+			// swapped nav becomes a Load More button again. Grid mode
+			// has no pagination nav, so this is a no-op there.
+			if ( ! gridMode ) {
+				destroyLoadMore( calendar );
+				initLoadMore( calendar );
+			}
 		}
 	);
 }

--- a/inc/Blocks/Calendar/src/modules/api-client.ts
+++ b/inc/Blocks/Calendar/src/modules/api-client.ts
@@ -279,6 +279,21 @@ function updatePagination(
 	calendar: HTMLElement,
 	pagination: { html: string } | null
 ): void {
+	// A prior Load More hydration (issue #314) may have replaced the
+	// numbered `.data-machine-events-pagination` nav with a
+	// `.data-machine-events-load-more-nav`. Remove that stale button
+	// so the fresh server-rendered pagination nav can be re-injected
+	// and then re-hydrated by `initLoadMore` on the content-updated
+	// event. Without this, the selector below misses the converted
+	// nav and we leak a duplicate, producing a Load More button
+	// stacked above numbered pagination on archive re-fetches.
+	const loadMoreNav = calendar.querySelector(
+		'.data-machine-events-load-more-nav'
+	);
+	if ( loadMoreNav ) {
+		loadMoreNav.remove();
+	}
+
 	const paginationContainer = calendar.querySelector(
 		'.data-machine-events-pagination'
 	);


### PR DESCRIPTION
## Summary

Fixes the **double pagination on archive pages** — a Load More button stranded *above* numbered pagination — by finishing the #314 Load More migration for the **dynamic re-fetch paths** (phase 2 of #298).

## Root cause

The #314 migration hydrated the server-rendered `paginate_links()` nav into a Load More button **only on initial mount**. But every dynamic re-fetch path re-injects fresh numbered pagination HTML:

- `api-client.ts` `updatePagination()` — runs on geo-sync map pan, scope switch, filter re-fetch
- `extrachill-events/discovery.js` — runs on location-archive scope-tab clicks (fixed in a companion PR)

The `content-updated` lifecycle owner in `frontend.ts` re-inits lazy-render / day-loader / carousel after a swap, but **never re-ran `initLoadMore`** — and load-more's `WeakMap` guard makes a bare re-init a no-op. So on archive pages the freshly re-injected numbered pagination never got converted, leaving:

```
[ Load More Events ]   ← from initial mount, never re-bound
1  2  3  4  »          ← re-injected on re-fetch, never hydrated
```

## Fix

- **`frontend.ts`** — Load More joins the single-owner `content-updated` lifecycle (`destroyLoadMore` + `initLoadMore`), so it re-hydrates the swapped pagination nav exactly like the other dynamic modules.
- **`api-client.ts`** — `updatePagination()` clears any stale `.data-machine-events-load-more-nav` before re-injecting pagination, so the converted nav isn't missed by the selector and duplicated.

## Verification

- `npm run build` (wp-scripts) compiles cleanly; bundle contains the new hydration path.
- Traced both re-fetch paths (geo-sync + companion discovery.js): each now converges on a single Load More button with no numbered pagination on archive pages.

## Notes

- Build artifacts under `build/` are gitignored and produced at deploy time (`homeboy build`) — only `src/` TypeScript changes are committed.
- Companion fix: Extra-Chill/extrachill-events#<discovery PR> applies the same stale-nav cleanup to the location-archive scope-tab switcher.