### PR TITLE
fix: skip taxonomy 404 prevention on feed queries (kills feed.php pluck/max ValueError firehose)

### DIFF
--- a/inc/Core/Event_Post_Type.php
+++ b/inc/Core/Event_Post_Type.php
@@ -202,6 +202,17 @@ class Event_Post_Type {
 			return;
 		}
 
+		// Never touch feed requests. Forcing fields=ids on a feed query makes
+		// $wp_query->posts hold scalar IDs instead of WP_Post objects, which
+		// breaks WordPress core's get_feed_build_date(): wp_list_pluck() emits
+		// a "values must be objects or arrays" notice and the subsequent
+		// max( $modified_times ) throws a ValueError on an empty array
+		// (feed.php). The 404-prevention logic below only matters for HTML
+		// archive pagination, never for feeds.
+		if ( $query->is_feed() ) {
+			return;
+		}
+
 		// Check query vars directly — conditional tags like is_tax() aren't
 		// reliable inside pre_get_posts because the query hasn't executed yet.
 		$event_taxonomies = get_object_taxonomies( self::POST_TYPE );


### PR DESCRIPTION
## Root cause

`prevent_taxonomy_archive_404()` in `inc/Core/Event_Post_Type.php` runs on **every** main query for an event taxonomy archive — including **RSS feed requests**. When the query var for a shared event taxonomy (`artist`, `venue`, `festival`, `location`) is present, it unconditionally does:

```php
$query->set( 'post_type', self::POST_TYPE );
$query->set( 'posts_per_page', 1 );
$query->set( 'fields', 'ids' );   // <-- the problem
```

For a **feed** request, `fields => 'ids'` makes `$wp_query->posts` an array of **integer IDs (scalars)** instead of `WP_Post` objects. WordPress core's `get_feed_build_date()` (`wp-includes/feed.php`) then runs:

1. `wp_list_pluck( $wp_query->posts, 'post_modified_gmt' )` on scalars → fires the `WP_List_Util::pluck was called incorrectly` (`doing_it_wrong`) notice ("Values for the input array must be either objects or arrays").
2. The pluck returns no usable values, so `max( $modified_times )` receives an **empty array** → **uncaught `ValueError`** at `feed.php:736` → **HTTP 500** for the feed.

## Exact feed URL(s) + subsite

Live trace on production captured 100% of the fatals as event-taxonomy feeds on **events.extrachill.com (blog 7)**, e.g.:

- `https://events.extrachill.com/artist/kos/feed`
- `https://events.extrachill.com/artist/spank-the-80s/feed`
- `https://events.extrachill.com/artist/stretch-armstrong/feed`
- `https://events.extrachill.com/artist/allan-gill-quartet/feed`

`curl` repro confirmed **HTTP 500** and incremented the `feed.php:736` fatal counter by exactly 1 per request. The affected terms DO have valid, published events with valid `post_modified_gmt` — so this is **not** a zero-GMT data problem (the eap#55 / Trac #59956 publish-row backfill is already complete on all 9 blogs). The trigger is purely the `fields=ids` mangling.

## Scale (production debug.log)

- ~21,744 `WP_List_Util::pluck` notices
- ~10,173 `feed.php` `max()` `ValueError` fatals
- Each fatal is an RSS2 event-taxonomy feed request that 500s

## The fix

Bail out of `prevent_taxonomy_archive_404()` for `$query->is_feed()` requests. The handler's entire rationale (preventing false 404s on **paginated HTML taxonomy archives** so the calendar block can render) does not apply to feeds, so feeds should simply pass through untouched and keep `WP_Post` objects.

```php
if ( $query->is_feed() ) {
    return;
}
```

## Before / after evidence

- **Before:** `curl -H 'Host: events.extrachill.com' https://.../artist/kos/feed` → HTTP 500, new `feed.php:736` ValueError + `WP_List_Util::pluck` notice on every hit (10,274 → 10,275 fatals during repro).
- **After (logic):** with `is_feed()` returning early, the feed query keeps default `fields=all`, so `$wp_query->posts` are `WP_Post` objects and `get_feed_build_date()` plucks valid `post_modified_gmt` values. Verified that the same artist-term query with `fields=all` plucks 4 non-empty modified dates (no empty `max()`).

> Post-merge/deploy verification on prod: re-curl the feed, confirm HTTP 200 and no new `feed.php` ValueError or `WP_List_Util::pluck` lines after the deploy timestamp.

## Related (WordPress core)

This is the **Extra Chill trigger**. There is also a parallel **WP core robustness fix** — Trac #59956 / `wordpress-develop` branch `fix/59956-feed-build-date-empty-array`, which adds an `if ( $modified_times )` guard around `max()` in `feed.php` so a scalar/empty post set can never fatal regardless of plugin behavior. The two fixes are independent and complementary; this PR removes the trigger, the core PR hardens core. Core is not patched on production.