### PR TITLE
feat: make Event Details block tense-aware (expose event timing + adapt past-event CTAs)

### DIFF
--- a/docs/event-details-block.md
+++ b/docs/event-details-block.md
@@ -24,6 +24,15 @@ The block exposes 15+ attributes (dates, venue, price, performer/organizer metad
 - Event dates are synced to the `datamachine_event_dates` table in `inc/Core/event-dates-sync.php`, keeping calendar queries performant, powering schema fallbacks, and enabling day-based pagination and REST filtering. Use global `datamachine_get_event_dates( $post_id )` to read.
 - Leaflet assets (`leaflet.css`, `leaflet.js`, `assets/js/venue-map.js`) load on event detail views via `enqueue_root_styles()` whenever the block or a `data_machine_events` post renders, so venue maps always display with consistent markers.
 
+## Tense-Aware Rendering
+
+The block derives an event's timing state once per render — `'upcoming'`, `'ongoing'`, or `'past'` — via the public `data_machine_events_get_timing( $post_id )` helper (same source-of-truth logic as the calendar's upcoming/past SQL filters). That single fact drives two things:
+
+- **Its own CTAs adapt to tense.** On a `past` event the block's ticket / event-link button and the Add-to-Calendar dropdown are suppressed by default — buying tickets to or calendaring a finished show are dead actions. Both defaults are filterable: `data_machine_events_show_ticket_button` and `data_machine_events_show_add_to_calendar` each receive `(bool $show, int $post_id, string $timing)` and default to `false` on `past`. A site that overrides the ticket button back on gets a `ticket-button--past` modifier class for de-emphasis styling.
+- **Consumers receive the timing without re-deriving it.** The `data_machine_events_action_buttons` and `data_machine_events_after_price_display` actions both pass `$timing` as their final argument, so downstream buttons (share, RSVP, and any consumer-supplied action) can compose tense-aware UI without re-querying the event-dates table. The argument is additive — callbacks registered with the old two-/one-arg signatures keep working unchanged.
+
+See `docs/integration-api.md` for the full filter/action signatures and the helper contract.
+
 ## Venue & Taxonomy Integration
 
 - Venue metadata lives in the `venue` taxonomy (address, city, state, zip, country, phone, website, capacity, coordinates) and surfaces across the REST API and Event Details block; `Venue_Taxonomy` and `VenueService` ensure find-or-create workflows keep term meta complete.

--- a/docs/integration-api.md
+++ b/docs/integration-api.md
@@ -92,8 +92,10 @@ signatures are stable.
 
 | Filter | Signature | Purpose |
 |---|---|---|
-| `data_machine_events_ticket_button_classes` | `(array $classes)` | Modify CSS classes on the ticket button. |
+| `data_machine_events_ticket_button_classes` | `(array $classes, int $post_id, string $timing)` | Modify CSS classes on the ticket button. `$post_id` and `$timing` (`'upcoming'`\|`'ongoing'`\|`'past'`) added in 0.46.0; existing callbacks accepting one arg keep working. On past events the block also appends a `ticket-button--past` modifier class after this filter runs. |
 | `data_machine_events_add_to_calendar_button_classes` | `(array $classes, int $post_id)` | Modify the style classes on the Add-to-Calendar toggle. Mirrors the ticket-button filter so consumers can route the toggle through their own button system (e.g. theme `button-*` classes). Base classes `dm-events-action-btn dm-events-add-to-calendar-toggle` are always present; default style class is `ticket-button`. |
+| `data_machine_events_show_ticket_button` | `(bool $show, int $post_id, string $timing)` | Whether to render the block's own ticket / event-link button. Defaults to `false` on `past` timing (a finished show's buy-tickets CTA is dead) and `true` otherwise. Override to force it on/off regardless of tense. |
+| `data_machine_events_show_add_to_calendar` | `(bool $show, int $post_id, string $timing)` | Whether to render the Add-to-Calendar button. Defaults to `false` on `past` timing and `true` otherwise. |
 | `data_machine_events_max_occurrence_display` | `(int $max)` | Cap on multi-occurrence display rows. |
 | `data_machine_events_non_ticket_price_patterns` | `(array $patterns)` | Strings that suppress the ticket button. |
 
