### PR TITLE
feat(events-map): add opt-in collapsible/expandable capability (#376)

### DIFF
--- a/inc/Blocks/EventsMap/block.json
+++ b/inc/Blocks/EventsMap/block.json
@@ -29,6 +29,14 @@
         "chronologicalRouteMode": {
             "type": "boolean",
             "default": false
+        },
+        "collapsible": {
+            "type": "boolean",
+            "default": false
+        },
+        "defaultCollapsed": {
+            "type": "boolean",
+            "default": false
         }
     },
     "supports": {

--- a/inc/Blocks/EventsMap/render.php
+++ b/inc/Blocks/EventsMap/render.php
@@ -134,11 +134,52 @@ $scope_token = '';
  */
 $scope_token = (string) apply_filters( 'data_machine_events_map_scope_token', $scope_token, $context );
 
+// Collapsible: opt-in capability letting a consumer make the map non-dominant
+// by rendering an expand/collapse control. Default false everywhere, so when
+// not enabled this block renders byte-identically to before. When enabled, the
+// map (the React root) is wrapped in a collapsible region driven by an
+// accessible toggle button; the frontend owns Leaflet's invalidateSize() on
+// expand so tiles re-render correctly. The generic block knows nothing about
+// which consumer/page enables it.
+$collapsible       = (bool) ( $attributes['collapsible'] ?? false );
+$default_collapsed = $collapsible && (bool) ( $attributes['defaultCollapsed'] ?? false );
+
+// IDs + accessible labels for the toggle <-> region relationship.
+$region_id = $map_id . '-region';
+$toggle_id = $map_id . '-toggle';
+$show_label = __( 'Show map', 'data-machine-events' );
+$hide_label = __( 'Hide map', 'data-machine-events' );
+
 ?>
 <div <?php echo $wrapper; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
+	<?php if ( $collapsible ) : ?>
+	<div class="data-machine-events-map-collapsible<?php echo $default_collapsed ? ' is-collapsed' : ''; ?>">
+		<button
+			type="button"
+			id="<?php echo esc_attr( $toggle_id ); ?>"
+			class="data-machine-events-map-toggle"
+			aria-expanded="<?php echo $default_collapsed ? 'false' : 'true'; ?>"
+			aria-controls="<?php echo esc_attr( $region_id ); ?>"
+			data-label-show="<?php echo esc_attr( $show_label ); ?>"
+			data-label-hide="<?php echo esc_attr( $hide_label ); ?>"
+		><?php echo esc_html( $default_collapsed ? $show_label : $hide_label ); ?></button>
+		<div
+			id="<?php echo esc_attr( $region_id ); ?>"
+			class="data-machine-events-map-region"
+			<?php echo $default_collapsed ? 'hidden' : ''; ?>
+		>
+	<?php endif; ?>
 	<div
 		id="<?php echo esc_attr( $map_id ); ?>"
 		class="data-machine-events-map-root"
+		<?php if ( $collapsible ) : ?>
+		data-collapsible="1"
+		data-toggle-id="<?php echo esc_attr( $toggle_id ); ?>"
+		data-region-id="<?php echo esc_attr( $region_id ); ?>"
+		<?php if ( $default_collapsed ) : ?>
+		data-default-collapsed="1"
+		<?php endif; ?>
+		<?php endif; ?>
 		data-height="<?php echo esc_attr( $height ); ?>"
 		data-zoom="<?php echo esc_attr( $zoom ); ?>"
 		data-map-type="<?php echo esc_attr( $map_type ); ?>"
@@ -173,4 +214,8 @@ $scope_token = (string) apply_filters( 'data_machine_events_map_scope_token', $s
 	 */
 	do_action( 'data_machine_events_map_after_summary', array(), $context );
 	?>
+	<?php if ( $collapsible ) : ?>
+		</div><!-- .data-machine-events-map-region -->
+	</div><!-- .data-machine-events-map-collapsible -->
+	<?php endif; ?>
 </div>

--- a/inc/Blocks/EventsMap/src/frontend.tsx
+++ b/inc/Blocks/EventsMap/src/frontend.tsx
@@ -578,6 +578,25 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 		// Force a resize check after mount.
 		setTimeout( () => map.invalidateSize(), 100 );
 
+		// Collapsible support: when the block is rendered inside a
+		// collapsible region, the container can be hidden (display:none /
+		// [hidden]) at the moment Leaflet first lays out, which leaves the
+		// map sized to a zero-height box and renders gray tiles. The mount
+		// layer (initEventsMap) defers React mount until the FIRST expand so
+		// init always happens with real dimensions; for every SUBSEQUENT
+		// expand it dispatches `data-machine-map-invalidate-size` at this
+		// container so Leaflet recomputes tiles. We listen for that here,
+		// mirroring the existing recenter/set-user-location event pattern.
+		const handleInvalidateSize = () => {
+			// rAF so we read the post-layout size after the collapsed class
+			// / [hidden] attribute has been removed by the toggle handler.
+			window.requestAnimationFrame( () => map.invalidateSize() );
+		};
+		el.addEventListener(
+			'data-machine-map-invalidate-size',
+			handleInvalidateSize,
+		);
+
 		// Fetch venues on mount and notify other blocks (e.g. calendar geo-sync).
 		if ( initialVenues.length === 0 ) {
 			// Small delay so map is fully sized first.
@@ -593,6 +612,10 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 		}
 
 		return () => {
+			el.removeEventListener(
+				'data-machine-map-invalidate-size',
+				handleInvalidateSize,
+			);
 			map.remove();
 			mapRef.current = null;
 			clusterGroupRef.current = null;
@@ -953,6 +976,103 @@ function parseMapProps( container: HTMLElement ): MapProps {
 	};
 }
 
+/**
+ * Mount the React map into its root container exactly once.
+ *
+ * Idempotent via the `initialized` dataset flag so the deferred-expand path
+ * and the normal path can both call it safely.
+ */
+function mountMap( container: HTMLElement ): void {
+	if ( container.dataset.initialized === '1' ) return;
+	container.dataset.initialized = '1';
+
+	const props = parseMapProps( container );
+	const root = createRoot( container );
+	root.render( <EventsMap { ...props } /> );
+}
+
+/**
+ * Wire the collapsible toggle for a map root, when the block opted in
+ * (`data-collapsible="1"` from render.php). Generic collapse/expand behavior:
+ *
+ * - The toggle is a real server-rendered <button> (accessible, keyboard
+ *   operable, aria-expanded reflecting state) found via `data-toggle-id`.
+ * - Leaflet must not initialize inside a zero-height (hidden) container or it
+ *   renders gray tiles. So when the region starts collapsed we DEFER the React
+ *   mount until the first expand; otherwise we mount immediately and only
+ *   invalidate size on subsequent expands.
+ *
+ * Returns true when the map's mount is being managed here (collapsed defer),
+ * so the caller skips its own immediate mount.
+ *
+ * @return Whether the immediate mount should be skipped (deferred to expand).
+ */
+function setupCollapsible( container: HTMLElement ): boolean {
+	if ( container.dataset.collapsible !== '1' ) return false;
+	if ( container.dataset.collapsibleBound === '1' ) {
+		// Already wired; report current defer state.
+		return container.dataset.initialized !== '1';
+	}
+	container.dataset.collapsibleBound = '1';
+
+	const toggleId = container.dataset.toggleId || '';
+	const regionId = container.dataset.regionId || '';
+	const toggle = toggleId
+		? document.getElementById( toggleId )
+		: null;
+	const region = regionId
+		? document.getElementById( regionId )
+		: null;
+	const wrapper = container.closest(
+		'.data-machine-events-map-collapsible',
+	) as HTMLElement | null;
+
+	// If the expected markup is missing, fall back to non-collapsible
+	// behavior so the map still renders.
+	if ( ! toggle || ! region ) return false;
+
+	const startCollapsed = container.dataset.defaultCollapsed === '1';
+
+	const setExpanded = ( expanded: boolean ) => {
+		toggle.setAttribute( 'aria-expanded', expanded ? 'true' : 'false' );
+		if ( wrapper ) {
+			wrapper.classList.toggle( 'is-collapsed', ! expanded );
+		}
+		if ( expanded ) {
+			region.removeAttribute( 'hidden' );
+		} else {
+			region.setAttribute( 'hidden', '' );
+		}
+
+		const showLabel = toggle.dataset.labelShow;
+		const hideLabel = toggle.dataset.labelHide;
+		const label = expanded ? hideLabel : showLabel;
+		if ( label ) {
+			toggle.textContent = label;
+		}
+
+		if ( expanded ) {
+			// Mount on first expand (deferred init), else just re-measure.
+			if ( container.dataset.initialized !== '1' ) {
+				mountMap( container );
+			} else {
+				container.dispatchEvent(
+					new CustomEvent( 'data-machine-map-invalidate-size' ),
+				);
+			}
+		}
+	};
+
+	toggle.addEventListener( 'click', () => {
+		const expanded = toggle.getAttribute( 'aria-expanded' ) === 'true';
+		setExpanded( ! expanded );
+	} );
+
+	// When it starts collapsed, defer the React mount until first expand so
+	// Leaflet never initializes in a zero-height container.
+	return startCollapsed;
+}
+
 function initEventsMap(): void {
 	const containers = document.querySelectorAll<HTMLElement>(
 		'.data-machine-events-map-root',
@@ -960,11 +1080,11 @@ function initEventsMap(): void {
 
 	containers.forEach( ( container ) => {
 		if ( container.dataset.initialized === '1' ) return;
-		container.dataset.initialized = '1';
 
-		const props = parseMapProps( container );
-		const root = createRoot( container );
-		root.render( <EventsMap { ...props } /> );
+		const deferMount = setupCollapsible( container );
+		if ( deferMount ) return;
+
+		mountMap( container );
 	} );
 }
 

--- a/inc/Blocks/EventsMap/src/index.tsx
+++ b/inc/Blocks/EventsMap/src/index.tsx
@@ -18,6 +18,7 @@ import {
 	PanelBody,
 	RangeControl,
 	SelectControl,
+	ToggleControl,
 } from '@wordpress/components';
 
 import type { MapAttributes, MapType } from './types';
@@ -37,7 +38,8 @@ const MAP_STYLE_OPTIONS: { label: string; value: MapType }[] = [
 
 registerBlockType<MapAttributes>( 'data-machine-events/events-map', {
 	edit: function Edit( { attributes, setAttributes }: EditProps ) {
-		const { height, zoom, mapType } = attributes;
+		const { height, zoom, mapType, collapsible, defaultCollapsed } =
+			attributes;
 		const blockProps = useBlockProps( {
 			className: 'data-machine-events-map-block',
 		} );
@@ -76,6 +78,38 @@ registerBlockType<MapAttributes>( 'data-machine-events/events-map', {
 							setAttributes( { mapType: value as MapType } )
 						}
 					/>
+						<ToggleControl
+							label={ __(
+								'Collapsible',
+								'data-machine-events',
+							) }
+							help={ __(
+								'Add an expand/collapse control so the map can be hidden behind a toggle.',
+								'data-machine-events',
+							) }
+							checked={ !! collapsible }
+							onChange={ ( value ) =>
+								setAttributes( { collapsible: value } )
+							}
+						/>
+						{ collapsible && (
+							<ToggleControl
+								label={ __(
+									'Collapsed by default',
+									'data-machine-events',
+								) }
+								help={ __(
+									'Start with the map collapsed; visitors expand it via the toggle.',
+									'data-machine-events',
+								) }
+								checked={ !! defaultCollapsed }
+								onChange={ ( value ) =>
+									setAttributes( {
+										defaultCollapsed: value,
+									} )
+								}
+							/>
+						) }
 					</PanelBody>
 				</InspectorControls>
 

--- a/inc/Blocks/EventsMap/src/types.ts
+++ b/inc/Blocks/EventsMap/src/types.ts
@@ -64,6 +64,10 @@ export interface MapAttributes {
 	zoom: number;
 	mapType: MapType;
 	chronologicalRouteMode?: boolean;
+	/** Opt-in: render an expand/collapse control on the map. */
+	collapsible?: boolean;
+	/** Initial collapsed state when collapsible. */
+	defaultCollapsed?: boolean;
 }
 
 /**

--- a/inc/Blocks/EventsMap/style.css
+++ b/inc/Blocks/EventsMap/style.css
@@ -22,3 +22,63 @@
 	background: none;
 	border: none;
 }
+
+/* ---------- Collapsible (opt-in) ---------- */
+
+/* The collapsible wrapper exists only when the block opts in via the
+   `collapsible` attribute. Default-off blocks never emit this markup. */
+.data-machine-events-map-collapsible {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+
+/* Toggle is a real <button> — keyboard operable, accessible. Styled as a
+   slim header bar so the collapsed state reads as a clear "Show map" peek. */
+.data-machine-events-map-toggle {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5rem;
+	align-self: flex-start;
+	padding: 0.5rem 0.875rem;
+	font-size: 0.875rem;
+	font-weight: 600;
+	cursor: pointer;
+	border: 1px solid var(--data-machine-border-default, #d1d5db);
+	border-radius: var(--data-machine-border-radius, 8px);
+	background: var(--data-machine-background-light, #f3f4f6);
+	color: var(--data-machine-text-primary, #111827);
+	transition: background 0.15s ease, color 0.15s ease;
+}
+
+.data-machine-events-map-toggle:hover {
+	background: var(--data-machine-background-hover, #e5e7eb);
+	color: var(--data-machine-text-accent, #2563eb);
+}
+
+.data-machine-events-map-toggle:focus-visible {
+	outline: 2px solid var(--data-machine-border-focus, #2563eb);
+	outline-offset: 2px;
+}
+
+/* A small disclosure caret that rotates with state. */
+.data-machine-events-map-toggle::before {
+	content: "";
+	width: 0;
+	height: 0;
+	border-left: 5px solid transparent;
+	border-right: 5px solid transparent;
+	border-top: 6px solid currentColor;
+	transition: transform 0.2s ease;
+}
+
+.data-machine-events-map-collapsible.is-collapsed .data-machine-events-map-toggle::before {
+	transform: rotate(-90deg);
+}
+
+/* The collapsible region. When collapsed it is hidden via the [hidden]
+   attribute (set by render.php and toggled by the frontend), which keeps the
+   map out of the layout so Leaflet doesn't init in a zero-height box. */
+.data-machine-events-map-region[hidden] {
+	display: none;
+}


### PR DESCRIPTION
## Summary

Gives the **EventsMap block** a generic, opt-in **collapse/expand** capability so a consumer can make the map non-dominant by default without forking layout. This is the map half of #373 (Gardner's "the map feels too dominant" feedback), mirroring the generic-capability→consumer-enables pattern from #374 / extrachill-events#180. Default-off everywhere → zero change for existing consumers until a consumer opts in.

### Block attributes (`block.json`)
Both default `false`, so unset = current behavior:
- `collapsible` — when true, render an expand/collapse control on the map.
- `defaultCollapsed` — initial collapsed state when collapsible.

### Render (`render.php`)
- When `collapsible`, the map root is wrapped in a `.data-machine-events-map-collapsible` region driven by a real `<button>` toggle: `aria-expanded` reflects state, `aria-controls` points at the region, labels are "Show map" / "Hide map", and the region carries the `[hidden]` attribute when collapsed.
- Honors `defaultCollapsed` for the server-rendered initial state (`is-collapsed` class + `aria-expanded="false"` + region `hidden`).
- When `collapsible` is false, **no wrapper and no button are emitted** — the block renders identically to before (the new `data-collapsible` attributes use the same conditional-attribute pattern as the existing `showLocationSearch` / `chronologicalRouteMode` / `userLocation` blocks).

### Frontend (`frontend.tsx`) — Leaflet `invalidateSize` handling
Leaflet renders gray/broken tiles if its container resizes or initializes at zero height, so the JS resize hook is the reason this lives in the block.

- **Zero-height-init approach chosen: defer mount until first expand.** When the region starts collapsed (`defaultCollapsed`), the mount layer skips `createRoot().render()` and waits. On the first expand, the toggle handler removes `[hidden]` **then** mounts React, so Leaflet always initializes in a container with real dimensions. The init effect's existing post-mount `invalidateSize()` further guarantees correct first paint.
- **Subsequent expands:** the toggle dispatches a `data-machine-map-invalidate-size` event at the map root; the map listens for it (mirroring the existing `data-machine-map-recenter` / `data-machine-map-set-user-location` event pattern) and calls `map.invalidateSize()` inside a `requestAnimationFrame`, after the `[hidden]`/collapsed class flip, so Leaflet re-measures against the real post-layout size.
- Collapse logic is centralized at the mount layer (`setupCollapsible` + idempotent `mountMap`) where the server-rendered toggle button lives, keeping the React component's single-owner module lifecycle intact (it just adds one event listener + matching cleanup).

### Presentation (`style.css`)
Collapsed state hides the map body behind a slim toggle bar (disclosure caret rotates with state), all via `--data-machine-*` design tokens. The collapsed region is removed from layout via `[hidden]` so Leaflet never lays out in a zero-height box.

### Editor (`index.tsx`)
Adds `Collapsible` and (conditionally) `Collapsed by default` `ToggleControl`s to the existing Inspector panel.

## A11y
Toggle is a real keyboard-operable `<button>`, `aria-expanded` reflects state, the collapsible region is labelled via `aria-controls`, and `[hidden]` keeps collapsed content out of the a11y tree.

## Layer purity
Generic only — "a map block that can collapse." No Extra Chill / Charleston / consumer / SEO vocabulary anywhere.

## Manual verification (reasoned)
- **(a) `collapsible=false`** → no wrapper, no button; identical DOM to before; frontend mounts immediately as today.
- **(b) `collapsible=true`, `defaultCollapsed=false`** → open map with a "Hide map" control; map mounts immediately with real dimensions; collapse → re-expand dispatches `invalidateSize()` (no gray tiles).
- **(c) `collapsible=true`, `defaultCollapsed=true`** → collapsed map behind a "Show map" control; React mount is deferred until the first expand, so Leaflet initializes against a visible container and **renders correctly on first expand** (no zero-height/gray-tile bug).

Build verified: `npm install && npm run build` in `inc/Blocks/EventsMap/` compiles clean (no TS errors). `php -l render.php` passes. Build artifacts are gitignored in this repo (built on deploy), so only source is committed.

## Follow-up
Enabling this in `extrachill-events` (which pages collapse, default-collapsed on mobile, etc.) is a **separate follow-up PR** in the consumer, mirroring how #180 consumed #374. No consumer enablement is included here.

Closes #376