### PR TITLE
fix: cap scraped ICS recurrence horizon + per-scrape event count

### DIFF
--- a/inc/Steps/EventImport/Handlers/WebScraper/Extractors/BaseExtractor.php
+++ b/inc/Steps/EventImport/Handlers/WebScraper/Extractors/BaseExtractor.php
@@ -270,6 +270,151 @@ abstract class BaseExtractor implements ExtractorInterface {
 	}
 
 	/**
+	 * Forward-occurrence horizon (days) for scraped ICS calendars.
+	 *
+	 * Open-ended RRULE recurrences (no UNTIL/COUNT) project years into the
+	 * future. This bounds the user-visible forward window so an open-ended
+	 * weekly residency yields ~13 occurrences (90 days) instead of ~104 (2 years).
+	 *
+	 * Filterable so a legitimately long-horizon source (e.g. a festival
+	 * announcing a year out) can opt into a wider window.
+	 *
+	 * @since 0.46.1
+	 *
+	 * @param array $context Optional context (source_url, method) for filter callbacks.
+	 * @return int Horizon in days. Default 90.
+	 */
+	protected function getRecurrenceHorizonDays( array $context = array() ): int {
+		/**
+		 * Filter the forward-occurrence horizon (days) for scraped ICS calendars.
+		 *
+		 * Open-ended RRULE recurrences are dropped once their start exceeds
+		 * now + horizon days. Raise this for a source that legitimately
+		 * publishes far-future events.
+		 *
+		 * @param int   $days    Default horizon in days.
+		 * @param array $context Optional context (source_url, method).
+		 */
+		$days = (int) apply_filters( 'data_machine_events_scraper_recurrence_horizon_days', 90, $context );
+
+		return $days > 0 ? $days : 90;
+	}
+
+	/**
+	 * Maximum events a single ICS scrape may emit.
+	 *
+	 * Backstop so no single run can dump thousands of items even if the
+	 * recurrence-horizon logic regresses. The nearest events are kept.
+	 *
+	 * Filterable so a legitimately high-volume source can raise the ceiling.
+	 *
+	 * @since 0.46.1
+	 *
+	 * @param array $context Optional context.
+	 * @return int Max events. Default 200.
+	 */
+	protected function getMaxScrapeEvents( array $context = array() ): int {
+		/**
+		 * Filter the per-scrape event cap for ICS extractors.
+		 *
+		 * @param int   $max     Default max events per scrape.
+		 * @param array $context Optional context (source_url, method).
+		 */
+		$max = (int) apply_filters( 'data_machine_events_scraper_max_events', 200, $context );
+
+		return $max > 0 ? $max : 200;
+	}
+
+	/**
+	 * Constrain expanded ICal recurrence events to a forward horizon and total cap.
+	 *
+	 * Drops any occurrence whose start is more than the horizon (days) in the
+	 * future, then caps the remaining set to the max-events backstop, keeping
+	 * the nearest events. Operates on raw ICal\Event objects before
+	 * normalization so far-future occurrences never pay normalization cost.
+	 *
+	 * This is the single source of truth for the forward window; the vendored
+	 * parser's defaultSpan is intentionally left unchanged so this filter is
+	 * not silently re-capped by the parser.
+	 *
+	 * @since 0.46.1
+	 *
+	 * @param array $events  Expanded ICal events (any shape with a ->dtstart).
+	 * @param array $context Optional context for filters.
+	 * @return array Filtered + capped events, nearest first.
+	 */
+	protected function constrainRecurrenceHorizon( array $events, array $context = array() ): array {
+		if ( empty( $events ) ) {
+			return $events;
+		}
+
+		$horizon_days = $this->getRecurrenceHorizonDays( $context );
+		$max_events   = $this->getMaxScrapeEvents( $context );
+
+		try {
+			$cutoff_ts = ( new \DateTime( '+' . $horizon_days . ' days' ) )->getTimestamp();
+		} catch ( \Exception $e ) {
+			$cutoff_ts = ( new \DateTime( '+90 days' ) )->getTimestamp();
+		}
+
+		$kept = array();
+		foreach ( $events as $event ) {
+			$ts = $this->getEventStartTimestamp( $event );
+			// Drop occurrences beyond the forward horizon. Events with an
+			// unreadable start are kept defensively rather than silently dropped.
+			if ( null !== $ts && $ts > $cutoff_ts ) {
+				continue;
+			}
+
+			$kept[] = $event;
+		}
+
+		if ( empty( $kept ) ) {
+			return $kept;
+		}
+
+		// ICal::events() returns feed order, not date order. Sort ascending by
+		// start before slicing so the cap keeps the nearest events.
+		usort(
+			$kept,
+			function ( $a, $b ) {
+				$ta = $this->getEventStartTimestamp( $a ) ?? PHP_INT_MAX;
+				$tb = $this->getEventStartTimestamp( $b ) ?? PHP_INT_MAX;
+				return $ta <=> $tb;
+			}
+		);
+
+		if ( count( $kept ) > $max_events ) {
+			$kept = array_slice( $kept, 0, $max_events );
+		}
+
+		return $kept;
+	}
+
+	/**
+	 * Best-effort Unix timestamp for an ICal\Event start.
+	 *
+	 * @since 0.46.1
+	 *
+	 * @param object $event ICal event object with a ->dtstart property.
+	 * @return int|null Timestamp, or null if the start is unreadable.
+	 */
+	protected function getEventStartTimestamp( object $event ): ?int {
+		$start = $event->dtstart ?? null;
+
+		if ( $start instanceof \DateTime ) {
+			return $start->getTimestamp();
+		}
+
+		if ( is_string( $start ) && '' !== $start ) {
+			$ts = strtotime( $start );
+			return false !== $ts ? $ts : null;
+		}
+
+		return null;
+	}
+
+	/**
 	 * Load an HTML string into a DOMDocument + DOMXPath pair.
 	 *
 	 * Eliminates the repeated 5-line DOM bootstrap boilerplate

--- a/inc/Steps/EventImport/Handlers/WebScraper/Extractors/EmbeddedCalendarExtractor.php
+++ b/inc/Steps/EventImport/Handlers/WebScraper/Extractors/EmbeddedCalendarExtractor.php
@@ -40,7 +40,7 @@ class EmbeddedCalendarExtractor extends BaseExtractor {
 		}
 
 		$calendar_timezone                 = $calendar_data['timezone'] ? $calendar_data['timezone'] : '';
-		[$ical_events, $calendar_timezone] = $this->parseIcsContent( $ics_content, $calendar_timezone );
+		[$ical_events, $calendar_timezone] = $this->parseIcsContent( $ics_content, $calendar_timezone, $source_url );
 
 		if ( empty( $ical_events ) ) {
 			return array();
@@ -158,8 +158,13 @@ class EmbeddedCalendarExtractor extends BaseExtractor {
 
 	/**
 	 * Parse ICS content using ICal library.
+	 *
+	 * @param string $ics_content       Raw ICS feed content.
+	 * @param string $calendar_timezone Calendar timezone hint.
+	 * @param string $source_url        Source URL, passed as filter context.
+	 * @return array{0: array, 1: string} [events, resolved timezone].
 	 */
