### PR TITLE
fix: tighten low-density (1–2 event) calendar day layout so it stops looking puffy (CSS-only)

### DIFF
--- a/inc/Blocks/Calendar/style.css
+++ b/inc/Blocks/Calendar/style.css
@@ -958,7 +958,9 @@
     width: 100%;
     height: auto;
     flex: 1 1 100%;
-    padding: 0.85rem 1rem;
+    /* Tighter vertical padding so a single-row card doesn't read puffy;
+     * horizontal padding unchanged for breathing room at the card edges. */
+    padding: 0.55rem 1rem;
 }
 
 .data-machine-events-calendar .data-machine-date-group[data-event-count="2"] .data-machine-event-item {
@@ -969,21 +971,27 @@
 
 .data-machine-events-calendar .data-machine-date-group[data-event-count="1"] .data-machine-event-link,
 .data-machine-events-calendar .data-machine-date-group[data-event-count="2"] .data-machine-event-link {
-    /* Collapse the title-above-meta column layout into a single row strip. */
+    /* Collapse the title-above-meta column layout into a single row strip.
+     * Tighter row/column gaps keep everything compact-but-breathable and
+     * baseline-aligned across title, meta, badges and More Info. */
     flex-direction: row;
     align-items: center;
     justify-content: space-between;
     flex-wrap: wrap;
-    gap: 0.5rem 1rem;
+    gap: 0.35rem 0.85rem;
     height: auto;
+    line-height: 1.3;
 }
 
 .data-machine-events-calendar .data-machine-date-group[data-event-count="1"] .data-machine-event-title,
 .data-machine-events-calendar .data-machine-date-group[data-event-count="2"] .data-machine-event-title {
-    /* Title sits inline with meta instead of stacking above it. */
+    /* Title sits inline with meta instead of stacking above it. This higher-specificity
+     * rule already overrides the stacked-card `.data-machine-date-group .data-machine-event-title`
+     * margin-bottom that would otherwise re-add dead vertical space here. */
     margin: 0;
     flex: 1 1 auto;
     min-width: 0;
+    line-height: 1.3;
 }
 
 .data-machine-events-calendar .data-machine-date-group[data-event-count="1"] .data-machine-event-meta,
@@ -991,7 +999,9 @@
     flex-direction: row;
     align-items: center;
     flex-wrap: wrap;
-    gap: 0.75rem;
+    /* Tighter inline gap between time / performer / badges so the meta row
+     * stays a single compact strip rather than spreading out. */
+    gap: 0.5rem 0.85rem;
 }
 
 /* Badges sit inline with everything else in the row strip, so drop the
@@ -1006,6 +1016,17 @@
 .data-machine-events-calendar .data-machine-date-group[data-event-count="2"] .taxonomy-badges {
     margin-bottom: 0;
     align-items: center;
+    flex: 0 0 auto;
+}
+
+/* More Info button in the single-row strip: the base rule uses
+ * `align-self: flex-start` + `margin-top: auto` to pin the button to the bottom
+ * of a fixed-height stacked card. In the centered row strip those push it out of
+ * alignment and add stray space, so neutralize them and let it sit inline. */
+.data-machine-events-calendar .data-machine-date-group[data-event-count="1"] .data-machine-more-info-button,
+.data-machine-events-calendar .data-machine-date-group[data-event-count="2"] .data-machine-more-info-button {
+    align-self: center;
+    margin-top: 0;
     flex: 0 0 auto;
 }
 


### PR DESCRIPTION
Closes #354.

## What this does
Tightens the vertical rhythm of the **low-density (1–2 event) day layout** on the events calendar so those days read as a clean, compact single-row strip instead of looking puffy — per Chris Gardner's design feedback ("I just want the days to stop looking puffy really, but not affecting the days with many events").

## Changes (all in `inc/Blocks/Calendar/style.css`)
- **Card padding:** `.data-machine-event-item` vertical padding `0.85rem` → `0.55rem` (horizontal `1rem` unchanged) — removes the main source of dead vertical space.
- **Row gaps:** `.data-machine-event-link` gap `0.5rem 1rem` → `0.35rem 0.85rem`, plus `line-height: 1.3`.
- **Meta gaps:** `.data-machine-event-meta` gap `0.75rem` → `0.5rem 0.85rem` so time / performer / badges stay one compact strip.
- **Title:** added `line-height: 1.3` (margin already collapsed to 0 in the existing rule).
- **More Info button:** new scoped rule neutralizing the stacked-card `align-self: flex-start` + `margin-top: auto` so the button sits inline and baseline-aligned in the row strip (`align-self: center; margin-top: 0; flex: 0 0 auto`).

Before/after intent: same single-row strip, just compact-but-breathable instead of puffy — title, time, performer, badges, and More Info sit cleanly on one baseline-aligned row. The 2-up wide / 1-col `<=600px` mobile behavior is untouched.

## Scope & safety
- **CSS-only.** No PHP template, TS module, `block.json`, or carousel JS touched. `style.css` is the source (the Calendar webpack build only compiles `index.tsx`/`frontend.ts`, not CSS), so no build step is involved. `git status` shows exactly one changed file.
- **Scoped to `[data-event-count="1"]` / `[data-event-count="2"]`.** Every changed/added selector carries the `data-event-count` attribute. **Days with 3+ events (the carousel) are unaffected** — no selector that applies to them was touched.
- **Layer purity / grep-clean:** changed lines reuse the existing single-row layout structure and introduce **no hardcoded hex colors and no EC / my-shows identifiers** — `grep -iE "my.?shows|extrachill|#[0-9a-fA-F]{3,6}"` on the changed lines returns clean.

## Out of scope
The deeper clean-markup refactor is tracked separately as **#353** and is intentionally not addressed here — this is the fast, low-risk visual fix.