### PR TITLE
fix(schema): remove stale skip_item references; describe behavior not tool name

### DIFF
--- a/inc/Core/EventSchemaProvider.php
+++ b/inc/Core/EventSchemaProvider.php
@@ -76,7 +76,7 @@ class EventSchemaProvider {
 		'startTime'       => array(
 			'type'            => 'string',
 			'required'        => true,
-			'description'     => 'Event start time (HH:MM 24-hour format). REQUIRED. If not provided in structured data, extract from the event title or description (e.g., "6-9pm" → "18:00", "doors at 7" → "19:00", "starts 8pm" → "20:00"). If no start time can be determined from any source, use skip_item instead — do not publish events without a start time.',
+			'description'     => 'Event start time (HH:MM 24-hour format). REQUIRED. If not provided in structured data, extract from the event title or description (e.g., "6-9pm" → "18:00", "doors at 7" → "19:00", "starts 8pm" → "20:00"). If no start time can be determined from any source, reject this item via the rejection disposition tool instead — do not publish events without a start time.',
 			'schema_property' => null,
 		),
 		'endTime'         => array(

--- a/inc/Steps/EventImport/EventEngineData.php
+++ b/inc/Steps/EventImport/EventEngineData.php
@@ -282,11 +282,11 @@ class EventEngineData {
 	}
 
 	/**
-	 * Store item context in engine data for skip_item tool.
+	 * Store item context in engine data for the fetch disposition tools.
 	 *
-	 * This enables the skip_item tool to mark items as processed even when
-	 * the AI decides to skip them. Without this, skipped items would be
-	 * refetched on subsequent runs.
+	 * This enables reject_source to mark items as processed even when the AI
+	 * decides to reject them. Without this, rejected items would be refetched
+	 * on subsequent runs.
 	 *
 	 * @param int $job_id Job ID
 	 * @param string $item_identifier Item identifier (event_identifier, uid, etc.)

--- a/inc/Steps/EventImport/Handlers/EventImportHandler.php
+++ b/inc/Steps/EventImport/Handlers/EventImportHandler.php
@@ -165,7 +165,8 @@ abstract class EventImportHandler extends FetchHandler {
 	 * Called by FetchHandler::dedup() after marking an item as processed.
 	 *
 	 * Stores item context (item_identifier + source_type) in engine data so the
-	 * skip_item AI tool can find and mark items correctly.
+	 * fetch disposition tools (reject_source / defer_item) can find and mark
+	 * items correctly.
 	 *
 	 * @param ExecutionContext $context Execution context.
 	 * @param array            $item    The item that was just marked as processed.


### PR DESCRIPTION
## Summary

Fixes #369 — the root cause of the #367 junk-title leak. `skip_item` was split into `reject_source`/`defer_item` in data-machine #1815 (May 2026), but DME still referenced the dead tool name in 3 places, most critically a **model-facing schema description shipped on every upsert call**.

## Changes

- `inc/Core/EventSchemaProvider.php:79` — `startTime` description now says *"reject this item via the rejection disposition tool"* instead of *"use skip_item"*. **Behavior, not name**: the concrete tool name (`reject_source`) is owned by data-machine core's `FetchHandler`, whose injected tool definition self-describes when to use it. Naming it here recreates the cross-layer string coupling that caused this bug — core renames, DME's instruction silently turns into gibberish for the model, and the model improvises (#367: 23 junk-titled events published).
- `inc/Steps/EventImport/Handlers/EventImportHandler.php` — docblock updated to "fetch disposition tools (reject_source / defer_item)".
- `inc/Steps/EventImport/EventEngineData.php` — docblock updated likewise.

Docblocks may name the concrete tools (they're for humans reading against core source); the model-facing schema string may not.

## Verification

- `grep -rn skip_item inc/ tests/` → zero matches
- `php -l` clean on all 3 files

## Related

- #367 (the leak), #368 (upsert guard backstop), data-machine #1815 (the rename)
- Remaining stale reference is the live `global_system_prompt` on events.extrachill.com ("use skip_item" ×2) — settings edit, human deploy-time action, tracked in extrachill-event-bundles PR #2