### PR TITLE
fix: strip generic content-writing tools from events AI steps

### DIFF
--- a/data-machine-events.php
+++ b/data-machine-events.php
@@ -99,6 +99,13 @@ require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Core/retention.php';
 require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Core/web-fetch-guard.php';
 \DataMachineEvents\Core\register_web_fetch_guard();
 
+// Strip generic content-writing tools from events AI steps so the model can only
+// publish through the adjacent `upsert_event` handler (see issue #412). Hooked
+// unconditionally so it is registered before any pipeline AI step resolves; the
+// `datamachine_resolved_tools` filter never fires when Data Machine is inactive.
+require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Core/event-tool-guard.php';
+\DataMachineEvents\Core\register_event_tool_guard();
+
 	// Load REST API routes (modular)
 if ( file_exists( DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Api/Routes.php' ) ) {
 	require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Api/Routes.php';

--- a/inc/Core/event-tool-guard.php
+++ b/inc/Core/event-tool-guard.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * Event AI tool guard.
+ *
+ * Events pipelines are shaped `event_import → ai → upsert` where the upsert
+ * handler is `upsert_event` (creates `data_machine_events` posts). The AI step
+ * is the only place the model can decide to publish — and it is supposed to
+ * reach ONLY the events upsert tool plus the fetch disposition tools
+ * (`reject_source` / `defer_item`) and read/research tools.
+ *
+ * Data Machine core, however, exposes generic content-publishing ability tools
+ * (`upsert_post`, `insert_content`) to EVERY pipeline AI step by default: they
+ * declare `modes` including `pipeline`, and `ToolPolicyResolver` only narrows
+ * the set when a step carries an explicit `enabled_tools` allow-list. Events
+ * flows were seeded with `enabled_tools: []` (no allow-list), so the events AI
+ * agent could reach past `upsert_event` and publish plain `post`-type junk
+ * ("rejection reports", "admin logs"). On events.extrachill.com this leaked
+ * 224 junk `post` items across ~75 flows (see issue #412).
+ *
+ * Events pipelines are hand-built in the DM UI and stored as flow_config data;
+ * this plugin does not seed them programmatically, so a code default for new
+ * flows could not retroactively protect the existing flow rows. Instead this
+ * guard hooks DM core's `datamachine_resolved_tools` filter and strips the
+ * generic content-writing tools whenever the AI step being resolved is
+ * adjacent to an `upsert_event` upsert step. Detection keys off the events
+ * handler shape (`upsert_event` in an adjacent step's `handler_slugs`), never
+ * off hardcoded flow IDs, so it covers every existing events flow at resolution
+ * time with no data migration.
+ *
+ * The durable fix — making generic publish tools opt-in in DM core — is tracked
+ * separately in Extra-Chill/data-machine#2852. This is the events-layer
+ * mitigation: it is generic within this layer and becomes a harmless
+ * belt-and-suspenders once the core fix lands.
+ *
+ * @package DataMachineEvents
+ * @subpackage Core
+ * @since 0.46.0
+ */
+
+namespace DataMachineEvents\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * The events upsert handler slug this guard keys off.
+ */
+const EVENT_UPSERT_HANDLER_SLUG = 'upsert_event';
+
+/**
+ * Register the resolved-tools guard.
+ *
+ * Hooks `datamachine_resolved_tools`, the single filter DM core fires after
+ * assembling the tool set for any execution context (see ToolPolicyResolver).
+ */
+function register_event_tool_guard(): void {
+	add_filter( 'datamachine_resolved_tools', __NAMESPACE__ . '\\apply_event_tool_guard', 10, 3 );
+}
+
+/**
+ * Generic content-writing tool names stripped from events AI steps.
+ *
+ * These are the DM core ability/handler tools that can mint an arbitrary
+ * WordPress post outside the `upsert_event` handler (and thus bypass
+ * EventUpsert's junk-title guard and PostIdentityIndex). None of them is
+ * something an events pipeline ever needs: the only legitimate publish path is
+ * the adjacent `upsert_event` handler tool, which is preserved.
+ *
+ * - `upsert_post`      — UpsertPostAbility (modes: chat/pipeline/system).
+ * - `insert_content`   — InsertContentAbility (modes: chat/pipeline/system/editor).
+ * - `wordpress_publish`— generic publish-step handler tool (only present when a
+ *                        publish step is adjacent; stripped defensively).
+ *
+ * @return string[] Lowercase tool names to strip.
+ */
+function event_ai_blocked_tools(): array {
+	$tools = array(
+		'upsert_post',
+		'insert_content',
+		'wordpress_publish',
+	);
+
+	/**
+	 * Filter the generic content-writing tools stripped from events AI steps.
+	 *
+	 * Site operators can tighten or loosen the strip list without a code change.
+	 * Tools listed here are removed from the resolved set ONLY when the AI step
+	 * is adjacent to an `upsert_event` upsert; they are untouched for every
+	 * other pipeline and for chat/system mode.
+	 *
+	 * @param string[] $tools Lowercase tool names to strip.
+	 */
+	$tools = apply_filters( 'data_machine_events_event_ai_blocked_tools', $tools );
+
+	return array_values( array_unique( array_filter( array_map( 'strval', (array) $tools ) ) ) );
+}
+
+/**
+ * Determine whether a resolved-tools request targets an events AI step.
+ *
+ * True when the resolution runs in pipeline mode AND one of the steps adjacent
+ * to the AI step is an `upsert` step whose handler list contains
+ * `upsert_event`. This mirrors the shape used by DM core's own
+ * `FlowStepConfig::getAdjacentRequiredHandlerSlugsForAi` (which already trusts
+ * the adjacent step configs for required-handler detection), so the signal is
+ * exactly as reliable as the mechanism that wires the `upsert_event` tool
+ * itself.
+ *
+ * Adjacent step configs are populated by `AIStep` only for pipeline AI steps,
+ * so the predicate is inherently scoped to that context; the explicit
+ * pipeline-mode check is defensive.
+ *
+ * @param array $args Resolved-tools filter args (modes + adjacent step configs).
+ * @return bool True when this is an events AI step adjacent to upsert_event.
+ */
+function is_event_upsert_ai_step( array $args ): bool {
+	$modes = is_array( $args['modes'] ?? null ) ? $args['modes'] : array( $args['mode'] ?? '' );
+	if ( ! is_array( $modes ) ) {
+		$modes = array( $modes );
+	}
+	$modes = array_map( 'strval', $modes );
+
+	if ( ! in_array( 'pipeline', $modes, true ) ) {
+		return false;
+	}
+
+	foreach ( array( $args['previous_step_config'] ?? null, $args['next_step_config'] ?? null ) as $step_config ) {
+		if ( ! is_array( $step_config ) ) {
+			continue;
+		}
+
+		$handler_slugs = is_array( $step_config['handler_slugs'] ?? null )
+			? $step_config['handler_slugs']
+			: array();
+
+		if ( in_array( EVENT_UPSERT_HANDLER_SLUG, $handler_slugs, true ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Strip generic content-writing tools from an events AI step.
+ *
+ * Pure transform over the resolved tools array. Exposed (not just used as the
+ * filter callback) so it can be unit-tested without firing the real filter.
+ *
+ * Preserves every other tool — `upsert_event`, `reject_source`, `defer_item`,
+ * web/post read tools, duplicate-detection tools — untouched.
+ *
+ * @param array $tools Resolved tools keyed by tool name.
+ * @param array $args  Resolved-tools filter args.
+ * @return array Filtered tools, unchanged when this is not an events AI step.
+ */
+function strip_event_ai_content_tools( array $tools, array $args ): array {
+	if ( ! is_event_upsert_ai_step( $args ) ) {
+		return $tools;
+	}
+
+	$blocked = event_ai_blocked_tools();
+	if ( array() === $blocked ) {
+		return $tools;
+	}
+
+	$blocked_lookup = array_flip( $blocked );
+
+	$removed = array();
+	foreach ( $tools as $name => $tool ) {
+		if ( isset( $blocked_lookup[ $name ] ) ) {
+			unset( $tools[ $name ] );
+			$removed[] = $name;
+		}
+	}
+
+	if ( array() !== $removed && function_exists( 'do_action' ) ) {
+		do_action(
+			'datamachine_log',
+			'debug',
+			'Event Tool Guard: stripped generic content-writing tools from events AI step',
+			array(
+				'context'         => 'Event Tool Guard',
+				'removed_tools'   => $removed,
+				'retained_sample' => array_slice( array_keys( $tools ), 0, 20 ),
+			)
+		);
+	}
+
+	return $tools;
+}
+
+/**
+ * `datamachine_resolved_tools` filter callback.
+ *
+ * @param array               $tools Resolved tools keyed by tool name.
+ * @param string|array|string $mode  Active mode(s) — unused; gating is args-driven.
+ * @param array               $args  Full resolution arguments.
+ * @return array Filtered tools.
+ */
+function apply_event_tool_guard( array $tools, $mode, array $args ): array {
+	unset( $mode );
+	return strip_event_ai_content_tools( $tools, $args );
+}

--- a/tests/Unit/EventToolGuardTest.php
+++ b/tests/Unit/EventToolGuardTest.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ * Event Tool Guard Tests
+ *
+ * Covers the `datamachine_resolved_tools` filter that strips generic
+ * content-writing tools from events AI steps so the model can only publish
+ * through the adjacent `upsert_event` upsert handler (issue #412).
+ *
+ * The guard keys off the events pipeline shape — an AI step adjacent to an
+ * `upsert` step whose handler is `upsert_event` — and removes the DM core
+ * ability/handler tools that can mint an arbitrary `post` outside EventUpsert
+ * (`upsert_post`, `insert_content`, `wordpress_publish`). It must preserve the
+ * events publish path (`upsert_event`), the fetch disposition tools
+ * (`reject_source`, `defer_item`), and read/research tools.
+ *
+ * @package DataMachineEvents\Tests\Unit
+ * @since   0.46.0
+ */
+
+namespace DataMachineEvents\Tests\Unit;
+
+use WP_UnitTestCase;
+
+use function DataMachineEvents\Core\event_ai_blocked_tools;
+use function DataMachineEvents\Core\is_event_upsert_ai_step;
+use function DataMachineEvents\Core\strip_event_ai_content_tools;
+
+class EventToolGuardTest extends WP_UnitTestCase {
+
+	/**
+	 * A resolved-tools args blob for a pipeline AI step whose NEXT step is the
+	 * events upsert — the canonical `event_import → ai → upsert` shape.
+	 */
+	private function eventsAiArgs( array $overrides = array() ): array {
+		return array_merge(
+			array(
+				'modes'                => array( 'pipeline' ),
+				'previous_step_config' => array(
+					'step_type'      => 'event_import',
+					'handler_slugs'  => array( 'ticketmaster' ),
+					'flow_step_id'   => 'import_1',
+				),
+				'next_step_config'     => array(
+					'step_type'      => 'upsert',
+					'handler_slugs'  => array( 'upsert_event' ),
+					'flow_step_id'   => 'upsert_1',
+				),
+				'pipeline_step_id'     => 'ai_1',
+			),
+			$overrides
+		);
+	}
+
+	/**
+	 * A sample resolved tool set mimicking what ToolPolicyResolver hands the
+	 * filter: the events handler tool, the fetch dispositions, read/research
+	 * tools, and the generic content-writing tools that must be stripped.
+	 */
+	private function sampleTools(): array {
+		return array(
+			'upsert_event'    => array( 'handler' => 'upsert_event' ),
+			'reject_source'   => array( 'handler' => 'fetch_disposition' ),
+			'defer_item'      => array( 'handler' => 'fetch_disposition' ),
+			'web_fetch'       => array(),
+			'query_posts'     => array(),
+			// Generic content-writing tools — the leak vector from issue #412.
+			'upsert_post'     => array( 'ability' => 'datamachine/upsert-post' ),
+			'insert_content'  => array( 'ability' => 'datamachine/insert-content' ),
+			'wordpress_publish' => array( 'handler' => 'wordpress_publish' ),
+		);
+	}
+
+	// ────────────────────────────────────────────────────────────────────
+	// event_ai_blocked_tools
+	// ────────────────────────────────────────────────────────────────────
+
+	public function test_default_block_list_targets_generic_content_writers(): void {
+		$blocked = event_ai_blocked_tools();
+
+		$this->assertContains( 'upsert_post', $blocked );
+		$this->assertContains( 'insert_content', $blocked );
+		$this->assertContains( 'wordpress_publish', $blocked );
+
+		// The events publish path and dispositions must never be in the strip list.
+		$this->assertNotContains( 'upsert_event', $blocked );
+		$this->assertNotContains( 'reject_source', $blocked );
+		$this->assertNotContains( 'defer_item', $blocked );
+	}
+
+	public function test_block_list_is_filterable(): void {
+		$added = static function ( $tools ) {
+			$tools[] = 'custom_leaky_tool';
+			return $tools;
+		};
+		add_filter( 'data_machine_events_event_ai_blocked_tools', $added );
+
+		$blocked = event_ai_blocked_tools();
+
+		remove_filter( 'data_machine_events_event_ai_blocked_tools', $added );
+
+		$this->assertContains( 'custom_leaky_tool', $blocked );
+	}
+
+	// ────────────────────────────────────────────────────────────────────
+	// is_event_upsert_ai_step
+	// ────────────────────────────────────────────────────────────────────
+
+	public function test_detects_events_ai_step_via_next_upsert(): void {
+		$this->assertTrue( is_event_upsert_ai_step( $this->eventsAiArgs() ) );
+	}
+
+	public function test_detects_events_ai_step_via_previous_upsert(): void {
+		$args = array(
+			'modes'                => array( 'pipeline' ),
+			'previous_step_config' => array(
+				'step_type'     => 'upsert',
+				'handler_slugs' => array( 'upsert_event' ),
+			),
+			'next_step_config'     => array(
+				'step_type'     => 'event_import',
+				'handler_slugs' => array( 'ticketmaster' ),
+			),
+		);
+
+		$this->assertTrue( is_event_upsert_ai_step( $args ) );
+	}
+
+	public function test_ignores_non_pipeline_mode(): void {
+		$args = $this->eventsAiArgs( array( 'modes' => array( 'chat' ) ) );
+
+		// Chat/system resolution must never be narrowed by this pipeline guard.
+		$this->assertFalse( is_event_upsert_ai_step( $args ) );
+	}
+
+	public function test_ignores_ai_step_adjacent_to_non_event_upsert(): void {
+		// A generic wordpress_publish upsert/publish step is NOT an events step.
+		$args = array(
+			'modes'                => array( 'pipeline' ),
+			'next_step_config'     => array(
+				'step_type'     => 'publish',
+				'handler_slugs' => array( 'wordpress_publish' ),
+			),
+		);
+
+		$this->assertFalse( is_event_upsert_ai_step( $args ) );
+	}
+
+	public function test_ignores_step_when_no_adjacent_handlers(): void {
+		$this->assertFalse( is_event_upsert_ai_step( array( 'modes' => array( 'pipeline' ) ) ) );
+	}
+
+	public function test_ignores_upsert_step_without_event_handler(): void {
+		$args = array(
+			'modes'                => array( 'pipeline' ),
+			'next_step_config'     => array(
+				'step_type'     => 'upsert',
+				'handler_slugs' => array( 'some_other_upsert' ),
+			),
+		);
+
+		$this->assertFalse( is_event_upsert_ai_step( $args ) );
+	}
+
+	// ────────────────────────────────────────────────────────────────────
+	// strip_event_ai_content_tools
+	// ────────────────────────────────────────────────────────────────────
+
+	public function test_strips_generic_content_tools_from_events_ai_step(): void {
+		$tools = strip_event_ai_content_tools( $this->sampleTools(), $this->eventsAiArgs() );
+
+		$this->assertArrayNotHasKey( 'upsert_post', $tools );
+		$this->assertArrayNotHasKey( 'insert_content', $tools );
+		$this->assertArrayNotHasKey( 'wordpress_publish', $tools );
+	}
+
+	public function test_preserves_events_publish_and_disposition_tools(): void {
+		$tools = strip_event_ai_content_tools( $this->sampleTools(), $this->eventsAiArgs() );
+
+		$this->assertArrayHasKey( 'upsert_event', $tools );
+		$this->assertArrayHasKey( 'reject_source', $tools );
+		$this->assertArrayHasKey( 'defer_item', $tools );
+	}
+
+	public function test_preserves_read_and_research_tools(): void {
+		$tools = strip_event_ai_content_tools( $this->sampleTools(), $this->eventsAiArgs() );
+
+		$this->assertArrayHasKey( 'web_fetch', $tools );
+		$this->assertArrayHasKey( 'query_posts', $tools );
+	}
+
+	public function test_leaves_tools_unchanged_for_non_events_step(): void {
+		$args = array(
+			'modes'                => array( 'pipeline' ),
+			'next_step_config'     => array(
+				'step_type'     => 'publish',
+				'handler_slugs' => array( 'wordpress_publish' ),
+			),
+		);
+
+		$tools = strip_event_ai_content_tools( $this->sampleTools(), $args );
+
+		// A blog-publish pipeline keeps its generic tools — only events is narrowed.
+		$this->assertArrayHasKey( 'upsert_post', $tools );
+		$this->assertArrayHasKey( 'insert_content', $tools );
+		$this->assertArrayHasKey( 'wordpress_publish', $tools );
+	}
+
+	public function test_leaves_tools_unchanged_for_chat_mode(): void {
+		$args = $this->eventsAiArgs( array( 'modes' => array( 'chat' ) ) );
+
+		$tools = strip_event_ai_content_tools( $this->sampleTools(), $args );
+
+		$this->assertArrayHasKey( 'upsert_post', $tools );
+	}
+
+	public function test_no_op_when_block_list_emptied(): void {
+		// An operator who filters the strip list down to nothing opts out of the
+		// guard; the resolved set must pass through verbatim.
+		$clear = static function () {
+			return array();
+		};
+		add_filter( 'data_machine_events_event_ai_blocked_tools', $clear );
+
+		$tools = strip_event_ai_content_tools( $this->sampleTools(), $this->eventsAiArgs() );
+
+		remove_filter( 'data_machine_events_event_ai_blocked_tools', $clear );
+
+		$this->assertArrayHasKey( 'upsert_post', $tools );
+		$this->assertArrayHasKey( 'insert_content', $tools );
+	}
+
+	public function test_actually_hooks_the_resolved_tools_filter(): void {
+		// The plugin bootstrap registers the filter; verify the callback is
+		// wired so the guard is live on real AI step resolutions, not just
+		// callable as a pure function.
+		$this->assertTrue(
+			has_filter( 'datamachine_resolved_tools', 'DataMachineEvents\Core\apply_event_tool_guard' ) !== false,
+			'apply_event_tool_guard must be hooked on datamachine_resolved_tools'
+		);
+	}
+}


### PR DESCRIPTION
Fixes Extra-Chill/data-machine-events#412

## Root cause

Events pipelines are shaped `event_import → ai → upsert`, where the upsert handler is `upsert_event` (creates `data_machine_events` posts). The AI step carried an empty `enabled_tools` allow-list. DM core exposes generic content-publishing ability tools (`upsert_post`, `insert_content`) to **every** pipeline AI step by default — they declare `modes` including `pipeline`, and `ToolPolicyResolver` only narrows the set when a step explicitly carries an allow-list. With no allow-list set, the events AI agent could reach past `upsert_event` and publish plain `post`-type junk ("rejection reports", "admin logs"), bypassing `EventUpsert` and its junk-title guard entirely. This leaked **224 junk `post` items** across ~75 flows on the events site.

## What I changed and why this layer

I read the seeding path first: this plugin does **not** programmatically create/register pipelines or AI-step defaults (no pipeline/flow/step-default seeding code exists — `load_data_machine_components()` only instantiates handlers, abilities, and filter registrations). Events flows are hand-built in the DM UI and stored as `flow_config` data. A code default for new flows therefore could not retroactively protect the ~75 existing flow rows.

So the fix hooks DM core's `datamachine_resolved_tools` filter (`ToolPolicyResolver::resolve()`, ~line 151) and **strips the generic content-writing tools** whenever the AI step being resolved is adjacent to an `upsert_event` upsert step. New file: `inc/Core/event-tool-guard.php`, following the proven `web-fetch-guard.php` pattern.

**Detection keys off the events pipeline shape, not flow IDs:** an AI step is treated as an "events AI step" iff it resolves in `pipeline` mode AND one of its adjacent step configs carries `upsert_event` in its `handler_slugs`. This reuses the exact signal DM core's own `FlowStepConfig::getAdjacentRequiredHandlerSlugsForAi` trusts to wire the `upsert_event` tool itself. Because the filter runs at resolution time, **every existing events flow is covered automatically with no data migration.**

### The strip list (filterable via `data_machine_events_event_ai_blocked_tools`)
- `upsert_post` — `UpsertPostAbility` (modes: chat/pipeline/system). Can mint any post type.
- `insert_content` — `InsertContentAbility` (modes: chat/pipeline/system/editor). Can write arbitrary post content.
- `wordpress_publish` — generic publish-step handler tool (only present when a publish step is adjacent; stripped defensively).

### Preserved (untouched)
- `upsert_event` — the declared events publish handler (the only legitimate publish path).
- `reject_source`, `defer_item` — fetch disposition tools (the *correct* way to drop a non-music item).
- `web_fetch`, read/dedup/research tools — the read/research surface the flows rely on.

A deny-strip (rather than a hard allow-list) is the deliberate choice here: it surgically removes the leak vector while preserving every research tool the flows already depend on, so it cannot silently break an existing flow. The strip list is also filterable so operators can adjust without code changes.

## Tests

`tests/Unit/EventToolGuardTest.php` (follows the `WebFetchGuardTest` pattern) asserts:
- Given an AI step adjacent to an `upsert_event` upsert, the resolved set **excludes** `upsert_post` / `insert_content` / `wordpress_publish` and **includes** `upsert_event`, `reject_source`, `defer_item`, `web_fetch`.
- A non-events pipeline (e.g. adjacent `wordpress_publish` publish step) is **left unchanged** — the guard only narrows events.
- Chat/system mode is never narrowed.
- Detection works via either previous or next adjacent upsert step.
- The block list is filterable (including empty-list opt-out = no-op).
- `apply_event_tool_guard` is actually hooked on `datamachine_resolved_tools`.

Note: the repo's PHPUnit suite needs the WordPress test bootstrap which isn't provisioned on the authoring host; I verified the pure-function logic with a standalone harness (all 18 assertions pass) and syntax-linted every changed file. The suite runs in the homeboy/CI sandbox.

## Existing flow rows — covered?

**Yes, retroactively.** Because this is a runtime filter on tool resolution (not a data default applied at flow creation), it applies to the existing ~75 events flows on the next AI step resolution without any data migration. No backfill WP-CLI command is needed for the allow-list itself. (The 224 already-leaked junk posts are out of scope for this PR — that's a one-off cleanup, tracked separately.)

## Durable core fix

The real fix — making generic publish tools opt-in in DM core so no pipeline AI step sees them without an explicit allow-list — is tracked in **Extra-Chill/data-machine#2852**. This PR is the events-layer mitigation. Once the core fix lands, this guard becomes harmless belt-and-suspenders.