### PR TITLE
fix: log and harden empty-startDate rejection gate at event upsert

### DIFF
--- a/inc/Steps/Upsert/Events/EventUpsert.php
+++ b/inc/Steps/Upsert/Events/EventUpsert.php
@@ -118,12 +118,35 @@ class EventUpsert extends UpsertHandler {
 		$datetime_confidence = $this->getDateTimeConfidence( $parameters, $engine );
 
 		if ( 'none' === $datetime_confidence ) {
+			// A startTime present with an empty/unparseable startDate is the
+			// exact signature of a date-extraction failure upstream (the fetch
+			// step got the time but not the date). Surface it as a distinct
+			// warning so the source parser can be improved, and reject the
+			// item instead of publishing an undated event. See issue #415.
+			$start_time = trim( (string) ( $engine->get( 'startTime' ) ?? $parameters['startTime'] ?? '' ) );
+
+			if ( '' !== $start_time ) {
+				do_action(
+					'datamachine_log',
+					'warning',
+					'Event Upsert: rejected undated event — startTime present but startDate is missing or unparseable (upstream date extraction failed)',
+					array(
+						'title'               => $title,
+						'venue'               => $venue,
+						'startDate'           => $startDate,
+						'startTime'           => $start_time,
+						'datetime_confidence' => $datetime_confidence,
+					)
+				);
+			}
+
 			return $this->errorResponse(
 				'valid startDate is required for event upsert',
 				array(
 					'title'               => $title,
 					'venue'               => $venue,
 					'startDate'           => $startDate,
+					'startTime'           => $start_time,
 					'datetime_confidence' => $datetime_confidence,
 				)
 			);

--- a/tests/Unit/EventUpsertTest.php
+++ b/tests/Unit/EventUpsertTest.php
@@ -178,6 +178,116 @@ class EventUpsertTest extends WP_UnitTestCase {
 		$this->assertSame( 'date_only', $result );
 	}
 
+	public function test_datetime_confidence_full_with_date_and_time(): void {
+		$method = new \ReflectionMethod( $this->handler, 'getDateTimeConfidence' );
+		$method->setAccessible( true );
+
+		$engine = new \DataMachine\Core\EngineData( array(), 0 );
+
+		$result = $method->invoke(
+			$this->handler,
+			array(
+				'title'     => 'Full Event',
+				'startDate' => '2026-07-05',
+				'startTime' => '20:00',
+			),
+			$engine
+		);
+
+		$this->assertSame( 'full', $result, 'A valid Y-m-d date plus a time must yield full datetime confidence.' );
+	}
+
+	/**
+	 * Regression: an event with no startDate must be rejected at the upsert
+	 * boundary — an undated event can never be published.
+	 *
+	 * @see https://github.com/Extra-Chill/data-machine-events/issues/415
+	 */
+	public function test_execute_upsert_rejects_empty_start_date(): void {
+		$method = new \ReflectionMethod( $this->handler, 'executeUpsert' );
+		$method->setAccessible( true );
+
+		$engine = new \DataMachine\Core\EngineData( array(), 0 );
+
+		$result = $method->invoke(
+			$this->handler,
+			array(
+				'title'  => 'Undated Event ' . uniqid(),
+				'engine' => $engine,
+				'job_id' => 0,
+			),
+			array()
+		);
+
+		$this->assertFalse( $result['success'] ?? null, 'Upsert with an empty startDate must not succeed.' );
+		$this->assertStringContainsString( 'startDate', $result['error'] ?? '', 'Error must reference the missing startDate.' );
+	}
+
+	/**
+	 * Regression: a startTime present with an empty startDate is the exact
+	 * failure signature of upstream date-extraction failure (the scraper got
+	 * the time but not the date). It must be rejected, never published.
+	 *
+	 * @see https://github.com/Extra-Chill/data-machine-events/issues/415
+	 */
+	public function test_execute_upsert_rejects_start_time_without_start_date(): void {
+		$method = new \ReflectionMethod( $this->handler, 'executeUpsert' );
+		$method->setAccessible( true );
+
+		$engine = new \DataMachine\Core\EngineData(
+			array(
+				'startTime' => '19:00',
+			),
+			0
+		);
+
+		$result = $method->invoke(
+			$this->handler,
+			array(
+				'title'    => 'Time Only Event ' . uniqid(),
+				'startTime' => '19:00',
+				'engine'   => $engine,
+				'job_id'   => 0,
+			),
+			array()
+		);
+
+		$this->assertFalse( $result['success'] ?? null, 'Upsert with a startTime but no startDate must not succeed.' );
+		$this->assertStringContainsString( 'startDate', $result['error'] ?? '' );
+	}
+
+	/**
+	 * Regression: an unparseable startDate (wrong format / impossible calendar
+	 * date) must be rejected just like a missing one.
+	 *
+	 * @see https://github.com/Extra-Chill/data-machine-events/issues/415
+	 */
+	public function test_execute_upsert_rejects_unparseable_start_date(): void {
+		$method = new \ReflectionMethod( $this->handler, 'executeUpsert' );
+		$method->setAccessible( true );
+
+		$engine = new \DataMachine\Core\EngineData(
+			array(
+				'startDate' => '2026-13-99',
+			),
+			0
+		);
+
+		$result = $method->invoke(
+			$this->handler,
+			array(
+				'title'     => 'Bad Date Event ' . uniqid(),
+				'startDate' => '2026-13-99',
+				'engine'    => $engine,
+				'job_id'    => 0,
+			),
+			array()
+		);
+
+		$this->assertFalse( $result['success'] ?? null, 'Upsert with an unparseable startDate must not succeed.' );
+		$this->assertStringContainsString( 'startDate', $result['error'] ?? '' );
+	}
+
 	/**
 	 * Verify that recurring series events with the same title but different
 	 * dates are treated as distinct events, not duplicates.


### PR DESCRIPTION
Closes #415

## Root cause

The event upsert handler (`EventUpsert::executeUpsert`) **already rejects** events with an empty or unparseable `startDate` via the `getDateTimeConfidence()` guard that returns `'none'` → `errorResponse` (returning `success: false` before the `datamachine/upsert-post` ability is ever called). That guard has been in place since #99 (Mar 2026) and there are **no** `wp_insert_post` paths that bypass the upsert handler for events.

The 11 live published events with `{"startDate":"","startTime":"19:00",...}` (all from the Armadillo Den scraper flow) were **legacy data** created before the guard existed / via the now-replaced `Publisher` code path. They have been cleaned up operationally (set to draft) per the issue's cleanup note — confirmed 0 such events remain on `events.extrachill.com` (blog 7).

So publication of *new* undated events is **already prevented**. The genuine gaps this PR closes:

1. **No diagnostic logging of the exact failure signature.** When `startTime` is present but `startDate` is empty/unparseable, the rejection was logged only as a generic upsert error. That specific combination is the fingerprint of an upstream date-extraction failure (the fetch step got the time but not the date) and should be surfaced so the source parser can be improved — the issue explicitly calls this out.
2. **No regression test through the full `executeUpsert` path.** Only the isolated `getDateTimeConfidence()` helper had coverage; nothing proved the end-to-end guard actually rejects (and never publishes) an undated event.

## Where the gate was added / changed

`inc/Steps/Upsert/Events/EventUpsert.php` — inside the existing `getDateTimeConfidence() === 'none'` block (the last gate before write, protecting **every** fetch handler: web scraper, Ticketmaster, Dice).

The change:
- Captures `startTime` and, when present alongside an empty/unparseable `startDate`, emits a **distinct `warning`** log naming the signature ("startTime present but startDate is missing or unparseable (upstream date extraction failed)").
- Adds `startTime` to the `errorResponse` context.
- **Generic** — validates normalized event data only; no venue/vendor names (layer purity).

## Skip-vs-draft decision

**Matched the existing codebase convention: skip-and-log (errorResponse).** The upsert handler's established pattern for every rejection (missing title, junk-title markers from #349/#367, missing date) is to return `errorResponse` (`success: false`) without creating a post, letting the AI call the `reject_source` disposition tool. Routing to `draft` would introduce a second, divergent rejection path and accumulate review-backlog noise from scraper noise. Keeping a single, consistent rejection path is the right call here.

## Files changed

- `inc/Steps/Upsert/Events/EventUpsert.php` — enriched the empty/unparseable-startDate rejection with signature-specific warning logging + `startTime` context.
- `tests/Unit/EventUpsertTest.php` — added regression tests through the full `executeUpsert` guard:
  - `test_execute_upsert_rejects_empty_start_date` — no date → rejected.
  - `test_execute_upsert_rejects_start_time_without_start_date` — the exact failure signature → rejected.
  - `test_execute_upsert_rejects_unparseable_start_date` — `"2026-13-99"` → rejected.
  - `test_datetime_confidence_full_with_date_and_time` — valid date + time → full confidence (guard does **not** fire).

## Test / lint results

- `php -l` clean on both changed files.
- PHPStan (homeboy lint, level 7) **passed** for this component.
- `homeboy lint` overall reported `failed` only on the **eslint** step (JS blocks, unrelated to this PHP-only change).
- **PHPUnit could not run — test sandbox unavailable on this host.** `php -l` is clean and the new tests will run in CI. The tests use `ReflectionMethod` on `executeUpsert`/`getDateTimeConfidence` with an `EngineData` stub and assert the guard returns `success: false` before any post/ability/DB interaction, so they are isolated and deterministic.

## Notes

- No release / deploy / merge (per task scope).
- CHANGELOG and version strings untouched (homeboy owns both).