@@ -112,8 +114,8 @@ signatures are stable.
 
 | Action | Signature | Purpose |
 |---|---|---|
-| `data_machine_events_after_price_display` | `(int $post_id, string $price)` | Render extra UI after the price line. |
-| `data_machine_events_action_buttons` | `(int $post_id, string $ticket_url)` | Add buttons to the event action row (alongside the ticket button). |
+| `data_machine_events_after_price_display` | `(int $post_id, string $price, string $timing)` | Render extra UI after the price line. `$timing` (`'upcoming'`\|`'ongoing'`\|`'past'`) added in 0.46.0; callbacks accepting fewer args keep working. |
+| `data_machine_events_action_buttons` | `(int $post_id, string $ticket_url, string $timing)` | Add buttons to the event action row (alongside the ticket button). `$timing` (`'upcoming'`\|`'ongoing'`\|`'past'`) added in 0.46.0 so consumers can compose tense-aware UI without re-deriving it; callbacks accepting two args keep working. |
 | `data_machine_events_map_after_summary` | `(array $venues, array $context)` | Render extra UI after the map summary block. |
 
 ## Public functions
@@ -197,6 +199,28 @@ exists for the post in the `datamachine_event_dates` table. Equivalent to
 calling the existing `datamachine_get_event_dates()` and reading
 `start_datetime`.
 
+### `data_machine_events_get_timing( int $post_id ): string`
+
+Return the timing state of an event relative to now — `'upcoming'`,
+`'ongoing'`, or `'past'` — derived from the event's start/end datetimes in the
+authoritative `datamachine_event_dates` table:
+
+- `upcoming` — start >= now
+- `ongoing` — start < now AND end >= now
+- `past` — start < now AND (end < now OR end is null)
+
+Events with no parseable start datetime are treated as `'past'`. This is the
+canonical way for a consumer to know an event's tense; call it instead of
+re-querying the event-dates table yourself. Prefer this prefixed helper over
+`datamachine_get_event_timing()` — both are stable and identical, but this name
+matches the rest of the `data_machine_events_*` surface.
+
+```php
+if ( 'past' === data_machine_events_get_timing( $post_id ) ) {
+    // Render a post-show layout instead of buy-tickets CTAs.
+}
+```
+
 ### Pre-existing helpers (kept stable)
 
 These functions predate this document and remain part of the public API:
@@ -204,7 +228,8 @@ These functions predate this document and remain part of the public API:
 - `datamachine_get_event_dates( int $post_id ): ?object` — full event-dates
   row from the `datamachine_event_dates` table.
 - `datamachine_get_event_timing( int $post_id ): string` — `'upcoming'` |
-  `'ongoing'` | `'past'`.
+  `'ongoing'` | `'past'`. Equivalent to `data_machine_events_get_timing()`;
+  the prefixed name is preferred for new code.
 
 ## Public constants
 

