### PR TITLE
refactor: make DisplayVars the single source of truth for event cards (#381)

### DIFF
--- a/docs/calendar-data-schema.md
+++ b/docs/calendar-data-schema.md
@@ -42,7 +42,7 @@ full-response cache key (`CalendarCache::generate_full_response_key()`).
   "success": true,
   "schema": {
     "name": "calendar-data",
-    "version": 1,
+    "version": 2,
     "phase": 1,
     "issue": 298
   },
@@ -51,7 +51,7 @@ full-response cache key (`CalendarCache::generate_full_response_key()`).
     "ordered_dates": [ "2026-06-12", "2026-06-13", "..." ],
     "by_date": {
       "2026-06-12": [
-        { "post_id": 12345, "display_context": { /* ... */ } }
+        { "post_id": 12345, "display_context": { /* ... */ }, "display": { /* ... */ } }
       ]
     },
     "gaps": { "2026-06-15": 3 }
@@ -81,9 +81,23 @@ full-response cache key (`CalendarCache::generate_full_response_key()`).
 ### `schema`
 
 Identifies the schema for forward compatibility. Clients should check
-`schema.name === 'calendar-data'` and `schema.version === 1` before
+`schema.name === 'calendar-data'` and `schema.version === 2` before
 reading the rest. Future phases bump `phase`; backward-incompatible
 shape changes bump `version`.
+
+`schema.version` is also folded into the full-response cache key (as
+`data_schema` — see [Caching](#caching)), so a deploy that bumps the
+version can never serve a stale older-shape envelope to the newer client
+for the cache TTL window.
+
+**v2 ([#381](https://github.com/Extra-Chill/data-machine-events/issues/381)):** each `grouping.by_date`
+occurrence now carries a server-computed `display` block. The client-side
+event renderer consumes those values verbatim instead of re-deriving
+time / date / unicode formatting in JavaScript, making
+`DisplayVars::build()` the single source of truth for every render path
+(PHP template, lazy-render hydration, and the client event renderer).
+This closed the badge- and time-format drift bugs where client-rendered
+(Load More) cards diverged from server-rendered ones.
 
 ### `events`
 
@@ -170,6 +184,34 @@ the same `post_id` appears under every spanned date, each with its own
 }
 ```
 
+#### `display` (v2, [#381](https://github.com/Extra-Chill/data-machine-events/issues/381))
+
+Each occurrence also carries a server-computed `display` block, produced
+by `DisplayVars::build( $event_data, $display_context )` — the single
+source of truth for every render path's display strings. It lives
+**per-occurrence** (not on the event) because the formatted time string
+varies by occurrence for multi-day events: the same `post_id` reads as a
+timed range on its start day and `"Ongoing · ends Mar 22"` on
+continuation days.
+
+```jsonc
+{
+  "formatted_time_display": "7:30 - 10:00 PM",   // ready-to-print, e.g. "Ongoing · ends Mar 22"
+  "multi_day_label":        "",                  // "through Mar 22" on a multi-day start day, else ""
+  "iso_start_date":         "2026-06-12T20:30:00-04:00", // timezone-aware, for the data-date attribute
+  "venue_name":             "The Royal American", // unicode-decoded, for data-venue
+  "performer_name":         "Headliner Name",      // unicode-decoded, for data-performer
+  "show_performer":         false,
+  "show_ticket_link":       true,
+  "is_continuation":        false,
+  "is_multi_day":           false
+}
+```
+
+Clients should render these verbatim and must **not** re-derive time,
+date, or unicode formatting locally — doing so reintroduces the
+server/client drift this block exists to eliminate.
+
 ### `pagination`, `counter`, `navigation`
 
 Pure metadata — no HTML strings. Field meanings mirror the legacy
@@ -200,6 +242,13 @@ As of [#318](https://github.com/Extra-Chill/data-machine-events/issues/318) the 
 `month` envelope field, so month-grid responses scoped to a specific
 `YYYY-MM` window don't collide with list-mode responses for the same
 archive.
+
+As of [#381](https://github.com/Extra-Chill/data-machine-events/issues/381) the cache key also includes
+`data_schema` (the data-envelope `schema.version`, set only for
+`format=data` requests). Bumping `Calendar::DATA_SCHEMA_VERSION` therefore
+isolates the new envelope shape into fresh cache buckets, so a deploy that
+changes the shape never serves a stale older-shape response to the newer
+client for the cache TTL window.
 
 ## Month-grid scoping (#318)
 

--- a/inc/Api/Controllers/Calendar.php
+++ b/inc/Api/Controllers/Calendar.php
@@ -37,6 +37,7 @@ use WP_REST_Request;
 use DataMachineEvents\Abilities\CalendarAbilities;
 use DataMachineEvents\Api\BrowserNavigationGuard;
 use DataMachineEvents\Blocks\Calendar\Cache\CalendarCache;
+use DataMachineEvents\Blocks\Calendar\Display\DisplayVars;
 use DataMachineEvents\Blocks\Calendar\Query\CalendarRequest;
 use DataMachineEvents\Blocks\Calendar\Taxonomy\Badges;
 
@@ -44,6 +45,18 @@ use DataMachineEvents\Blocks\Calendar\Taxonomy\Badges;
  * Calendar API controller
  */
 class Calendar {
+
+	/**
+	 * Schema version of the `format=data` response envelope.
+	 *
+	 * Bump this whenever the data-envelope SHAPE changes in a way the client
+	 * renderer depends on. It is folded into the full-response cache key so a
+	 * deploy that changes the shape can never serve a stale older-shape
+	 * envelope to the newer client (and vice-versa) for the cache TTL window.
+	 *
+	 * v2 (#381): per-occurrence `display` block added to `grouping.by_date`.
+	 */
+	const DATA_SCHEMA_VERSION = 2;
 
 	/**
 	 * Calendar endpoint implementation
@@ -74,6 +87,13 @@ class Calendar {
 		// (the ability-side envelope only sees the derived `include_html`).
 		$envelope['format'] = $calendar_request->format();
 		$is_data_format     = ( 'data' === $envelope['format'] );
+
+		// Fold the data-envelope schema version into the cache key (data
+		// format only) so a shape change across a deploy never serves a
+		// stale older-shape envelope to the newer client. See #381.
+		if ( $is_data_format ) {
+			$envelope['data_schema_version'] = self::DATA_SCHEMA_VERSION;
+		}
 
 		// Editors with `manage_options` always bypass the cache so they
 		// see fresh data immediately after publishing / editing events.
@@ -173,6 +193,16 @@ class Calendar {
 		// lives on the grouping entry, not on the event itself, because
 		// the same post can be a "start day" on one date and a
 		// "continuation" on the next.
+		//
+		// The per-occurrence `display` block (server-computed via
+		// DisplayVars::build()) ALSO lives on the grouping entry, not the
+		// event, for the same reason: the formatted time string differs by
+		// occurrence (a multi-day event reads "7:30 PM" on its start day
+		// and "Ongoing · ends Mar 22" on continuation days). Shipping it
+		// here keeps DisplayVars the single source of truth for all render
+		// paths (PHP template, lazy-render hydration, and the client-side
+		// event-renderer) — the client never re-derives time/date strings.
+		// See #381.
 		$events_by_id  = array();
 		$grouping      = array();
 		$ordered_dates = array();
@@ -196,9 +226,15 @@ class Calendar {
 					$events_by_id[ $post_id ] = $this->serialize_event( $post_id, $event_entry );
 				}
 
+				$display_context = $event_entry['display_context'] ?? array();
+
 				$grouping[ $date_key ][] = array(
 					'post_id'         => $post_id,
-					'display_context' => $event_entry['display_context'] ?? array(),
+					'display_context' => $display_context,
+					'display'         => $this->serialize_display(
+						$event_entry['event_data'] ?? array(),
+						$display_context
+					),
 				);
 			}
 		}
@@ -211,7 +247,12 @@ class Calendar {
 			'success'    => true,
 			'schema'     => array(
 				'name'    => 'calendar-data',
-				'version' => 1,
+				// v2 (#381): each `grouping.by_date` occurrence now carries a
+				// server-computed `display` block (DisplayVars::build()) so the
+				// client renderer never re-derives time/date strings. The cache
+				// key folds in this version so stale v1 buckets (which lack the
+				// `display` block) are never served to the v2 client.
+				'version' => self::DATA_SCHEMA_VERSION,
 				'phase'   => 1,
 				'issue'   => 298,
 			),
@@ -320,6 +361,42 @@ class Calendar {
 					array( 'data-machine-more-info-button' )
 				)
 			),
+		);
+	}
+
+	/**
+	 * Serialize the per-occurrence display block for the data envelope.
+	 *
+	 * Thin pass-through over `DisplayVars::build()` — the single source of
+	 * truth for every render path's display strings (formatted time range,
+	 * multi-day "through"/"Ongoing · ends" labels, ISO start date, decoded
+	 * venue/performer names, and the show_* flags). The client-side
+	 * `event-renderer.ts` consumes these verbatim instead of re-deriving
+	 * time/date/unicode logic in JavaScript, which is what let badge and
+	 * time formatting drift between server- and client-rendered cards. See #381.
+	 *
+	 * Lives per-occurrence (on the `grouping.by_date` entry) rather than on
+	 * the event because the formatted time string varies by occurrence for
+	 * multi-day events — the same post reads as a timed range on its start
+	 * day and "Ongoing · ends X" on continuation days.
+	 *
+	 * @param array $event_data      Hydrated event_data array for the event.
+	 * @param array $display_context Per-occurrence context (is_multi_day / is_continuation / ...).
+	 * @return array<string,mixed>
+	 */
+	private function serialize_display( array $event_data, array $display_context ): array {
+		$vars = DisplayVars::build( $event_data, $display_context );
+
+		return array(
+			'formatted_time_display' => (string) ( $vars['formatted_time_display'] ?? '' ),
+			'multi_day_label'        => (string) ( $vars['multi_day_label'] ?? '' ),
+			'iso_start_date'         => (string) ( $vars['iso_start_date'] ?? '' ),
+			'venue_name'             => (string) ( $vars['venue_name'] ?? '' ),
+			'performer_name'         => (string) ( $vars['performer_name'] ?? '' ),
+			'show_performer'         => (bool) ( $vars['show_performer'] ?? false ),
+			'show_ticket_link'       => (bool) ( $vars['show_ticket_link'] ?? true ),
+			'is_continuation'        => (bool) ( $vars['is_continuation'] ?? false ),
+			'is_multi_day'           => (bool) ( $vars['is_multi_day'] ?? false ),
 		);
 	}
 

--- a/inc/Blocks/Calendar/Cache/CalendarCache.php
+++ b/inc/Blocks/Calendar/Cache/CalendarCache.php
@@ -122,6 +122,13 @@ class CalendarCache {
 			// buckets — otherwise the first response shape served
 			// for a given envelope sticks for the cache TTL.
 			'format'           => (string) ( $envelope['format'] ?? '' ),
+			// #381: data-envelope schema version. Folding it into the key
+			// means a deploy that changes the envelope SHAPE never serves a
+			// stale older-shape response to the newer client for the cache
+			// TTL window. Only set for the data format (see Calendar
+			// controller); empty for HTML responses, which keeps their
+			// existing buckets unchanged.
+			'data_schema'      => (int) ( $envelope['data_schema_version'] ?? 0 ),
 			// #318: month-grid mode scopes events to a specific YYYY-MM
 			// window (regardless of past/upcoming). Fold the month into
 			// the key so grid and list responses for the same archive

--- a/inc/Blocks/Calendar/src/modules/date-group-renderer.ts
+++ b/inc/Blocks/Calendar/src/modules/date-group-renderer.ts
@@ -99,7 +99,7 @@ export function renderDateGroup(
 		if ( ! event ) {
 			return;
 		}
-		const card = renderEventCard( event, occurrence.display_context );
+		const card = renderEventCard( event, occurrence );
 		wrapper.appendChild( card );
 	} );
 

--- a/inc/Blocks/Calendar/src/modules/event-renderer.ts
+++ b/inc/Blocks/Calendar/src/modules/event-renderer.ts
@@ -1,54 +1,45 @@
 /**
- * Event card renderer — TypeScript port of `inc/Blocks/Calendar/templates/event-item.php`.
+ * Event card renderer — TypeScript DOM assembler for the
+ * `inc/Blocks/Calendar/templates/event-item.php` markup.
  *
  * Produces the same DOM tree the PHP template emits so that
- * client-appended cards (Load More, future progressive renders) look
+ * client-appended cards (Load More, progressive day-loader) look
  * byte-identical to server-rendered cards. Existing TS modules
  * (carousel, lazy-render, day-loader) hook onto these via class names
  * and data attributes — both paths must produce the same surface.
  *
- * Fidelity scope (mirrors `event-item.php`):
- *   - `.data-machine-event-item` wrapper with continuation / multi-day
- *     modifier classes, plus `data-title|venue|performer|date|ticket-url|has-tickets` attrs.
- *   - `.data-machine-event-link` → `.data-machine-taxonomy-badges` + `.data-machine-event-title` + `.data-machine-event-meta`.
- *   - `.data-machine-event-meta` → time / performer / more-info button.
- *
- * Phase-1.5 deferred concerns (documented in PR body for #314):
- *   - `formatted_time_display`, `multi_day_label`, `iso_start_date` are
- *     computed client-side here because the #301 data envelope does
- *     not (yet) expose these pre-formatted strings. See `formatTimeDisplay`
- *     and friends below — port of `DisplayVars::build()` in PHP.
- *   - `data_machine_events_badge_classes` server filter IS now honored on
- *     client-rendered cards: the data envelope ships `event.badges_html`
- *     (server-rendered via `Taxonomy\Badges::render_taxonomy_badges()`)
- *     and `renderBadges()` injects it directly, falling back to client
- *     reconstruction from raw terms only when it's absent. See #381.
- *   - `data_machine_events_more_info_button_classes` server filter IS now
- *     honored on client-rendered cards: the data envelope ships
- *     `event.button_classes` (the filtered class list) and `renderEventCard()`
- *     applies it to the More Info button, falling back to the default class
- *     only when absent. See #381.
+ * Single source of truth: this renderer is a pure DOM assembler. It does
+ * NOT compute any display strings. All display-ready values — the
+ * formatted time range, multi-day labels, ISO start date, decoded
+ * venue/performer names, show_* flags, badge markup, and the More Info
+ * button class list — are computed server-side (`DisplayVars::build()`
+ * and `Taxonomy\Badges::render_taxonomy_badges()`) and shipped in the
+ * `format=data` envelope: per-occurrence values on `occurrence.display`,
+ * per-event values (badges_html, button_classes) on the event. This is
+ * what keeps server- and client-rendered cards from drifting — there is
+ * exactly one place (PHP) that knows how to format an event. See #381.
  */
 
 import type {
 	CalendarEventItem,
-	CalendarEventOccurrenceContext,
+	CalendarEventOccurrence,
 	CalendarEventTaxonomyTerm,
 } from '../types';
 
 /**
  * Render a single event card.
  *
- * @param event   Structured event from `CalendarDataResponse.events`.
- * @param context Per-occurrence display context (continuation, multi-day flags).
- *                Defaults to an empty object — single-day events have no flags.
+ * @param event      Structured event from `CalendarDataResponse.events`.
+ * @param occurrence Per-occurrence entry from `grouping.by_date`, carrying
+ *                   the server-computed `display` block and `display_context`.
  */
 export function renderEventCard(
 	event: CalendarEventItem,
-	context: CalendarEventOccurrenceContext = {}
+	occurrence: CalendarEventOccurrence
 ): HTMLElement {
-	const isContinuation = context.is_continuation === true;
-	const isMultiDay = context.is_multi_day === true;
+	const display = occurrence.display;
+	const isContinuation = display.is_continuation === true;
+	const isMultiDay = display.is_multi_day === true;
 
 	const item = document.createElement( 'div' );
 	const classes = [ 'data-machine-event-item' ];
@@ -60,20 +51,16 @@ export function renderEventCard(
 	}
 	item.className = classes.join( ' ' );
 
-	const venueName = decodeUnicode( event.venue?.name || '' );
-	const performerName = decodeUnicode( event.performer?.name || '' );
+	const venueName = display.venue_name || '';
+	const performerName = display.performer_name || '';
 	const ticketUrl = event.ticket?.url || '';
-	const isoStartDate = buildIsoStartDate( event );
-	// `show_ticket_link` defaults to true in DisplayVars; client-side
-	// fallback uses the same default. There is no per-event override
-	// surfaced in the data envelope today.
-	const showTicketLink = true;
+	const showTicketLink = display.show_ticket_link !== false;
 	const hasTickets = showTicketLink && ticketUrl !== '';
 
 	item.dataset.title = event.title;
 	item.dataset.venue = venueName;
 	item.dataset.performer = performerName;
-	item.dataset.date = isoStartDate;
+	item.dataset.date = display.iso_start_date || '';
 	item.dataset.ticketUrl = ticketUrl;
 	item.dataset.hasTickets = hasTickets ? 'true' : 'false';
 
@@ -96,8 +83,8 @@ export function renderEventCard(
 	const meta = document.createElement( 'div' );
 	meta.className = 'data-machine-event-meta';
 
-	const formattedTimeDisplay = formatTimeDisplay( event, context );
-	const multiDayLabel = buildMultiDayLabel( event, context );
+	const formattedTimeDisplay = display.formatted_time_display || '';
+	const multiDayLabel = display.multi_day_label || '';
 
 	if ( formattedTimeDisplay ) {
 		const timeRow = document.createElement( 'div' );
@@ -109,7 +96,9 @@ export function renderEventCard(
 
 		// Mirror the PHP template: raw text inserted after the icon,
 		// then optional multi-day label as a separate child span.
-		timeRow.appendChild( document.createTextNode( ' ' + formattedTimeDisplay ) );
+		timeRow.appendChild(
+			document.createTextNode( ' ' + formattedTimeDisplay )
+		);
 
 		if ( multiDayLabel ) {
 			const labelSpan = document.createElement( 'span' );
@@ -122,27 +111,25 @@ export function renderEventCard(
 		meta.appendChild( timeRow );
 	}
 
-	// `show_performer` is hardcoded to `false` in DisplayVars::build()
-	// (see PHP source). We mirror that behavior — performer row is
-	// suppressed on the calendar surface, even when a performer name
-	// exists. Kept here as dead code path for parity tracing.
-	const showPerformer = false;
-	if ( showPerformer && performerName ) {
+	// `show_performer` is computed server-side (currently always false on
+	// the calendar surface, per DisplayVars::build()). We honor whatever
+	// the server sends rather than hardcoding the policy here.
+	if ( display.show_performer && performerName ) {
 		const performerRow = document.createElement( 'div' );
 		performerRow.className = 'data-machine-event-performer';
 		const performerIcon = document.createElement( 'span' );
 		performerIcon.className = 'dashicons dashicons-admin-users';
 		performerRow.appendChild( performerIcon );
-		performerRow.appendChild( document.createTextNode( ' ' + performerName ) );
+		performerRow.appendChild(
+			document.createTextNode( ' ' + performerName )
+		);
 		meta.appendChild( performerRow );
 	}
 
 	const moreInfo = document.createElement( 'a' );
 	moreInfo.href = event.permalink;
-	// Prefer the server-filtered class list shipped in the data envelope
-	// (runs `data_machine_events_more_info_button_classes`), falling back to
-	// the default class only when absent. Keeps client-appended cards in
-	// parity with server-rendered ones. See #381.
+	// Server-filtered class list (runs `data_machine_events_more_info_button_classes`),
+	// falling back to the default class only when absent. See #381.
 	moreInfo.className =
 		( event.button_classes || '' ).trim() || 'data-machine-more-info-button';
 	moreInfo.textContent = 'More Info';
@@ -155,7 +142,7 @@ export function renderEventCard(
 }
 
 /* ------------------------------------------------------------------ */
-/*  Badge rendering — port of Taxonomy\Badges::render_taxonomy_badges */
+/*  Badge rendering — server-rendered HTML injection                   */
 /* ------------------------------------------------------------------ */
 
 function renderBadges( event: CalendarEventItem ): HTMLElement | null {
@@ -243,230 +230,4 @@ function renderServerBadges( badgesHtml?: string ): HTMLElement | null {
 	template.innerHTML = html;
 	const node = template.content.firstElementChild;
 	return node instanceof HTMLElement ? node : null;
-}
-
-/* ------------------------------------------------------------------ */
-/*  Display formatting — port of Display\DisplayVars::build()          */
-/* ------------------------------------------------------------------ */
-
-/**
- * Build the ISO 8601 timestamp the server stores in `data-date`.
- *
- * Server uses `DateTime::format('c')` against the event timezone.
- * Reproducing the full TZ-aware timestamp client-side without the
- * IANA zone database is fragile; we emit the closest reasonable
- * approximation by combining date + time into a local naive ISO,
- * which is enough for the existing consumers (sort keys, label
- * read-back). Same-page parity with server-rendered cards is the
- * goal; downstream consumers do not parse this with timezone math.
- */
-function buildIsoStartDate( event: CalendarEventItem ): string {
-	const date = event.date?.start_date || '';
-	const time = event.date?.start_time || '';
-	if ( ! date ) {
-		return '';
-	}
-	const timePart = time || '00:00:00';
-	// Naive ISO; matches `Y-m-d\TH:i:s` shape, omits offset because
-	// we don't have the canonical IANA offset for the event TZ in JS.
-	return `${ date }T${ timePart }`;
-}
-
-/**
- * Reproduce `DisplayVars::format_time_range` + the multi-day "Ongoing
- * · ends X" / "through X" logic.
- *
- * Logic mirror:
- *   - Multi-day + continuation → "Ongoing · ends MMM D"
- *   - Multi-day + start day    → start-time range (multi_day_label set separately)
- *   - Single day, sentinel end → just start time
- *   - Single day, real range, same AM/PM → "7:30 - 10:00 PM"
- *   - Single day, real range, diff AM/PM → "11:30 AM - 1:00 PM"
- */
-function formatTimeDisplay(
-	event: CalendarEventItem,
-	context: CalendarEventOccurrenceContext
-): string {
-	const startDate = event.date?.start_date || '';
-	const startTime = event.date?.start_time || '';
-	const endDate = event.date?.end_date || '';
-	const endTime = event.date?.end_time || '';
-
-	if ( ! startDate ) {
-		return '';
-	}
-
-	const isMultiDay = context.is_multi_day === true;
-	const isContinuation = context.is_continuation === true;
-
-	if ( isMultiDay && endDate ) {
-		if ( isContinuation ) {
-			return 'Ongoing · ends ' + formatMonthDay( endDate );
-		}
-		// Start day of multi-day: show start-time range, multi-day
-		// label appended separately by the caller.
-		return formatTimeRange( startDate, startTime, endDate, endTime );
-	}
-
-	return formatTimeRange( startDate, startTime, endDate, endTime );
-}
-
-function buildMultiDayLabel(
-	event: CalendarEventItem,
-	context: CalendarEventOccurrenceContext
-): string {
-	const endDate = event.date?.end_date || '';
-	const isMultiDay = context.is_multi_day === true;
-	const isContinuation = context.is_continuation === true;
-	if ( isMultiDay && endDate && ! isContinuation ) {
-		return 'through ' + formatMonthDay( endDate );
-	}
-	return '';
-}
-
-function formatTimeRange(
-	startDate: string,
-	startTime: string,
-	endDate: string,
-	endTime: string
-): string {
-	const startMoment = parseDateTime( startDate, startTime );
-	if ( ! startMoment ) {
-		return '';
-	}
-	const startFormatted = formatClock( startMoment );
-
-	if ( ! endDate || ! endTime || isSentinelEndTime( endTime ) ) {
-		return startFormatted;
-	}
-
-	const endMoment = parseDateTime( endDate, endTime );
-	if ( ! endMoment ) {
-		return startFormatted;
-	}
-
-	// No real end time when start == end.
-	if (
-		startMoment.dateKey === endMoment.dateKey &&
-		startMoment.h === endMoment.h &&
-		startMoment.m === endMoment.m
-	) {
-		return startFormatted;
-	}
-
-	// Cross-day range: only show the start (mirrors PHP behavior).
-	if ( startMoment.dateKey !== endMoment.dateKey ) {
-		return startFormatted;
-	}
-
-	const startPeriod = startMoment.h >= 12 ? 'PM' : 'AM';
-	const endPeriod = endMoment.h >= 12 ? 'PM' : 'AM';
-
-	if ( startPeriod === endPeriod ) {
-		// "7:30 - 10:00 PM"
-		const startNoSuffix = formatClockNoSuffix( startMoment );
-		const endFormatted = formatClock( endMoment );
-		return startNoSuffix + ' - ' + endFormatted;
-	}
-
-	// "11:30 AM - 1:00 PM"
-	const endFormatted = formatClock( endMoment );
-	return startFormatted + ' - ' + endFormatted;
-}
-
-interface ParsedTime {
-	dateKey: string; // "Y-m-d"
-	h: number; // 0..23
-	m: number; // 0..59
-}
-
-function parseDateTime( date: string, time: string ): ParsedTime | null {
-	if ( ! date ) {
-		return null;
-	}
-	const t = time || '00:00:00';
-	const parts = t.split( ':' );
-	const h = parseInt( parts[ 0 ] || '0', 10 );
-	const m = parseInt( parts[ 1 ] || '0', 10 );
-	if ( isNaN( h ) || isNaN( m ) ) {
-		return null;
-	}
-	return { dateKey: date, h, m };
-}
-
-function formatClock( pt: ParsedTime ): string {
-	const period = pt.h >= 12 ? 'PM' : 'AM';
-	let displayHour = pt.h % 12;
-	if ( displayHour === 0 ) {
-		displayHour = 12;
-	}
-	const mm = pt.m < 10 ? '0' + pt.m : String( pt.m );
-	return `${ displayHour }:${ mm } ${ period }`;
-}
-
-function formatClockNoSuffix( pt: ParsedTime ): string {
-	let displayHour = pt.h % 12;
-	if ( displayHour === 0 ) {
-		displayHour = 12;
-	}
-	const mm = pt.m < 10 ? '0' + pt.m : String( pt.m );
-	return `${ displayHour }:${ mm }`;
-}
-
-/**
- * Match `DisplayVars::is_sentinel_end_time`. The "23:59" sentinel is
- * an internal SQL-range marker and should never appear in display
- * strings.
- */
-function isSentinelEndTime( time: string ): boolean {
-	const normalized = ( time || '' ).slice( 0, 5 );
-	return normalized === '23:59';
-}
-
-/**
- * Format `YYYY-MM-DD` → "Mar 22" (PHP `M j`).
- */
-function formatMonthDay( date: string ): string {
-	const parts = date.split( '-' );
-	if ( parts.length < 3 ) {
-		return date;
-	}
-	const year = parseInt( parts[ 0 ], 10 );
-	const month = parseInt( parts[ 1 ], 10 );
-	const day = parseInt( parts[ 2 ], 10 );
-	if ( isNaN( year ) || isNaN( month ) || isNaN( day ) ) {
-		return date;
-	}
-	const monthNames = [
-		'Jan',
-		'Feb',
-		'Mar',
-		'Apr',
-		'May',
-		'Jun',
-		'Jul',
-		'Aug',
-		'Sep',
-		'Oct',
-		'Nov',
-		'Dec',
-	];
-	const monthName = monthNames[ month - 1 ] || '';
-	return `${ monthName } ${ day }`;
-}
-
-/**
- * Mirror `DisplayVars::decode_unicode` — converts `\uXXXX` escape
- * sequences to their character form. The PHP path runs on raw
- * block-attribute strings; the data envelope generally ships
- * already-decoded venue/performer names, but mirroring the helper
- * keeps the surface identical when the server hasn't decoded yet.
- */
-function decodeUnicode( str: string ): string {
-	if ( ! str ) {
-		return '';
-	}
-	return str.replace( /\\u([0-9a-fA-F]{4})/g, ( _match, hex ) =>
-		String.fromCharCode( parseInt( hex, 16 ) )
-	);
 }

--- a/inc/Blocks/Calendar/src/modules/load-more.ts
+++ b/inc/Blocks/Calendar/src/modules/load-more.ts
@@ -423,10 +423,7 @@ function appendPage(
 					if ( ! event ) {
 						return;
 					}
-					const card = renderEventCard(
-						event,
-						occurrence.display_context
-					);
+					const card = renderEventCard( event, occurrence );
 					wrapper.appendChild( card );
 				} );
 				// Update the count badge.

--- a/inc/Blocks/Calendar/src/types.ts
+++ b/inc/Blocks/Calendar/src/types.ts
@@ -221,10 +221,37 @@ export interface CalendarEventOccurrenceContext {
 	total_days?: number;
 }
 
+/**
+ * Server-computed display strings for a single occurrence, produced by
+ * `DisplayVars::build()` (the one source of truth for all render paths).
+ *
+ * The client renderer consumes these verbatim rather than re-deriving
+ * time / date / unicode logic in JS. Lives per-occurrence because the
+ * formatted time string varies by occurrence for multi-day events. See #381.
+ */
+export interface CalendarEventDisplay {
+	/** Ready-to-print time string, e.g. "7:30 - 10:00 PM" or "Ongoing · ends Mar 22". */
+	formatted_time_display: string;
+	/** Multi-day "through Mar 22" label shown on a start day, or "". */
+	multi_day_label: string;
+	/** Timezone-aware ISO 8601 start timestamp for the `data-date` attribute. */
+	iso_start_date: string;
+	/** Unicode-decoded venue name for the `data-venue` attribute. */
+	venue_name: string;
+	/** Unicode-decoded performer name for the `data-performer` attribute. */
+	performer_name: string;
+	show_performer: boolean;
+	show_ticket_link: boolean;
+	is_continuation: boolean;
+	is_multi_day: boolean;
+}
+
 /** A single occurrence of an event on a specific date. */
 export interface CalendarEventOccurrence {
 	post_id: number;
 	display_context: CalendarEventOccurrenceContext;
+	/** Server-computed display strings for this occurrence. See #381. */
+	display: CalendarEventDisplay;
 }
 
 /** Date grouping index. Date keys are `Y-m-d` strings. */


### PR DESCRIPTION
## Summary

Follow-up to the badge/button parity fixes merged in #382. Those two fixes shipped pre-computed `badges_html` and `button_classes` in the `format=data` envelope so client-rendered (Load More) cards stopped dropping styling. This PR finishes the convergence: the client event renderer no longer re-derives **any** display logic.

`event-renderer.ts` was a ~470-line hand-port of the PHP card renderer, re-implementing `DisplayVars` in TypeScript — AM/PM-collapse time ranges, multi-day labels, ISO start dates, sentinel end-time detection, and unicode decoding. Every one of those was a drift landmine; the badge and button bugs were the same class of bug surfacing twice, and the timezone-aware ISO timestamp already carried documented fidelity compromises it couldn't reproduce in JS.

## Change

- Ship a server-computed `display` block **per occurrence** in the `format=data` envelope, via `DisplayVars::build()`.
- `event-renderer.ts` consumes it verbatim; deletes ~290 lines of re-derivation.
- `DisplayVars::build()` becomes the one place that knows how to format an event — matching how the `lazy-render.ts` hydration path already worked.

The `display` block lives per-occurrence (on `grouping.by_date` entries), not per-event, because a multi-day event's formatted time differs by day (timed range on the start day, "Ongoing - ends X" on continuation days).

## Cache safety

Bumped the data-envelope schema to **v2** and folded `Calendar::DATA_SCHEMA_VERSION` into the full-response cache key (`data_schema`), so a deploy never serves a stale v1 envelope (lacking the `display` block) to the v2 client during the cache TTL window (up to 24h for past events).

## Result

- `event-renderer.ts`: ~470 -> ~245 lines; all time/date/unicode logic gone.
- Net **-82 lines** despite added server code + docs.
- `docs/calendar-data-schema.md` updated to v2 with the `display` block + cache documentation.

## Verification

- `npm run build` (wp-scripts) compiles cleanly; `tsc --noEmit` reports **0 errors in changed files** (remaining errors are pre-existing missing-`@wordpress/*`-types noise in untouched files).
- `php -l` + `phpcs --standard=WordPress` pass on both PHP files (0 findings).
- Cherry-picked cleanly onto current `main` (on top of the merged #382 fixes); `build/` is a gitignored artifact, only source committed.

Relates to #381