### PR TITLE
fix(upsert): broaden junk-title guard to dedup markers and control characters

### DIFF
--- a/inc/Steps/Upsert/Events/EventUpsert.php
+++ b/inc/Steps/Upsert/Events/EventUpsert.php
@@ -81,19 +81,22 @@ class EventUpsert extends UpsertHandler {
 			);
 		}
 
-		// Belt-and-suspenders guard against "Rejected:" leakage (see issue #349).
+		// Belt-and-suspenders guard against junk-title leakage (see issues #349, #367).
 		//
 		// When the AI recognizes a source item is not a real, attendable event
-		// (e.g. season-ticket packages, parking passes), it is supposed to call
-		// the reject_source disposition tool. If the per-pipeline prompt lacks
-		// rejection guidance, the model sometimes improvises by publishing the
-		// item with a "Rejected:" prefix in the title instead — leaking junk
-		// onto the public calendar. This guard refuses to create/update any
-		// post whose title starts with "Rejected:" or "Rejected -" so a prompt
-		// regression can never silently publish a rejected item again.
-		if ( $this->isRejectedTitle( $title ) ) {
+		// (e.g. season-ticket packages, parking passes) or is a duplicate of an
+		// existing event, it is supposed to call the reject_source disposition
+		// tool. If the per-pipeline prompt lacks rejection/dedup guidance, the
+		// model sometimes improvises by publishing the item with a marker in
+		// the title instead — "Rejected:" prefixes (#349) or dedup markers like
+		// "(duplicate)", "Duplicate:", "Consolidate:", "(merged)", "see
+		// canonical listing" (#367) — leaking junk onto the public calendar.
+		// This guard refuses to create/update any post whose title carries such
+		// a marker (or any control characters / null bytes) so a prompt
+		// regression can never silently publish a junk item again.
+		if ( $this->isJunkTitle( $title ) ) {
 			return $this->errorResponse(
-				'Refusing to upsert event with a "Rejected:" title; the AI should call reject_source instead of publishing a rejected item (see issue #349)',
+				'Refusing to upsert event with a junk marker title (Rejected/Duplicate/Consolidate/merged/see canonical, or control characters); the AI should call reject_source instead of publishing a marked item (see issues #349, #367)',
 				array(
 					'title' => $title,
 				)
@@ -140,21 +143,50 @@ class EventUpsert extends UpsertHandler {
 	}
 
 	/**
-	 * Determine whether an event title indicates a rejected source item.
+	 * Determine whether an event title is a junk-marker leak.
 	 *
-	 * Matches titles that begin with "Rejected:" or "Rejected -" (case-insensitive,
-	 * after trimming surrounding whitespace). The AI is meant to call the
-	 * reject_source disposition tool for non-events; when a stale prompt omits
-	 * rejection guidance it can instead improvise a "Rejected:" prefixed title and
-	 * publish the junk item. See issue #349.
+	 * The AI is meant to call the reject_source disposition tool for non-events
+	 * and discovered duplicates; when a stale prompt omits that guidance it can
+	 * instead improvise a marker in the title and publish the junk item. This
+	 * catches (case-insensitive, after trimming surrounding whitespace):
+	 *
+	 * - "Rejected:" / "Rejected -" / "Rejected —" prefixes (issue #349)
+	 * - "Duplicate:" / "Consolidate:" prefixes and their dash variants (issue #367)
+	 * - "(duplicate)" / "(merged)" / "(consolidated)" markers anywhere in the title
+	 * - "see canonical" substring (e.g. "— see canonical listing")
+	 * - Any control characters or null bytes (unconditionally rejected)
+	 *
+	 * See issues #349 and #367.
 	 *
 	 * @param string $title Event title.
-	 * @return bool True if the title is a rejected-item leak.
+	 * @return bool True if the title is a junk-marker leak.
 	 */
-	private function isRejectedTitle( string $title ): bool {
+	private function isJunkTitle( string $title ): bool {
+		// Control characters / null bytes are never legitimate in a title.
+		if ( preg_match( '/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/', $title ) ) {
+			return true;
+		}
+
 		$trimmed = trim( $title );
 
-		return (bool) preg_match( '/^rejected\s*[:\-]/i', $trimmed );
+		// "Rejected:" / "Duplicate:" / "Consolidate:" prefixes with colon,
+		// hyphen, en dash, or em dash separators (issue #349, #367).
+		if ( preg_match( '/^(rejected|duplicate|consolidate)\s*[:\-\x{2013}\x{2014}]/iu', $trimmed ) ) {
+			return true;
+		}
+
+		// "(duplicate)" / "(merged)" / "(consolidated)" markers anywhere,
+		// including compound forms like "(Duplicate — Consolidated)".
+		if ( preg_match( '/\(\s*(duplicate|merged|consolidated)\b[^)]*\)/i', $trimmed ) ) {
+			return true;
+		}
+
+		// "see canonical" substring (e.g. "— see canonical listing").
+		if ( false !== stripos( $trimmed, 'see canonical' ) ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**

--- a/tests/Unit/EventUpsertTest.php
+++ b/tests/Unit/EventUpsertTest.php
@@ -250,8 +250,8 @@ class EventUpsertTest extends WP_UnitTestCase {
 	 *
 	 * @see https://github.com/Extra-Chill/data-machine-events/issues/349
 	 */
-	public function test_is_rejected_title_refuses_colon_prefix(): void {
-		$method = new \ReflectionMethod( $this->handler, 'isRejectedTitle' );
+	public function test_is_junk_title_refuses_colon_prefix(): void {
+		$method = new \ReflectionMethod( $this->handler, 'isJunkTitle' );
 		$method->setAccessible( true );
 
 		$this->assertTrue(
@@ -271,8 +271,8 @@ class EventUpsertTest extends WP_UnitTestCase {
 	 *
 	 * @see https://github.com/Extra-Chill/data-machine-events/issues/349
 	 */
-	public function test_is_rejected_title_refuses_dash_prefix(): void {
-		$method = new \ReflectionMethod( $this->handler, 'isRejectedTitle' );
+	public function test_is_junk_title_refuses_dash_prefix(): void {
+		$method = new \ReflectionMethod( $this->handler, 'isJunkTitle' );
 		$method->setAccessible( true );
 
 		$this->assertTrue(
@@ -282,13 +282,111 @@ class EventUpsertTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A normal event title is NOT treated as a rejected item, including titles
-	 * that merely contain the word "rejected" elsewhere.
+	 * Dedup-marker prefixes ("Duplicate:", "Consolidate:") and dash/em-dash
+	 * variants are refused.
+	 *
+	 * @see https://github.com/Extra-Chill/data-machine-events/issues/367
+	 */
+	public function test_is_junk_title_refuses_dedup_prefixes(): void {
+		$method = new \ReflectionMethod( $this->handler, 'isJunkTitle' );
+		$method->setAccessible( true );
+
+		$this->assertTrue(
+			$method->invoke( $this->handler, 'Duplicate: ÉLA-Vated Saturdays (merged)' ),
+			'A title starting with "Duplicate:" must be refused.'
+		);
+
+		$this->assertTrue(
+			$method->invoke( $this->handler, 'Duplicate — Dan Spencer / Drip Fed / Tied Up (canonical moved)' ),
+			'A title starting with "Duplicate —" (em dash) must be refused.'
+		);
+
+		$this->assertTrue(
+			$method->invoke( $this->handler, 'Consolidate: Smokedope2016 duplicates' ),
+			'A title starting with "Consolidate:" must be refused.'
+		);
+	}
+
+	/**
+	 * Parenthesized dedup markers anywhere in the title are refused.
+	 *
+	 * @see https://github.com/Extra-Chill/data-machine-events/issues/367
+	 */
+	public function test_is_junk_title_refuses_paren_markers(): void {
+		$method = new \ReflectionMethod( $this->handler, 'isJunkTitle' );
+		$method->setAccessible( true );
+
+		$this->assertTrue(
+			$method->invoke( $this->handler, 'Kev G Mor (duplicate)' ),
+			'A title with a "(duplicate)" suffix must be refused.'
+		);
+
+		$this->assertTrue(
+			$method->invoke( $this->handler, 'Kinky Coffee  NEW (Duplicate)' ),
+			'A title with a "(Duplicate)" suffix must be refused.'
+		);
+
+		$this->assertTrue(
+			$method->invoke( $this->handler, 'Some Event (merged)' ),
+			'A title with a "(merged)" marker must be refused.'
+		);
+
+		$this->assertTrue(
+			$method->invoke( $this->handler, 'Some Event (Duplicate — Consolidated)' ),
+			'A title with a compound "(Duplicate — Consolidated)" marker must be refused.'
+		);
+	}
+
+	/**
+	 * The "see canonical" marker substring is refused.
+	 *
+	 * @see https://github.com/Extra-Chill/data-machine-events/issues/367
+	 */
+	public function test_is_junk_title_refuses_see_canonical(): void {
+		$method = new \ReflectionMethod( $this->handler, 'isJunkTitle' );
+		$method->setAccessible( true );
+
+		$this->assertTrue(
+			$method->invoke( $this->handler, 'Tommy Stinson (duplicate) — see canonical listing' ),
+			'A title containing "see canonical" must be refused.'
+		);
+
+		$this->assertTrue(
+			$method->invoke( $this->handler, 'Some Event — See Canonical Listing' ),
+			'A title containing "See Canonical" (any case) must be refused.'
+		);
+	}
+
+	/**
+	 * Titles containing control characters or null bytes are refused
+	 * unconditionally.
+	 *
+	 * @see https://github.com/Extra-Chill/data-machine-events/issues/367
+	 */
+	public function test_is_junk_title_refuses_control_characters(): void {
+		$method = new \ReflectionMethod( $this->handler, 'isJunkTitle' );
+		$method->setAccessible( true );
+
+		$this->assertTrue(
+			$method->invoke( $this->handler, "Duplicate: \0\0\0ÉLA-Vated Saturdays (merged)" ),
+			'A title containing null bytes must be refused.'
+		);
+
+		$this->assertTrue(
+			$method->invoke( $this->handler, "Innocuous Title\x01 With Control Char" ),
+			'A title containing any control character must be refused.'
+		);
+	}
+
+	/**
+	 * A normal event title is NOT treated as junk, including titles that
+	 * merely contain guarded words in legitimate positions.
 	 *
 	 * @see https://github.com/Extra-Chill/data-machine-events/issues/349
+	 * @see https://github.com/Extra-Chill/data-machine-events/issues/367
 	 */
-	public function test_is_rejected_title_allows_normal_title(): void {
-		$method = new \ReflectionMethod( $this->handler, 'isRejectedTitle' );
+	public function test_is_junk_title_allows_normal_title(): void {
+		$method = new \ReflectionMethod( $this->handler, 'isJunkTitle' );
 		$method->setAccessible( true );
 
 		$this->assertFalse(
@@ -299,6 +397,18 @@ class EventUpsertTest extends WP_UnitTestCase {
 		$this->assertFalse(
 			$method->invoke( $this->handler, 'Eggy at Charleston Pour House' ),
 			'A normal event title must NOT be refused.'
+		);
+
+		// "Duplicate" as a band/title word without a separator is fine.
+		$this->assertFalse(
+			$method->invoke( $this->handler, 'Duplicate Minds at The Sinkhole' ),
+			'A title beginning with the word "Duplicate" but no marker separator must NOT be refused.'
+		);
+
+		// Em dashes and parens in normal titles are fine.
+		$this->assertFalse(
+			$method->invoke( $this->handler, 'Dan Spencer / Drip Fed / Tied Up — The Royal American (late show)' ),
+			'A normal title with em dash and parenthetical must NOT be refused.'
 		);
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #367 — the dedup workflow leaks junk-titled PUBLISHED events. The `isRejectedTitle()` guard added in #350 (for #349) only matched `Rejected:` / `Rejected -` prefixes; the agent's dedup improvisation vocabulary is wider, and **23 published events** carried dedup-marker titles on production (6 live on the public calendar), e.g.:

- `Kev G Mor (duplicate)`
- `Kinky Coffee  NEW (Duplicate)` ×4
- `Duplicate — Dan Spencer / Drip Fed / Tied Up (canonical moved)`
- `Consolidate: Smokedope2016 duplicates`
- `Tommy Stinson (duplicate) — see canonical listing`
- `Duplicate: \0\0\0ÉLA-Vated Saturdays (merged)` — literal null bytes in `post_title`

All 23 were trashed during cleanup on 2026-06-12; this PR closes the guard gap so the bug class can't republish.

## Changes

`isRejectedTitle()` → `isJunkTitle()` in `inc/Steps/Upsert/Events/EventUpsert.php`, covering case-insensitively:

| Pattern | Source |
|---|---|
| `^Rejected[:\-–—]` | existing #349 behavior, preserved |
| `^Duplicate[:\-–—]`, `^Consolidate[:\-–—]` | #367 prefix variants |
| `\((duplicate\|merged\|consolidated)...\)` anywhere | #367 suffix/compound markers incl. `(Duplicate — Consolidated)` |
| `see canonical` substring | #367 |
| **any control characters / null bytes** | unconditional reject (the `\0\0\0` case) |

Refusal behavior is identical to #350: the upsert fails with a clear loggable `errorResponse` so prompt regressions surface in the jobs table instead of publishing junk. Docblocks updated to reference both #349 and #367.

## Before / after

- **Before:** `Kev G Mor (duplicate)` sails through `isRejectedTitle()` and is published to the public calendar.
- **After:** the upsert is refused with `Refusing to upsert event with a junk marker title (...)` and the failure is visible in the jobs table.

## Tests

Extended `tests/Unit/EventUpsertTest.php` (runs via homeboy CI / `WP_UnitTestCase`):

- All existing #349 cases preserved (renamed to `test_is_junk_title_*`)
- New cases for every production-observed pattern: dedup prefixes (colon + em-dash), paren markers incl. compound, `see canonical`, **null-byte and control-character titles**
- Negative cases: normal titles, "The Rejects", "Duplicate Minds" (no separator), em-dash/parenthetical titles like `(late show)`, `(Rescheduled)`

`php -l` clean on both files; regex matrix also verified standalone against all 13 junk + 6 clean fixtures.

## Companion change

The other half of #367 (prompt gap — the events-bot prompt says nothing about discovered duplicates, which is why the model improvises title-vandalism) is addressed separately in the extrachill-event-bundles repo.