### PR TITLE
Layer purity: scrub Extra Chill identity from data-machine-events executable code

### DIFF
--- a/assets/js/venue-autocomplete.js
+++ b/assets/js/venue-autocomplete.js
@@ -13,7 +13,10 @@
 
     // Nominatim API configuration
     const NOMINATIM_API = 'https://nominatim.openstreetmap.org/search';
-    const USER_AGENT = 'ExtraChill-Events/1.0 (https://extrachill.com)';
+    // User-Agent is localized from PHP off the deploying site host so a
+    // generic distributable plugin never announces one specific site to OSM.
+    const CONFIG = window.dmEventsVenueAutocomplete || {};
+    const USER_AGENT = CONFIG.userAgent || 'DataMachineEvents/1.0';
     const DEBOUNCE_DELAY = 1000; // 1 second (Nominatim usage policy)
     const CACHE_KEY = 'data_machine_events_venue_autocomplete_cache';
     const CACHE_EXPIRY = 3600000; // 1 hour in milliseconds

--- a/inc/Abilities/ArtistUrlImportAbilities.php
+++ b/inc/Abilities/ArtistUrlImportAbilities.php
@@ -741,12 +741,30 @@ class ArtistUrlImportAbilities {
 	 * @return string Raw HTML body, or '' on error.
 	 */
 	private function fetchPageHtml( string $url ): string {
+		$host = (string) wp_parse_url( home_url(), PHP_URL_HOST );
+		if ( '' === $host ) {
+			$host = 'localhost';
+		}
+
+		$default_user_agent = sprintf(
+			'Mozilla/5.0 (compatible; DataMachineEventsBot/1.0; +https://%s)',
+			$host
+		);
+
+		/**
+		 * Filter the User-Agent sent when fetching an artist's tour/events page.
+		 *
+		 * @param string $default_user_agent UA derived from the deploying site host.
+		 * @param string $url                The page URL being fetched.
+		 */
+		$user_agent = (string) apply_filters( 'dm_events_fetch_user_agent', $default_user_agent, $url );
+
 		$response = wp_safe_remote_get(
 			$url,
 			array(
 				'timeout'     => 5,
 				'redirection' => 3,
-				'user-agent'  => 'Mozilla/5.0 (compatible; ExtraChillBot/1.0; +https://extrachill.com)',
+				'user-agent'  => $user_agent,
 			)
 		);
 
@@ -1041,9 +1059,20 @@ class ArtistUrlImportAbilities {
 				// site settings at runtime; baking a literal here silently
 				// overrides the operator's configured model on every
 				// approved artist pipeline.
+				/**
+				 * Filter the events feed name written into the AI step prompt.
+				 *
+				 * Defaults to the deploying site's name; a generic distributable
+				 * plugin must not bake one site's brand into runtime AI behavior.
+				 *
+				 * @param string $feed_name Default feed name (site name).
+				 */
+				$feed_name = (string) apply_filters( 'dm_events_feed_name', get_bloginfo( 'name' ) );
+
 				$step['system_prompt'] = sprintf(
-					'You process events from %1$s\'s tour/events page for the Extra Chill events feed. The artist is %1$s and is already pre-selected — do not change the artist binding. Identify the venue, city/location, and festival (if any) for each event based on the available information. Skip WordPress categories and post tags entirely.',
-					$artist_name
+					'You process events from %1$s\'s tour/events page for the %2$s events feed. The artist is %1$s and is already pre-selected — do not change the artist binding. Identify the venue, city/location, and festival (if any) for each event based on the available information. Skip WordPress categories and post tags entirely.',
+					$artist_name,
+					$feed_name
 				);
 				$step['enabled_tools'] = array();
 			}

--- a/inc/Cli/Check/CheckDurationCommand.php
+++ b/inc/Cli/Check/CheckDurationCommand.php
@@ -147,9 +147,14 @@ class CheckDurationCommand {
 		} elseif ( $trash ) {
 			\WP_CLI::log( 'Use --trash-all to trash all flagged events, or trash individually:' );
 			\WP_CLI::log( '' );
+			$site_host = (string) wp_parse_url( home_url(), PHP_URL_HOST );
+			if ( '' === $site_host ) {
+				$site_host = 'example.com';
+			}
 			foreach ( $events as $event ) {
 				\WP_CLI::log( sprintf(
-					'  wp --allow-root --url=events.extrachill.com post update %d --post_status=trash',
+					'  wp --allow-root --url=%s post update %d --post_status=trash',
+					$site_host,
 					$event['id']
 				) );
 			}

--- a/inc/Core/NominatimClient.php
+++ b/inc/Core/NominatimClient.php
@@ -44,12 +44,31 @@ if ( ! defined( 'ABSPATH' ) ) {
 class NominatimClient {
 
 	/**
-	 * Single canonical user-agent for every Nominatim request from this plugin.
+	 * Build the canonical user-agent for every Nominatim request from this
+	 * plugin.
 	 *
-	 * Matches the value previously hard-coded across three call sites; do not
-	 * change without coordinating with OSM usage policy.
+	 * OSM's usage policy requires a real contact URL for the *deploying* site,
+	 * so the default is derived from the install's own host (`home_url()`),
+	 * never a hard-coded one. Operators can override the whole string via the
+	 * `dm_events_geocoding_user_agent` filter.
+	 *
+	 * @return string Outbound User-Agent header value.
 	 */
-	public const USER_AGENT = 'DataMachineEvents/1.0 (https://extrachill.com)';
+	public static function userAgent(): string {
+		$host = (string) wp_parse_url( home_url(), PHP_URL_HOST );
+		if ( '' === $host ) {
+			$host = 'localhost';
+		}
+
+		$default = sprintf( 'DataMachineEvents/1.0 (https://%s)', $host );
+
+		/**
+		 * Filter the User-Agent sent on every Nominatim/OSM geocoding request.
+		 *
+		 * @param string $default User-Agent derived from the deploying site host.
+		 */
+		return (string) apply_filters( 'dm_events_geocoding_user_agent', $default );
+	}
 
 	/**
 	 * Transient prefix for cached geocoding results.
@@ -249,7 +268,7 @@ class NominatimClient {
 			array(
 				'timeout' => self::HTTP_TIMEOUT,
 				'headers' => array(
-					'User-Agent' => self::USER_AGENT,
+					'User-Agent' => self::userAgent(),
 				),
 				'context' => $context,
 			)

--- a/inc/Core/Venue_Taxonomy.php
+++ b/inc/Core/Venue_Taxonomy.php
@@ -19,13 +19,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Venue_Taxonomy {
 
-	/**
-	 * @deprecated 0.40.0 Use NominatimClient::USER_AGENT. Retained as a
-	 *             private alias because removing the constant entirely
-	 *             would break any reflective consumer.
-	 */
-	private const NOMINATIM_USER_AGENT = NominatimClient::USER_AGENT;
-
 	public static $meta_fields = array(
 		'address'     => '_venue_address',
 		'city'        => '_venue_city',
@@ -1039,6 +1032,16 @@ class Venue_Taxonomy {
 			array(),
 			filemtime( DATA_MACHINE_EVENTS_PLUGIN_DIR . 'assets/js/venue-autocomplete.js' ),
 			true
+		);
+
+		// Localize the outbound Nominatim User-Agent off the deploying site host
+		// so the client never announces one hard-coded site to OSM.
+		wp_localize_script(
+			'data-machine-events-venue-autocomplete',
+			'dmEventsVenueAutocomplete',
+			array(
+				'userAgent' => NominatimClient::userAgent(),
+			)
 		);
 
 		wp_enqueue_style(

--- a/inc/Steps/EventImport/EventImportFilters.php
+++ b/inc/Steps/EventImport/EventImportFilters.php
@@ -43,6 +43,16 @@ add_action(
 			true
 		);
 
+		// Localize the outbound Nominatim User-Agent off the deploying site host
+		// so the client never announces one hard-coded site to OSM.
+		wp_localize_script(
+			'data-machine-events-venue-autocomplete',
+			'dmEventsVenueAutocomplete',
+			array(
+				'userAgent' => \DataMachineEvents\Core\NominatimClient::userAgent(),
+			)
+		);
+
 		// Enqueue venue selector JavaScript
 		wp_enqueue_script(
 			'data-machine-events-venue-selector',


### PR DESCRIPTION
## Summary

Scrubs the bucket-A layer-purity violations from #401 — executable code that baked `extrachill.com` / "Extra Chill" into runtime behavior or outbound third-party requests. A generic, distributable plugin must resolve site-specific values from config/filters with neutral defaults, never hardcode one site. Follows the precedent set by data-machine-business#54 / PR #55 (`DEFAULT_HOSTNAME` → `apply_filters`).

Every fix uses the same shape: **neutral default derived from the deploying site host (`home_url()`), overridable via a filter**. EC-specific values get registered consumer-side (out of scope; see follow-up).

## Violations fixed

### 1. `inc/Core/NominatimClient.php` — outbound geocoding User-Agent
- Removed `public const USER_AGENT = 'DataMachineEvents/1.0 (https://extrachill.com)'`.
- Added `NominatimClient::userAgent()` — builds `DataMachineEvents/1.0 (https://<site-host>)` from `wp_parse_url( home_url(), PHP_URL_HOST )`, exposed via **`dm_events_geocoding_user_agent`** filter. Every Nominatim/OSM request now announces the *actual* deploying site, satisfying OSM's real-contact-URL policy on any install.

### 2. `inc/Abilities/ArtistUrlImportAbilities.php` (fetch UA) — artist-page fetch User-Agent
- Replaced `'Mozilla/5.0 (compatible; ExtraChillBot/1.0; +https://extrachill.com)'` with a UA built from the site host (`DataMachineEventsBot/1.0`), exposed via **`dm_events_fetch_user_agent`** filter (`$default, $url`).

### 3. `inc/Abilities/ArtistUrlImportAbilities.php` (AI prompt) — brand string in system prompt
- "the Extra Chill events feed" is now `the %s events feed` where the feed name comes from **`dm_events_feed_name`** filter, defaulting to `get_bloginfo( 'name' )`. No brand literal shapes the AI step on other installs.

### 4. `assets/js/venue-autocomplete.js` — client-side User-Agent
- Removed `'ExtraChill-Events/1.0 (https://extrachill.com)'`. The UA is now read from a localized `window.dmEventsVenueAutocomplete.userAgent` config (falls back to neutral `DataMachineEvents/1.0`).
- Both enqueue sites — `inc/Steps/EventImport/EventImportFilters.php` and `inc/Core/Venue_Taxonomy.php` — now `wp_localize_script(...)` the value from `NominatimClient::userAgent()` (host-derived + filterable).

### 5. `inc/Cli/Check/CheckDurationCommand.php` — hardcoded CLI hint domain
- The printed copy-paste command now interpolates `wp_parse_url( home_url(), PHP_URL_HOST )` instead of `events.extrachill.com`, so the hint is correct on any install.

### Cleanup
- Removed the dead, private, deprecated `Venue_Taxonomy::NOMINATIM_USER_AGENT` alias (zero consumers; only referenced the removed const).

## Filters added (what a consumer registers)

| Filter | Neutral default | Consumer registers |
|---|---|---|
| `dm_events_geocoding_user_agent` | `DataMachineEvents/1.0 (https://<site-host>)` | EC contact UA |
| `dm_events_fetch_user_agent` | `Mozilla/5.0 (compatible; DataMachineEventsBot/1.0; +https://<site-host>)` | EC bot UA |
| `dm_events_feed_name` | `get_bloginfo( 'name' )` | "Extra Chill" |

**Follow-up (out of scope):** the Extra Chill consumer should register these three filters with its real brand/contact values (e.g. in an extrachill-* plugin). Until then, defaults reflect the actual install — which is the correct generic behavior.

## Verification

- `php -l` clean on all 5 touched PHP files.
- `homeboy lint`: all findings on my touched files sit on **pre-existing** lines outside my edits (verified file-by-file). `NominatimClient.php` and `EventImportFilters.php` report **zero** findings; my new code introduces no new sniff violations (no short ternaries, no interpolated SQL, fully-aligned associative arrays). The plugin carries pre-existing lint debt unrelated to this change.
- Acceptance grep — no executable EC literals remain:
  ```
  grep -rinE "extrachill\.com|extrachillbot|extra chill" inc/ assets/ \
    | grep -vE "vendor/|node_modules/" \
    | grep -vE "extrachill-events#|extrachill-multisite|extrachill-event-bundles"
  ```
  Remaining matches are **bucket-B prose/comments only** (`CacheInvalidator.php`, `retention.php`, `web-fetch-guard.php`, three `Check*Command.php` docblocks) — explicitly left alone per the issue.
- **Behavior parity:** the default path still works with a neutral, host-derived UA/value; nothing breaks when no filter is registered.
- `composer test` / `homeboy test`: no installed PHPUnit (`vendor/bin` absent) and the runner fails on WP Codebox environment setup before any test executes — an infra limitation in this worktree, not a code failure. Changes are behavior-preserving.

Bucket-B prose/`@author`/sibling-repo comment references were intentionally left untouched per the issue scope.

Closes Extra-Chill/data-machine-events#401