### PR TITLE
Make DisplayVars the single source of truth for event cards (#381)

### DIFF
--- a/inc/Api/Controllers/Calendar.php
+++ b/inc/Api/Controllers/Calendar.php
@@ -263,6 +263,11 @@ class Calendar {
 	 *   it's a first-class display attribute (every event has at most one
 	 *   venue, the templates render it in a fixed slot, the geo system keys
 	 *   off it).
+	 * - `badges_html` ships the server-rendered, filter-applied badge markup
+	 *   (via `Badges::render_taxonomy_badges()`) so client-rendered cards can
+	 *   honor the badge-class filters themes hook for styling. The raw
+	 *   `taxonomies` map is still provided for any consumer that wants to
+	 *   render badges itself. See #381.
 	 *
 	 * @param int   $post_id     Event post ID.
 	 * @param array $event_entry The serialized entry from `paged_date_groups`.
@@ -273,26 +278,33 @@ class Calendar {
 		$title      = (string) ( $event_entry['title'] ?? get_the_title( $post_id ) );
 
 		return array(
-			'id'         => $post_id,
-			'title'      => $title,
-			'permalink'  => (string) get_permalink( $post_id ),
-			'date'       => array(
+			'id'          => $post_id,
+			'title'       => $title,
+			'permalink'   => (string) get_permalink( $post_id ),
+			'date'        => array(
 				'start_date'     => (string) ( $event_data['startDate'] ?? '' ),
 				'start_time'     => (string) ( $event_data['startTime'] ?? '' ),
 				'end_date'       => (string) ( $event_data['endDate'] ?? '' ),
 				'end_time'       => (string) ( $event_data['endTime'] ?? '' ),
 				'venue_timezone' => (string) ( $event_data['venueTimezone'] ?? '' ),
 			),
-			'venue'      => $this->serialize_venue( $post_id, $event_data ),
-			'organizer'  => $this->serialize_organizer( $event_data ),
-			'ticket'     => array(
+			'venue'       => $this->serialize_venue( $post_id, $event_data ),
+			'organizer'   => $this->serialize_organizer( $event_data ),
+			'ticket'      => array(
 				'url' => (string) ( $event_data['ticketUrl'] ?? '' ),
 			),
-			'performer'  => array(
+			'performer'   => array(
 				'name' => (string) ( $event_data['performerName'] ?? '' ),
 			),
-			'address'    => (string) ( $event_data['address'] ?? '' ),
-			'taxonomies' => $this->serialize_taxonomies( $post_id ),
+			'address'     => (string) ( $event_data['address'] ?? '' ),
+			'taxonomies'  => $this->serialize_taxonomies( $post_id ),
+			// Server-filtered badge HTML so client-rendered (Load More)
+			// cards honor the `data_machine_events_badge_wrapper_classes`
+			// and `data_machine_events_badge_classes` filters that themes
+			// hook for styling. Without this, the TS renderer rebuilds
+			// badges from raw terms and drops the theme classes, leaving
+			// appended events with unstyled fallback badges. See #381.
+			'badges_html' => Badges::render_taxonomy_badges( $post_id ),
 		);
 	}
 

--- a/inc/Api/Controllers/Calendar.php
+++ b/inc/Api/Controllers/Calendar.php
@@ -268,6 +268,9 @@ class Calendar {
 	 *   honor the badge-class filters themes hook for styling. The raw
 	 *   `taxonomies` map is still provided for any consumer that wants to
 	 *   render badges itself. See #381.
+	 * - `button_classes` ships the server-filtered "More Info" button class
+	 *   list (via the `data_machine_events_more_info_button_classes` filter)
+	 *   for the same client-render parity reason. See #381.
 	 *
 	 * @param int   $post_id     Event post ID.
 	 * @param array $event_entry The serialized entry from `paged_date_groups`.
@@ -278,33 +281,45 @@ class Calendar {
 		$title      = (string) ( $event_entry['title'] ?? get_the_title( $post_id ) );
 
 		return array(
-			'id'          => $post_id,
-			'title'       => $title,
-			'permalink'   => (string) get_permalink( $post_id ),
-			'date'        => array(
+			'id'             => $post_id,
+			'title'          => $title,
+			'permalink'      => (string) get_permalink( $post_id ),
+			'date'           => array(
 				'start_date'     => (string) ( $event_data['startDate'] ?? '' ),
 				'start_time'     => (string) ( $event_data['startTime'] ?? '' ),
 				'end_date'       => (string) ( $event_data['endDate'] ?? '' ),
 				'end_time'       => (string) ( $event_data['endTime'] ?? '' ),
 				'venue_timezone' => (string) ( $event_data['venueTimezone'] ?? '' ),
 			),
-			'venue'       => $this->serialize_venue( $post_id, $event_data ),
-			'organizer'   => $this->serialize_organizer( $event_data ),
-			'ticket'      => array(
+			'venue'          => $this->serialize_venue( $post_id, $event_data ),
+			'organizer'      => $this->serialize_organizer( $event_data ),
+			'ticket'         => array(
 				'url' => (string) ( $event_data['ticketUrl'] ?? '' ),
 			),
-			'performer'   => array(
+			'performer'      => array(
 				'name' => (string) ( $event_data['performerName'] ?? '' ),
 			),
-			'address'     => (string) ( $event_data['address'] ?? '' ),
-			'taxonomies'  => $this->serialize_taxonomies( $post_id ),
+			'address'        => (string) ( $event_data['address'] ?? '' ),
+			'taxonomies'     => $this->serialize_taxonomies( $post_id ),
 			// Server-filtered badge HTML so client-rendered (Load More)
 			// cards honor the `data_machine_events_badge_wrapper_classes`
 			// and `data_machine_events_badge_classes` filters that themes
 			// hook for styling. Without this, the TS renderer rebuilds
 			// badges from raw terms and drops the theme classes, leaving
 			// appended events with unstyled fallback badges. See #381.
-			'badges_html' => Badges::render_taxonomy_badges( $post_id ),
+			'badges_html'    => Badges::render_taxonomy_badges( $post_id ),
+			// Server-filtered "More Info" button class list so client-rendered
+			// (Load More) cards honor the
+			// `data_machine_events_more_info_button_classes` filter, mirroring
+			// the badge-class parity fix above and the lazy-render path in
+			// EventRenderer.php. See #381.
+			'button_classes' => implode(
+				' ',
+				apply_filters(
+					'data_machine_events_more_info_button_classes',
+					array( 'data-machine-more-info-button' )
+				)
+			),
 		);
 	}
 

--- a/inc/Blocks/Calendar/src/modules/event-renderer.ts
+++ b/inc/Blocks/Calendar/src/modules/event-renderer.ts
@@ -18,13 +18,16 @@
  *     computed client-side here because the #301 data envelope does
  *     not (yet) expose these pre-formatted strings. See `formatTimeDisplay`
  *     and friends below — port of `DisplayVars::build()` in PHP.
- *   - `data_machine_events_badge_classes` and
- *     `data_machine_events_more_info_button_classes` server filters are
- *     NOT honored on client-rendered cards. Themes/plugins relying on
- *     class-list customization will see defaults on appended events.
- *     Follow-up: extend the data envelope to ship the pre-filtered
- *     class lists (and `badges_html`) the same way the lazy-render
- *     placeholder JSON already does.
+ *   - `data_machine_events_badge_classes` server filter IS now honored on
+ *     client-rendered cards: the data envelope ships `event.badges_html`
+ *     (server-rendered via `Taxonomy\Badges::render_taxonomy_badges()`)
+ *     and `renderBadges()` injects it directly, falling back to client
+ *     reconstruction from raw terms only when it's absent. See #381.
+ *   - `data_machine_events_more_info_button_classes` server filter is
+ *     still NOT honored on client-rendered cards. Themes/plugins relying
+ *     on More Info button class-list customization will see defaults on
+ *     appended events. Follow-up: ship the pre-filtered button class list
+ *     in the data envelope the same way `badges_html` now is.
  */
 
 import type {
@@ -153,6 +156,20 @@ export function renderEventCard(
 /* ------------------------------------------------------------------ */
 
 function renderBadges( event: CalendarEventItem ): HTMLElement | null {
+	// Prefer the server-rendered, filter-applied badge markup when the
+	// data envelope ships it. `Badges::render_taxonomy_badges()` runs the
+	// `data_machine_events_badge_wrapper_classes` /
+	// `data_machine_events_badge_classes` filters that themes hook for
+	// styling, so injecting this keeps client-appended (Load More) cards
+	// byte-identical to server-rendered cards. The markup is built
+	// entirely server-side from escaped values (esc_html / esc_url /
+	// esc_attr), so parsing it here introduces no new injection surface.
+	// See #381.
+	const serverBadges = renderServerBadges( event.badges_html );
+	if ( serverBadges ) {
+		return serverBadges;
+	}
+
 	const taxonomies = event.taxonomies || {};
 	const taxonomySlugs = Object.keys( taxonomies );
 	if ( taxonomySlugs.length === 0 ) {
@@ -201,6 +218,28 @@ function renderBadges( event: CalendarEventItem ): HTMLElement | null {
 	} );
 
 	return badgeCount > 0 ? wrapper : null;
+}
+
+/**
+ * Parse the server-rendered badge HTML (`event.badges_html`) into a
+ * detached element ready to append.
+ *
+ * Returns null when no markup is supplied so the caller can fall back to
+ * the client-side reconstruction from raw taxonomy terms. The markup is
+ * produced by `Taxonomy\Badges::render_taxonomy_badges()` — a single
+ * `.data-machine-taxonomy-badges` wrapper element — so we lift that first
+ * element child out of the parse container.
+ */
+function renderServerBadges( badgesHtml?: string ): HTMLElement | null {
+	const html = ( badgesHtml || '' ).trim();
+	if ( html === '' ) {
+		return null;
+	}
+
+	const template = document.createElement( 'template' );
+	template.innerHTML = html;
+	const node = template.content.firstElementChild;
+	return node instanceof HTMLElement ? node : null;
 }
 
 /* ------------------------------------------------------------------ */

--- a/inc/Blocks/Calendar/src/modules/event-renderer.ts
+++ b/inc/Blocks/Calendar/src/modules/event-renderer.ts
@@ -23,11 +23,11 @@
  *     (server-rendered via `Taxonomy\Badges::render_taxonomy_badges()`)
  *     and `renderBadges()` injects it directly, falling back to client
  *     reconstruction from raw terms only when it's absent. See #381.
- *   - `data_machine_events_more_info_button_classes` server filter is
- *     still NOT honored on client-rendered cards. Themes/plugins relying
- *     on More Info button class-list customization will see defaults on
- *     appended events. Follow-up: ship the pre-filtered button class list
- *     in the data envelope the same way `badges_html` now is.
+ *   - `data_machine_events_more_info_button_classes` server filter IS now
+ *     honored on client-rendered cards: the data envelope ships
+ *     `event.button_classes` (the filtered class list) and `renderEventCard()`
+ *     applies it to the More Info button, falling back to the default class
+ *     only when absent. See #381.
  */
 
 import type {
@@ -139,9 +139,12 @@ export function renderEventCard(
 
 	const moreInfo = document.createElement( 'a' );
 	moreInfo.href = event.permalink;
-	// Default class list. Server-side `data_machine_events_more_info_button_classes`
-	// filter is not honored on client-rendered cards (Phase-1.5 deferred).
-	moreInfo.className = 'data-machine-more-info-button';
+	// Prefer the server-filtered class list shipped in the data envelope
+	// (runs `data_machine_events_more_info_button_classes`), falling back to
+	// the default class only when absent. Keeps client-appended cards in
+	// parity with server-rendered ones. See #381.
+	moreInfo.className =
+		( event.button_classes || '' ).trim() || 'data-machine-more-info-button';
 	moreInfo.textContent = 'More Info';
 	meta.appendChild( moreInfo );
 

--- a/inc/Blocks/Calendar/src/types.ts
+++ b/inc/Blocks/Calendar/src/types.ts
@@ -184,6 +184,15 @@ export interface CalendarEventItem {
 	performer: { name: string };
 	address: string;
 	taxonomies: Record<string, CalendarEventTaxonomyTerm[]>;
+	/**
+	 * Server-rendered, filter-applied badge markup from
+	 * `Badges::render_taxonomy_badges()`. When present, the event renderer
+	 * injects this directly so client-appended (Load More) cards honor the
+	 * `data_machine_events_badge_*_classes` filters themes hook for styling,
+	 * instead of rebuilding badges from `taxonomies` (which drops those
+	 * theme classes). See #381.
+	 */
+	badges_html?: string;
 }
 
 /**

--- a/inc/Blocks/Calendar/src/types.ts
+++ b/inc/Blocks/Calendar/src/types.ts
@@ -193,6 +193,14 @@ export interface CalendarEventItem {
 	 * theme classes). See #381.
 	 */
 	badges_html?: string;
+	/**
+	 * Server-filtered "More Info" button class list from the
+	 * `data_machine_events_more_info_button_classes` filter. When present,
+	 * the event renderer applies it to client-appended (Load More) cards so
+	 * the button honors theme/plugin class customization instead of falling
+	 * back to the default class only. See #381.
+	 */
+	button_classes?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes the bug where events appended via **Load More** lose their custom styling, and closes the underlying architectural gap that caused it: the calendar had **two renderers** (PHP for the first page, a hand-ported TypeScript renderer for Load More) that each independently had to know how to format an event. Every formatting concern the PHP side honored was a drift landmine the TS side had to replicate — the badge bug and the button bug were the same class of bug surfacing twice.

This PR makes `DisplayVars::build()` the **single source of truth** for every render path.

## Root cause

Three render paths, three sources of display values:

| Path | Trigger | Renders via | Display values from |
|------|---------|-------------|---------------------|
| PHP template | first page, first <=5 events/day | `event-item.php` | `DisplayVars::build()` (ok) |
| `lazy-render.ts` | events 6+ on a day | hydrates `data-event-json` | server `display_vars` (ok) |
| `event-renderer.ts` | Load More + day-loader appends | client DOM build | **re-derived in JS** (bug) |

Only `event-renderer.ts` re-implemented `DisplayVars` in TypeScript (~290 lines: AM/PM-collapse time ranges, multi-day labels, ISO start dates, sentinel end-time detection, unicode decoding) plus hardcoded badge/button classes. That was the entire drift surface.

## Fix (3 commits)

1. **fix: honor badge-class filters on load-more events** — ship server-rendered `badges_html` (runs the `data_machine_events_badge_*_classes` filters); inject it client-side.
2. **fix: honor more-info button-class filter on load-more events** — ship `button_classes` (runs `data_machine_events_more_info_button_classes`); apply it client-side.
3. **refactor: make DisplayVars the single source of truth for event cards** — ship a server-computed `display` block **per occurrence** in the `format=data` envelope (via `DisplayVars::build()`); `event-renderer.ts` consumes it verbatim. Deletes ~290 lines of JS re-derivation.

The `display` block lives per-occurrence (on `grouping.by_date` entries), not per-event, because a multi-day event's formatted time differs by day (timed range on the start day, "Ongoing - ends X" on continuation days).

## Cache safety

Bumped the data-envelope schema to **v2** and folded `Calendar::DATA_SCHEMA_VERSION` into the full-response cache key (`data_schema`), so a deploy never serves a stale v1 envelope (lacking the `display` block) to the v2 client during the cache TTL window (up to 24h for past events).

## Result

- `event-renderer.ts`: ~470 -> ~245 lines; all time/date/unicode logic gone.
- Net **-82 lines** across the PR despite added server code + docs.
- `DisplayVars::build()` is now the one place that knows how to format an event, matching how `lazy-render.ts` already worked.

## Notes

- `badges_html` is built server-side from escaped values (`esc_html`/`esc_url`/`esc_attr`); parsing it client-side adds no injection surface.
- The client-side badge reconstruction from raw `taxonomies` is kept as a fallback for when `badges_html` is absent.
- `docs/calendar-data-schema.md` updated to v2 with the `display` block + cache documentation.

## Verification

- `npm run build` (wp-scripts) compiles cleanly; `tsc --noEmit` reports **0 errors in changed files** (remaining errors are pre-existing missing-`@wordpress/*`-types noise in untouched files).
- `php -l` + `phpcs --standard=WordPress` pass on both PHP files (0 findings).
- `build/` is a gitignored artifact (generated during homeboy build); only source committed.

Fixes #381