### PR TITLE
fix(geocode): never geocode a context-free bare street (Reno-NV coordinate roulette, #379)

### DIFF
--- a/inc/Core/Venue_Taxonomy.php
+++ b/inc/Core/Venue_Taxonomy.php
@@ -608,8 +608,24 @@ class Venue_Taxonomy {
 			$queries['name_lookup'] = implode( ', ', $parts );
 		}
 
-		// Strategy 4: Raw address field as-is (in case it's already a complete, well-formatted address)
-		if ( ! empty( $address ) && $address !== ( $queries['cleaned_address'] ?? '' ) ) {
+		// Strategy 4: Raw address field as-is (in case it's already a complete, well-formatted address).
+		//
+		// Guard against coordinate roulette: a bare street with no embedded
+		// city/state (e.g. "500 College Drive") must NOT be geocoded alone when
+		// we have separate city meta to build a contextual query — Nominatim
+		// will happily match the street number to an unrelated city (the real
+		// "500 College Drive" resolves to Reno, NV, mis-placing a Lake Jackson,
+		// TX venue 1,500+ miles away). See data-machine-events#379.
+		//
+		// Only fall back to the raw address when it carries its own context
+		// (contains a comma, i.e. multi-part) OR when there is no city meta to
+		// produce a better-scoped query in strategies 1-3.
+		$raw_has_context = false !== strpos( $address, ',' );
+		if (
+			! empty( $address )
+			&& $address !== ( $queries['cleaned_address'] ?? '' )
+			&& ( $raw_has_context || empty( $city ) )
+		) {
 			$queries['raw_address'] = html_entity_decode( $address );
 		}
 

--- a/tests/geocode-query-fallback-smoke.php
+++ b/tests/geocode-query-fallback-smoke.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Geocode query-strategy fallback smoke test.
+ *
+ * Self-contained (no PHPUnit / WP test framework). Verifies that
+ * Venue_Taxonomy::build_geocode_queries() does NOT emit a context-free
+ * bare-street `raw_address` fallback when separate city meta is available.
+ *
+ * Regression guard for data-machine-events#379: a bare street like
+ * "500 College Drive" was being geocoded alone after the contextual
+ * strategies returned no Nominatim match, resolving to an unrelated city
+ * (Reno, NV) and mis-placing a Lake Jackson, TX venue 1,500+ miles away.
+ *
+ * Run directly:
+ *   php tests/geocode-query-fallback-smoke.php
+ *
+ * @package DataMachineEvents\Tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+// Minimal WP shims used by build_geocode_queries (pure string logic).
+if ( ! function_exists( 'html_entity_decode' ) ) {
+	// Always available in PHP core; guard for paranoia only.
+	function html_entity_decode( $s ) {
+		return $s;
+	}
+}
+
+require_once dirname( __DIR__ ) . '/inc/Core/Venue_Taxonomy.php';
+
+use DataMachineEvents\Core\Venue_Taxonomy;
+
+$method = new ReflectionMethod( Venue_Taxonomy::class, 'build_geocode_queries' );
+$method->setAccessible( true );
+
+/**
+ * Invoke the private query builder.
+ *
+ * @param array $venue_data Venue data.
+ * @return array Strategy => query string.
+ */
+function build_queries( array $venue_data ): array {
+	global $method;
+	return $method->invoke( null, $venue_data );
+}
+
+$pass = 0;
+$fail = 0;
+
+/**
+ * Assert helper.
+ *
+ * @param string $label     Case label.
+ * @param bool   $condition Result.
+ */
+function check( string $label, bool $condition ): void {
+	global $pass, $fail;
+	if ( $condition ) {
+		++$pass;
+	} else {
+		++$fail;
+		echo "FAIL: {$label}\n";
+	}
+}
+
+// Case 1: The Brazosport regression — bare street + separate city meta.
+// raw_address (bare "500 College Drive") must NOT be emitted.
+$q = build_queries(
+	array(
+		'address' => '500 College Drive',
+		'city'    => 'Lake Jackson',
+		'state'   => 'TX',
+		'zip'     => '77566',
+		'country' => 'US',
+		'name'    => 'The Clarion at Brazosport College',
+	)
+);
+check( 'bare street + city: cleaned_address present', isset( $q['cleaned_address'] ) );
+check( 'bare street + city: no bare raw_address fallback', ! isset( $q['raw_address'] ) );
+check(
+	'bare street + city: cleaned_address is fully scoped',
+	'500 College Drive, Lake Jackson, TX, 77566' === ( $q['cleaned_address'] ?? '' )
+);
+
+// Case 2: Raw address that already carries context (comma) — raw_address allowed.
+$q = build_queries(
+	array(
+		'address' => '123 Main St, Austin, TX 78701',
+		'city'    => '',
+		'state'   => '',
+		'zip'     => '',
+		'country' => 'US',
+		'name'    => 'Some Venue',
+	)
+);
+check( 'context-rich raw address: raw_address allowed', isset( $q['raw_address'] ) );
+
+// Case 3: Bare street with NO city meta — raw_address is the only signal, allow it.
+$q = build_queries(
+	array(
+		'address' => '500 College Drive',
+		'city'    => '',
+		'state'   => '',
+		'zip'     => '',
+		'country' => '',
+		'name'    => '',
+	)
+);
+check( 'bare street, no city: raw_address allowed as last resort', isset( $q['raw_address'] ) );
+
+// Case 4: Name + city lookup still produced when name present.
+$q = build_queries(
+	array(
+		'address' => '500 College Drive',
+		'city'    => 'Lake Jackson',
+		'state'   => 'TX',
+		'zip'     => '77566',
+		'country' => 'US',
+		'name'    => 'The Clarion at Brazosport College',
+	)
+);
+check( 'name_lookup still produced', isset( $q['name_lookup'] ) );
+
+printf( "\n%d passed, %d failed\n", $pass, $fail );
+
+exit( $fail > 0 ? 1 : 0 );


### PR DESCRIPTION
Refs #379

## Problem

`Venue_Taxonomy::build_geocode_queries()` tries several Nominatim query
strategies in order and falls back to **Strategy 4: the raw address field
verbatim**. When the contextual strategies return no match and the raw address
is a **bare street with no embedded city** (e.g. `500 College Drive`), Nominatim
matches the street number to an unrelated city.

Concrete failure (surfaced in #379): **The Clarion at Brazosport College**
(`500 College Drive, Lake Jackson, TX 77566`) got coordinates
`39.5415898,-119.8218904` = **Reno, NV** — ~1,500 miles from the real venue.

### Reproduction (production, events.extrachill.com)

~~~
500 College Drive, Lake Jackson, TX, 77566           => 404 no results
500 College Drive, Lake Jackson, TX                  => 404 no results
The Clarion at Brazosport College, Lake Jackson, TX  => 404 no results
500 College Drive                                    => 39.54,-119.82  (Reno, NV) ← fallback fires
~~~

The bare-street fallback is coordinate roulette: it geocodes to whatever city
happens to have that street number. **~3,649 venues** network-wide have
bare-street addresses (no embedded comma) with separate city meta — all exposed
to this failure mode.

## Fix

Only emit the `raw_address` fallback when it carries its own context (contains a
comma → multi-part address) **or** there is no city meta to build a
better-scoped query in strategies 1–3. A bare street with city meta available
now relies on the contextual strategies and simply fails to geocode (correct)
rather than silently landing in the wrong state.

This keeps the legitimate use of strategy 4 (already-complete addresses stored
in a single field) while removing the dangerous bare-street path.

## Tests

`tests/geocode-query-fallback-smoke.php` (self-contained, run
`php tests/geocode-query-fallback-smoke.php`): 6 cases — the Brazosport
regression (no bare raw_address), context-rich raw address allowed, bare street
with no city allowed as last resort, name_lookup still produced. **6/6 pass.**

- `php -l`: clean
- phpcs: no new findings in the changed lines (the file's pre-existing
  Yoda/escaping/nonce baseline findings are unchanged and unrelated).

## Note on existing bad data

This stops *new* mis-geocodes. The already-stored Reno coords on Brazosport (and
any other venue that hit this path) still need re-geocoding after deploy:

~~~bash
# after deploy
wp --url=events.extrachill.com data-machine-events geocode-venues --venue-id=21417 --force
# audit for other venues with out-of-region coords
wp --url=events.extrachill.com data-machine-events audit-venues
~~~