-	private function parseIcsContent( string $ics_content, string $calendar_timezone = 'UTC' ): array {
+	private function parseIcsContent( string $ics_content, string $calendar_timezone = 'UTC', string $source_url = '' ): array {
 		try {
 			$ical = new ICal(
 				false,
@@ -180,7 +185,16 @@ class EmbeddedCalendarExtractor extends BaseExtractor {
 				$calendar_timezone = $extracted_timezone;
 			}
 
-			return array( $ical->events() ?? array(), $calendar_timezone );
+			$events = $ical->events() ?? array();
+			$events = $this->constrainRecurrenceHorizon(
+				$events,
+				array(
+					'source_url' => $source_url,
+					'method'     => $this->getMethod(),
+				)
+			);
+
+			return array( $events, $calendar_timezone );
 		} catch ( \Exception $e ) {
 			return array( array(), '' );
 		}

--- a/inc/Steps/EventImport/Handlers/WebScraper/Extractors/IcsExtractor.php
+++ b/inc/Steps/EventImport/Handlers/WebScraper/Extractors/IcsExtractor.php
@@ -59,6 +59,14 @@ class IcsExtractor extends BaseExtractor {
 				return array();
 			}
 
+			$events = $this->constrainRecurrenceHorizon(
+				$events,
+				array(
+					'source_url' => $source_url,
+					'method'     => $this->getMethod(),
+				)
+			);
+
 			$calendar_timezone = $ical->calendarTimeZone() ?? '';
 
 			// Fallback: extract timezone from X-WR-TIMEZONE when the library returned UTC.

--- a/tests/Unit/IcsExtractorTest.php
+++ b/tests/Unit/IcsExtractorTest.php
@@ -120,4 +120,99 @@ ICS;
 	public function test_extraction_method_is_ics_feed() {
 		$this->assertEquals( 'ics_feed', $this->extractor->getMethod() );
 	}
+
+	/**
+	 * Build a minimal single-event ICS feed at the given DTSTART.
+	 */
+	private function build_ics( string $dtstart, string $summary = 'Test Event' ): string {
+		return <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VTIMEZONE
+TZID:America/New_York
+END:VTIMEZONE
+BEGIN:VEVENT
+DTSTART;TZID=America/New_York:{$dtstart}
+DTEND;TZID=America/New_York:{$dtstart}
+SUMMARY:{$summary}
+LOCATION:Test Venue
+END:VEVENT
+END:VCALENDAR
+ICS;
+	}
+
+	public function test_recurrence_horizon_drops_far_future_occurrences() {
+		// ~1 year out — well beyond the default 90-day horizon.
+		$far_date = gmdate( 'Ymd\THis', strtotime( '+1 year' ) );
+		$ics      = $this->build_ics( $far_date, 'Year Out' );
+
+		$events = $this->extractor->extract( $ics, 'https://example.com/events.ics' );
+
+		$this->assertEmpty( $events, 'Far-future occurrence beyond the horizon must be dropped' );
+	}
+
+	public function test_recurrence_horizon_filter_extends_window() {
+		$far_date = gmdate( 'Ymd\THis', strtotime( '+1 year' ) );
+		$ics      = $this->build_ics( $far_date, 'Year Out' );
+
+		add_filter(
+			'data_machine_events_scraper_recurrence_horizon_days',
+			static function () {
+				return 400;
+			}
+		);
+
+		$events = $this->extractor->extract( $ics, 'https://example.com/events.ics' );
+
+		$this->assertCount( 1, $events, 'Far-future occurrence must be kept when horizon is raised via filter' );
+		$this->assertEquals( 'Year Out', $events[0]['title'] );
+	}
+
+	public function test_recurrence_cap_keeps_nearest_events() {
+		// Three near-term events (all within the default 90-day horizon).
+		$d1 = gmdate( 'Ymd\THis', strtotime( '+5 days' ) );
+		$d2 = gmdate( 'Ymd\THis', strtotime( '+20 days' ) );
+		$d3 = gmdate( 'Ymd\THis', strtotime( '+30 days' ) );
+
+		$ics = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VTIMEZONE
+TZID:America/New_York
+END:VTIMEZONE
+BEGIN:VEVENT
+DTSTART;TZID=America/New_York:{$d3}
+SUMMARY:Mid30
+LOCATION:Test Venue
+END:VEVENT
+BEGIN:VEVENT
+DTSTART;TZID=America/New_York:{$d1}
+SUMMARY:Near5
+LOCATION:Test Venue
+END:VEVENT
+BEGIN:VEVENT
+DTSTART;TZID=America/New_York:{$d2}
+SUMMARY:Mid20
+LOCATION:Test Venue
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+		// Lower the cap to 2 so the farthest (+30d) is dropped.
+		add_filter(
+			'data_machine_events_scraper_max_events',
+			static function () {
+				return 2;
+			}
+		);
+
+		$events = $this->extractor->extract( $ics, 'https://example.com/events.ics' );
+
+		$this->assertCount( 2, $events, 'Cap must keep only the nearest N events' );
+		$titles = array_column( $events, 'title' );
+		$this->assertEquals( array( 'Near5', 'Mid20' ), $titles, 'Cap must keep the nearest events, ascending' );
+		$this->assertNotContains( 'Mid30', $titles, 'Farthest event within horizon must be dropped when cap bites' );
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #411. Scraped venue Google Calendars with open-ended iCalendar `RRULE` recurrences (no `UNTIL`/`COUNT`) were expanded ~2 years into the future by the vendored parser's `defaultSpan => 2`, with no per-scrape cap (`getDefaultMaxItems() === 0`). One venue could dump ~1,800 events. Live impact: 4,551 events dated 2027+ across 297 venues.

This adds a shared, **filterable** forward-occurrence horizon (default **90 days**) and a **filterable** per-scrape event cap (default **200**) applied in our extractors. An open-ended `FREQ=WEEKLY` residency now yields **~13 occurrences** instead of ~104.

## Root cause

The `universal_web_scraper` handler correctly follows Google Calendar iframes to the real `.ics` feed — the events are genuine, not hallucinated. The defect is purely the recurrence horizon + missing cap:

- `EmbeddedCalendarExtractor` / `IcsExtractor` construct `ICal\ICal` with `defaultSpan => 2`, `skipRecurrence => false`.
- The vendored `processRecurrences()` expands an open-ended RRULE to `now + defaultSpan years` = **now + 2 years**.
- `Handlers/EventImportHandler::getDefaultMaxItems()` returns `0` (unlimited), so nothing bounded total item count.

## Changes

- **`inc/.../Extractors/BaseExtractor.php`** — three new `protected` helpers shared by all ICS extractors:
  - `getRecurrenceHorizonDays($context)` → filterable horizon. Filter: `` `data_machine_events_scraper_recurrence_horizon_days` `` (default `90`).
  - `getMaxScrapeEvents($context)` → filterable cap. Filter: `` `data_machine_events_scraper_max_events` `` (default `200`).
  - `constrainRecurrenceHorizon($events, $context)` → drops occurrences whose start is more than the horizon days in the future, then caps the remainder to the max-events backstop, **keeping the nearest events**. Applied on raw `ICal\Event` objects before normalization so far-future occurrences never pay normalization cost. Note: `ICal::events()` returns **feed order, not date order**, so the set is sorted ascending by start before slicing — the cap therefore keeps the *nearest* events, not an arbitrary first-N.
  - `getEventStartTimestamp($event)` → best-effort timestamp read off `->dtstart` (DateTime or string).
- **`EmbeddedCalendarExtractor.php`** + **`IcsExtractor.php`** — call `constrainRecurrenceHorizon()` immediately after `$ical->events()`, passing `source_url` + `method` as filter context. `parseIcsContent()` now threads `source_url` through for context.
- **`tests/Unit/IcsExtractorTest.php`** — adds three tests: far-future drop at default horizon, horizon filter extends the window, and cap keeps the nearest events (ordered).

## Approach decisions

- **Horizon value: 90 days** (filterable). ~13 weeks of a weekly residency is the right discovery window for a music calendar; legitimately longer-horizon sources opt in via the filter.
- **Cap approach: enforced in the ICS path, not via `getDefaultMaxItems()`.** The `0`/unlimited default is **load-bearing** — its own docblock documents that the base `FetchHandler` default of 1 is too conservative and discards legit structured events after dedup. Changing the global default would affect every event-import handler, not just ICS. Per the issue guidance, the cap therefore lives specifically in the ICS expansion path. Default **200** (filterable).
- **Filter prefix `data_machine_events_*`** matches the dominant existing convention in the plugin (e.g. `data_machine_events_map_center`, `data_machine_events_excluded_taxonomies`).
- **Vendored `defaultSpan` left at 2 intentionally.** Lowering it as belt-and-suspenders would re-introduce a hidden parser-level ceiling that silently fights a filter requesting a wider window. The post-filter is the single source of truth for the forward window. (Lowering it also would not reduce correctness — the post-filter already drops the tail — and the transient expansion cost is negligible: ~100 Event objects per open-ended RRULE.)
- **Layer purity:** no venue/vendor names anywhere — generic horizon/cap policy only.

## Verification

- **PHP lint (`php -l`):** clean on all 4 changed files.
- **PHPStan:** passes at level 7 (`PHPStan analysis passed`).
- **Algorithm sanity check** (standalone replica with stubbed `apply_filters`):
  - Open-ended weekly residency: **104 → 13** occurrences at 90-day horizon ✅ (matches the issue's predicted ~13).
  - Cap: 250 events over 75 days → **200 kept** ✅.
  - Far-future (365d) event dropped at 90d horizon ✅; kept when horizon filter raised to 400 ✅.
  - Cap keeps the **nearest** events (sorted ascending), not feed-order ✅.
- **Existing `IcsExtractorTest` tests:** unaffected — they use past-dated events (Jan 2026), which survive the horizon filter (only occurrences beyond now+90d are dropped).
- **PHPUnit suite:** could not be executed in this worktree — `homeboy test` requires a WP Codebox sandbox and the worktree host has no working `wp-codebox` binary (`` Error: wp-codebox was found, but no candidate passed 'wp-codebox --version' ``). The new tests target `IcsExtractor::extract()` via the standard WP test suite and will run in CI / sandbox.

## Sanity reasoning

An open-ended `FREQ=WEEKLY` RRULE now yields **~13** occurrences (90 days / 7) rather than ~104 (2 years / 7). ✅

Closes #411

> Note: the ~4,551 existing 2027+ events already on production are out of scope for this fix (per the issue, they get trashed operationally once this lands so they don't regenerate on the next daily run).