### PR TITLE
fix: serve 200 on all paginated event XML sitemap pages (#334)

### DIFF
--- a/inc/Core/Event_Post_Type.php
+++ b/inc/Core/Event_Post_Type.php
@@ -97,7 +97,54 @@ class Event_Post_Type {
 		// without the storage cost.
 		add_filter( 'wp_revisions_to_keep', array( __CLASS__, 'limit_event_revisions' ), 10, 2 );
 
+		// Prevent WordPress core from stamping a 404 status on paginated XML
+		// sitemap pages. See prevent_sitemap_404() for the full explanation.
+		add_filter( 'pre_handle_404', array( __CLASS__, 'prevent_sitemap_404' ), 10, 2 );
+
 		self::setup_admin_menu_control();
+	}
+
+	/**
+	 * Prevent WordPress core from returning a 404 status on paginated XML
+	 * sitemap pages.
+	 *
+	 * The event post type advertises far more sub-sitemap pages
+	 * (`wp-sitemap-posts-data_machine_events-N.xml`) than the site has pages
+	 * of regular blog posts. During a sitemap request WordPress still builds a
+	 * "main" query that defaults to the `post` post type with the site's
+	 * `posts_per_page`. WP_Sitemaps renders the correct event XML on
+	 * `template_redirect` from its own provider query, but `WP::handle_404()`
+	 * runs earlier (on the `wp` action) against that dummy main query. Once the
+	 * requested `paged` value exceeds the number of regular blog-post pages,
+	 * the main query returns zero posts and core flags `is_404()` —
+	 * stamping a 404 status header on a response whose body is valid event XML.
+	 *
+	 * Net effect: every advertised sitemap page beyond the blog's page count
+	 * (e.g. pages 6–40 of 40) returns HTTP 404 to crawlers despite carrying a
+	 * full, valid `<urlset>`, so Google discards them and most events never get
+	 * indexed.
+	 *
+	 * Fix: short-circuit `handle_404()` for any WP core sitemap request. The
+	 * sitemap renderer remains fully responsible for the response, including
+	 * issuing its own legitimate 404 when a page genuinely has no URLs
+	 * (see WP_Sitemaps::render_sitemaps()).
+	 *
+	 * @since 0.25.0
+	 *
+	 * @param bool      $preempt  Whether to short-circuit default 404 handling.
+	 * @param \WP_Query $wp_query The main query (unused; kept for signature parity).
+	 * @return bool True to bypass core 404 handling on sitemap requests, otherwise the original value.
+	 */
+	public static function prevent_sitemap_404( $preempt, $wp_query ) {
+		// Only intervene on WP core XML sitemap routes. The `sitemap` query var
+		// is set exclusively by WP_Sitemaps rewrite rules
+		// (wp-sitemap*.xml / .xsl), so this never affects normal front-end
+		// requests.
+		if ( get_query_var( 'sitemap' ) || get_query_var( 'sitemap-stylesheet' ) ) {
+			return true;
+		}
+
+		return $preempt;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes #334. WordPress core was stamping **HTTP 404** on most event sub-sitemap pages (`wp-sitemap-posts-data_machine_events-N.xml`) even though the response body contained full, valid XML — hiding ~88% of the 78k events (and most artist-archive URLs) from Google.

## Root cause (confirmed at origin, not assumed)

The two suspected hooks (`prevent_taxonomy_archive_404` / `sort_by_event_date`) are **not** the cause — they are correctly `is_main_query()` / `is_admin()` guarded and never touch the sitemap provider's `new WP_Query`.

The real cause is core's own 404 handling:

1. A sitemap URL like `…-data_machine_events-6.xml` rewrites to `index.php?sitemap=posts&sitemap-subtype=data_machine_events&paged=6`.
2. `WP_Sitemaps::render_sitemaps()` runs on `template_redirect` (priority 10) and renders the **correct** event XML from its own provider query (page 6 = 2000 URLs, page 40 = 277 URLs).
3. But `WP::handle_404()` runs **earlier**, on the `wp` action, against the **dummy main query** — which defaults to the `post` post type at the site's `posts_per_page` (20). events.extrachill.com has 81 published blog posts = exactly **5 pages**.
4. For `paged >= 6`, that main query returns **zero posts** and is paged, so core flags `is_404()` and calls `status_header(404)` — stamping a 404 on a response whose body is a valid `<urlset>`.

This is why the cutover is exactly at page 6 for events (5 blog-post pages) and page 3 for the artist taxonomy (2 blog-post pages) — the boundary tracks the blog's post count, not the events. WP core registers no `pre_handle_404` bypass for sitemap routes in WP 7.0, so nothing prevents this.

### Evidence (origin, Cloudflare bypassed)

```
# before fix
events page 1/5: 200   events page 6/20/40: 404   artist 1/2: 200   artist 3..25: 404
main query on page 6: paged=6 posts=0 found=0 is_404=true  (querying blog posts, not events)
main query on page 1: paged=1 posts=20 found=81 is_404=false
```

## The fix

Register a `pre_handle_404` filter that short-circuits core 404 handling **only** for WP core sitemap routes (`sitemap` / `sitemap-stylesheet` query vars, set exclusively by `WP_Sitemaps` rewrite rules). The sitemap renderer stays fully responsible for the response and still issues its own legitimate 404 when a page genuinely has no URLs (`WP_Sitemaps::render_sitemaps()` line ~211).

Surgical, single-file change. The existing taxonomy-archive 404-prevention hooks are untouched.

## Validation (what I could verify live)

Validated at origin with `--resolve events.extrachill.com:443:127.0.0.1` using a mirror mu-plugin carrying the identical filter (the running site loads the deployed plugin, not this worktree):

| Check | Result |
|---|---|
| events pages 1, 5, 6, 20, 40 | **200** ✅ |
| artist taxonomy pages 1, 2, 3, 25 | **200** ✅ |
| page 40 body | valid `<urlset>`, **277** `<url>` entries ✅ |
| page 6 body | **2000** `<url>` entries ✅ |
| out-of-range page 99 | **404** (core's own empty-list 404 still fires) ✅ |
| sitemap index + `post` subtype | **200** ✅ |
| front-end `/artist/<term>/` + `?paged=2` | **200** (no regression to calendar-block archive pagination) ✅ |

The mirror mu-plugin was removed after validation; the live site is back to 404 until this is deployed.

### What needs post-deploy verification

- The fix lives in this worktree, so the **production confirmation** (events 1–40 + artist 1–25 all returning 200) must be re-run at origin after `homeboy build` + `homeboy deploy`.
- Extra-Chill/extrachill-seo#17's sitemap-health guardrail (samples first + last page of each subtype) is the natural regression check post-deploy.

## Checks

- `php -l`: clean
- `homeboy lint`: my change adds **0 new findings** in `Event_Post_Type.php` (verified by diffing findings against the base branch; the unused `$wp_query` param is required by the `pre_handle_404` hook signature). Pre-existing repo-wide lint findings are unrelated.
- `homeboy test`: fails in the SQLite test harness during the data-machine plugin's activation (`no such table: wptests_users`) — a pre-existing environment/bootstrap issue, unrelated to this one-line filter.

cc <@532385681268408341>