### PR TITLE
fix: generic scope_token passthrough so consumer query scoping survives REST (#160)

### DIFF
--- a/inc/Api/Controllers/VenueMap.php
+++ b/inc/Api/Controllers/VenueMap.php
@@ -49,6 +49,13 @@ class VenueMap {
 				'taxonomy'       => $request->get_param( 'taxonomy' ) ?? '',
 				'term_id'        => $request->get_param( 'term_id' ) ?? 0,
 				'include_events' => $wants_events,
+				// #160: opaque consumer-minted scope token. Threaded into
+				// the ability input so the data_machine_events_map_query_args
+				// and data_machine_events_map_venues filters receive it and
+				// a consumer can re-apply owner scoping that would otherwise
+				// die over REST (page-context gates don't hold). The generic
+				// layer never interprets it.
+				'scope_token'    => (string) ( $request->get_param( 'scope_token' ) ?? '' ),
 			)
 		);
 

--- a/inc/Api/Routes.php
+++ b/inc/Api/Routes.php
@@ -88,6 +88,12 @@ function register_routes() {
 					'sanitize_callback' => 'sanitize_text_field',
 					'description'       => 'Visible month for month-grid display (YYYY-MM). When set, the response is scoped to that calendar month and pagination is collapsed to a single page (issue #318). Invalid values fall back as if absent.',
 				),
+				'scope_token'      => array(
+					'type'              => 'string',
+					'default'           => '',
+					'sanitize_callback' => 'sanitize_text_field',
+					'description'       => 'Opaque consumer-minted scope token. data-machine-events does not interpret it; it is passed through to the data_machine_events_calendar_query_args filter $input so a consumer can re-apply a server-side query constraint (e.g. owner scoping) that must survive the REST round-trip. The minting + validation is owned entirely by the consumer.',
+				),
 			),
 		)
 	);
@@ -182,6 +188,12 @@ function register_routes() {
 					'type'              => 'boolean',
 					'sanitize_callback' => 'rest_sanitize_boolean',
 					'description'       => 'Boolean shortcut equivalent to include=events.',
+				),
+				'scope_token' => array(
+					'type'              => 'string',
+					'default'           => '',
+					'sanitize_callback' => 'sanitize_text_field',
+					'description'       => 'Opaque consumer-minted scope token. data-machine-events does not interpret it; it is passed through to the data_machine_events_map_query_args and data_machine_events_map_venues filter $input so a consumer can re-apply a server-side constraint (e.g. owner scoping) that must survive the REST round-trip. Minting + validation owned entirely by the consumer.',
 				),
 			),
 		)

--- a/inc/Blocks/Calendar/Cache/CalendarCache.php
+++ b/inc/Blocks/Calendar/Cache/CalendarCache.php
@@ -128,6 +128,14 @@ class CalendarCache {
 			// never share a cache bucket, and so distinct grid months
 			// each get their own bucket.
 			'month'            => (string) ( $envelope['month'] ?? '' ),
+			// #160: an opaque consumer-minted scope token narrows the
+			// result set server-side (e.g. owner scoping via the
+			// query-args filter). Fold it into the key so a scoped
+			// response can NEVER be served to a different viewer (or to
+			// the public, unscoped, calendar) and vice-versa. Distinct
+			// tokens each get their own bucket; the empty-token (public)
+			// bucket stays isolated from every scoped bucket.
+			'scope_token'      => (string) ( $envelope['scope_token'] ?? '' ),
 		);
 
 		return self::FULL_PREFIX . md5( wp_json_encode( $key_data ) );

