### PR TITLE
fix: stop dead-DNS scraper sources from flooding the error log

### DIFF
--- a/inc/Steps/EventImport/Handlers/WebScraper/UniversalWebScraper.php
+++ b/inc/Steps/EventImport/Handlers/WebScraper/UniversalWebScraper.php
@@ -730,12 +730,38 @@ class UniversalWebScraper extends EventImportHandler {
 		}
 
 		if ( ! $result['success'] ) {
+			$error_message = $result['error'] ?? 'Unknown error';
+
+			// Distinguish permanently-unreachable sources (DNS gone) from
+			// transient transport failures. A dead-DNS venue site retries its
+			// WP REST + Tribe Events fallbacks every cron cycle and would
+			// otherwise log at `error` severity indefinitely, flooding the log.
+			//
+			// Downgrade unrecoverable-source failures to a single clear
+			// `warning` signal. This mirrors the existing HttpClient policy of
+			// treating expected external attrition (bot-blocks, moved pages,
+			// origin-down) as `warning` rather than a Data-Machine-side fault.
+			// Operators surface these via the venues tooling for re-qualify or
+			// removal; the flow itself is left untouched here.
+			if ( $this->isUnrecoverableSourceError( $error_message ) ) {
+				$context->log(
+					'warning',
+					'Universal Web Scraper: Source permanently unreachable (DNS failure) — skipping',
+					array(
+						'url'    => $url,
+						'error'  => $error_message,
+						'reason' => 'dns_unresolvable',
+					)
+				);
+				return '';
+			}
+
 			$context->log(
 				'error',
 				'Universal Web Scraper: HTTP request failed',
 				array(
 					'url'   => $url,
-					'error' => $result['error'] ?? 'Unknown error',
+					'error' => $error_message,
 				)
 			);
 			return '';
@@ -753,6 +779,53 @@ class UniversalWebScraper extends EventImportHandler {
 		}
 
 		return $result['data'];
+	}
+
+	/**
+	 * Classify an HTTP failure message as an unrecoverable source error.
+	 *
+	 * Unrecoverable means the source host cannot be reached at all because its
+	 * DNS no longer resolves (the domain is dead / gone, not rate-limited or
+	 * temporarily down). These never succeed on retry, so they should not be
+	 * logged at `error` severity on every cron cycle.
+	 *
+	 * Detection is signature-based against the cURL / resolver error strings
+	 * that surface through WordPress' HTTP transport. It is intentionally
+	 * generic — no hardcoded hostnames.
+	 *
+	 * Matched signatures:
+	 * - `cURL error 6` — CURLE_COULDNT_RESOLVE_HOST
+	 * - `Could not resolve host` — cURL human-readable message
+	 * - `Could not resolve: ...` — alternate cURL resolver phrasing
+	 * - `Name or service not known` / `nodename nor servname` — getaddrinfo
+	 * - `NXDOMAIN` — non-existent domain from the resolver
+	 *
+	 * @param string $error_message The failure message from the HTTP result.
+	 * @return bool True when the source is permanently unreachable.
+	 */
+	private function isUnrecoverableSourceError( string $error_message ): bool {
+		if ( '' === $error_message ) {
+			return false;
+		}
+
+		$signatures = array(
+			'curl error 6',
+			'could not resolve host',
+			'could not resolve:',
+			'name or service not known',
+			'nodename nor servname',
+			'nxdomain',
+		);
+
+		$haystack = strtolower( $error_message );
+
+		foreach ( $signatures as $signature ) {
+			if ( false !== strpos( $haystack, $signature ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Closes #390

## Symptom

`events.extrachill.com` logged **19** `Universal Web Scraper: HTTP request failed` entries in 24h for a venue whose domain no longer resolves. Real log context from `c8c_7_datamachine_logs`:

```json
{"execution_mode":"flow","pipeline_id":14,"flow_id":113,"url":"https:\/\/www.elrockolounge.com\/","error":"Failed to connect to Universal Web Scraper (Fallback): cURL error 6: Could not resolve host: www.elrockolounge.com","handler":"universal_web_scraper","agent_id":6}
```

Confirmed from the VPS: that domain returns `Could not resolve host` — permanently dead DNS, not transient. The scraper retried its WP REST + Tribe Events API fallbacks every cron cycle and hard-errored each time.

## What changed

`UniversalWebScraper::fetch_html()` now classifies an HTTP failure as **unrecoverable** when the source host's DNS no longer resolves, and emits a single clear `warning` signal instead of an `error` on every cycle.

- New private helper `isUnrecoverableSourceError()` does signature-based matching against the resolver/cURL error strings that surface through WordPress' HTTP transport:
  - `cURL error 6` (CURLE_COULDNT_RESOLVE_HOST)
  - `Could not resolve host` / `Could not resolve:`
  - `Name or service not known` / `nodename nor servname` (getaddrinfo)
  - `NXDOMAIN`
- When matched, the handler logs `warning` (`reason: dns_unresolvable`, with the URL) and returns empty, exactly as before — no behavior change to the fetch flow, only log severity.
- Transient failures (timeouts, 5xx, bot-blocks, connection resets) still log at `error` / flow normally, unchanged.

## Detection approach: unrecoverable vs transient

The classifier matches only the DNS-resolution family of failures, which never recover on retry (the domain is gone). Everything else — rate limits, captchas, origin-down, TLS errors, timeouts — stays on the existing `error` path because those can legitimately succeed on a later cycle. Detection is intentionally **generic with no hardcoded hostnames**, so it applies to any dead venue source.

This mirrors the existing policy already in DM core's `HttpClient::handleHttpError()`, which deliberately downgrades "expected external attrition" (403 bot-blocks, 404 moved pages, 5xx origin-down) to `warning` while keeping true transport faults at `error`. This PR extends that same philosophy to the one unrecoverable transport class — dead DNS — at the handler level.

## Reuse vs new primitive

I checked the existing flow-health / consecutive-failure machinery in DM core (`get_flow_health`, `update_flow_health_cache`, `FlowHealthAbility`, `ProblemFlowsAbility`) before adding anything:

- That system is a **job-level monitoring/reporting** primitive — it counts consecutive failed *jobs* for surfacing problem flows to an operator. It does **not** suppress per-source retries and does **not** change log severity, so it would not stop the per-cron error flood on its own.
- It also keys on job status, not per-source HTTP reachability, so it can't distinguish a dead-DNS source from any other failure.

So rather than build a parallel quarantine table, this PR makes the **handler** stop classifying a permanently-dead source as an `error` — the minimal, correct fix for the flood. The existing `ProblemFlowsAbility` continues to surface the flow as a problem flow for operator review (it still produces no items), and operators can re-qualify/remove dead sources via the `wp extrachill venues` tooling. The unrecoverable `warning` (with `reason: dns_unresolvable`) is the clear, greppable signal for that.

## Fork decisions / out of scope

- **Severity-downgrade over auto-disable.** Issue #390 floated either (a) a consecutive-failure quarantine that auto-disables a flow, or (b) downgrading unrecoverable errors to a single clear signal. I chose (b) because the prompt and issue both state the operator owns the prod cleanup (disabling/removing the elrockolounge flow), and auto-disabling a flow from inside a fetch handler is a heavier, riskier behavior change that belongs in the flow/scheduler layer, not the scraper. The downgrade fully resolves the stated acceptance criteria (dead sources no longer retry-and-error-log at error severity; a clear `dns_unresolvable` signal exists).
- **Did not edit DM core `HttpClient`.** The result array it returns to the handler does not expose `error_code`, only the `error` string, so classification is done by matching that string in the events handler. Surfacing a structured `error_code` from core would be a cleaner long-term contract but is a separate cross-repo change, out of scope for this events-only PR.
- The operator handles the one-off prod flow cleanup; no production flow is touched here.