--- a/inc/Blocks/EventDetails/add-to-calendar-button.php
+++ b/inc/Blocks/EventDetails/add-to-calendar-button.php
@@ -26,7 +26,7 @@ add_action(
 	'data_machine_events_action_buttons',
 	'data_machine_events_render_add_to_calendar_button',
 	7,
-	2
+	3
 );
 
 if ( ! function_exists( 'data_machine_events_render_add_to_calendar_button' ) ) {
@@ -35,12 +35,39 @@ if ( ! function_exists( 'data_machine_events_render_add_to_calendar_button' ) ) 
 	 *
 	 * @param int    $post_id    Event post ID.
 	 * @param string $ticket_url Ticket URL (unused here, present for hook signature parity).
+	 * @param string $timing     Event timing state: 'upcoming' | 'ongoing' | 'past'.
+	 *                           Defaults to 'upcoming' when omitted (older callers
+	 *                           of the action that pass only two args).
 	 */
-	function data_machine_events_render_add_to_calendar_button( $post_id, $ticket_url ) {
+	function data_machine_events_render_add_to_calendar_button( $post_id, $ticket_url, $timing = 'upcoming' ) {
 		unset( $ticket_url );
 
 		$post_id = (int) $post_id;
 		if ( $post_id <= 0 ) {
+			return;
+		}
+
+		/**
+		 * Whether to render the Add-to-Calendar button for this event.
+		 *
+		 * Defaults to false for past events — adding a finished show to a
+		 * personal calendar is not a useful action — and true otherwise.
+		 * Filterable so a consuming site can override the default in either
+		 * direction.
+		 *
+		 * @since 0.46.0
+		 *
+		 * @param bool   $show    Whether to show the Add-to-Calendar button. Default: false on past, true otherwise.
+		 * @param int    $post_id Event post ID.
+		 * @param string $timing  Event timing state: 'upcoming' | 'ongoing' | 'past'.
+		 */
+		$show_add_to_calendar = apply_filters(
+			'data_machine_events_show_add_to_calendar',
+			'past' !== $timing,
+			$post_id,
+			$timing
+		);
+		if ( ! $show_add_to_calendar ) {
 			return;
 		}
 

--- a/inc/Blocks/EventDetails/render.php
+++ b/inc/Blocks/EventDetails/render.php
@@ -33,6 +33,21 @@ $occurrence_dates = $attributes['occurrenceDates'] ?? array();
 
 $post_id = get_the_ID();
 
+/*
+ * Event timing state: 'upcoming' | 'ongoing' | 'past'.
+ *
+ * Derived from the authoritative event-dates table via the canonical
+ * public helper (same source-of-truth logic as the calendar's
+ * upcoming/past SQL filters), so consumers and this block share one
+ * definition of tense instead of each re-deriving it. Falls back to
+ * 'upcoming' if the helper is somehow unavailable, so a missing helper
+ * never suppresses live CTAs on a genuinely upcoming event.
+ */
+$event_timing = function_exists( 'data_machine_events_get_timing' )
+	? data_machine_events_get_timing( (int) $post_id )
+	: 'upcoming';
+$is_past      = ( 'past' === $event_timing );
+
 $venue_data  = null;
 $venue_terms = get_the_terms( $post_id, 'venue' );
 if ( $venue_terms && ! is_wp_error( $venue_terms ) ) {
@@ -179,15 +194,53 @@ $event_schema     = EventSchemaProvider::generateSchemaOrg( $event_data, $venue_
 			 *
 			 * @param int    $post_id Current event post ID.
 			 * @param string $price   Event price string (may be empty).
+			 * @param string $timing  Event timing state: 'upcoming' | 'ongoing' | 'past'.
+			 *                        Added in 0.46.0; consumers hooking with fewer
+			 *                        params keep working (extra args are ignored).
 			 */
-			do_action( 'data_machine_events_after_price_display', $post_id, $price );
+			do_action( 'data_machine_events_after_price_display', $post_id, $price, $event_timing );
 			?>
 		</div>
 	</div>
 
 	<div class="event-action-buttons">
-		<?php if ( $ticket_url ) : ?>
-			<a href="<?php echo esc_url( $ticket_url ); ?>" class="<?php echo esc_attr( implode( ' ', apply_filters( 'data_machine_events_ticket_button_classes', array( 'ticket-button' ) ) ) ); ?>" target="_blank" rel="noopener">
+		<?php
+		/**
+		 * Whether to render the block's own ticket / event-link button.
+		 *
+		 * Defaults to true for upcoming and ongoing events and false for past
+		 * events — buying tickets to a show that already happened is a dead CTA,
+		 * so the generically-correct default is to suppress it once the event is
+		 * over. Sites that still want the link on past events (e.g. to point at
+		 * an archived listing) can force it back on via this filter.
+		 *
+		 * @since 0.46.0
+		 *
+		 * @param bool   $show    Whether to show the ticket button. Default: false on past, true otherwise.
+		 * @param int    $post_id Current event post ID.
+		 * @param string $timing  Event timing state: 'upcoming' | 'ongoing' | 'past'.
+		 */
+		$show_ticket_button = apply_filters(
+			'data_machine_events_show_ticket_button',
+			! $is_past,
+			$post_id,
+			$event_timing
+		);
+		?>
+		<?php if ( $ticket_url && $show_ticket_button ) : ?>
+			<?php
+			/*
+			 * De-emphasis class hook for past-but-still-shown ticket buttons.
+			 * The default filter above suppresses the button on past events, but
+			 * when a site overrides that to keep it visible, tag it with a
+			 * modifier class so themes can visually de-emphasize it.
+			 */
+			$ticket_classes = apply_filters( 'data_machine_events_ticket_button_classes', array( 'ticket-button' ), $post_id, $event_timing );
+			if ( $is_past ) {
+				$ticket_classes[] = 'ticket-button--past';
+			}
+			?>
+			<a href="<?php echo esc_url( $ticket_url ); ?>" class="<?php echo esc_attr( implode( ' ', $ticket_classes ) ); ?>" target="_blank" rel="noopener">
 				<?php echo esc_html( $ticket_button_text ); ?>
 			</a>
 		<?php endif; ?>
@@ -198,10 +251,13 @@ $event_schema     = EventSchemaProvider::generateSchemaOrg( $event_data, $venue_
 		 *
 		 * Allows themes and plugins to add buttons (share, RSVP, etc.) alongside the ticket button.
 		 *
-		 * @param int $post_id Current event post ID
+		 * @param int    $post_id    Current event post ID
 		 * @param string $ticket_url Ticket URL if available (empty string if not)
+		 * @param string $timing     Event timing state: 'upcoming' | 'ongoing' | 'past'.
+		 *                           Added in 0.46.0; consumers hooking with fewer
+		 *                           params keep working (extra args are ignored).
 		 */
-		do_action( 'data_machine_events_action_buttons', $post_id, $ticket_url );
+		do_action( 'data_machine_events_action_buttons', $post_id, $ticket_url, $event_timing );
 		?>
 	</div>
 

--- a/inc/public-api.php
+++ b/inc/public-api.php
@@ -280,3 +280,37 @@ if ( ! function_exists( 'data_machine_events_get_event_datetime' ) ) {
 		return $dates && ! empty( $dates->start_datetime ) ? (string) $dates->start_datetime : '';
 	}
 }
+
+if ( ! function_exists( 'data_machine_events_get_timing' ) ) {
+	/**
+	 * Get the timing state of an event relative to now.
+	 *
+	 * Returns one of `'upcoming'`, `'ongoing'`, or `'past'`, derived from the
+	 * event's start/end datetimes in the authoritative `datamachine_event_dates`
+	 * table using the same source-of-truth logic as the calendar's
+	 * upcoming/past SQL filters:
+	 *
+	 *   - `upcoming` — start >= now
+	 *   - `ongoing`  — start < now AND end >= now
+	 *   - `past`     — start < now AND (end < now OR end is null)
+	 *
+	 * Events with no parseable start datetime are treated as `'past'`.
+	 *
+	 * Prefer this prefixed helper over calling `datamachine_get_event_timing()`
+	 * directly; both are stable, but this name matches the rest of the public
+	 * `data_machine_events_*` surface. Consuming plugins should call this instead
+	 * of re-querying the event-dates table to derive tense themselves.
+	 *
+	 * @since 0.46.0
+	 *
+	 * @param int $post_id Event post ID.
+	 * @return string `'upcoming'` | `'ongoing'` | `'past'`.
+	 */
+	function data_machine_events_get_timing( int $post_id ): string {
+		if ( ! function_exists( 'datamachine_get_event_timing' ) ) {
+			return 'past';
+		}
+
+		return datamachine_get_event_timing( $post_id );
+	}
+}


### PR DESCRIPTION
## Summary

Closes #406.

The Event Details block (`inc/Blocks/EventDetails/render.php`) was **tense-blind**: it knew the start/end datetimes but never derived or exposed whether an event is past / ongoing / upcoming, and its button hooks only passed `($post_id, $ticket_url)`. Every consumer had to re-query the event-dates table to derive tense itself, and the block rendered a live "Get Tickets" button + a full Add-to-Calendar dropdown even on shows that already happened.

This PR makes the generic layer **know and share tense**, and makes its **own** CTAs tense-aware — without introducing any consumer-specific concept.

## What changed

### Timing states computed
Timing is computed once per render as `'upcoming' | 'ongoing' | 'past'`, using the **canonical** public helper — the same source-of-truth logic (`start >= now` = upcoming, `start < now && end >= now` = ongoing, else past) already used by the calendar's upcoming/past SQL filters (`datamachine_get_event_timing()` / `UpcomingFilter`). No new date-math was invented.

### New hook argument (back-compatible)
`$timing` is now passed as the trailing argument to:
- `data_machine_events_action_buttons` → `(int $post_id, string $ticket_url, string $timing)`
- `data_machine_events_after_price_display` → `(int $post_id, string $price, string $timing)`

Existing args are preserved. WordPress actions ignore extra args for callbacks registered with a lower accepted-arg count, so **every existing 2-arg / 1-arg consumer keeps working unchanged**. The bundled Add-to-Calendar callback was bumped from `2` → `3` accepted args (with a defaulted `$timing = 'upcoming'` param) so it can react to tense.

### New filters (sensible generic default, overridable)
- `data_machine_events_show_ticket_button` `(bool $show, int $post_id, string $timing)` — **defaults to `false` on `past`**, `true` otherwise. Buying tickets to a finished show is a dead CTA.
- `data_machine_events_show_add_to_calendar` `(bool $show, int $post_id, string $timing)` — **defaults to `false` on `past`**, `true` otherwise.

When a site overrides the ticket button back on for a past event, it renders with an extra `ticket-button--past` modifier class for de-emphasis styling. The existing `data_machine_events_ticket_button_classes` filter now also receives `$post_id` and `$timing` (additive; 1-arg callbacks unaffected).

### Public helper
`data_machine_events_get_timing( int $post_id ): string` added to `inc/public-api.php`, delegating to the existing `datamachine_get_event_timing()`. It matches the rest of the prefixed `data_machine_events_*` public surface so consumers stop re-querying the dates table to derive tense. Falls back to `'past'` if the underlying helper is unavailable.

## Back-compat

Fully back-compatible:
- All existing hook args preserved; new args are trailing-only.
- Old-arity `add_action`/`add_filter` callbacks receive no extra args and keep working.
- New behavior (hiding CTAs on past) only activates for `past` timing and is filterable in both directions.

## Layer purity

No consumer-specific concepts introduced — grepped the added lines for `attendance|concert|my-shows|setlist|import|extrachill` and confirmed clean. This layer only knows/shares **tense** and adapts its **own** ticket/calendar CTAs; consumer-side composition (attendance-first layouts, etc.) stays in the downstream plugin per the issue.

## Verification

- `php -l` clean on all three changed PHP files.
- `homeboy lint data-machine-events`: **phpstan (level 7) passes with 0 findings** on the change. The `eslint` step fails, but it fails **identically on clean `main`** and this PR touches **zero JS files** — pre-existing env/config issue, not introduced here.
- `homeboy test data-machine-events` could not run: the runner aborts at "WP Codebox CLI setup" (`no candidate passed 'wp-codebox --version'`) before any test executes — a stale host wrapper, not a code failure. No existing test references the changed hooks, and all changes are additive/back-compatible.

## Docs

Updated `docs/integration-api.md` (new filters, updated action signatures, new helper) and `docs/event-details-block.md` (new "Tense-Aware Rendering" section).