### PR TITLE
fix(events-map): clamp emoji pin size so host-theme img rules can't balloon markers

### DIFF
--- a/inc/Blocks/EventsMap/style.css
+++ b/inc/Blocks/EventsMap/style.css
@@ -23,6 +23,31 @@
 	border: none;
 }
 
+/* Emoji pin sizing must be self-contained, not dependent on ambient CSS.
+   The marker is an L.divIcon whose glyph size comes from an inline
+   `font-size` on its inner <span>. WordPress core's emoji feature rewrites
+   the literal 📍 into an <img class="emoji">, and themes that don't ship
+   the core `img.emoji { width: 1em; height: 1em }` clamp (or that load it
+   in a context the dynamically-injected Leaflet marker never inherits) let
+   that <img> render at its intrinsic size — a giant pin. Pin the glyph box
+   to the divIcon's iconSize (28px) here so the marker is correct regardless
+   of theme, emoji replacement, or wrapper layout. */
+.data-machine-events-map .emoji-marker span {
+	display: block;
+	width: 28px;
+	height: 28px;
+	font-size: 28px;
+	line-height: 1;
+}
+
+.data-machine-events-map .emoji-marker img {
+	width: 28px;
+	height: 28px;
+	max-width: none;
+	margin: 0;
+	vertical-align: top;
+}
+
 /* ---------- Collapsible (opt-in) ---------- */
 
 /* The collapsible wrapper exists only when the block opts in via the


### PR DESCRIPTION
## Summary

Defensive fix so the EventsMap block's emoji pins can't be stretched by an over-broad host-theme `img` rule.

The venue marker is an `L.divIcon` whose 📍 glyph is sized only by an inline `font-size` on its inner `<span>`. WordPress core's emoji feature rewrites the literal emoji into an `<img class="emoji">`. A host theme with a broad selector like `.archive img { height: 260px }` then catches that dynamically-injected `<img>` and balloons the pin (observed live on extrachill-events archives).

## Fix

Pin the `.emoji-marker` glyph box (the inner `<span>` and any emoji `<img>`) to the divIcon's 28px `iconSize` in the block's own `style.css`, so markers render correctly **regardless of theme, emoji replacement, or wrapper layout**. Self-contained — no dependency on ambient CSS.

```css
.data-machine-events-map .emoji-marker span { display: block; width: 28px; height: 28px; font-size: 28px; line-height: 1; }
.data-machine-events-map .emoji-marker img  { width: 28px; height: 28px; max-width: none; margin: 0; vertical-align: top; }
```

## Layer purity

Generic — the block makes its own markers bulletproof. No consumer/theme vocabulary. The consuming theme's over-broad rule is fixed separately in `Extra-Chill/extrachill` (the true root cause); this is defense-in-depth so the block is correct on any theme.

`style.css` is loaded directly via `block.json` `style` (no build step needed). `php -l` n/a (CSS only).