### PR TITLE
fix: bind job_id context to upsert_event tool (events publish degradation)

### DIFF
--- a/inc/Steps/Upsert/Events/EventUpsertFilters.php
+++ b/inc/Steps/Upsert/Events/EventUpsertFilters.php
@@ -105,12 +105,13 @@ class EventUpsertFilters {
 		$parameters = self::composeCanonicalParameters( $fragments );
 
 		return array(
-			'class'          => EventUpsert::class,
-			'method'         => 'handle_tool_call',
-			'handler'        => 'upsert_event',
-			'description'    => 'Create or update WordPress event post. Automatically finds existing events by title, venue, and date. Updates if data changed, skips if unchanged, creates if new.',
-			'parameters'     => $parameters,
-			'handler_config' => $ue_config,
+			'class'                   => EventUpsert::class,
+			'client_context_bindings' => array( 'job_id' ),
+			'method'                  => 'handle_tool_call',
+			'handler'                 => 'upsert_event',
+			'description'             => 'Create or update WordPress event post. Automatically finds existing events by title, venue, and date. Updates if data changed, skips if unchanged, creates if new.',
+			'parameters'              => $parameters,
+			'handler_config'          => $ue_config,
 		);
 	}
 


### PR DESCRIPTION
## Summary
Unblocks the active event-publish degradation on events.extrachill.com (Extra-Chill/data-machine#2560).

The `upsert_event` tool definition in `EventUpsertFilters::getDynamicEventTool()` omitted `client_context_bindings`. After data-machine's explicit-context-bindings migration, `job_id` never reached `EventUpsert::handle_tool_call()`, so every event write bounced at the base `UpsertHandler` `job_id` guard (`job_id parameter is required for update operations`) — 9k+ rejected upsert calls and stalled event writes since ~16:00 UTC June 6.

## What changed
- Declare `'client_context_bindings' => array( 'job_id' )` on the `upsert_event` tool def, matching the data-machine core publish/upsert/fetch handlers.

## Note
data-machine core also now auto-binds `job_id` for handler-class tools (Extra-Chill/data-machine#2561), but declaring it here unblocks event writes immediately regardless of deployed core version.

## Testing
- `php -l` clean.

Refs Extra-Chill/data-machine#2560