--- a/inc/Blocks/Calendar/Query/CalendarRequest.php
+++ b/inc/Blocks/Calendar/Query/CalendarRequest.php
@@ -74,6 +74,24 @@ final class CalendarRequest {
 	 */
 	private string $month;
 
+	/**
+	 * Opaque consumer-minted scope token.
+	 *
+	 * data-machine-events treats this as an uninterpreted string. It is
+	 * threaded through {@see toAbilitiesArgs()} into the ability `$input`
+	 * so the `data_machine_events_calendar_query_args` filter receives it
+	 * and a consumer can re-apply a server-side query constraint (e.g.
+	 * owner scoping) that would otherwise be lost on the REST round-trip
+	 * (page-context gates like `is_page()` do not hold over REST).
+	 *
+	 * The generic layer never mints, validates, or branches on this value
+	 * — that is entirely the consumer's responsibility. Empty string when
+	 * no consumer supplied one.
+	 *
+	 * See Extra-Chill/data-machine-events#160.
+	 */
+	private string $scope_token;
+
 	/** @var array<string,int[]> Sanitized taxonomy filter map. */
 	private array $tax_filter;
 
@@ -111,7 +129,8 @@ final class CalendarRequest {
 		int $geo_radius,
 		string $geo_radius_unit,
 		string $format = '',
-		string $month = ''
+		string $month = '',
+		string $scope_token = ''
 	) {
 		$this->paged            = $paged;
 		$this->past             = $past;
@@ -128,6 +147,7 @@ final class CalendarRequest {
 		$this->geo_radius_unit  = $geo_radius_unit;
 		$this->format           = $format;
 		$this->month            = $month;
+		$this->scope_token      = $scope_token;
 	}
 
 	/**
@@ -166,6 +186,8 @@ final class CalendarRequest {
 
 		$month = isset( $get['month'] ) ? self::sanitize_month( wp_unslash( $get['month'] ) ) : '';
 
+		$scope_token = isset( $get['scope_token'] ) ? sanitize_text_field( wp_unslash( $get['scope_token'] ) ) : '';
+
 		return new self(
 			$paged,
 			$past,
@@ -181,7 +203,8 @@ final class CalendarRequest {
 			$geo_radius,
 			$geo_radius_unit,
 			'', // format is REST-only.
-			$month
+			$month,
+			$scope_token
 		);
 	}
 
@@ -226,6 +249,8 @@ final class CalendarRequest {
 
 		$month = self::sanitize_month( (string) ( $request->get_param( 'month' ) ?? '' ) );
 
+		$scope_token = sanitize_text_field( (string) ( $request->get_param( 'scope_token' ) ?? '' ) );
+
 		return new self(
 			$paged,
 			$past,
@@ -241,7 +266,8 @@ final class CalendarRequest {
 			$geo_radius,
 			$geo_radius_unit,
 			$format,
-			$month
+			$month,
+			$scope_token
 		);
 	}
 
@@ -284,6 +310,11 @@ final class CalendarRequest {
 			'include_gaps'     => true,
 			'progressive'      => ! $is_data_format,
 			'month'            => $this->month,
+			// Opaque passthrough — reaches the
+			// data_machine_events_calendar_query_args filter $input so a
+			// consumer can re-apply a server-side constraint that must
+			// survive the REST round-trip. #160.
+			'scope_token'      => $this->scope_token,
 		);
 	}
 
@@ -365,6 +396,15 @@ final class CalendarRequest {
 	 */
 	public function month(): string {
 		return $this->month;
+	}
+
+	/**
+	 * Opaque consumer-minted scope token, or empty string when none.
+	 * data-machine-events never interprets this value. See `$scope_token`
+	 * doc for semantics. #160.
+	 */
+	public function scopeToken(): string {
+		return $this->scope_token;
 	}
 
 	/* ------------------------------------------------------------------ */

--- a/inc/Blocks/Calendar/render.php
+++ b/inc/Blocks/Calendar/render.php
@@ -73,6 +73,47 @@ if ( ! isset( $query_args['scope'] ) && ! empty( $attributes['defaultDateRange']
 	$query_args['scope'] = (string) $attributes['defaultDateRange'];
 }
 
+// #160: let a consumer inject an opaque scope token at server-render time.
+// The token is uninterpreted by data-machine-events — it is emitted as a
+// `data-scope-token` attribute on the calendar root so the frontend
+// re-sends it on every prev/next month REST fetch, and threaded into the
+// ability `$input` so a consumer's query-args filter can re-apply a
+// server-side constraint that would otherwise die over REST. The block
+// render path has no `$_GET['scope_token']` (the embedded calendar is
+// rendered via do_blocks(), not a URL), so the filter is the only way a
+// consumer can seed it on initial paint. URL-driven values (set via the
+// passthrough above on the JS round-trip) win when present.
+if ( empty( $query_args['scope_token'] ) ) {
+	/**
+	 * Filter the opaque scope token emitted on the calendar root and
+	 * threaded into the ability input.
+	 *
+	 * Generic seam: data-machine-events neither mints nor validates this
+	 * value. A consumer (e.g. a "my tracked shows" page) returns a
+	 * non-spoofable, server-minted token here; the same consumer validates
+	 * it inside its `data_machine_events_calendar_query_args` callback. The
+	 * token must round-trip through the public REST endpoint, so consumers
+	 * MUST make it tamper-evident (HMAC / signed nonce) rather than a plain
+	 * identifier.
+	 *
+	 * @since 0.41.0
+	 *
+	 * @param string $scope_token Default empty string (no scoping).
+	 * @param array  $context     Render context: block `attributes` + resolved `display_mode`.
+	 */
+	$injected_scope_token = (string) apply_filters(
+		'data_machine_events_calendar_scope_token',
+		'',
+		array(
+			'attributes'   => $attributes,
+			'display_mode' => $display_mode,
+		)
+	);
+	if ( '' !== $injected_scope_token ) {
+		$query_args['scope_token'] = $injected_scope_token;
+	}
+}
+
 // #318: in month-grid mode, default to the current month (in the site
 // timezone) when no `?month=YYYY-MM` was supplied. The CalendarRequest
 // sanitizer still validates the format — we only default when it would
@@ -226,9 +267,18 @@ $scope_data_attr = '';
 if ( ! empty( $scope ) ) {
 	$scope_data_attr = sprintf( ' data-scope="%s"', esc_attr( $scope ) );
 }
+
+// #160: opaque scope token round-trip attribute. The frontend re-sends
+// this on every month-grid prev/next REST fetch so the server-side
+// constraint survives the round-trip.
+$scope_token_data_attr = '';
+$scope_token_value     = $request->scopeToken();
+if ( '' !== $scope_token_value ) {
+	$scope_token_data_attr = sprintf( ' data-scope-token="%s"', esc_attr( $scope_token_value ) );
+}
 ?>
 
-<div data-instance-id="<?php echo esc_attr( $instance_id ); ?>"<?php echo $archive_data_attrs; ?><?php echo $geo_data_attrs; ?><?php echo $scope_data_attr; ?><?php echo $display_mode_attr; ?> <?php echo $wrapper_attributes; ?>>
+<div data-instance-id="<?php echo esc_attr( $instance_id ); ?>"<?php echo $archive_data_attrs; ?><?php echo $geo_data_attrs; ?><?php echo $scope_data_attr; ?><?php echo $scope_token_data_attr; ?><?php echo $display_mode_attr; ?> <?php echo $wrapper_attributes; ?>>
 	<?php
 	\DataMachineEvents\Blocks\Calendar\Template_Loader::include_template(
 		'filter-bar',

--- a/inc/Blocks/Calendar/src/modules/api-client.ts
+++ b/inc/Blocks/Calendar/src/modules/api-client.ts
@@ -36,6 +36,11 @@ const CALENDAR_PASSTHROUGH_KEYS: ( keyof CalendarRequest )[] = [
 	'paged',
 	'date_start',
 	'date_end',
+	// #160: opaque scope token. Passed through from the URL so re-fetches
+	// preserve it; the month-grid nav also injects it from the calendar
+	// root's `data-scope-token` attribute (a server-embedded calendar has
+	// no `?scope_token=` in the URL on first paint).
+	'scope_token',
 ];
 
 /**

--- a/inc/Blocks/Calendar/src/modules/month-grid-nav.ts
+++ b/inc/Blocks/Calendar/src/modules/month-grid-nav.ts
@@ -111,6 +111,21 @@ class MonthGridController {
 		// `overrides` because they aren't in the CalendarRequest type.
 		params.set( 'format', 'data' );
 		params.set( 'month', month );
+
+		// #160: re-send the opaque scope token so a consumer's server-side
+		// query constraint (e.g. owner scoping) survives the prev/next
+		// REST fetch. The token rides on the calendar root as
+		// `data-scope-token`; the URL has no `?scope_token=` on the
+		// embedded-calendar first paint, so reading it from the DOM is the
+		// authoritative source. data-machine-events never interprets it.
+		const scopeToken = this.readScopeToken();
+		if ( scopeToken ) {
+			params.set( 'scope_token', scopeToken );
+		} else {
+			// No token present — make sure a stale one never leaks in from
+			// the URL passthrough for an unscoped calendar.
+			params.delete( 'scope_token' );
+		}
 		// Past / paged are irrelevant in grid mode — the month IS the
 		// page. Drop them so they don't pollute the cache key.
 		params.delete( 'past' );
@@ -211,6 +226,14 @@ class MonthGridController {
 			};
 		}
 		return {};
+	}
+
+	/**
+	 * Read the opaque scope token emitted on the calendar root by
+	 * render.php (`data-scope-token`). Empty string when absent. #160.
+	 */
+	private readScopeToken(): string {
+		return this.calendar.getAttribute( 'data-scope-token' ) ?? '';
 	}
 
 	private readGeoContext(): Partial< GeoContext > {

--- a/inc/Blocks/Calendar/src/types.ts
+++ b/inc/Blocks/Calendar/src/types.ts
@@ -98,6 +98,14 @@ export interface CalendarRequest {
 	lng: string;
 	radius: string;
 	radius_unit: string;
+	/**
+	 * Opaque consumer-minted scope token. data-machine-events does not
+	 * interpret it; it round-trips from the calendar root's
+	 * `data-scope-token` attribute to the REST endpoint so a server-side
+	 * query constraint (e.g. owner scoping) survives the prev/next month
+	 * fetch. See Extra-Chill/data-machine-events#160.
+	 */
+	scope_token: string;
 }
 
 /* ------------------------------------------------------------------ */

--- a/inc/Blocks/EventsMap/render.php
+++ b/inc/Blocks/EventsMap/render.php
@@ -109,6 +109,31 @@ $chronological_route_mode = (bool) ( $attributes['chronologicalRouteMode'] ?? fa
  */
 $chronological_route_mode = (bool) apply_filters( 'data_machine_events_map_chronological_route', $chronological_route_mode, $context );
 
+// #160: opaque scope token. Mirrors the calendar's scope_token seam. A
+// consumer (e.g. a "my tracked shows" map) returns a non-spoofable,
+// server-minted token here; data-machine-events emits it as
+// `data-scope-token` on the map root so the frontend re-sends it on every
+// venue fetch (mount + pan/zoom), and the consumer validates it inside its
+// `data_machine_events_map_query_args` / `data_machine_events_map_venues`
+// callbacks. The map fetches venues over the public REST endpoint on
+// mount, where page-context gates like is_page() do NOT hold — so without
+// this token the consumer's owner-scoping silently drops and the map leaks
+// the full venue set. The generic layer never mints or validates the token.
+$scope_token = '';
+/**
+ * Filter the opaque scope token emitted on the events-map root.
+ *
+ * Generic seam: data-machine-events neither mints nor validates this
+ * value. Consumers MUST make it tamper-evident (HMAC / signed nonce)
+ * because the venues REST endpoint is public.
+ *
+ * @since 0.41.0
+ *
+ * @param string $scope_token Default empty string (no scoping).
+ * @param array  $context     Map render context (taxonomy/term/attributes).
+ */
+$scope_token = (string) apply_filters( 'data_machine_events_map_scope_token', $scope_token, $context );
+
 ?>
 <div <?php echo $wrapper; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 	<div
@@ -132,6 +157,9 @@ $chronological_route_mode = (bool) apply_filters( 'data_machine_events_map_chron
 		<?php endif; ?>
 		<?php if ( $chronological_route_mode ) : ?>
 		data-chronological-route-mode="1"
+		<?php endif; ?>
+		<?php if ( '' !== $scope_token ) : ?>
+		data-scope-token="<?php echo esc_attr( $scope_token ); ?>"
 		<?php endif; ?>
 	></div>
 	<?php if ( ! empty( $summary ) ) : ?>

--- a/inc/Blocks/EventsMap/src/api-client.ts
+++ b/inc/Blocks/EventsMap/src/api-client.ts
@@ -23,6 +23,12 @@ interface FetchVenuesParams {
 	 * taxonomy/term filter (e.g. chronological-route mode).
 	 */
 	includeEvents?: boolean;
+	/**
+	 * Opaque consumer-minted scope token. Sent as `scope_token` so a
+	 * consumer's server-side venue scoping (e.g. owner scoping) survives
+	 * the REST round-trip. data-machine-events does not interpret it. #160.
+	 */
+	scopeToken?: string;
 }
 
 /**
@@ -74,6 +80,10 @@ export async function fetchVenues(
 
 	if ( params.includeEvents ) {
 		url.searchParams.set( 'include', 'events' );
+	}
+
+	if ( params.scopeToken ) {
+		url.searchParams.set( 'scope_token', params.scopeToken );
 	}
 
 	const response = await fetch( url.toString(), {

--- a/inc/Blocks/EventsMap/src/frontend.tsx
+++ b/inc/Blocks/EventsMap/src/frontend.tsx
@@ -401,6 +401,7 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 		showLocationSearch,
 		geocodeUrl,
 		chronologicalRouteMode,
+		scopeToken,
 	} = props;
 
 	const mapRef = useRef<L.Map | null>( null );
@@ -442,6 +443,11 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 					// per-venue upcoming events array. Other contexts stay
 					// on the lean default response shape.
 					includeEvents: chronologicalRouteMode || undefined,
+					// #160: re-send the opaque scope token so a consumer's
+					// server-side venue scoping survives this REST fetch
+					// (mount + every pan/zoom). Without it the public
+					// endpoint returns the full venue set.
+					scopeToken: scopeToken || undefined,
 				} );
 				setVenues( result.venues );
 			} catch ( err ) {
@@ -451,7 +457,7 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 				setLoading( false );
 			}
 		},
-		[ restUrl, nonce, taxonomy, termId, chronologicalRouteMode ],
+		[ restUrl, nonce, taxonomy, termId, chronologicalRouteMode, scopeToken ],
 	);
 
 	/* --- debounced bounds handler --- */
@@ -943,6 +949,7 @@ function parseMapProps( container: HTMLElement ): MapProps {
 		showLocationSearch: data.showLocationSearch === '1',
 		geocodeUrl: data.geocodeUrl || '',
 		chronologicalRouteMode: data.chronologicalRouteMode === '1',
+		scopeToken: data.scopeToken || '',
 	};
 }
 

--- a/inc/Blocks/EventsMap/src/types.ts
+++ b/inc/Blocks/EventsMap/src/types.ts
@@ -86,6 +86,14 @@ export interface MapProps {
 	showLocationSearch: boolean;
 	geocodeUrl: string;
 	chronologicalRouteMode: boolean;
+	/**
+	 * Opaque consumer-minted scope token, read from the map root's
+	 * `data-scope-token` attribute. Re-sent on every venue fetch (mount +
+	 * pan/zoom) so a consumer's server-side owner scoping survives the REST
+	 * round-trip. data-machine-events does not interpret it.
+	 * See Extra-Chill/data-machine-events#160.
+	 */
+	scopeToken: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds a **generic, opaque `scope_token` passthrough** to the calendar and events-map blocks so a consumer's server-side query scoping survives the client-side REST round-trip. This is the data-machine-events half of the **Extra-Chill/extrachill-events#160** owner-scope leak fix.

**This PR must land together with Extra-Chill/extrachill-events PR `fix-160-calendar-scope`** (the consumer that mints + validates the token). On its own this PR is inert — it adds an uninterpreted passthrough param that no DME code branches on.

## Root cause (the bug this enables fixing)

The calendar/map blocks expose generic query-args filters:
- `data_machine_events_calendar_query_args`
- `data_machine_events_map_query_args` / `data_machine_events_map_venues`

Consumers (e.g. a "my tracked shows" page) used these to inject owner scoping, gating their callback on **page context** (`is_page()`). That gate is TRUE on the initial PHP render but **FALSE on the blocks' own client-side REST re-fetches**:
- Calendar prev/next month → `GET /events/calendar` (REST) → `is_page()` false → scoping dropped → **entire network calendar leaked**.
- Events-map mount + pan/zoom → `GET /events/venues` (REST) → same gate, same leak.

`is_page()` was never a sound place to carry per-user scope across a stateless REST call.

## Data-flow of the new scope token

```
EC render (/my-shows/)                         DME
  └─ data_machine_events_calendar_scope_token  ──► render.php emits
       filter returns HMAC(owner)                    data-scope-token="<tok>"
                                                          │
month-grid-nav.ts reads data-scope-token  ◄──────────────┘
  └─ sends ?scope_token=<tok> on prev/next fetch ──► Routes.php arg
                                                     └─ CalendarRequest::scope_token
                                                        └─ toAbilitiesArgs()['scope_token']
                                                           └─ $input at
                                                              data_machine_events_calendar_query_args
                                                              └─ EC validates tok → owner id → post__in
```

Map path is identical via `data_machine_events_map_scope_token`, the events-map frontend's `scopeToken`, the `/events/venues` `scope_token` arg, `VenueMap` controller → `executeListVenues` input → `data_machine_events_map_query_args` / `data_machine_events_map_venues` `$input`.

## Changes

**Calendar**
- `Routes.php`: `scope_token` arg on `/events/calendar`.
- `CalendarRequest.php`: carries `scope_token` (both constructors) into `toAbilitiesArgs()` so it reaches the query-args filter `$input`.
- `Calendar/render.php`: new `data_machine_events_calendar_scope_token` filter seam; emits `data-scope-token` on the calendar root.
- `CalendarCache.php`: folds `scope_token` into the full-response cache key — a scoped month can **never** be served to a different (or unscoped) viewer. Closes the cache-poisoning angle from #160.
- `src/modules/month-grid-nav.ts` + `api-client.ts` + `types.ts`: read `data-scope-token`, send `scope_token` on re-fetch.

**Map**
- `Routes.php`: `scope_token` arg on `/events/venues`.
- `VenueMap.php` controller: threads `scope_token` into `executeListVenues` input (reaches both map filters' `$input`, no ability change needed).
- `EventsMap/render.php`: new `data_machine_events_map_scope_token` filter seam; emits `data-scope-token` on the map root.
- `EventsMap/src/frontend.tsx` + `api-client.ts` + `types.ts`: read + send the token on mount and every pan/zoom fetch.

## Security mechanism

DME treats `scope_token` as an **uninterpreted string** — it never mints, validates, or branches on the value. The route is public (`__return_true`); making the token non-spoofable is the consumer's responsibility (the EC PR uses an HMAC of the owner id keyed on `wp_salt('auth')`). The filter docblocks state this contract explicitly.

## Layer purity (grep-clean confirmation)

No consumer-specific identifiers were added to this generic layer. Verified — grep of **only the added lines** across all 12 changed files:

```
git diff <files> | grep '^+' | grep -v '^+++' | grep -iE 'my.?shows|extrachill'
→ (no matches)
```

(The repo still contains pre-existing `extrachill-events#NNN` cross-refs and a "My Shows, festival pages" comment, but those are untouched baseline lines, not introduced here.)

## Verify

- `wp-scripts build` passes for both the Calendar and EventsMap blocks (TS type-checks clean).
- `php -l` clean on all changed PHP.
- PHPStan analysis passes. Remaining phpcs findings are pre-existing baseline violations in unrelated files (none in the files changed here).

## Cross-refs

- Consumer PR (must land together): Extra-Chill/extrachill-events `fix-160-calendar-scope` → fixes Extra-Chill/extrachill-events#160.
- Coordinates with #158 (calendar Load More) and #298 (data envelope) — same calendar REST + cache machinery, no overlap with their hunks.