### PR TITLE
ci: use review audit command

### DIFF
--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -50,6 +50,6 @@ jobs:
 
       - uses: Extra-Chill/homeboy-action@v2
         with:
-          commands: audit
+          commands: review audit
           app-token: ${{ steps.app-token.outputs.token || '' }}
           autofix: 'false'


### PR DESCRIPTION
Part of the review-pillar vocabulary cut (Extra-Chill/homeboy#7456, homeboy#7590).

Updates the Homeboy workflow command input to the review-nested audit vocabulary accepted by homeboy-action v2.8.6.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Applied the workflow vocabulary update and prepared this PR.