### PR TITLE
fix(calendar): stop Load More from killing its own button on append (#158)

### DIFF
--- a/inc/Blocks/Calendar/src/frontend.ts
+++ b/inc/Blocks/Calendar/src/frontend.ts
@@ -151,9 +151,31 @@ function initCalendarInstance( calendar: HTMLElement ): void {
 			// down the stale binding and re-hydrate so the freshly
 			// swapped nav becomes a Load More button again. Grid mode
 			// has no pagination nav, so this is a no-op there.
+			//
+			// CRITICAL (#158): only re-hydrate when a fresh NUMBERED
+			// `.data-machine-events-pagination` nav is actually
+			// present. The Load More APPEND path (load-more.ts) fires
+			// this same `content-updated` event to re-init the sibling
+			// modules above on the newly-appended date groups — but it
+			// does NOT re-inject a numbered nav (it appended in place;
+			// the working `.data-machine-events-load-more-nav` button
+			// is already bound). Unconditionally running
+			// destroyLoadMore + initLoadMore there tore the listener
+			// off the live button, and initLoadMore then early-returned
+			// because there is no `.data-machine-events-pagination` to
+			// hydrate — leaving a DEAD button that froze the calendar
+			// at the first appended page boundary (reported as "stuck
+			// at June 9"). Gate the re-hydrate on the numbered nav so
+			// the append path leaves its own working button untouched
+			// while full content swaps still re-hydrate as before.
 			if ( ! gridMode ) {
-				destroyLoadMore( calendar );
-				initLoadMore( calendar );
+				const hasNumberedNav = calendar.querySelector(
+					'.data-machine-events-pagination'
+				);
+				if ( hasNumberedNav ) {
+					destroyLoadMore( calendar );
+					initLoadMore( calendar );
+				}
 			}
 		}
 	);


### PR DESCRIPTION
## Summary

Fixes **Extra-Chill/extrachill-events#158** — "Calendar **Load more** frozen on June 9." On events.extrachill.com (blog 7) the calendar's Load More button advanced a couple of pages then went dead, so anonymous visitors couldn't load events past the page-3 boundary (June 9).

The code lives in the **data-machine-events** Calendar block (`inc/Blocks/Calendar/`), so the fix is here even though the issue was filed on extrachill-events.

## Root cause — the client tore down its own working button

The backend was healthy: hitting the data envelope anonymously returns the full pagination on every page (verified live):

```
?paged=2&format=data → current=2 total_pages=165 events=468
?paged=3&format=data → current=3 total_pages=165 events=478
?paged=4&format=data → current=4 total_pages=165 events=483
```

The defect was purely client-side, in the Load More re-hydration path:

```
load-more.ts click → appendPage() appends new date groups
                   → dispatch 'data-machine-calendar-content-updated'   (to re-init sibling modules)
                          │
                          ▼
frontend.ts content-updated handler:
   destroyLazyRender/initLazyRender · destroyDayLoader/initDayLoader · carousel   ✅ correct
   destroyLoadMore(calendar)  ← rips the click listener off the LIVE button
   initLoadMore(calendar)     → replacePaginationWithLoadMore()
                              → querySelector('.data-machine-events-pagination') = null
                              → early return, button NEVER re-bound          ❌ dead button
```

At first mount the numbered `.data-machine-events-pagination` nav is replaced by a `.data-machine-events-load-more-nav` button (`nav.replaceWith()`). A Load More **append** does **not** re-inject a numbered nav — it appends date groups in place. So on the content-updated event fired by the append, `destroyLoadMore()` removed the listener from the still-present, working button and `initLoadMore()` then early-returned because there was no numbered nav to hydrate. Result: a button in the DOM with no click handler → frozen calendar at the first appended page boundary (June 9 = page-3 start).

This also explains why it was **only reproducible logged-out**: editors with `manage_options` bypass the calendar response cache, but the bug is in the JS append path, so it hit everyone — the "couple of pages then stuck" matches the append path killing the button after its first successful append.

## Fix

Gate the Load More re-hydrate in `frontend.ts` on the presence of a numbered `.data-machine-events-pagination` nav:

```ts
if ( ! gridMode ) {
    const hasNumberedNav = calendar.querySelector( '.data-machine-events-pagination' );
    if ( hasNumberedNav ) {
        destroyLoadMore( calendar );
        initLoadMore( calendar );
    }
}
```

- **Full content swaps** (geo-sync, scope tabs, filters) go through `api-client.fetchCalendarEvents()` → `updatePagination()` which re-injects the numbered `paginate_links()` nav. Those still re-hydrate exactly as before (the guard sees the numbered nav).
- **Load More appends** have no numbered nav (the working button is already bound), so the guard skips the destroy/re-init and leaves the live button untouched — while the sibling modules (lazy-render, day-loader, carousel) above still re-init on the newly-appended groups.

One-line behavioral discriminator; no change to the append renderer, the data envelope, or `paginate_links()` config.

## Validation

- `wp-scripts build` (the release build path) **compiles successfully**; the guard is present in the emitted `frontend.js`.
- `homeboy lint` PHPCS passes. The 3 ESLint errors reported are **pre-existing baseline** (unused `destroyFilterModal` import; missing JSDoc `@param` on `handleFilterChange`/`navigateToUrl`) — identical count with this change stashed. This PR adds **zero** new lint findings.
- `build/` is gitignored (homeboy builds at release), so only the `frontend.ts` source change is committed, per repo convention.

## Manual verification suggestion for review

Logged out (or private window) on https://events.extrachill.com: click **Load more events** repeatedly — it should now advance past June 9 / June 13 through the full 165 pages instead of freezing.

Fixes Extra-Chill/extrachill-events#158