### PR TITLE
Stabilize event date handling: validating chokepoint across AI gate, storage, and render

### DIFF
--- a/inc/Blocks/Calendar/Display/DisplayVars.php
+++ b/inc/Blocks/Calendar/Display/DisplayVars.php
@@ -15,6 +15,7 @@ namespace DataMachineEvents\Blocks\Calendar\Display;
 use DateTime;
 use DateTimeZone;
 use DataMachineEvents\Blocks\Calendar\Grouping\DateGrouper;
+use DataMachineEvents\Core\DateTimeParser;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -39,17 +40,25 @@ class DisplayVars {
 		$iso_start_date         = '';
 		$multi_day_label        = '';
 
-		if ( $start_date ) {
-			$event_tz           = DateGrouper::get_event_timezone( $event_data );
-			$start_datetime_obj = new DateTime( $start_date . ' ' . $start_time, $event_tz );
-			$iso_start_date     = $start_datetime_obj->format( 'c' );
+		$event_tz           = DateGrouper::get_event_timezone( $event_data );
+		$start_datetime_obj = $start_date
+			? DateTimeParser::safeCreate( $start_date . ' ' . $start_time, $event_tz )
+			: null;
+
+		// A malformed/placeholder startDate that predates the prevention layers
+		// cannot be formatted. Degrade gracefully — return empty display vars for
+		// the date fields rather than throwing on the render path. See #394.
+		if ( $start_datetime_obj instanceof DateTime ) {
+			$iso_start_date = $start_datetime_obj->format( 'c' );
 
 			$is_multi_day    = ! empty( $display_context['is_multi_day'] );
 			$is_continuation = ! empty( $display_context['is_continuation'] );
 
-			if ( $is_multi_day && ! empty( $end_date ) ) {
-				$end_datetime_obj = new DateTime( $end_date, $event_tz );
+			$end_datetime_obj = ( $is_multi_day && ! empty( $end_date ) )
+				? DateTimeParser::safeCreate( $end_date, $event_tz )
+				: null;
 
+			if ( $is_multi_day && ! empty( $end_date ) && $end_datetime_obj instanceof DateTime ) {
 				if ( $is_continuation ) {
 					$formatted_time_display = sprintf(
 						/* translators: %s: end date. Example: "Ongoing · ends Mar 22" */
@@ -101,7 +110,12 @@ class DisplayVars {
 			return $start_formatted_full;
 		}
 
-		$end_datetime_obj = new DateTime( $end_date . ' ' . $end_time, $event_tz );
+		$end_datetime_obj = DateTimeParser::safeCreate( $end_date . ' ' . $end_time, $event_tz );
+
+		// A malformed end date can't form a range; just show the start time.
+		if ( ! $end_datetime_obj instanceof DateTime ) {
+			return $start_formatted_full;
+		}
 
 		// Don't show a range when start and end are identical (no real end time).
 		if ( $start_datetime_obj->format( 'Y-m-d H:i' ) === $end_datetime_obj->format( 'Y-m-d H:i' ) ) {

--- a/inc/Blocks/Calendar/Grouping/DateGrouper.php
+++ b/inc/Blocks/Calendar/Grouping/DateGrouper.php
@@ -15,6 +15,7 @@ use DateTime;
 use DateTimeZone;
 use WP_Query;
 use DataMachineEvents\Blocks\Calendar\Data\EventHydrator;
+use DataMachineEvents\Core\DateTimeParser;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -43,10 +44,17 @@ class DateGrouper {
 			if ( $event_data ) {
 				$start_time     = $event_data['startTime'] ?? '00:00:00';
 				$event_tz       = self::get_event_timezone( $event_data );
-				$event_datetime = new DateTime(
-					$event_data['startDate'] . ' ' . $start_time,
+				$event_datetime = DateTimeParser::safeCreate(
+					( $event_data['startDate'] ?? '' ) . ' ' . $start_time,
 					$event_tz
 				);
+
+				// A malformed/placeholder startDate that slipped into storage
+				// before the prevention layers existed cannot be rendered.
+				// Skip it rather than fataling the whole calendar. See #394.
+				if ( null === $event_datetime ) {
+					continue;
+				}
 
 				$paged_events[] = array(
 					'post'       => $event_post,
@@ -139,7 +147,12 @@ class DateGrouper {
 			}
 
 			foreach ( $event_dates as $index => $date_key ) {
-				$display_datetime_obj = new DateTime( $date_key . ' 00:00:00', $event_tz );
+				$display_datetime_obj = DateTimeParser::safeCreate( $date_key . ' 00:00:00', $event_tz );
+
+				// Defensive: a malformed date key cannot anchor a day group.
+				if ( null === $display_datetime_obj ) {
+					continue;
+				}
 
 				if ( ! isset( $date_groups[ $date_key ] ) ) {
 					$date_groups[ $date_key ] = array(
@@ -235,15 +248,22 @@ class DateGrouper {
 		$previous_date = null;
 
 		foreach ( $date_groups as $date_key => $date_group ) {
+			$current_date = DateTimeParser::safeCreate( $date_key, wp_timezone() );
+
+			// A malformed group key can't participate in gap math; skip it
+			// without throwing or resetting the previous-date cursor.
+			if ( null === $current_date ) {
+				continue;
+			}
+
 			if ( null !== $previous_date ) {
-				$current_date = new DateTime( $date_key, wp_timezone() );
-				$days_diff    = $current_date->diff( $previous_date )->days;
+				$days_diff = $current_date->diff( $previous_date )->days;
 
 				if ( $days_diff > 1 ) {
 					$gaps[ $date_key ] = $days_diff;
 				}
 			}
-			$previous_date = new DateTime( $date_key, wp_timezone() );
+			$previous_date = $current_date;
 		}
 
 		return $gaps;

--- a/inc/Blocks/Calendar/Grouping/MultiDayResolver.php
+++ b/inc/Blocks/Calendar/Grouping/MultiDayResolver.php
@@ -15,6 +15,7 @@ namespace DataMachineEvents\Blocks\Calendar\Grouping;
 use DateTime;
 use DateTimeZone;
 use DataMachineEvents\Admin\Settings_Page;
+use DataMachineEvents\Core\DateTimeParser;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -47,7 +48,7 @@ class MultiDayResolver {
 		// Placeholder / TBD dates (e.g. "2026-07-??") are not parseable and
 		// cannot be expanded into a date range. Treat them as single-day so
 		// the calendar still renders rather than throwing a fatal.
-		if ( ! self::is_valid_date( $start_date ) || ! self::is_valid_date( $end_date ) ) {
+		if ( ! DateTimeParser::isValidYmd( $start_date ) || ! DateTimeParser::isValidYmd( $end_date ) ) {
 			return false;
 		}
 
@@ -85,8 +86,8 @@ class MultiDayResolver {
 		// Guard against placeholder / malformed dates that would throw a
 		// DateMalformedStringException. is_multi_day() already filters these,
 		// but get_date_range() is a public entry point in its own right.
-		if ( ! self::is_valid_date( $start_date ) || ! self::is_valid_date( $end_date ) ) {
-			if ( self::is_valid_date( $start_date ) ) {
+		if ( ! DateTimeParser::isValidYmd( $start_date ) || ! DateTimeParser::isValidYmd( $end_date ) ) {
+			if ( DateTimeParser::isValidYmd( $start_date ) ) {
 				$dates[] = $start_date;
 			}
 
@@ -106,24 +107,5 @@ class MultiDayResolver {
 		}
 
 		return $dates;
-	}
-
-	/**
-	 * Strictly validate a Y-m-d date string.
-	 *
-	 * Rejects placeholder / TBD values (e.g. "2026-07-??") and any string
-	 * that does not represent a real calendar date, so callers can avoid
-	 * passing unparseable input into DateTime and triggering a
-	 * DateMalformedStringException.
-	 *
-	 * @param string $date Date string to validate.
-	 * @return bool True when $date is a valid Y-m-d calendar date.
-	 */
-	private static function is_valid_date( string $date ): bool {
-		if ( ! preg_match( '/^(\d{4})-(\d{2})-(\d{2})$/', $date, $matches ) ) {
-			return false;
-		}
-
-		return checkdate( (int) $matches[2], (int) $matches[3], (int) $matches[1] );
 	}
 }

--- a/inc/Core/DateTimeParser.php
+++ b/inc/Core/DateTimeParser.php
@@ -260,6 +260,67 @@ class DateTimeParser {
 	}
 
 	/**
+	 * Strictly validate a Y-m-d date string.
+	 *
+	 * The single source of truth for "is this a real calendar date in
+	 * canonical YYYY-MM-DD form?". Rejects placeholder / TBD values
+	 * (e.g. "2026-07-??", "2026-??-??"), out-of-range values
+	 * (e.g. "2026-13-01"), and impossible calendar dates
+	 * (e.g. "2026-02-30"). Used at the AI gate, the storage chokepoint,
+	 * and the render path so an unparseable string can never reach a
+	 * `new DateTime()` and throw a DateMalformedStringException.
+	 *
+	 * @param string $date Date string to validate.
+	 * @return bool True when $date is a valid Y-m-d calendar date.
+	 */
+	public static function isValidYmd( string $date ): bool {
+		if ( ! preg_match( '/^(\d{4})-(\d{2})-(\d{2})$/', $date, $matches ) ) {
+			return false;
+		}
+
+		return checkdate( (int) $matches[2], (int) $matches[3], (int) $matches[1] );
+	}
+
+	/**
+	 * Non-throwing DateTime factory.
+	 *
+	 * Returns null instead of throwing when the date is not a valid
+	 * Y-m-d calendar date. Render-path callers use this to degrade
+	 * gracefully (skip a row / fall back) when a malformed date slipped
+	 * into storage before the prevention layers existed.
+	 *
+	 * The date is validated with isValidYmd() first; a DateTime is only
+	 * constructed when the date is known-good, so this never throws.
+	 * An optional time-of-day suffix (e.g. " 00:00:00" or " 19:30") may
+	 * be appended after the Y-m-d date.
+	 *
+	 * @param string            $date Date string. May be a bare Y-m-d or
+	 *                                "Y-m-d H:i[:s]" — only the leading
+	 *                                Y-m-d portion is validated.
+	 * @param DateTimeZone|null  $tz   Optional timezone.
+	 * @return DateTime|null DateTime on success, null on invalid input.
+	 */
+	public static function safeCreate( string $date, ?DateTimeZone $tz = null ): ?DateTime {
+		$date = trim( $date );
+
+		if ( '' === $date ) {
+			return null;
+		}
+
+		// Only the leading Y-m-d is validated; an optional time suffix may follow.
+		$ymd = substr( $date, 0, 10 );
+		if ( ! self::isValidYmd( $ymd ) ) {
+			return null;
+		}
+
+		try {
+			return null !== $tz ? new DateTime( $date, $tz ) : new DateTime( $date );
+		} catch ( Exception $e ) {
+			return null;
+		}
+	}
+
+	/**
 	 * Validate IANA timezone identifier.
 	 *
 	 * @param string $timezone Timezone to validate

--- a/inc/Core/event-dates-sync.php
+++ b/inc/Core/event-dates-sync.php
@@ -206,6 +206,42 @@ function data_machine_events_sync_datetime_meta( $post_id, $post, $update ) {
 				$end_time .= ':00';
 			}
 
+			// Universal write chokepoint: never let a malformed/placeholder date
+			// (e.g. "2026-07-??") be concatenated into a DATETIME and written to
+			// the event_dates table. On non-strict sql_mode MySQL silently
+			// coerces these to "0000-00-00 00:00:00", which then detonates on the
+			// render path. Every write path (AI, manual, CLI, backfill) funnels
+			// through save_post, so guarding here protects all of them. Skip the
+			// datetime sync cleanly rather than throwing or writing a junk row.
+			// See issue #394.
+			$has_valid_start = $start_date && DateTimeParser::isValidYmd( $start_date );
+			$has_invalid_end = $end_date && ! DateTimeParser::isValidYmd( $end_date );
+
+			if ( $start_date && ( ! $has_valid_start || $has_invalid_end ) ) {
+				do_action(
+					'datamachine_log',
+					'warning',
+					'Event date sync skipped: malformed startDate/endDate would write an invalid DATETIME',
+					array(
+						'post_id'   => $post_id,
+						'startDate' => $start_date,
+						'endDate'   => $end_date,
+					)
+				);
+
+				// Still keep the ticket URL meta in sync, then stop before the
+				// datetime write. Do not fall through to the EventDatesTable::delete()
+				// branch — that is reserved for the genuinely date-less case.
+				$ticket_url = $block['attrs']['ticketUrl'] ?? '';
+				if ( $ticket_url ) {
+					update_post_meta( $post_id, EVENT_TICKET_URL_META_KEY, datamachine_normalize_ticket_url( $ticket_url ) );
+				} else {
+					delete_post_meta( $post_id, EVENT_TICKET_URL_META_KEY );
+				}
+
+				break;
+			}
+
 			if ( $start_date ) {
 				$effective_start_time = $start_time ? $start_time : '00:00:00';
 				$datetime             = $start_date . ' ' . $effective_start_time;

--- a/inc/Steps/Upsert/Events/EventUpsert.php
+++ b/inc/Steps/Upsert/Events/EventUpsert.php
@@ -1239,8 +1239,23 @@ class EventUpsert extends UpsertHandler {
 	private function getDateTimeConfidence( array $parameters, EngineData $engine ): string {
 		$start_date = trim( (string) ( $engine->get( 'startDate' ) ?? $parameters['startDate'] ?? '' ) );
 		$start_time = trim( (string) ( $engine->get( 'startTime' ) ?? $parameters['startTime'] ?? '' ) );
+		$end_date   = trim( (string) ( $engine->get( 'endDate' ) ?? $parameters['endDate'] ?? '' ) );
 
 		if ( '' === $start_date ) {
+			return 'none';
+		}
+
+		// A non-empty-but-unparseable startDate (e.g. "2026-07-??", "2026-??-??")
+		// must not auto-publish a junk date. Treat it like a missing date so the
+		// existing rejection path fires and the AI calls reject_source instead.
+		// Mirrors the junk-title guard. See issue #394.
+		if ( ! \DataMachineEvents\Core\DateTimeParser::isValidYmd( $start_date ) ) {
+			return 'none';
+		}
+
+		// A present-but-invalid endDate is equally unstorable; reject rather than
+		// concatenate a malformed DATETIME downstream.
+		if ( '' !== $end_date && ! \DataMachineEvents\Core\DateTimeParser::isValidYmd( $end_date ) ) {
 			return 'none';
 		}
 

--- a/tests/Unit/DateTimeParserTest.php
+++ b/tests/Unit/DateTimeParserTest.php
@@ -11,6 +11,8 @@
 namespace DataMachineEvents\Tests\Unit;
 
 use WP_UnitTestCase;
+use DateTime;
+use DateTimeZone;
 use DataMachineEvents\Core\DateTimeParser;
 
 class DateTimeParserTest extends WP_UnitTestCase {
@@ -154,5 +156,94 @@ class DateTimeParserTest extends WP_UnitTestCase {
 		$this->assertFalse( DateTimeParser::isValidTimezone( 'Invalid/Timezone' ) );
 		$this->assertFalse( DateTimeParser::isValidTimezone( '' ) );
 		$this->assertFalse( DateTimeParser::isValidTimezone( 'CST' ) );
+	}
+
+	/**
+	 * isValidYmd is the single source of truth for "is this a real
+	 * canonical Y-m-d date?". It must reject the placeholder / TBD strings
+	 * (e.g. "2026-07-??") that caused the original fatal (#394), out-of-range
+	 * months/days, impossible calendar dates, and empty input — while
+	 * accepting genuine dates.
+	 */
+	public function test_is_valid_ymd_rejects_placeholder_day() {
+		$this->assertFalse( DateTimeParser::isValidYmd( '2026-07-??' ) );
+	}
+
+	public function test_is_valid_ymd_rejects_placeholder_month_and_day() {
+		$this->assertFalse( DateTimeParser::isValidYmd( '2026-??-??' ) );
+	}
+
+	public function test_is_valid_ymd_rejects_out_of_range_month() {
+		$this->assertFalse( DateTimeParser::isValidYmd( '2026-13-01' ) );
+	}
+
+	public function test_is_valid_ymd_rejects_impossible_calendar_date() {
+		$this->assertFalse( DateTimeParser::isValidYmd( '2026-02-30' ) );
+	}
+
+	public function test_is_valid_ymd_rejects_empty_string() {
+		$this->assertFalse( DateTimeParser::isValidYmd( '' ) );
+	}
+
+	public function test_is_valid_ymd_rejects_non_ymd_shapes() {
+		$this->assertFalse( DateTimeParser::isValidYmd( '07/15/2026' ) );
+		$this->assertFalse( DateTimeParser::isValidYmd( '2026-7-5' ) );
+		$this->assertFalse( DateTimeParser::isValidYmd( '2026-07-15 19:30' ) );
+	}
+
+	public function test_is_valid_ymd_accepts_real_date() {
+		$this->assertTrue( DateTimeParser::isValidYmd( '2026-07-15' ) );
+		$this->assertTrue( DateTimeParser::isValidYmd( '2024-02-29' ) );
+	}
+
+	/**
+	 * safeCreate is the non-throwing factory used on the render path. It must
+	 * return null (never throw) for any input isValidYmd rejects, and a real
+	 * DateTime for valid input — including an optional time-of-day suffix.
+	 */
+	public function test_safe_create_returns_null_for_placeholder_day() {
+		$this->assertNull( DateTimeParser::safeCreate( '2026-07-??' ) );
+	}
+
+	public function test_safe_create_returns_null_for_placeholder_month_and_day() {
+		$this->assertNull( DateTimeParser::safeCreate( '2026-??-??' ) );
+	}
+
+	public function test_safe_create_returns_null_for_out_of_range_month() {
+		$this->assertNull( DateTimeParser::safeCreate( '2026-13-01' ) );
+	}
+
+	public function test_safe_create_returns_null_for_impossible_calendar_date() {
+		$this->assertNull( DateTimeParser::safeCreate( '2026-02-30' ) );
+	}
+
+	public function test_safe_create_returns_null_for_empty_string() {
+		$this->assertNull( DateTimeParser::safeCreate( '' ) );
+	}
+
+	public function test_safe_create_returns_datetime_for_valid_date() {
+		$dt = DateTimeParser::safeCreate( '2026-07-15' );
+
+		$this->assertInstanceOf( DateTime::class, $dt );
+		$this->assertEquals( '2026-07-15', $dt->format( 'Y-m-d' ) );
+	}
+
+	public function test_safe_create_accepts_time_suffix() {
+		$dt = DateTimeParser::safeCreate( '2026-07-15 19:30:00' );
+
+		$this->assertInstanceOf( DateTime::class, $dt );
+		$this->assertEquals( '2026-07-15 19:30:00', $dt->format( 'Y-m-d H:i:s' ) );
+	}
+
+	public function test_safe_create_honors_timezone() {
+		$tz = new DateTimeZone( 'America/New_York' );
+		$dt = DateTimeParser::safeCreate( '2026-07-15 00:00:00', $tz );
+
+		$this->assertInstanceOf( DateTime::class, $dt );
+		$this->assertEquals( 'America/New_York', $dt->getTimezone()->getName() );
+	}
+
+	public function test_safe_create_rejects_malformed_date_even_with_time_suffix() {
+		$this->assertNull( DateTimeParser::safeCreate( '2026-07-?? 00:00:00' ) );
 	}
 }


### PR DESCRIPTION
## Summary

Closes #394. A published event with date `2026-07-??` caused an uncaught `DateMalformedStringException` fatal in `MultiDayResolver`. v0.44.1 (#393) reactively guarded that one render site. This PR fixes the **root cause**: malformed/incomplete date strings could enter storage and publish with zero validation, because there was no canonical date chokepoint.

Four-part change, prevention-first:

1. **Shared helper (single source of truth)** — `Core/DateTimeParser` gains:
   - `isValidYmd( string ): bool` — strict `^\d{4}-\d{2}-\d{2}$` + `checkdate()` (promoted from `MultiDayResolver::is_valid_date()`).
   - `safeCreate( string, ?DateTimeZone ): ?DateTime` — non-throwing factory that validates with `isValidYmd()` first and returns `null` instead of throwing on bad input. Accepts an optional `H:i[:s]` suffix after the Y-m-d.

2. **Prevention #1 — AI gate** (`EventUpsert::getDateTimeConfidence()`) — a non-empty-but-invalid `startDate`/`endDate` (fails `isValidYmd`) now resolves to `'none'` confidence, so the existing `errorResponse`/rejection at the call site fires — mirroring the junk-title guard.

3. **Defense — storage chokepoint** (`event-dates-sync.php::data_machine_events_sync_datetime_meta()`, hooked `save_post`) — validate-or-bail before concatenating `$start_date . ' ' . $time`. On invalid start/end it logs a warning, keeps ticket-URL meta in sync, and skips the datetime write cleanly (no `0000-00-00` row, no throw). This is the universal write chokepoint; every write path (AI, manual, CLI, backfill) funnels through it.

4. **Resilience — render path** — `DateGrouper` (build/group/gap-detect) and `DisplayVars` (start/end/format-range) route their `new DateTime()` sites through `safeCreate()` and skip-the-row / fall-back when it returns null. `MultiDayResolver` migrated to `DateTimeParser::isValidYmd()`; its inline `is_valid_date()` removed.

## Product decision implemented (AI gate)

Per the issue, the AI gate **hard-rejects** an unparseable date via the existing rejection disposition rather than storing a junk date or auto-publishing it. This is option **(c)/(a)** behavior from the issue: never auto-publish an unparseable date. The richer **"date TBA" state (option b)** — an explicit incomplete-date concept surfaced on the calendar ("Coming July 2026 — date TBA") — is explicitly deferred as a future product enhancement and **not** built here, since it touches schema, block, render, and schema.org mapping. The conservative safety behavior ships now; the richer UX is a follow-up.

## Data cleanup

The data cleanup (#395) is tracked separately. The 7 affected live events are already handled (post 261090 unpublished; 6 drafts parked), so this PR is purely the code-side stabilization.

## Tests

- Added unit coverage to `tests/Unit/DateTimeParserTest.php` for `isValidYmd()` and `safeCreate()`: `2026-07-??` → invalid/null, `2026-??-??` → invalid/null, `2026-13-01` → invalid, `2026-02-30` → invalid, `2026-07-15` → valid, `` → invalid, plus time-suffix and timezone cases.
- The existing `tests/Unit/MultiDayResolverTest.php` (#393) still passes after the migration (it exercises the same regex+checkdate logic, now via the shared helper).
- `php -l` clean on all 7 touched files.

### Pre-existing test-harness gap

`homeboy test data-machine-events` currently fails before running any tests with `project PHPUnit bootstrap file not found: tests/bootstrap.php`. This is a **pre-existing harness gap** — `tests/bootstrap.php` does not exist on `main` either (`git show main:tests/bootstrap.php` → path does not exist), so `main` fails identically. Not introduced by this PR and out of scope. The new validation logic was verified instead with a standalone PHP reproduction (all `isValidYmd`/`safeCreate` cases pass).

## Touched files

- `inc/Core/DateTimeParser.php` — `isValidYmd()` + `safeCreate()`
- `inc/Steps/Upsert/Events/EventUpsert.php` — AI gate
- `inc/Core/event-dates-sync.php` — storage chokepoint
- `inc/Blocks/Calendar/Grouping/DateGrouper.php` — render
- `inc/Blocks/Calendar/Display/DisplayVars.php` — render
- `inc/Blocks/Calendar/Grouping/MultiDayResolver.php` — migrate to shared helper
- `tests/Unit/DateTimeParserTest.php` — unit tests