### PR TITLE
fix: stop hardcoding AI model in approved artist pipelines

### DIFF
--- a/inc/Abilities/ArtistUrlImportAbilities.php
+++ b/inc/Abilities/ArtistUrlImportAbilities.php
@@ -65,13 +65,6 @@ class ArtistUrlImportAbilities {
 	private const ARTIST_FUZZY_MATCH_THRESHOLD = 85;
 
 	/**
-	 * Default AI provider/model for the pipeline AI step. Mirrors the
-	 * defaults used by CityAbilities so behavior stays consistent.
-	 */
-	private const DEFAULT_AI_PROVIDER = 'openai';
-	private const DEFAULT_AI_MODEL    = 'gpt-5-mini';
-
-	/**
 	 * Default author for events published by an approved pipeline.
 	 */
 	private const DEFAULT_POST_AUTHOR = 32;
@@ -1016,7 +1009,8 @@ class ArtistUrlImportAbilities {
 
 	/**
 	 * Configure the pipeline AI step with an artist-scoped system
-	 * prompt. Mirrors CityAbilities::configurePipelineAiStep().
+	 * prompt. Does not set a provider/model — those are resolved by
+	 * AIStep from agent_config and site settings at runtime.
 	 *
 	 * @param int    $pipeline_id
 	 * @param string $artist_name
@@ -1042,11 +1036,11 @@ class ArtistUrlImportAbilities {
 
 		foreach ( $config as &$step ) {
 			if ( ( $step['step_type'] ?? '' ) === 'ai' ) {
-				$step['provider']      = self::DEFAULT_AI_PROVIDER;
-				$step['model']         = self::DEFAULT_AI_MODEL;
-				$step['providers']     = array(
-					self::DEFAULT_AI_PROVIDER => array( 'model' => self::DEFAULT_AI_MODEL ),
-				);
+				// Do NOT write a provider/model into the pipeline AI step.
+				// AIStep resolves the model/provider from agent_config and
+				// site settings at runtime; baking a literal here silently
+				// overrides the operator's configured model on every
+				// approved artist pipeline.
 				$step['system_prompt'] = sprintf(
 					'You process events from %1$s\'s tour/events page for the Extra Chill events feed. The artist is %1$s and is already pre-selected — do not change the artist binding. Identify the venue, city/location, and festival (if any) for each event based on the available information. Skip WordPress categories and post tags entirely.',
 					$artist_name


### PR DESCRIPTION
## Summary

Fixes #361.

`ArtistUrlImportAbilities` hardcoded a literal AI provider/model (`openai` / `gpt-5-mini`) into every artist-tour pipeline created via the artist-URL-import approval flow. A handler/ability plugin must **not** hardcode a model — the model must be resolved from configuration (agent `agent_config` / site `default_model` settings).

## The bug

**File:** `inc/Abilities/ArtistUrlImportAbilities.php`

- Constants `DEFAULT_AI_PROVIDER = 'openai'` / `DEFAULT_AI_MODEL = 'gpt-5-mini'` (old lines 71-72).
- `configurePipelineAiStep()` wrote `provider`, `model`, and `providers` into every AI step of every approved artist pipeline (old lines 1045-1048).

**Real-world impact:** on `events.extrachill.com` the site `default_model` and all 189 pipelines were configured for `gpt-5.4-nano`, but OpenAI dispatches ran on the pricier `gpt-5-mini`. This hardcode is a latent landmine that re-bakes the wrong model into every newly-approved artist pipeline regardless of any settings/agent-config fix.

## The fix

- **Removed** the `DEFAULT_AI_PROVIDER` / `DEFAULT_AI_MODEL` constants.
- **Stopped writing** `provider` / `model` / `providers` into the pipeline AI step. `AIStep` resolves the model/provider from `agent_config` and site settings at runtime, so the pipeline-level value was both wrong and redundant.
- **Kept intact** the artist-scoped `system_prompt` and `enabled_tools` logic.
- **Corrected** two misleading docblocks that cited a non-existent `CityAbilities` class as justification for the hardcode (no `CityAbilities` file/class exists in the plugin).

## Verification

- `php -l inc/Abilities/ArtistUrlImportAbilities.php` — clean.
- `grep -rniE "gpt-5" inc/` — no matches remain.
- `grep -rn "DEFAULT_AI_MODEL|DEFAULT_AI_PROVIDER" inc/` — no matches remain.
- Existing `tests/Unit/ArtistUrlImportAbilitiesTest.php` does not assert the removed behavior, so no test regressions from this change.

> Note: `homeboy test data-machine-events` currently fails at bootstrap due to a pre-existing test-env issue (`an_main.php` requiring a missing `events-db.php`), unrelated to this change — it fails before any test runs.

## Blast radius

Every artist-tour pipeline created via the artist-URL-import approval flow (`configurePipelineAiStep()` runs on each approval).