### PR TITLE
fix: make Ticketmaster HTTP 429 spike-arrest non-fatal with backoff

### DIFF
--- a/inc/Steps/EventImport/Handlers/Ticketmaster/Ticketmaster.php
+++ b/inc/Steps/EventImport/Handlers/Ticketmaster/Ticketmaster.php
@@ -35,6 +35,28 @@ class Ticketmaster extends EventImportHandler {
 
 	const MAX_PAGE = 19;
 
+	/**
+	 * Maximum number of retry attempts when the Discovery API answers HTTP 429
+	 * (spike-arrest). Ticketmaster's spike-arrest window is short (rate is
+	 * expressed per-second/per-minute), so a few bounded retries reliably clear
+	 * it without hard-failing the job or losing import volume.
+	 */
+	const RATE_LIMIT_MAX_RETRIES = 3;
+
+	/**
+	 * Base back-off in seconds for the first 429 retry. Subsequent retries grow
+	 * exponentially (base, base*2, base*4, ...) with added jitter so that the
+	 * many per-city geo-radius pipelines that tripped the limit together do not
+	 * all wake up and re-fire on the same instant.
+	 */
+	const RATE_LIMIT_BACKOFF_BASE_SECONDS = 1;
+
+	/**
+	 * Upper bound on a single back-off sleep, in seconds. Keeps a job from
+	 * parking on a sleep() longer than is useful inside one fetch run.
+	 */
+	const RATE_LIMIT_BACKOFF_MAX_SECONDS = 8;
+
 	public function __construct() {
 		parent::__construct( 'ticketmaster' );
 
@@ -364,18 +386,18 @@ class Ticketmaster extends EventImportHandler {
 	private function fetch_events( array $params, ExecutionContext $context ): array {
 		$url = self::API_BASE . 'events.json?' . http_build_query( $params );
 
-		$result = $this->httpGet(
-			$url,
-			array(
-				'timeout' => 30,
-				'headers' => array(
-					'Accept' => 'application/json',
-				),
-			)
-		);
+		$result = $this->request_events_page( $url, $context );
 
 		if ( ! $result['success'] ) {
-			$context->log( 'error', 'Ticketmaster: API request failed', array( 'error' => $result['error'] ?? 'Unknown error' ) );
+			// A 429 that survived every retry is a transient throttle, not a
+			// Data-Machine-side fault — log it at warning so it stops flooding
+			// the error log. Any other failure stays an error.
+			$severity = $this->is_rate_limited( $result ) ? 'warning' : 'error';
+			$context->log(
+				$severity,
+				'Ticketmaster: API request failed',
+				array( 'error' => $result['error'] ?? 'Unknown error' )
+			);
 			return array(
 				'events' => array(),
 				'page'   => array(
@@ -395,6 +417,164 @@ class Ticketmaster extends EventImportHandler {
 				'totalPages' => 1,
 			),
 		);
+	}
+
+	/**
+	 * GET an events page, retrying through Ticketmaster spike-arrest (HTTP 429).
+	 *
+	 * Multiple per-city geo-radius pipelines drain on the same heartbeat cron
+	 * tick and collectively blow Ticketmaster's spike-arrest limit (5 messages
+	 * per period). The window is short, so instead of hard-failing the job we
+	 * back off and retry in-process. Events still import — just a beat later —
+	 * so import volume is preserved and the error log stays quiet.
+	 *
+	 * The back-off respects the API's `Retry-After` header when present (and
+	 * when the underlying client surfaces it), otherwise it grows exponentially
+	 * with jitter to de-synchronise the pipelines that tripped the limit
+	 * together.
+	 *
+	 * @param string           $url     Fully built Discovery API events URL.
+	 * @param ExecutionContext $context Execution context for logging.
+	 * @return array HttpClient-shaped result (success/data/error/...).
+	 */
+	private function request_events_page( string $url, ExecutionContext $context ): array {
+		$attempt = 0;
+
+		do {
+			$result = $this->httpGet(
+				$url,
+				array(
+					'timeout' => 30,
+					'headers' => array(
+						'Accept' => 'application/json',
+					),
+				)
+			);
+
+			if ( $result['success'] || ! $this->is_rate_limited( $result ) ) {
+				return $result;
+			}
+
+			if ( $attempt >= self::RATE_LIMIT_MAX_RETRIES ) {
+				return $result;
+			}
+
+			$delay = $this->rate_limit_backoff_seconds( $result, $attempt );
+
+			$context->log(
+				'warning',
+				'Ticketmaster: spike-arrest (HTTP 429), backing off before retry',
+				array(
+					'attempt'       => $attempt + 1,
+					'max_retries'   => self::RATE_LIMIT_MAX_RETRIES,
+					'delay_seconds' => $delay,
+				)
+			);
+
+			if ( $delay > 0 ) {
+				sleep( $delay );
+			}
+
+			++$attempt;
+		} while ( $attempt <= self::RATE_LIMIT_MAX_RETRIES );
+
+		return $result;
+	}
+
+	/**
+	 * Whether an HttpClient result represents a Ticketmaster spike-arrest (429).
+	 *
+	 * HttpClient collapses non-2xx responses to `{ success: false, error }` and
+	 * does not surface the numeric status code on the failure path, so the 429
+	 * is detected from the error message it builds
+	 * (`"<context> GET returned HTTP 429: ..."`).
+	 *
+	 * @param array $result HttpClient-shaped result.
+	 * @return bool
+	 */
+	private function is_rate_limited( array $result ): bool {
+		if ( ! empty( $result['success'] ) ) {
+			return false;
+		}
+
+		if ( isset( $result['status_code'] ) && 429 === (int) $result['status_code'] ) {
+			return true;
+		}
+
+		$error = (string) ( $result['error'] ?? '' );
+
+		return false !== stripos( $error, 'HTTP 429' );
+	}
+
+	/**
+	 * Compute the back-off delay (seconds) before the next 429 retry.
+	 *
+	 * Prefers the server's `Retry-After` hint when the client surfaces response
+	 * headers; otherwise falls back to exponential growth with jitter, clamped
+	 * to a sane upper bound.
+	 *
+	 * @param array $result  HttpClient-shaped result for the throttled request.
+	 * @param int   $attempt Zero-based retry attempt index.
+	 * @return int Delay in whole seconds (>= 0).
+	 */
+	private function rate_limit_backoff_seconds( array $result, int $attempt ): int {
+		$retry_after = $this->retry_after_seconds( $result );
+		if ( null !== $retry_after ) {
+			return min( max( $retry_after, 0 ), self::RATE_LIMIT_BACKOFF_MAX_SECONDS );
+		}
+
+		$base   = self::RATE_LIMIT_BACKOFF_BASE_SECONDS * ( 2 ** $attempt );
+		$base   = min( $base, self::RATE_LIMIT_BACKOFF_MAX_SECONDS );
+		$jitter = wp_rand( 0, 1 );
+
+		return min( $base + $jitter, self::RATE_LIMIT_BACKOFF_MAX_SECONDS );
+	}
+
+	/**
+	 * Extract a `Retry-After` delay in seconds from a result's response headers.
+	 *
+	 * Supports both delta-seconds (`Retry-After: 5`) and HTTP-date forms. When
+	 * the client does not surface headers on the failure path (the common case
+	 * today) this returns null and the caller falls back to exponential backoff.
+	 *
+	 * @param array $result HttpClient-shaped result.
+	 * @return int|null Seconds to wait, or null when unavailable.
+	 */
+	private function retry_after_seconds( array $result ): ?int {
+		$headers = $result['headers'] ?? null;
+
+		$value = null;
+		if ( is_array( $headers ) ) {
+			foreach ( $headers as $name => $header_value ) {
+				if ( 0 === strcasecmp( (string) $name, 'Retry-After' ) ) {
+					$value = is_array( $header_value ) ? reset( $header_value ) : $header_value;
+					break;
+				}
+			}
+		} elseif ( is_object( $headers ) && method_exists( $headers, 'offsetGet' ) && method_exists( $headers, 'offsetExists' ) ) {
+			// wp_remote_retrieve_headers() returns a Requests case-insensitive
+			// dictionary implementing ArrayAccess.
+			if ( $headers->offsetExists( 'retry-after' ) ) {
+				$value = $headers->offsetGet( 'retry-after' );
+			}
+		}
+
+		if ( null === $value || '' === $value ) {
+			return null;
+		}
+
+		$value = trim( (string) $value );
+
+		if ( ctype_digit( $value ) ) {
+			return (int) $value;
+		}
+
+		$timestamp = strtotime( $value );
+		if ( false === $timestamp ) {
+			return null;
+		}
+
+		return max( $timestamp - time(), 0 );
 	}
 
 	private function map_ticketmaster_event( array $tm_event ): array {

--- a/tests/Unit/TicketmasterHandlerTest.php
+++ b/tests/Unit/TicketmasterHandlerTest.php
@@ -178,6 +178,125 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 		$this->assertEquals( '', $result['price'] );
 	}
 
+	public function test_is_rate_limited_detects_429_from_error_message() {
+		$method = $this->getProtectedMethod( 'is_rate_limited' );
+
+		$result = array(
+			'success' => false,
+			'error'   => 'Ticketmaster GET returned HTTP 429: {"fault":{"faultstring":"Spike arrest violation"}}',
+		);
+
+		$this->assertTrue( $method->invoke( $this->handler, $result ) );
+	}
+
+	public function test_is_rate_limited_detects_429_from_status_code() {
+		$method = $this->getProtectedMethod( 'is_rate_limited' );
+
+		$result = array(
+			'success'     => false,
+			'status_code' => 429,
+			'error'       => 'throttled',
+		);
+
+		$this->assertTrue( $method->invoke( $this->handler, $result ) );
+	}
+
+	public function test_is_rate_limited_false_for_success() {
+		$method = $this->getProtectedMethod( 'is_rate_limited' );
+
+		$result = array(
+			'success'     => true,
+			'status_code' => 200,
+			'data'        => '{}',
+		);
+
+		$this->assertFalse( $method->invoke( $this->handler, $result ) );
+	}
+
+	public function test_is_rate_limited_false_for_other_errors() {
+		$method = $this->getProtectedMethod( 'is_rate_limited' );
+
+		$result = array(
+			'success' => false,
+			'error'   => 'Ticketmaster GET returned HTTP 500: server error',
+		);
+
+		$this->assertFalse( $method->invoke( $this->handler, $result ) );
+	}
+
+	public function test_retry_after_seconds_parses_delta_seconds_header() {
+		$method = $this->getProtectedMethod( 'retry_after_seconds' );
+
+		$result = array(
+			'success' => false,
+			'headers' => array( 'Retry-After' => '5' ),
+		);
+
+		$this->assertSame( 5, $method->invoke( $this->handler, $result ) );
+	}
+
+	public function test_retry_after_seconds_is_case_insensitive() {
+		$method = $this->getProtectedMethod( 'retry_after_seconds' );
+
+		$result = array(
+			'success' => false,
+			'headers' => array( 'retry-after' => '3' ),
+		);
+
+		$this->assertSame( 3, $method->invoke( $this->handler, $result ) );
+	}
+
+	public function test_retry_after_seconds_null_when_absent() {
+		$method = $this->getProtectedMethod( 'retry_after_seconds' );
+
+		$result = array(
+			'success' => false,
+			'error'   => 'Ticketmaster GET returned HTTP 429: throttled',
+		);
+
+		$this->assertNull( $method->invoke( $this->handler, $result ) );
+	}
+
+	public function test_backoff_grows_exponentially_and_is_clamped() {
+		$method = $this->getProtectedMethod( 'rate_limit_backoff_seconds' );
+
+		$result = array(
+			'success' => false,
+			'error'   => 'Ticketmaster GET returned HTTP 429: throttled',
+		);
+
+		// Without a Retry-After header, delay grows with the attempt index and
+		// is clamped to RATE_LIMIT_BACKOFF_MAX_SECONDS. Jitter adds 0 or 1s.
+		$delay0 = $method->invoke( $this->handler, $result, 0 );
+		$delay3 = $method->invoke( $this->handler, $result, 3 );
+
+		$this->assertGreaterThanOrEqual( 1, $delay0 );
+		$this->assertLessThanOrEqual( 8, $delay0 );
+		$this->assertLessThanOrEqual( 8, $delay3 );
+	}
+
+	public function test_backoff_respects_retry_after_header() {
+		$method = $this->getProtectedMethod( 'rate_limit_backoff_seconds' );
+
+		$result = array(
+			'success' => false,
+			'headers' => array( 'Retry-After' => '4' ),
+		);
+
+		$this->assertSame( 4, $method->invoke( $this->handler, $result, 0 ) );
+	}
+
+	public function test_backoff_clamps_oversized_retry_after_header() {
+		$method = $this->getProtectedMethod( 'rate_limit_backoff_seconds' );
+
+		$result = array(
+			'success' => false,
+			'headers' => array( 'Retry-After' => '600' ),
+		);
+
+		$this->assertSame( 8, $method->invoke( $this->handler, $result, 0 ) );
+	}
+
 	private function getProtectedMethod( string $name ) {
 		$reflection = new ReflectionClass( $this->handler );
 		$method     = $reflection->getMethod( $name );


### PR DESCRIPTION
## Summary

Makes Ticketmaster Discovery API **HTTP 429 (spike-arrest)** non-fatal. The handler now backs off and retries in-process instead of hard-failing the job and flooding the error log.

Closes #389

## The 429 evidence

From `c8c_7_datamachine_logs` on events.extrachill.com — 10 errors in 24h, same signature across multiple pipelines:

```json
{"execution_mode":"flow","pipeline_id":34,"flow_id":178,"error":"Ticketmaster GET returned HTTP 429: {\"fault\":{\"faultstring\":\"Spike arrest violation. Allowed rate : MessageRate{messagesPerPeriod=5, ...","handler":"ticketmaster","agent_id":6}
```

Same 429 on pipeline 29 (flow 163) and others. The bulk geo-radius layer is one DM pipeline per city; when the heartbeat cron drains all due pipelines on one tick, they hit the Discovery API concurrently and collectively blow the **5 messages/period** spike-arrest. The events still import on a later run — it was wasteful and noisy, not a real failure.

## What changed and why (backoff + severity)

In `inc/Steps/EventImport/Handlers/Ticketmaster/Ticketmaster.php`:

- **Backoff + retry** — new `request_events_page()` wraps the events GET and retries through 429 with **bounded attempts (3) and exponential backoff + jitter** (`1s, 2s, 4s` base, clamped to `8s`). The spike-arrest window is short, so a few retries reliably clear it. Jitter de-synchronises the per-city pipelines that tripped the limit together, so they don't all wake and re-fire on the same instant. **Events still import — just a beat later — so import volume is preserved.**
- **Retry-After aware** — `rate_limit_backoff_seconds()` prefers a `Retry-After` header (delta-seconds or HTTP-date) when the client surfaces one, clamped to the upper bound; otherwise it falls back to exponential growth.
- **Severity downgrade** — a 429 that survives every retry is logged at `warning` (transient throttle), not `error`. This matches the existing precedent in data-machine core's `HttpClient::handleHttpError()`, which already logs received-but-non-2xx responses at `warning` as "expected external attrition." All other failures stay `error`.

New unit tests in `tests/Unit/TicketmasterHandlerTest.php` cover 429 detection (from error message and status code), `Retry-After` parsing (case-insensitive, delta-seconds, absent), and backoff growth/clamping.

## Fork decisions & reasoning

- **In-handler retry vs. core change to surface `Retry-After`.** data-machine core's `HttpClient::handleHttpError()` collapses non-2xx responses to `{ success: false, error }` and **drops `status_code` and `headers` on the failure path** — so the handler can't read the `Retry-After` header today. Modifying core is a different repo and out of scope for this events-only issue, so 429 is detected from the error message string (`"...returned HTTP 429..."`) that `HttpClient` builds. The Retry-After plumbing is written to *also* work the moment the client surfaces headers (it checks `status_code` and `headers` first), so it degrades gracefully and improves automatically if core starts surfacing them. **Follow-up worth filing against data-machine core:** have `handleHttpError()` include `status_code` + `headers` in the failure return so rate-limit handling everywhere can be header-driven rather than string-sniffing.
- **In-process `sleep()` backoff vs. rescheduling the job via Action Scheduler.** Rescheduling would require threading retry state through the fetch/batch lifecycle (the handler returns plain item arrays and has no reschedule hook). In-process backoff is self-contained, keeps the fix inside the handler, and the spike-arrest window is short enough (seconds) that a bounded sleep is appropriate and far simpler than a stateful reschedule.

## Deliberately out of scope

- **Schedule stagger across per-city pipelines.** The issue lists backoff **and/or** schedule stagger. Staggering the cron schedules of N per-city pipelines is a scheduling-layer concern (pipeline/flow scheduling), not a handler concern, and would be a larger, separate change. Backoff + jitter already breaks the synchronized-fire problem from the handler side without it. If 429s persist at scale, a stagger pass on the geo-radius pipeline schedules is the natural next step — but it does not belong in this handler PR.
- **Core change to surface `Retry-After`** — noted above; belongs in data-machine, not data-machine-events.

## Testing

- `php -l` clean on both files.
- `homeboy lint --changed-since origin/main`: **PHPCS passed, PHPStan passed, Linting passed.** (The only non-zero exit was a CI-parity warning that the local `data-machine` dependency checkout is 14 commits behind origin/main — an environment condition, not a finding on these changes.)