### PR TITLE
feat: register a reflected AGENTS.md section for the data-machine-events CLI surface

### DIFF
--- a/data-machine-events.php
+++ b/data-machine-events.php
@@ -108,101 +108,50 @@ if ( file_exists( DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Api/Routes.php' ) ) {
 	require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Api/Routes.php';
 }
 
-	// WP-CLI commands (optional)
-if ( defined( 'WP_CLI' ) && WP_CLI && file_exists( DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Cli/UniversalWebScraperTestCommand.php' ) ) {
-	require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Cli/UniversalWebScraperTestCommand.php';
-	\WP_CLI::add_command( 'data-machine-events test-event-scraper', \DataMachineEvents\Cli\UniversalWebScraperTestCommand::class );
-}
+/*
+|--------------------------------------------------------------------------
+| AGENTS.md — composable file section registration
+|--------------------------------------------------------------------------
+| Registers the Data Machine Events CLI section in the AGENTS.md composable
+| file so external agent runtimes discover this (largest extension) CLI
+| surface automatically. Runs outside the WP_CLI guard below because compose
+| and auto-regeneration fire in non-CLI (web/cron) contexts where the
+| WP-CLI runner / PSR-4 autoloader are not loaded — the section generator
+| resolves command class files from disk and reflects over them.
+*/
+add_action( 'plugins_loaded', function () {
+	if ( ! class_exists( '\DataMachine\Engine\AI\SectionRegistry' ) ) {
+		return;
+	}
 
-if ( defined( 'WP_CLI' ) && WP_CLI && file_exists( DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Cli/SettingsCommand.php' ) ) {
-	require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Cli/SettingsCommand.php';
-	\WP_CLI::add_command( 'data-machine-events settings', \DataMachineEvents\Cli\SettingsCommand::class );
-}
+	require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Cli/CommandRegistry.php';
+	require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Cli/AgentsMdSection.php';
 
-if ( defined( 'WP_CLI' ) && WP_CLI && file_exists( DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Cli/GetVenueEventsCommand.php' ) ) {
-	require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Cli/GetVenueEventsCommand.php';
-	\WP_CLI::add_command( 'data-machine-events get-venue-events', \DataMachineEvents\Cli\GetVenueEventsCommand::class );
-}
+	$wp = 'wp --allow-root --path=' . ABSPATH;
 
-// check subcommands (replaces health-check monolith)
+	\DataMachine\Engine\AI\SectionRegistry::register( 'AGENTS.md', 'data-machine-events', 55, function () use ( $wp ) {
+		return \DataMachineEvents\Cli\AgentsMdSection::render( $wp );
+	}, array(
+		'label'       => 'Data Machine Events CLI',
+		'description' => 'Event + venue data-quality and maintenance WP-CLI commands.',
+		'freshness'   => 'generated',
+	) );
+}, 22 );
+
+// WP-CLI commands — registered from the single-source-of-truth CommandRegistry
+// map, which also drives the AGENTS.md section generator above so the
+// documented surface can never drift from what is actually registered here.
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
-	\WP_CLI::add_command( 'data-machine-events check times', \DataMachineEvents\Cli\Check\CheckTimesCommand::class );
-	\WP_CLI::add_command( 'data-machine-events check venues', \DataMachineEvents\Cli\Check\CheckVenuesCommand::class );
-	\WP_CLI::add_command( 'data-machine-events check encoding', \DataMachineEvents\Cli\Check\CheckEncodingCommand::class );
-	\WP_CLI::add_command( 'data-machine-events check meta-sync', \DataMachineEvents\Cli\Check\CheckMetaSyncCommand::class );
-	\WP_CLI::add_command( 'data-machine-events check duration', \DataMachineEvents\Cli\Check\CheckDurationCommand::class );
-	\WP_CLI::add_command( 'data-machine-events check duplicates', \DataMachineEvents\Cli\Check\CheckDuplicatesCommand::class );
-	\WP_CLI::add_command( 'data-machine-events check clean-duplicates', \DataMachineEvents\Cli\Check\CleanDuplicatesCommand::class );
-	\WP_CLI::add_command( 'data-machine-events check merged-bills', \DataMachineEvents\Cli\Check\CheckMergedBillsCommand::class );
-	\WP_CLI::add_command( 'data-machine-events check merge-duplicate-venues', \DataMachineEvents\Cli\Check\CheckMergeDuplicateVenuesCommand::class );
-	\WP_CLI::add_command( 'data-machine-events check missing-venue-addresses', \DataMachineEvents\Cli\Check\CheckMissingVenueAddressesCommand::class );
-	\WP_CLI::add_command( 'data-machine-events check orphan-venues', \DataMachineEvents\Cli\Check\CheckOrphanVenuesCommand::class );
-	\WP_CLI::add_command( 'data-machine-events check orphan-pipelines', \DataMachineEvents\Cli\Check\CheckOrphanPipelinesCommand::class );
-	\WP_CLI::add_command( 'data-machine-events check quality', \DataMachineEvents\Cli\Check\CheckQualityCommand::class );
-	\WP_CLI::add_command( 'data-machine-events check all', \DataMachineEvents\Cli\Check\CheckAllCommand::class );
-}
+	require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Cli/CommandRegistry.php';
 
-if ( defined( 'WP_CLI' ) && WP_CLI ) {
-	\WP_CLI::add_command( 'datamachine-events backfill-event-dates', function( $args, $assoc_args ) {
-		\DataMachineEvents\Core\EventDatesTable::create_table();
-		\WP_CLI::log( 'Table ensured. Starting backfill...' );
-
-		$total = \DataMachineEvents\Core\EventDatesTable::backfill(
-			500,
-			function( $count ) {
-				if ( $count % 500 === 0 ) {
-					\WP_CLI::log( "Backfilled {$count} events..." );
-				}
-			}
-		);
-
-		\WP_CLI::success( "Backfilled {$total} events into datamachine_event_dates table." );
-	});
-}
-
-if ( defined( 'WP_CLI' ) && WP_CLI && file_exists( DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Cli/UpdateEventCommand.php' ) ) {
-	require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Cli/UpdateEventCommand.php';
-	\WP_CLI::add_command( 'data-machine-events update-event', \DataMachineEvents\Cli\UpdateEventCommand::class );
-}
-
-if ( defined( 'WP_CLI' ) && WP_CLI && file_exists( DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Cli/BatchTimeFixCommand.php' ) ) {
-	require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Cli/BatchTimeFixCommand.php';
-	\WP_CLI::add_command( 'data-machine-events batch-time-fix', \DataMachineEvents\Cli\BatchTimeFixCommand::class );
-}
-
-if ( defined( 'WP_CLI' ) && WP_CLI && file_exists( DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Cli/EncodingFixCommand.php' ) ) {
-	require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Cli/EncodingFixCommand.php';
-	\WP_CLI::add_command( 'data-machine-events fix-encoding', \DataMachineEvents\Cli\EncodingFixCommand::class );
-}
-
-if ( defined( 'WP_CLI' ) && WP_CLI && file_exists( DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Cli/TicketUrlResyncCommand.php' ) ) {
-	require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Cli/TicketUrlResyncCommand.php';
-	\WP_CLI::add_command( 'data-machine-events resync-ticket-urls', \DataMachineEvents\Cli\TicketUrlResyncCommand::class );
-}
-
-if ( defined( 'WP_CLI' ) && WP_CLI && file_exists( DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Cli/ResyncMetaCommand.php' ) ) {
-	require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Cli/ResyncMetaCommand.php';
-	\WP_CLI::add_command( 'data-machine-events resync-meta', \DataMachineEvents\Cli\ResyncMetaCommand::class );
-}
-
-if ( defined( 'WP_CLI' ) && WP_CLI && file_exists( DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Cli/TicketmasterTestCommand.php' ) ) {
-	require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Cli/TicketmasterTestCommand.php';
-	\WP_CLI::add_command( 'data-machine-events test-ticketmaster', \DataMachineEvents\Cli\TicketmasterTestCommand::class );
-}
-
-if ( defined( 'WP_CLI' ) && WP_CLI && file_exists( DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Cli/DiceFmTestCommand.php' ) ) {
-	require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Cli/DiceFmTestCommand.php';
-	\WP_CLI::add_command( 'data-machine-events test-dice-fm', \DataMachineEvents\Cli\DiceFmTestCommand::class );
-}
-
-if ( defined( 'WP_CLI' ) && WP_CLI && file_exists( DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Cli/GeocodeVenuesCommand.php' ) ) {
-	require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Cli/GeocodeVenuesCommand.php';
-	\WP_CLI::add_command( 'data-machine-events geocode-venues', \DataMachineEvents\Cli\GeocodeVenuesCommand::class );
-}
-
-if ( defined( 'WP_CLI' ) && WP_CLI && file_exists( DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Cli/AuditVenuesCommand.php' ) ) {
-	require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Cli/AuditVenuesCommand.php';
-	\WP_CLI::add_command( 'data-machine-events audit-venues', \DataMachineEvents\Cli\AuditVenuesCommand::class );
+	foreach ( \DataMachineEvents\Cli\CommandRegistry::map() as $command => $entry ) {
+		if ( isset( $entry['file'] ) && is_readable( $entry['file'] ) ) {
+			require_once $entry['file'];
+		}
+		if ( isset( $entry['class'] ) && class_exists( $entry['class'] ) ) {
+			\WP_CLI::add_command( $command, $entry['class'] );
+		}
+	}
 }
 
 /**

--- a/inc/Cli/AgentsMdSection.php
+++ b/inc/Cli/AgentsMdSection.php
@@ -1,0 +1,409 @@
+<?php
+/**
+ * AGENTS.md Section Generator
+ *
+ * Generates the "Data Machine Events CLI" section of the composed AGENTS.md
+ * file by introspecting the real registered command tree instead of
+ * hand-maintaining a heredoc. Walks every command registered in
+ * CommandRegistry, reflects over each command class, and emits each command
+ * with its real short description (and any named subcommands).
+ *
+ * Context-safety: the section callback runs on `datamachine_sections` /
+ * `plugins_loaded` during composition, which can fire in non-CLI contexts
+ * (web/cron auto-regeneration). The command classes are only wired into WP-CLI
+ * under `if ( WP_CLI )`, and the plugin's `vendor/` PSR-4 autoloader is not
+ * guaranteed to be present, so the live WP-CLI runner / autoloader are NOT a
+ * reliable source. This generator therefore resolves each command class FILE
+ * from disk (the files guard only on ABSPATH, never on WP_CLI) and reflects
+ * over the class, working in any execution context.
+ *
+ * Shared-helper preference: the canonical introspection home is
+ * `\DataMachine\Engine\AI\CliCommandIntrospector` (data-machine core). This
+ * generator prefers it when present (class_exists / method_exists guard) and
+ * falls back to a self-contained local reflection path otherwise. The local
+ * fallback additionally handles `__invoke` leaf commands — most events CLI
+ * commands are single-`__invoke` handlers, and the shared helper's `__invoke`
+ * support (data-machine#2639) may not be merged yet, so the fallback never
+ * blocks on it.
+ *
+ * @package DataMachineEvents\Cli
+ */
+
+namespace DataMachineEvents\Cli;
+
+use ReflectionClass;
+use ReflectionMethod;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Reflects the registered events CLI command tree into an AGENTS.md section.
+ */
+class AgentsMdSection {
+
+	/**
+	 * Build the Markdown body for the Data Machine Events CLI AGENTS.md section.
+	 *
+	 * @param string $wp The `wp --allow-root --path=...` invocation prefix.
+	 * @return string
+	 */
+	public static function render( $wp ) {
+		self::register_autoloader();
+
+		$lines   = array();
+		$lines[] = '### Data Machine Events CLI';
+		$lines[] = '';
+		$lines[] = 'Event + venue data-quality, import-handler testing, and maintenance commands for the events site.';
+		$lines[] = "Discover everything: `{$wp} data-machine-events --help`";
+		$lines[] = '';
+
+		foreach ( self::collect_commands() as $command => $info ) {
+			if ( $info['leaf'] ) {
+				// Single-__invoke leaf command: one bullet, class/method docblock summary.
+				if ( '' !== $info['description'] ) {
+					$lines[] = "- `{$wp} {$command}` — {$info['description']}";
+				} else {
+					$lines[] = "- `{$wp} {$command}`";
+				}
+				continue;
+			}
+
+			// Namespace command with named subcommands.
+			$summary = self::summarize_subcommands( $info['subcommands'] );
+			if ( '' !== $summary ) {
+				$lines[] = "- `{$wp} {$command}` — {$summary}";
+			} else {
+				$lines[] = "- `{$wp} {$command}`";
+			}
+
+			foreach ( $info['subcommands'] as $sub ) {
+				$desc = $sub['description'];
+				if ( '' !== $desc ) {
+					$lines[] = "  - `{$sub['name']}` — {$desc}";
+				} else {
+					$lines[] = "  - `{$sub['name']}`";
+				}
+			}
+		}
+
+		$lines[] = '';
+		$lines[] = 'All commands support `--help` for full options and subcommand discovery.';
+
+		return implode( "\n", $lines );
+	}
+
+	/**
+	 * Register a minimal PSR-4 autoloader for the `DataMachineEvents\` namespace.
+	 *
+	 * The plugin's composer `vendor/` autoloader is not guaranteed in web/cron
+	 * compose contexts, yet command classes `use` sibling traits (e.g. the
+	 * Check commands share `EventQueryTrait`) and reference ability classes.
+	 * This namespace-scoped autoloader resolves those dependencies from the
+	 * `inc/` PSR-4 root so reflection never fatals on a missing trait. Idempotent.
+	 *
+	 * @return void
+	 */
+	private static function register_autoloader() {
+		static $registered = false;
+		if ( $registered ) {
+			return;
+		}
+		$registered = true;
+
+		// Ensure the WP-CLI base-class stub exists BEFORE the autoloader can
+		// fire, so a command class that extends it (loaded via class_exists()
+		// or `use` resolution) never fatals on the missing runtime base class.
+		self::ensure_wp_cli_base_class();
+
+		$inc = DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/';
+
+		spl_autoload_register(
+			function ( $class_name ) use ( $inc ) {
+				$prefix = 'DataMachineEvents\\';
+				$len    = strlen( $prefix );
+
+				if ( 0 !== strncmp( $prefix, $class_name, $len ) ) {
+					return;
+				}
+
+				$relative = substr( $class_name, $len );
+				$file     = $inc . str_replace( '\\', '/', $relative ) . '.php';
+
+				if ( is_readable( $file ) ) {
+					require_once $file;
+				}
+			}
+		);
+	}
+
+	/**
+	 * Walk the CommandRegistry and describe each command.
+	 *
+	 * @return array<string, array{leaf: bool, description: string, subcommands: array<int, array{name: string, description: string}>}>
+	 *               command string => descriptor.
+	 */
+	private static function collect_commands() {
+		$out = array();
+
+		foreach ( CommandRegistry::map() as $command => $entry ) {
+			$file  = isset( $entry['file'] ) ? (string) $entry['file'] : '';
+			$class = isset( $entry['class'] ) ? (string) $entry['class'] : '';
+
+			self::ensure_class_loaded( $class, $file );
+
+			if ( '' === $class || ! class_exists( $class ) ) {
+				continue;
+			}
+
+			$subcommands = self::describe_subcommands( $class );
+
+			if ( ! empty( $subcommands ) ) {
+				$out[ $command ] = array(
+					'leaf'        => false,
+					'description' => '',
+					'subcommands' => $subcommands,
+				);
+				continue;
+			}
+
+			// No named subcommands: treat as a leaf __invoke command described
+			// by its __invoke method docblock (falling back to the class docblock).
+			$out[ $command ] = array(
+				'leaf'        => true,
+				'description' => self::leaf_description( $class ),
+				'subcommands' => array(),
+			);
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Describe a command class's named subcommands.
+	 *
+	 * Prefers the shared `CliCommandIntrospector` helper when present and it
+	 * returns results; otherwise uses local reflection over the class's public,
+	 * non-magic methods.
+	 *
+	 * @param class-string $class Command class.
+	 * @return array<int, array{name: string, description: string}>
+	 */
+	private static function describe_subcommands( $class ) {
+		if ( class_exists( '\DataMachine\Engine\AI\CliCommandIntrospector' )
+			&& method_exists( '\DataMachine\Engine\AI\CliCommandIntrospector', 'describe_class' )
+		) {
+			$shared = \DataMachine\Engine\AI\CliCommandIntrospector::describe_class( $class );
+			if ( is_array( $shared ) && ! empty( $shared ) ) {
+				return $shared;
+			}
+			// Fall through to local reflection (e.g. __invoke leaf commands,
+			// which the shared helper skips until data-machine#2639 lands).
+		}
+
+		return self::reflect_subcommands( $class );
+	}
+
+	/**
+	 * Self-contained reflection over a command class's named subcommands.
+	 *
+	 * Public, non-static, non-magic methods are WP-CLI subcommands. The
+	 * subcommand name is taken from the `@subcommand <name>` annotation when
+	 * present, otherwise the method name with underscores converted to hyphens
+	 * (WP-CLI's own convention). `__invoke` leaf commands intentionally yield no
+	 * named subcommands here — they are rendered as a single bullet by the
+	 * caller using {@see self::leaf_description()}.
+	 *
+	 * @param class-string $class Command class.
+	 * @return array<int, array{name: string, description: string}>
+	 */
+	private static function reflect_subcommands( $class ) {
+		try {
+			$reflection = new ReflectionClass( $class );
+		} catch ( \Throwable $e ) {
+			return array();
+		}
+
+		$subcommands = array();
+
+		foreach ( $reflection->getMethods( ReflectionMethod::IS_PUBLIC ) as $method ) {
+			// Only methods declared on the command class itself.
+			if ( $method->getDeclaringClass()->getName() !== $reflection->getName() ) {
+				continue;
+			}
+
+			if ( $method->isStatic() || $method->isConstructor() || $method->isDestructor() ) {
+				continue;
+			}
+
+			$method_name = $method->getName();
+			$raw_doc     = $method->getDocComment();
+			$doc         = is_string( $raw_doc ) ? $raw_doc : '';
+			$annotated   = self::parse_subcommand_annotation( $doc );
+
+			if ( '' !== $annotated ) {
+				$name = $annotated;
+			} else {
+				// Skip magic methods (incl. __invoke — handled as a leaf).
+				if ( 0 === strpos( $method_name, '__' ) ) {
+					continue;
+				}
+				$name = str_replace( '_', '-', $method_name );
+			}
+
+			$subcommands[] = array(
+				'name'        => $name,
+				'description' => self::parse_short_description( $doc ),
+			);
+		}
+
+		return $subcommands;
+	}
+
+	/**
+	 * Derive the short description for a leaf (`__invoke`) command.
+	 *
+	 * Prefers the `__invoke` method docblock (the summary WP-CLI shows for the
+	 * command's `--help`), falling back to the class docblock.
+	 *
+	 * @param class-string $class Command class.
+	 * @return string
+	 */
+	private static function leaf_description( $class ) {
+		try {
+			$reflection = new ReflectionClass( $class );
+		} catch ( \Throwable $e ) {
+			return '';
+		}
+
+		if ( $reflection->hasMethod( '__invoke' ) ) {
+			$invoke_doc = $reflection->getMethod( '__invoke' )->getDocComment();
+			$desc       = self::parse_short_description( is_string( $invoke_doc ) ? $invoke_doc : '' );
+			if ( '' !== $desc ) {
+				return $desc;
+			}
+		}
+
+		$class_doc = $reflection->getDocComment();
+		return self::parse_short_description( is_string( $class_doc ) ? $class_doc : '' );
+	}
+
+	/**
+	 * Build a comma-separated summary of subcommand names for the headline.
+	 *
+	 * @param array<int, array{name: string, description: string}> $subcommands Subcommands.
+	 * @return string
+	 */
+	private static function summarize_subcommands( $subcommands ) {
+		$names = array();
+		foreach ( $subcommands as $sub ) {
+			$names[] = $sub['name'];
+		}
+
+		return implode( ', ', $names );
+	}
+
+	/**
+	 * Require a command class file from disk if the class is not yet loaded.
+	 *
+	 * The plugin's PSR-4 autoloader (vendor/) is not guaranteed in web/cron
+	 * compose contexts, so resolve the file directly. The command files guard
+	 * only on ABSPATH (never WP_CLI), so requiring them is safe in any context
+	 * — except that one command class extends the WP-CLI base class
+	 * `WP_CLI_Command`, which only exists when the WP-CLI runtime is loaded.
+	 * Reflecting over such a class would fatally fail in web/cron context, so a
+	 * minimal stub of the base class is defined first. The stub carries no
+	 * behaviour and is only ever defined when the real WP-CLI runtime is
+	 * absent, so it cannot interfere with actual command execution.
+	 *
+	 * @param string $class Fully-qualified class name.
+	 * @param string $file  Absolute path to the class source file.
+	 * @return void
+	 */
+	private static function ensure_class_loaded( $class, $file ) {
+		if ( '' === $class || class_exists( $class ) ) {
+			return;
+		}
+
+		if ( '' === $file || ! is_readable( $file ) ) {
+			return;
+		}
+
+		// The WP-CLI base-class stub is already defined by render() via
+		// register_autoloader(), so command classes that extend it can be
+		// required safely here as a fallback when the PSR-4 autoloader did not
+		// already resolve the class.
+		require_once $file;
+	}
+
+	/**
+	 * Define a minimal `\WP_CLI_Command` stub when the WP-CLI runtime is absent.
+	 *
+	 * Command classes that extend the WP-CLI base class cannot be loaded for
+	 * reflection in non-CLI compose contexts without it. The stub carries no
+	 * behaviour and is never defined when the real WP-CLI runtime is present,
+	 * so it cannot affect command execution.
+	 *
+	 * @return void
+	 */
+	private static function ensure_wp_cli_base_class() {
+		if ( class_exists( '\WP_CLI_Command' ) ) {
+			return;
+		}
+
+		require_once __DIR__ . '/wp-cli-command-stub.php';
+	}
+
+	/**
+	 * Parse the `@subcommand <name>` annotation from a docblock.
+	 *
+	 * @param string $doc Raw docblock.
+	 * @return string Subcommand name, or '' when not annotated.
+	 */
+	private static function parse_subcommand_annotation( $doc ) {
+		if ( preg_match( '/@subcommand\s+(\S+)/', $doc, $m ) ) {
+			return $m[1];
+		}
+		return '';
+	}
+
+	/**
+	 * Parse the short description (first prose line) from a docblock.
+	 *
+	 * Mirrors how WP-CLI derives a command's summary for `--help`: the first
+	 * non-empty content line of the docblock, before any `## SECTION` heading
+	 * or `@tag`.
+	 *
+	 * @param string $doc Raw docblock.
+	 * @return string
+	 */
+	private static function parse_short_description( $doc ) {
+		if ( '' === $doc ) {
+			return '';
+		}
+
+		// Strip the comment framing.
+		$doc   = preg_replace( '#^/\*\*|\*/$#', '', $doc );
+		$lines = preg_split( '/\r\n|\r|\n/', $doc );
+
+		foreach ( $lines as $line ) {
+			$line = preg_replace( '/^\s*\*\s?/', '', $line );
+			$line = trim( $line );
+
+			if ( '' === $line ) {
+				continue;
+			}
+
+			// Stop at structured sections / annotations.
+			if ( 0 === strpos( $line, '##' ) || 0 === strpos( $line, '@' ) ) {
+				return '';
+			}
+
+			// Drop a trailing period for a tighter inline summary.
+			return rtrim( $line, '.' );
+		}
+
+		return '';
+	}
+}

--- a/inc/Cli/BackfillEventDatesCommand.php
+++ b/inc/Cli/BackfillEventDatesCommand.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * WP-CLI command to backfill the event dates table.
+ *
+ * Ensures the datamachine_event_dates table exists, then backfills every
+ * existing event's start/end datetime into it from the Event Details block.
+ * One-off maintenance command used after the dedicated dates table was
+ * introduced.
+ *
+ * @package DataMachineEvents\Cli
+ */
+
+namespace DataMachineEvents\Cli;
+
+use DataMachineEvents\Core\EventDatesTable;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Backfill the event dates table from existing events.
+ */
+class BackfillEventDatesCommand {
+
+	/**
+	 * Backfill the datamachine_event_dates table from existing events.
+	 *
+	 * Creates the table if it does not exist, then walks every event and
+	 * writes its parsed start/end datetime into the dedicated dates table.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp data-machine-events backfill-event-dates
+	 *
+	 * @param array $args       Positional arguments (unused).
+	 * @param array $assoc_args Named arguments (unused).
+	 */
+	public function __invoke( array $args, array $assoc_args ): void {
+		EventDatesTable::create_table();
+		\WP_CLI::log( 'Table ensured. Starting backfill...' );
+
+		$total = EventDatesTable::backfill(
+			500,
+			function ( $count ) {
+				if ( 0 === $count % 500 ) {
+					\WP_CLI::log( "Backfilled {$count} events..." );
+				}
+			}
+		);
+
+		\WP_CLI::success( "Backfilled {$total} events into datamachine_event_dates table." );
+	}
+}

--- a/inc/Cli/CommandRegistry.php
+++ b/inc/Cli/CommandRegistry.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * CLI Command Registry
+ *
+ * Single source of truth mapping `wp data-machine-events ...` command strings
+ * to their implementing command classes. Both the WP-CLI bootstrap (which calls
+ * WP_CLI::add_command for each entry) and the AGENTS.md section generator
+ * (which reflects over each class to enumerate real subcommands) read from this
+ * map, so the documented CLI surface can never drift from what is actually
+ * registered.
+ *
+ * Each entry carries the command class's source FILE alongside the class name.
+ * The section generator runs on `plugins_loaded` in web/cron compose contexts
+ * where the plugin's `vendor/` PSR-4 autoloader may not be present (these
+ * command classes are otherwise only required under the `WP_CLI` guard). The
+ * file path lets the generator `require_once` the class on demand and reflect
+ * over it without relying on any autoloader or the live WP-CLI runner.
+ *
+ * @package DataMachineEvents\Cli
+ */
+
+namespace DataMachineEvents\Cli;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Single source of truth for the events WP-CLI command map.
+ */
+class CommandRegistry {
+
+	/**
+	 * Map of command string => command descriptor.
+	 *
+	 * Keys are the exact strings passed to WP_CLI::add_command (the command
+	 * namespace, e.g. "data-machine-events check times"). Order here determines
+	 * both registration order and documentation order. Each value is an array
+	 * with:
+	 *   - `file`  Absolute path to the command class source file.
+	 *   - `class` Fully-qualified command class name.
+	 *
+	 * @return array<string, array{file: string, class: class-string}>
+	 */
+	public static function map() {
+		$cli = DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Cli/';
+
+		return array(
+			// Handler / scraper testing.
+			'data-machine-events test-event-scraper'     => array(
+				'file'  => $cli . 'UniversalWebScraperTestCommand.php',
+				'class' => UniversalWebScraperTestCommand::class,
+			),
+			'data-machine-events test-ticketmaster'      => array(
+				'file'  => $cli . 'TicketmasterTestCommand.php',
+				'class' => TicketmasterTestCommand::class,
+			),
+			'data-machine-events test-dice-fm'           => array(
+				'file'  => $cli . 'DiceFmTestCommand.php',
+				'class' => DiceFmTestCommand::class,
+			),
+
+			// Settings + venue event lookups.
+			'data-machine-events settings'               => array(
+				'file'  => $cli . 'SettingsCommand.php',
+				'class' => SettingsCommand::class,
+			),
+			'data-machine-events get-venue-events'       => array(
+				'file'  => $cli . 'GetVenueEventsCommand.php',
+				'class' => GetVenueEventsCommand::class,
+			),
+
+			// Data quality checks (each a leaf __invoke command).
+			'data-machine-events check times'            => array(
+				'file'  => $cli . 'Check/CheckTimesCommand.php',
+				'class' => Check\CheckTimesCommand::class,
+			),
+			'data-machine-events check venues'           => array(
+				'file'  => $cli . 'Check/CheckVenuesCommand.php',
+				'class' => Check\CheckVenuesCommand::class,
+			),
+			'data-machine-events check encoding'         => array(
+				'file'  => $cli . 'Check/CheckEncodingCommand.php',
+				'class' => Check\CheckEncodingCommand::class,
+			),
+			'data-machine-events check meta-sync'        => array(
+				'file'  => $cli . 'Check/CheckMetaSyncCommand.php',
+				'class' => Check\CheckMetaSyncCommand::class,
+			),
+			'data-machine-events check duration'         => array(
+				'file'  => $cli . 'Check/CheckDurationCommand.php',
+				'class' => Check\CheckDurationCommand::class,
+			),
+			'data-machine-events check duplicates'       => array(
+				'file'  => $cli . 'Check/CheckDuplicatesCommand.php',
+				'class' => Check\CheckDuplicatesCommand::class,
+			),
+			'data-machine-events check clean-duplicates' => array(
+				'file'  => $cli . 'Check/CleanDuplicatesCommand.php',
+				'class' => Check\CleanDuplicatesCommand::class,
+			),
+			'data-machine-events check merged-bills'     => array(
+				'file'  => $cli . 'Check/CheckMergedBillsCommand.php',
+				'class' => Check\CheckMergedBillsCommand::class,
+			),
+			'data-machine-events check merge-duplicate-venues' => array(
+				'file'  => $cli . 'Check/CheckMergeDuplicateVenuesCommand.php',
+				'class' => Check\CheckMergeDuplicateVenuesCommand::class,
+			),
+			'data-machine-events check missing-venue-addresses' => array(
+				'file'  => $cli . 'Check/CheckMissingVenueAddressesCommand.php',
+				'class' => Check\CheckMissingVenueAddressesCommand::class,
+			),
+			'data-machine-events check orphan-venues'    => array(
+				'file'  => $cli . 'Check/CheckOrphanVenuesCommand.php',
+				'class' => Check\CheckOrphanVenuesCommand::class,
+			),
+			'data-machine-events check orphan-pipelines' => array(
+				'file'  => $cli . 'Check/CheckOrphanPipelinesCommand.php',
+				'class' => Check\CheckOrphanPipelinesCommand::class,
+			),
+			'data-machine-events check quality'          => array(
+				'file'  => $cli . 'Check/CheckQualityCommand.php',
+				'class' => Check\CheckQualityCommand::class,
+			),
+			'data-machine-events check all'              => array(
+				'file'  => $cli . 'Check/CheckAllCommand.php',
+				'class' => Check\CheckAllCommand::class,
+			),
+
+			// Event + venue maintenance.
+			'data-machine-events update-event'           => array(
+				'file'  => $cli . 'UpdateEventCommand.php',
+				'class' => UpdateEventCommand::class,
+			),
+			'data-machine-events batch-time-fix'         => array(
+				'file'  => $cli . 'BatchTimeFixCommand.php',
+				'class' => BatchTimeFixCommand::class,
+			),
+			'data-machine-events fix-encoding'           => array(
+				'file'  => $cli . 'EncodingFixCommand.php',
+				'class' => EncodingFixCommand::class,
+			),
+			'data-machine-events resync-ticket-urls'     => array(
+				'file'  => $cli . 'TicketUrlResyncCommand.php',
+				'class' => TicketUrlResyncCommand::class,
+			),
+			'data-machine-events resync-meta'            => array(
+				'file'  => $cli . 'ResyncMetaCommand.php',
+				'class' => ResyncMetaCommand::class,
+			),
+			'data-machine-events geocode-venues'         => array(
+				'file'  => $cli . 'GeocodeVenuesCommand.php',
+				'class' => GeocodeVenuesCommand::class,
+			),
+			'data-machine-events audit-venues'           => array(
+				'file'  => $cli . 'AuditVenuesCommand.php',
+				'class' => AuditVenuesCommand::class,
+			),
+			'data-machine-events backfill-event-dates'   => array(
+				'file'  => $cli . 'BackfillEventDatesCommand.php',
+				'class' => BackfillEventDatesCommand::class,
+			),
+		);
+	}
+}

--- a/inc/Cli/GetVenueEventsCommand.php
+++ b/inc/Cli/GetVenueEventsCommand.php
@@ -16,6 +16,28 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class GetVenueEventsCommand {
 
+	/**
+	 * List events for a venue.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [<venue>]
+	 * : Venue name or term. May also be passed via --venue.
+	 *
+	 * [--limit=<number>]
+	 * : Max events to return (default: 25).
+	 *
+	 * [--status=<status>]
+	 * : Post status filter (default: any).
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp data-machine-events get-venue-events "The Royal American"
+	 *     wp data-machine-events get-venue-events --venue="Exit/In" --limit=50
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Named arguments.
+	 */
 	public function __invoke( array $args, array $assoc_args ): void {
 		if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 			return;

--- a/inc/Cli/UniversalWebScraperTestCommand.php
+++ b/inc/Cli/UniversalWebScraperTestCommand.php
@@ -9,6 +9,22 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class UniversalWebScraperTestCommand {
+
+	/**
+	 * Test the universal web scraper against a target events URL.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--target_url=<url>]
+	 * : The events page URL to scrape.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp data-machine-events test-event-scraper --target_url=https://venue.com/shows
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Named arguments.
+	 */
 	public function __invoke( array $args, array $assoc_args ): void {
 		if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 			return;

--- a/inc/Cli/UpdateEventCommand.php
+++ b/inc/Cli/UpdateEventCommand.php
@@ -18,6 +18,34 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class UpdateEventCommand {
 
+	/**
+	 * Update one or more events' date, time, venue, and other fields.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <event_ids>
+	 * : One or more event IDs (comma-separated).
+	 *
+	 * [--startDate=<date>]
+	 * : New start date.
+	 *
+	 * [--startTime=<time>]
+	 * : New start time.
+	 *
+	 * [--venue=<venue>]
+	 * : New venue.
+	 *
+	 * [--format=<format>]
+	 * : Output format (default: table).
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp data-machine-events update-event 123 --startTime=20:00
+	 *     wp data-machine-events update-event 123,456 --venue="The Pour House"
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Named arguments.
+	 */
 	public function __invoke( array $args, array $assoc_args ): void {
 		if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 			return;

--- a/inc/Cli/wp-cli-command-stub.php
+++ b/inc/Cli/wp-cli-command-stub.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * WP-CLI base class stub.
+ *
+ * Defines an empty `\WP_CLI_Command` in the global namespace so that command
+ * classes which extend it can be loaded for REFLECTION ONLY in non-CLI
+ * (web/cron) AGENTS.md compose contexts, where the WP-CLI runtime — and thus
+ * the real base class — is not loaded.
+ *
+ * This file is only ever required by AgentsMdSection::ensure_wp_cli_base_class()
+ * after confirming the real `\WP_CLI_Command` does not exist, so it can never
+ * shadow or interfere with the genuine WP-CLI runtime during command execution.
+ *
+ * @package DataMachineEvents\Cli
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'WP_CLI_Command' ) ) {
+	/**
+	 * Minimal stand-in for the WP-CLI base command class.
+	 */
+	class WP_CLI_Command {} // phpcs:ignore Generic.Files.OneObjectStructurePerFile.MultipleFound, PEAR.NamingConventions.ValidClassName.Invalid
+}


### PR DESCRIPTION
## Summary

Closes #371. The ~27 `wp data-machine-events ...` commands — the largest extension CLI surface in the set — had **zero** AGENTS.md presence. This adds a reflected AGENTS.md section so agents discover the whole surface, copying the gold-standard `extrachill-cli` (`CommandRegistry` + `AgentsMdSection`) and `intelligence` (`command-introspection`) patterns.

- **`inc/Cli/CommandRegistry.php`** — single `command string => { file, class }` map. Both the WP-CLI bootstrap (`WP_CLI::add_command` loop) and the new section generator read from it, so the documented surface can never drift from what is actually registered. The `file` path is carried because the generator runs where no autoloader is guaranteed.
- **`inc/Cli/AgentsMdSection.php`** — reflects each command class and emits real short descriptions. Registered via core's `\DataMachine\Engine\AI\SectionRegistry::register('AGENTS.md', 'data-machine-events', 55, ...)` on `plugins_loaded` (outside the `WP_CLI` guard).
- **`data-machine-events.php`** — the ~27 hand-written `add_command` blocks collapse into one loop over `CommandRegistry::map()`.

## Context-safety (the hard part)

The section callback runs on `plugins_loaded` in web/cron compose, where neither the WP-CLI runner nor the plugin's `vendor/` PSR-4 autoloader is loaded. The generator handles this end to end:

1. **Disk resolution** — command class files are `require_once`'d from their registry `file` path (they guard only on `ABSPATH`, never `WP_CLI`).
2. **`__invoke` leaf commands** — nearly every events command is a single-`__invoke` handler. The shared `CliCommandIntrospector::describe_class()` skips `__invoke` (until data-machine#2639 lands), so the local fallback reflects `__invoke` and uses its method docblock (falling back to the class docblock) for the short description. The generator **prefers the shared helper when present and it returns results**, otherwise uses local reflection — exactly the intelligence pattern.
3. **`WP_CLI_Command` base class** — one command (`SettingsCommand`) extends the WP-CLI base class, which only exists in the runtime. A minimal `\WP_CLI_Command` stub (`inc/Cli/wp-cli-command-stub.php`) is defined **only when the real runtime is absent** so the class can be reflected.
4. **Sibling traits/abilities** — the `check` commands share `EventQueryTrait` and commands reference ability classes. A namespace-scoped `DataMachineEvents\` PSR-4 autoloader is registered during render so those dependencies resolve.

## Namespace prefix normalization (do-not-silently-rename note)

The issue flagged an inconsistent prefix: every command used `data-machine-events` **except** the inline `backfill-event-dates` closure, registered under `datamachine-events`. This PR:

- Extracts the closure into a proper `BackfillEventDatesCommand` class (so it reflects cleanly), and
- **Re-registers it under `data-machine-events backfill-event-dates`** for consistency.

⚠️ **This renames a public command string** (`datamachine-events backfill-event-dates` → `data-machine-events backfill-event-dates`). It is a one-off maintenance backfill, invoked manually, with no references anywhere else in the codebase (grep-confirmed), so the blast radius is nil — but calling it out explicitly per the "do not silently rename" rule.

## Also

Added missing `__invoke` docblocks to `test-event-scraper`, `get-venue-events`, and `update-event` so they expose real short descriptions to both `wp ... --help` and the generated section (they were otherwise blank).

## Verification

Rendered the section from this branch in a simulated **non-CLI** context (no `WP_CLI`, no composer autoloader) and in CLI context — both produce all 27 commands with accurate shortdescs and zero fatals:

```
### Data Machine Events CLI
- wp ... data-machine-events test-event-scraper — Test the universal web scraper against a target events URL
- wp ... data-machine-events settings — get, list, set
    - get — Get a setting value.
    - list — List all settings.
    - set — Set a setting value.
- wp ... data-machine-events check times — Check events for time-related issues
- ... (27 total)
- wp ... data-machine-events backfill-event-dates — Backfill the datamachine_event_dates table from existing events
```

`php -l` clean on all changed/new files. phpcs (WordPress) clean on the new files apart from this repo's standing PSR-4-filename convention (the existing command files trip the same `class-*.php` naming rule). The remaining phpcs noise is pre-existing camelCase private methods in `UpdateEventCommand` and the main plugin class — untouched here.

Part of the data-machine#2613 AGENTS.md dynamic-CLI fleet. Keystone: data-machine#2639.