### PR TITLE
style(events-map): polish collapsed map toggle (pin glyph + accent tint)

### DIFF
--- a/inc/Blocks/EventsMap/style.css
+++ b/inc/Blocks/EventsMap/style.css
@@ -59,7 +59,8 @@
 }
 
 /* Toggle is a real <button> — keyboard operable, accessible. Styled as a
-   slim header bar so the collapsed state reads as a clear "Show map" peek. */
+   slim bar; collapsed state gets an accent tint + pin glyph so "Show map"
+   reads as an intentional affordance (the map itself stays fully hidden). */
 .data-machine-events-map-toggle {
 	display: inline-flex;
 	align-items: center;
@@ -99,6 +100,24 @@
 
 .data-machine-events-map-collapsible.is-collapsed .data-machine-events-map-toggle::before {
 	transform: rotate(-90deg);
+}
+
+/* A map-pin glyph after the label so the toggle reads as a clear "there's a
+   map here" affordance — no asset, stays vendor-neutral. */
+.data-machine-events-map-toggle::after {
+	content: "\1F4CD"; /* 📍 */
+	font-size: 0.9375em;
+	line-height: 1;
+}
+
+/* Collapsed state: tint the bar with the accent color so the "Show map"
+   control reads as an intentional, tappable affordance rather than a bare
+   button. Kept fully hidden (no live map sliver) so collapsed = zero Leaflet
+   work. */
+.data-machine-events-map-collapsible.is-collapsed .data-machine-events-map-toggle {
+	border-color: var(--data-machine-border-focus, #2563eb);
+	background: var(--data-machine-background-accent-soft, rgba(37, 99, 235, 0.08));
+	color: var(--data-machine-text-accent, #2563eb);
 }
 
 /* The collapsible region. When collapsed it is hidden via the [hidden]


### PR DESCRIPTION
## Summary
Follow-up polish to the collapsible EventsMap capability (#376 / #377, now merged). The collapsed state stays **fully hidden** (zero Leaflet cost, no gray-tile risk, deferred-init preserved), but the "Show map" toggle now reads as an intentional, tappable affordance:

- **Map-pin glyph** (📍 via CSS `content`, no asset, vendor-neutral) after the toggle label.
- **Accent-tinted bar** when collapsed (`--data-machine-border-focus` / `--data-machine-background-accent-soft` / `--data-machine-text-accent`, with safe fallbacks) so the collapsed control doesn't look like a bare button.

No live-map "peek" — the deliberate decision was to keep collapsed = fully hidden so a collapsed map does no Leaflet work until expanded.

## Why a separate PR
The original polish commit was pushed to the `eventsmap-collapsible` branch *after* #377 was squash-merged, so it was stranded on a now-stale branch (9 commits behind main). Re-applying it from that branch would have reverted the #383 emoji-marker sizing fix that landed afterward. This PR applies **only** the toggle polish on top of current `main` — diff is 20 insertions / 1 line changed, touching nothing but the toggle styles.

## Verification
- Diff is `inc/Blocks/EventsMap/style.css` only; no `emoji-marker` rules removed (#383 intact).
- Token-driven with literal fallbacks; keyboard/`aria` behavior unchanged from #377.