### PR TITLE
fix: block AI web_fetch to bot-blocked ticketing domains

### DIFF
--- a/data-machine-events.php
+++ b/data-machine-events.php
@@ -98,6 +98,11 @@ require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Core/performance.php';
 // Load retention policy overrides (tightens Data Machine core defaults for this site's volume).
 require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Core/retention.php';
 
+// Short-circuit AI web_fetch requests to bot-blocked ticketing domains before they
+// burn a billed model turn returning HTTP 403 (Ticketmaster, TicketWeb, AXS, etc.).
+require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Core/web-fetch-guard.php';
+\DataMachineEvents\Core\register_web_fetch_guard();
+
 	// Load REST API routes (modular)
 if ( file_exists( DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Api/Routes.php' ) ) {
 	require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Api/Routes.php';

--- a/inc/Core/web-fetch-guard.php
+++ b/inc/Core/web-fetch-guard.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Short-circuit AI web_fetch requests to bot-blocked ticketing domains.
+ *
+ * The Data Machine `web_fetch` AI tool lets event pipelines fetch arbitrary
+ * URLs to enrich event data. In practice the AI repeatedly points it at
+ * ticketing platforms (Ticketmaster, TicketWeb, AXS, SeatGeek, etc.) that
+ * structurally block server-side bots and return HTTP 403 — regardless of
+ * User-Agent. Each blocked fetch still happens *inside* a billed AI model
+ * turn, so the failure is pure wasted OpenAI spend, and the job frequently
+ * ends in `failed - tool_result_failed`.
+ *
+ * On events.extrachill.com this accounted for ~195 HTTP 403 Web Fetch Tool
+ * failures over ~2.5 days, ~77% of them on the Ticketmaster domain family.
+ *
+ * Ticketmaster data is *already* imported through the structured Ticketmaster
+ * Discovery API handler (inc/Steps/EventImport/Handlers/Ticketmaster/), so the
+ * AI never needs to scrape ticketmaster.com at all.
+ *
+ * This guard hooks WordPress core's `pre_http_request` filter and refuses the
+ * request before it leaves the server when the target host is a known
+ * bot-blocked ticketing domain AND the request originates from the AI
+ * web_fetch tool (identified by the browser-mode header fingerprint the tool
+ * sends). It returns an instructive WP_Error so the AI is steered away from
+ * re-fetching the same blocked source instead of burning more turns.
+ *
+ * @package DataMachineEvents
+ * @subpackage Core
+ * @since 0.41.0
+ */
+
+namespace DataMachineEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Register the web_fetch guard.
+ */
+function register_web_fetch_guard(): void {
+	add_filter( 'pre_http_request', __NAMESPACE__ . '\\block_ticketing_web_fetch', 10, 3 );
+}
+
+/**
+ * Default list of host suffixes the AI web_fetch tool should never scrape.
+ *
+ * These are ticketing/discovery platforms that structurally block server-side
+ * bots (HTTP 403) and whose data is either already imported via a structured
+ * API handler (Ticketmaster Discovery API) or otherwise not usefully scrapable.
+ *
+ * Matched as case-insensitive host suffixes, so `ticketmaster.com` also covers
+ * `www.ticketmaster.com` and `ticketmaster.ca` is matched on its own entry.
+ *
+ * @return string[] Lowercase host suffixes.
+ */
+function blocked_web_fetch_hosts(): array {
+	$hosts = array(
+		// Ticketmaster family (already imported via the Discovery API handler).
+		'ticketmaster.com',
+		'ticketmaster.ca',
+		'ticketmaster.evyy.net',
+		'livenation.com',
+		// TicketWeb (Ticketmaster-owned, same bot block).
+		'ticketweb.com',
+		'ticketweb.ca',
+		// Other primary-ticketing platforms that reliably 403 server-side bots.
+		'axs.com',
+		'seatgeek.com',
+		'bandsintown.com',
+		'tixr.com',
+	);
+
+	/**
+	 * Filter the host suffixes blocked for the AI web_fetch tool.
+	 *
+	 * Other sites or future maintainers can add/remove ticketing domains
+	 * without a code change in this plugin.
+	 *
+	 * @param string[] $hosts Lowercase host suffixes.
+	 */
+	$hosts = apply_filters( 'data_machine_events_web_fetch_blocked_hosts', $hosts );
+
+	return array_values( array_filter( array_map( 'strtolower', (array) $hosts ) ) );
+}
+
+/**
+ * Short-circuit a web_fetch HTTP request to a bot-blocked ticketing domain.
+ *
+ * Hooked on `pre_http_request`. Returning a non-false value short-circuits
+ * WordPress's HTTP API and prevents the outbound request entirely.
+ *
+ * We only intervene when BOTH conditions hold:
+ *   1. The target host matches a blocked ticketing domain.
+ *   2. The request looks like the Data Machine web_fetch tool (browser-mode
+ *      GET with the navigate Sec-Fetch fingerprint), so we never interfere
+ *      with the plugin's own structured API calls (Ticketmaster Discovery,
+ *      DICE, etc.) which use a different header profile.
+ *
+ * @param false|array|\WP_Error $preempt Short-circuit return value. Default false.
+ * @param array                 $args    HTTP request arguments.
+ * @param string                $url     The request URL.
+ * @return false|\WP_Error False to allow the request, WP_Error to block it.
+ */
+function block_ticketing_web_fetch( $preempt, $args, $url ) {
+	// Respect any earlier short-circuit.
+	if ( false !== $preempt ) {
+		return $preempt;
+	}
+
+	if ( ! is_string( $url ) || '' === $url ) {
+		return $preempt;
+	}
+
+	// Only target the AI web_fetch tool's request fingerprint. The tool calls
+	// HttpClient::get() with browser_mode=true, which sends a navigate
+	// Sec-Fetch-Mode header. Structured API handlers in this plugin do not.
+	$headers = is_array( $args['headers'] ?? null ) ? $args['headers'] : array();
+	if ( ! is_web_fetch_request( $headers, $args ) ) {
+		return $preempt;
+	}
+
+	$host = strtolower( (string) wp_parse_url( $url, PHP_URL_HOST ) );
+	if ( '' === $host ) {
+		return $preempt;
+	}
+
+	if ( ! host_matches_blocklist( $host, blocked_web_fetch_hosts() ) ) {
+		return $preempt;
+	}
+
+	if ( function_exists( 'do_action' ) ) {
+		do_action(
+			'datamachine_log',
+			'info',
+			'Web Fetch Tool: blocked bot-protected ticketing domain before dispatch',
+			array(
+				'context' => 'Web Fetch Guard',
+				'url'     => $url,
+				'host'    => $host,
+			)
+		);
+	}
+
+	return new \WP_Error(
+		'web_fetch_blocked_ticketing_domain',
+		sprintf(
+			/* translators: %s: target host name. */
+			__( 'Fetching "%s" is blocked: this ticketing platform structurally blocks automated requests (HTTP 403) and its event data is already imported through a structured API handler. Do not web_fetch ticketing pages — use the imported event data instead.', 'data-machine-events' ),
+			$host
+		),
+		array( 'host' => $host )
+	);
+}
+
+/**
+ * Determine whether an HTTP request originates from the AI web_fetch tool.
+ *
+ * The web_fetch tool uses HttpClient browser_mode, which sets a distinctive
+ * set of browser navigation headers. We require the Sec-Fetch-Mode: navigate
+ * header (a fingerprint of browser_mode) on a GET request. This deliberately
+ * avoids blocking the plugin's own structured API calls.
+ *
+ * @param array $headers Request headers (header name => value).
+ * @param array $args    Full request args.
+ * @return bool True when the request matches the web_fetch tool fingerprint.
+ */
+function is_web_fetch_request( array $headers, array $args ): bool {
+	$method = strtoupper( (string) ( $args['method'] ?? 'GET' ) );
+	if ( 'GET' !== $method ) {
+		return false;
+	}
+
+	foreach ( $headers as $name => $value ) {
+		if ( 0 === strcasecmp( (string) $name, 'Sec-Fetch-Mode' ) && 'navigate' === strtolower( (string) $value ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Check whether a host matches any suffix in the blocklist.
+ *
+ * Matches exact host or any subdomain of a blocked suffix, e.g. `ticketmaster.com`
+ * matches `www.ticketmaster.com` and `ticketmaster.com`, but not `notticketmaster.com`.
+ *
+ * @param string   $host      Lowercase host to test.
+ * @param string[] $blocklist Lowercase host suffixes.
+ * @return bool True when the host is blocked.
+ */
+function host_matches_blocklist( string $host, array $blocklist ): bool {
+	foreach ( $blocklist as $blocked ) {
+		if ( '' === $blocked ) {
+			continue;
+		}
+		if ( $host === $blocked || str_ends_with( $host, '.' . $blocked ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}

--- a/tests/Unit/WebFetchGuardTest.php
+++ b/tests/Unit/WebFetchGuardTest.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * Web Fetch Guard Tests
+ *
+ * Covers the short-circuit that prevents the AI web_fetch tool from
+ * burning billed model turns fetching bot-blocked ticketing domains that
+ * always return HTTP 403.
+ *
+ * The guard hooks WordPress core's `pre_http_request` filter and refuses the
+ * request only when BOTH the host is on the ticketing blocklist AND the
+ * request carries the web_fetch tool's browser-mode fingerprint
+ * (Sec-Fetch-Mode: navigate). Structured API handlers (Ticketmaster
+ * Discovery, etc.) use a different header profile and must pass through.
+ *
+ * @package DataMachineEvents\Tests\Unit
+ * @since   0.41.0
+ */
+
+namespace DataMachineEvents\Tests\Unit;
+
+use WP_UnitTestCase;
+
+use function DataMachineEvents\Core\block_ticketing_web_fetch;
+use function DataMachineEvents\Core\host_matches_blocklist;
+use function DataMachineEvents\Core\is_web_fetch_request;
+use function DataMachineEvents\Core\blocked_web_fetch_hosts;
+
+class WebFetchGuardTest extends WP_UnitTestCase {
+
+	/**
+	 * Browser-mode header set matching what HttpClient sends for web_fetch.
+	 *
+	 * @return array<string,string>
+	 */
+	private function browserHeaders(): array {
+		return array(
+			'User-Agent'      => 'Mozilla/5.0',
+			'Sec-Fetch-Mode'  => 'navigate',
+			'Sec-Fetch-Dest'  => 'document',
+		);
+	}
+
+	/**
+	 * Args for a web_fetch-style GET request.
+	 */
+	private function webFetchArgs(): array {
+		return array(
+			'method'  => 'GET',
+			'headers' => $this->browserHeaders(),
+		);
+	}
+
+	// ────────────────────────────────────────────────────────────────────
+	// host_matches_blocklist
+	// ────────────────────────────────────────────────────────────────────
+
+	public function test_exact_host_matches(): void {
+		$this->assertTrue( host_matches_blocklist( 'ticketmaster.com', array( 'ticketmaster.com' ) ) );
+	}
+
+	public function test_subdomain_matches(): void {
+		$this->assertTrue( host_matches_blocklist( 'www.ticketmaster.com', array( 'ticketmaster.com' ) ) );
+		$this->assertTrue( host_matches_blocklist( 'ticketmaster.evyy.net', array( 'ticketmaster.evyy.net' ) ) );
+	}
+
+	public function test_lookalike_host_does_not_match(): void {
+		$this->assertFalse( host_matches_blocklist( 'notticketmaster.com', array( 'ticketmaster.com' ) ) );
+		$this->assertFalse( host_matches_blocklist( 'example.com', array( 'ticketmaster.com' ) ) );
+	}
+
+	// ────────────────────────────────────────────────────────────────────
+	// is_web_fetch_request
+	// ────────────────────────────────────────────────────────────────────
+
+	public function test_navigate_get_is_web_fetch(): void {
+		$this->assertTrue( is_web_fetch_request( $this->browserHeaders(), $this->webFetchArgs() ) );
+	}
+
+	public function test_non_get_is_not_web_fetch(): void {
+		$args = $this->webFetchArgs();
+		$args['method'] = 'POST';
+		$this->assertFalse( is_web_fetch_request( $this->browserHeaders(), $args ) );
+	}
+
+	public function test_plain_api_request_is_not_web_fetch(): void {
+		// Structured API handler profile: JSON accept, no Sec-Fetch headers.
+		$headers = array(
+			'User-Agent' => 'DataMachine/1.0',
+			'Accept'     => 'application/json',
+		);
+		$args = array( 'method' => 'GET', 'headers' => $headers );
+		$this->assertFalse( is_web_fetch_request( $headers, $args ) );
+	}
+
+	// ────────────────────────────────────────────────────────────────────
+	// block_ticketing_web_fetch (the pre_http_request filter callback)
+	// ────────────────────────────────────────────────────────────────────
+
+	public function test_blocks_ticketmaster_web_fetch(): void {
+		$result = block_ticketing_web_fetch(
+			false,
+			$this->webFetchArgs(),
+			'https://www.ticketmaster.com/event/2399925'
+		);
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'web_fetch_blocked_ticketing_domain', $result->get_error_code() );
+	}
+
+	public function test_blocks_ticketweb_web_fetch(): void {
+		$result = block_ticketing_web_fetch(
+			false,
+			$this->webFetchArgs(),
+			'https://www.ticketweb.com/event/some-show/123'
+		);
+		$this->assertInstanceOf( \WP_Error::class, $result );
+	}
+
+	public function test_allows_non_ticketing_web_fetch(): void {
+		$result = block_ticketing_web_fetch(
+			false,
+			$this->webFetchArgs(),
+			'https://www.someindievenue.com/shows'
+		);
+		$this->assertFalse( $result );
+	}
+
+	public function test_allows_ticketmaster_api_request_without_browser_fingerprint(): void {
+		// The Ticketmaster Discovery API call uses app.ticketmaster.com with a
+		// JSON Accept header and NO Sec-Fetch headers — must not be blocked.
+		$args = array(
+			'method'  => 'GET',
+			'headers' => array(
+				'User-Agent' => 'DataMachine/1.0',
+				'Accept'     => 'application/json',
+			),
+		);
+		$result = block_ticketing_web_fetch(
+			false,
+			$args,
+			'https://app.ticketmaster.com/discovery/v2/events.json?apikey=x'
+		);
+		$this->assertFalse( $result );
+	}
+
+	public function test_respects_earlier_short_circuit(): void {
+		$earlier = array( 'response' => array( 'code' => 200 ) );
+		$result  = block_ticketing_web_fetch(
+			$earlier,
+			$this->webFetchArgs(),
+			'https://www.ticketmaster.com/event/1'
+		);
+		$this->assertSame( $earlier, $result );
+	}
+
+	// ────────────────────────────────────────────────────────────────────
+	// blocked_web_fetch_hosts filter
+	// ────────────────────────────────────────────────────────────────────
+
+	public function test_blocklist_is_filterable(): void {
+		$added = function ( $hosts ) {
+			$hosts[] = 'customblocked.example';
+			return $hosts;
+		};
+		add_filter( 'data_machine_events_web_fetch_blocked_hosts', $added );
+
+		$result = block_ticketing_web_fetch(
+			false,
+			$this->webFetchArgs(),
+			'https://customblocked.example/page'
+		);
+
+		remove_filter( 'data_machine_events_web_fetch_blocked_hosts', $added );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+	}
+
+	public function test_default_blocklist_contains_ticketmaster_family(): void {
+		$hosts = blocked_web_fetch_hosts();
+		$this->assertContains( 'ticketmaster.com', $hosts );
+		$this->assertContains( 'ticketweb.com', $hosts );
+		$this->assertContains( 'ticketmaster.evyy.net', $hosts );
+	}
+}


### PR DESCRIPTION
Closes #362

## Problem

The AI `web_fetch` tool repeatedly fetches ticketing platforms — Ticketmaster, TicketWeb, AXS, SeatGeek, Bandsintown — that **structurally block server-side bots** and return **HTTP 403 regardless of User-Agent**. Each blocked fetch happens *inside* a billed AI model turn, so the failure is pure wasted OpenAI spend, and the job frequently ends in `failed - tool_result_failed`.

Measured on events.extrachill.com (blog 7) over ~2.5 days:

- **195** HTTP 403 `Web Fetch Tool` failures (of 650 Web Fetch failures total)
- **~77%** of those 403s on the Ticketmaster domain family (`ticketmaster.com` 86 + `ticketmaster.evyy.net` 64 = 150/195)
- **335** `failed - tool_result_failed` jobs in 7 days

## Root cause / key insight

Ticketmaster event data is **already imported** through the structured **Ticketmaster Discovery API handler** (`inc/Steps/EventImport/Handlers/Ticketmaster/`, API-key authenticated, hits `app.ticketmaster.com`). The AI then *redundantly* points `web_fetch` at the public `ticketmaster.com` pages to "enrich" data — and those pages 403. So we're paying for model turns to scrape a source we already have via API.

## Fix

A new guard hooks WordPress core's `pre_http_request` filter and short-circuits the request **before it leaves the server** when **both**:

1. The target host is on a filterable blocklist of bot-blocked ticketing domains, **and**
2. The request carries the `web_fetch` tool's browser-mode fingerprint (`Sec-Fetch-Mode: navigate` on a GET) — so structured API handlers are never touched.

It returns an instructive `WP_Error` ("this ticketing platform blocks bots and its data is already imported via API — don't web_fetch ticketing pages"), which steers the AI away from re-fetching the same dead source instead of burning more turns.

### Why this design

- **Lives entirely in data-machine-events.** Uses WP core's `pre_http_request` hook — no edit to data-machine core's `WebFetch.php` (read-only) and no new core filter required.
- **Saves the round-trip AND the wasted turn.** The 403 never happens; the AI gets an immediate, actionable failure.
- **Surgically scoped.** The `Sec-Fetch-Mode: navigate` gate means the plugin's own Ticketmaster Discovery API calls (`app.ticketmaster.com`, JSON `Accept`, no Sec-Fetch headers) pass through untouched. Verified in `Ticketmaster.php` (`HttpClient::get` with JSON profile, no `browser_mode`).
- **Tunable without code changes.** The blocklist is exposed via the `data_machine_events_web_fetch_blocked_hosts` filter.

### Default blocklist

`ticketmaster.com`, `ticketmaster.ca`, `ticketmaster.evyy.net`, `livenation.com`, `ticketweb.com`, `ticketweb.ca`, `axs.com`, `seatgeek.com`, `bandsintown.com`, `tixr.com` (matched as host suffixes, so subdomains are covered).

## Files

- `inc/Core/web-fetch-guard.php` — the guard (host-suffix matching, web_fetch fingerprint detection, filterable blocklist, `datamachine_log` audit entry on block).
- `data-machine-events.php` — require + register on load, next to the other Core hooks.
- `tests/Unit/WebFetchGuardTest.php` — covers host matching (exact/subdomain/lookalike), fingerprint detection, the `pre_http_request` callback (blocks Ticketmaster/TicketWeb, allows indie venues, allows the Ticketmaster API profile, respects earlier short-circuits), and the blocklist filter.

## Verification

- `php -l` clean on all changed files.
- `homeboy lint --changed-since origin/main`: eslint + phpstan **0 findings**; the 4 phpcs findings are **pre-existing** baseline lines in `data-machine-events.php` (confirmed via `git blame` — commits `5b487fc8` / `2bcf0010`, lines 145/152/214), none in the new files or the added lines.
- Repo test suite not run locally (host load too high for `homeboy test`); the new unit test follows the repo's existing `WP_UnitTestCase` + `pre_http_request` mocking pattern and will run in CI.

## Not in scope

No release, no deploy, no version/changelog edits (homeboy owns those).
