### PR TITLE
refactor: delete legacy meta_query dedup cascade — indexed strategy owns all duplicate detection

### DIFF
--- a/inc/Core/DuplicateDetection/EventDuplicateStrategy.php
+++ b/inc/Core/DuplicateDetection/EventDuplicateStrategy.php
@@ -15,6 +15,12 @@
  * All query logic uses PostIdentityIndex (indexed columns) instead of
  * wp_postmeta LIKE scans.
  *
+ * Date-awareness: every strategy scopes its index query by date_only
+ * (extracted from startDate in context). This means recurring series —
+ * same title and venue but a different calendar date — are never matched
+ * as duplicates. The same title + venue + date within a 2-hour time
+ * window IS a duplicate. See #423.
+ *
  * @package DataMachineEvents\Core\DuplicateDetection
  * @since   0.18.0
  */

--- a/inc/Steps/Upsert/Events/EventUpsert.php
+++ b/inc/Steps/Upsert/Events/EventUpsert.php
@@ -427,7 +427,7 @@ class EventUpsert extends UpsertHandler {
 	 * Execute the find-or-create logic within an advisory lock.
 	 *
 	 * Separated from executeUpsert() so the lock boundary is clear:
-	 * the lock is held from before findExistingEvent() through the
+	 * the lock is held from before findExistingEventViaAbility() through the
 	 * completion of the DM core upsert and post-processing.
 	 *
 	 * Domain-specific identity resolution (fuzzy title/venue/date matching,
@@ -585,8 +585,9 @@ class EventUpsert extends UpsertHandler {
 	 * the registered EventDuplicateStrategy, querying the PostIdentityIndex
 	 * with indexed lookups instead of postmeta LIKE scans.
 	 *
-	 * Falls back to the legacy findExistingEvent() if the ability or
-	 * identity index table is not available.
+	 * The indexed strategy is date-aware: every query scopes by date_only,
+	 * so recurring series (same title/venue, different date) are never
+	 * falsely matched. See #423.
 	 *
 	 * The `address` and `city` context fields let EventDuplicateStrategy
 	 * resolve the incoming venue via the same address-first cascade the
@@ -601,15 +602,21 @@ class EventUpsert extends UpsertHandler {
 	 * @return int|null Post ID if found, null otherwise.
 	 */
 	private function findExistingEventViaAbility( string $title, string $venue, string $startDate, string $ticketUrl, string $address = '', string $city = '' ): ?int {
-		// Check if the identity index table class exists (requires DM core >= 0.50.0).
-		if ( ! class_exists( 'DataMachine\\Core\\Database\\PostIdentityIndex\\PostIdentityIndex' ) ) {
-			return $this->findExistingEvent( $title, $venue, $startDate, $ticketUrl );
+		// The indexed EventDuplicateStrategy owns all event duplicate
+		// detection. If the index class or ability is unavailable (DM core
+		// too old), there is no safe fallback — return null so a new event
+		// is created rather than silently skipping dedup. In practice core
+		// is network-pinned so this branch is unreachable.
+		if ( ! class_exists( 'DataMachine\Core\Database\PostIdentityIndex\PostIdentityIndex' ) ) {
+			do_action( 'datamachine_log', 'warning', 'Event Upsert: PostIdentityIndex unavailable — skipping dedup, creating new event', array( 'title' => $title ) );
+			return null;
 		}
 
 		$duplicate_check = wp_get_ability( 'datamachine/check-duplicate' );
 
 		if ( ! $duplicate_check ) {
-			return $this->findExistingEvent( $title, $venue, $startDate, $ticketUrl );
+			do_action( 'datamachine_log', 'warning', 'Event Upsert: datamachine/check-duplicate ability unavailable — skipping dedup, creating new event', array( 'title' => $title ) );
+			return null;
 		}
 
 		$result = $duplicate_check->execute(
@@ -627,45 +634,50 @@ class EventUpsert extends UpsertHandler {
 			)
 		);
 
-		if ( is_array( $result ) && 'duplicate' === ( $result['verdict'] ?? '' ) ) {
-			$post_id = (int) ( $result['match']['post_id'] ?? 0 );
-			if ( $post_id > 0 ) {
-				// Verify the matched post has the same startDate. The core
-				// duplicate check matches on title similarity alone and does
-				// not consider event dates. Recurring series events (e.g.
-				// weekly "Barn Jam" at Awendaw Green) share the same title
-				// and venue but have different dates — these are distinct
-				// events, not duplicates.
-				// See: https://github.com/Extra-Chill/data-machine/issues/1108
-				if ( ! empty( $startDate ) ) {
-					$existing_data      = $this->extractEventData( $post_id );
-					$existing_startDate = $existing_data['startDate'] ?? '';
+		if ( ! ( is_array( $result ) && 'duplicate' === ( $result['verdict'] ?? '' ) ) ) {
+			return null;
+		}
 
-					if ( ! empty( $existing_startDate ) && $existing_startDate !== $startDate ) {
-						do_action(
-							'datamachine_log',
-							'info',
-							'Event Upsert: Ability matched title but startDate differs — treating as new event (recurring series)',
-							array(
-								'title'              => $title,
-								'venue'              => $venue,
-								'incoming_startDate' => $startDate,
-								'existing_startDate' => $existing_startDate,
-								'existing_post_id'   => $post_id,
-							)
-						);
+		$post_id = (int) ( $result['match']['post_id'] ?? 0 );
+		if ( $post_id <= 0 ) {
+			return null;
+		}
 
-						// Fall through to legacy date-aware lookup which
-						// searches by venue + date + fuzzy title.
-						return $this->findExistingEvent( $title, $venue, $startDate, $ticketUrl );
-					}
+		// Defensive date guard: EventDuplicateStrategy is date-aware (queries
+		// by date_only), so its own matches are always date-correct. However
+		// DM core may run additional strategies that match on title alone.
+		// If such a strategy returned this match and the existing event is
+		// on a genuinely different calendar date, treat it as a distinct
+		// recurring-series event rather than a duplicate.
+		// See: https://github.com/Extra-Chill/data-machine/issues/1108
+		if ( ! empty( $startDate ) ) {
+			$existing_data      = $this->extractEventData( $post_id );
+			$existing_startDate = $existing_data['startDate'] ?? '';
+
+			if ( ! empty( $existing_startDate ) ) {
+				$existing_date_only = self::extractDateForQuery( $existing_startDate );
+				$incoming_date_only = self::extractDateForQuery( $startDate );
+
+				if ( $existing_date_only !== $incoming_date_only ) {
+					do_action(
+						'datamachine_log',
+						'info',
+						'Event Upsert: Ability matched title but date differs — treating as new event (recurring series)',
+						array(
+							'title'            => $title,
+							'venue'            => $venue,
+							'incoming_date'    => $incoming_date_only,
+							'existing_date'    => $existing_date_only,
+							'existing_post_id' => $post_id,
+						)
+					);
+
+					return null;
 				}
-
-				return $post_id;
 			}
 		}
 
-		return null;
+		return $post_id;
 	}
 
 	/**
@@ -741,243 +753,9 @@ class EventUpsert extends UpsertHandler {
 	}
 
 	/**
-	 * Find existing event by title, venue, start date, and ticket URL
-	 *
-	 * Checks in order of reliability:
-	 * 1. Ticket URL matching (most reliable - stable identifier from ticketing platform)
-	 * 2. Fuzzy title matching at same venue/date
-	 * 3. Exact title matching
-	 *
-	 * @param string $title Event title
-	 * @param string $venue Venue name
-	 * @param string $startDate Start date (YYYY-MM-DD)
-	 * @param string $ticketUrl Ticket purchase URL
-	 * @return int|null Post ID if found, null otherwise
-	 */
-	private function findExistingEvent( string $title, string $venue, string $startDate, string $ticketUrl = '' ): ?int {
-		$identity_confidence = EventIdentifierGenerator::getIdentityConfidence( $title, $startDate, $venue );
-
-		// Try ticket URL matching first (most reliable)
-		if ( ! empty( $ticketUrl ) && ! empty( $startDate ) ) {
-			$ticket_match = $this->findEventByTicketUrl( $ticketUrl, $startDate );
-			if ( $ticket_match ) {
-				return $ticket_match;
-			}
-		}
-
-		// Try fuzzy title matching when we have venue and date
-		if ( ! empty( $venue ) && ! empty( $startDate ) ) {
-			$fuzzy_match = $this->findEventByVenueDateAndFuzzyTitle( $title, $venue, $startDate );
-			if ( $fuzzy_match ) {
-				return $fuzzy_match;
-			}
-		}
-
-		// Try exact title matching (with venue confirmation)
-		$exact_match = $this->findEventByExactTitle( $title, $venue, $startDate );
-		if ( $exact_match ) {
-			return $exact_match;
-		}
-
-		// Final safety net: fuzzy title + date search without venue constraint.
-		// Catches cross-source duplicates where venue names differ between scrapers
-		// (e.g. "Come and Take It Live" vs "Come and Take It Productions").
-		// Venue is passed for confirmation when both sides have it.
-		if ( ! empty( $startDate ) && 'low' !== $identity_confidence ) {
-			return $this->findEventByDateAndFuzzyTitle( $title, $startDate, $venue );
-		}
-
-		if ( ! empty( $startDate ) ) {
-			do_action(
-				'datamachine_log',
-				'debug',
-				'Event Upsert: Skipping venue-agnostic fuzzy fallback for low-confidence event identity',
-				array(
-					'title'               => $title,
-					'venue'               => $venue,
-					'startDate'           => $startDate,
-					'identity_confidence' => $identity_confidence,
-				)
-			);
-		}
-
-		return null;
-	}
-
-	/**
-	 * Find event by venue + date, then fuzzy title comparison
-	 *
-	 * Queries all events at a venue on a given date, then compares titles
-	 * using core title extraction to catch variations like tour names or openers.
-	 *
-	 * @param string $title Event title to match
-	 * @param string $venue Venue name
-	 * @param string $startDate Start date (YYYY-MM-DD)
-	 * @return int|null Post ID if fuzzy match found, null otherwise
-	 */
-	private function findEventByVenueDateAndFuzzyTitle( string $title, string $venue, string $startDate ): ?int {
-		if ( EventIdentifierGenerator::isLowConfidenceTitle( $title ) ) {
-			do_action(
-				'datamachine_log',
-				'debug',
-				'Event Upsert: Skipping venue-scoped fuzzy match for low-confidence title',
-				array(
-					'title'     => $title,
-					'venue'     => $venue,
-					'startDate' => $startDate,
-				)
-			);
-			return null;
-		}
-
-		// Find venue term — cascading lookup: exact name → slug → normalized name.
-		$venue_term = get_term_by( 'name', $venue, 'venue' );
-		if ( ! $venue_term ) {
-			$venue_slug = sanitize_title( $venue );
-			$venue_term = get_term_by( 'slug', $venue_slug, 'venue' );
-		}
-		if ( ! $venue_term ) {
-			$venue_term = \DataMachineEvents\Core\Venue_Taxonomy::find_venue_by_normalized_name_public( $venue );
-		}
-		if ( ! $venue_term ) {
-			do_action(
-				'datamachine_log',
-				'debug',
-				'Event Upsert: Venue term not found for fuzzy title matching, will try venue-agnostic fallback',
-				array(
-					'venue_name' => $venue,
-					'title'      => $title,
-					'startDate'  => $startDate,
-				)
-			);
-			return null;
-		}
-
-		// Query events at this venue on this date.
-		// Use date-only matching; time comparison is done separately.
-		$date_only  = self::extractDateForQuery( $startDate );
-		$ability    = new \DataMachineEvents\Abilities\EventDateQueryAbilities();
-		$result     = $ability->executeQueryEvents( array(
-			'date_match'  => $date_only,
-			'tax_filters' => array( 'venue' => array( $venue_term->term_id ) ),
-			'per_page'    => 10,
-			'status'      => 'any',
-		) );
-		$candidates = $result['posts'];
-
-		if ( empty( $candidates ) ) {
-			return null;
-		}
-
-		// Compare titles using core extraction and time window
-		foreach ( $candidates as $candidate ) {
-			if ( ! EventIdentifierGenerator::titlesMatch( $title, $candidate->post_title ) ) {
-				continue;
-			}
-
-			// Check time window if both events have time data
-			$candidate_dates   = \DataMachineEvents\Core\EventDatesTable::get( $candidate->ID );
-			$existing_datetime = $candidate_dates ? $candidate_dates->start_datetime : '';
-			if ( ! $this->isWithinTimeWindow( $startDate, $existing_datetime ) ) {
-				do_action(
-					'datamachine_log',
-					'debug',
-					'Event Upsert: Title matched but outside time window (possible early/late show)',
-					array(
-						'incoming_title'    => $title,
-						'matched_title'     => $candidate->post_title,
-						'incoming_datetime' => $startDate,
-						'existing_datetime' => $existing_datetime,
-						'post_id'           => $candidate->ID,
-					)
-				);
-				continue;
-			}
-
-			do_action(
-				'datamachine_log',
-				'info',
-				'Event Upsert: Fuzzy matched incoming title to existing event',
-				array(
-					'incoming_title' => $title,
-					'matched_title'  => $candidate->post_title,
-					'post_id'        => $candidate->ID,
-					'venue'          => $venue,
-					'date'           => $startDate,
-				)
-			);
-			return $candidate->ID;
-		}
-
-		return null;
-	}
-
-	/**
-	 * Check if two datetimes are within a tolerance window
-	 *
-	 * Used to distinguish early/late shows (3+ hours apart) from the same event
-	 * listed with different times across sources (typically within 1-2 hours).
-	 *
-	 * If either datetime lacks a time component, returns true (allows match).
-	 *
-	 * @param string $datetime1 First datetime (YYYY-MM-DD or YYYY-MM-DDTHH:MM)
-	 * @param string $datetime2 Second datetime (YYYY-MM-DD or YYYY-MM-DDTHH:MM)
-	 * @param int $windowHours Maximum hours apart to consider a match (default 2)
-	 * @return bool True if within window or time data unavailable
-	 */
-	private function isWithinTimeWindow( string $datetime1, string $datetime2, int $windowHours = 2 ): bool {
-		// If either is empty, allow match
-		if ( empty( $datetime1 ) || empty( $datetime2 ) ) {
-			return true;
-		}
-
-		// Normalize T separator to space for consistent parsing.
-		$datetime1 = self::normalizeDatetime( $datetime1 );
-		$datetime2 = self::normalizeDatetime( $datetime2 );
-
-		// Check if both have time components (space followed by time)
-		$has_time1 = preg_match( '/\s\d{2}:\d{2}/', $datetime1 );
-		$has_time2 = preg_match( '/\s\d{2}:\d{2}/', $datetime2 );
-
-		// If either lacks time, allow match (can't compare)
-		if ( ! $has_time1 || ! $has_time2 ) {
-			return true;
-		}
-
-		// Parse both datetimes
-		$time1 = strtotime( $datetime1 );
-		$time2 = strtotime( $datetime2 );
-
-		if ( false === $time1 || false === $time2 ) {
-			return true;
-		}
-
-		// Calculate absolute difference in hours
-		$diff_hours = abs( $time1 - $time2 ) / 3600;
-
-		return $diff_hours <= $windowHours;
-	}
-
-	/**
-	 * Normalize a datetime string for consistent comparison.
-	 *
-	 * Replaces ISO 8601 'T' separator with space so that LIKE queries
-	 * and string comparisons work against DB-stored values which use
-	 * space separators (e.g. '2026-03-20 21:00:00').
-	 *
-	 * @param string $datetime Datetime string in any common format.
-	 * @return string Normalized datetime with space separator.
-	 */
-	private static function normalizeDatetime( string $datetime ): string {
-		// Replace T separator with space: 2026-03-20T21:00:00 → 2026-03-20 21:00:00
-		return preg_replace( '/(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2})/', '$1 $2', $datetime );
-	}
-
-	/**
 	 * Extract just the date portion (YYYY-MM-DD) from a datetime string.
 	 *
-	 * Used for LIKE queries against the event datetime meta field.
-	 * The time comparison is done separately in isWithinTimeWindow().
+	 * Used for date-scoped queries and advisory-lock key derivation.
 	 *
 	 * @param string $datetime Datetime or date string.
 	 * @return string Date portion only (YYYY-MM-DD).
@@ -988,286 +766,6 @@ class EventUpsert extends UpsertHandler {
 			return $matches[1];
 		}
 		return $datetime;
-	}
-
-	/**
-	 * Find event by exact title match with venue confirmation
-	 *
-	 * Matches are returned when:
-	 * - No incoming venue (can't verify, trust the title+date match)
-	 * - Existing post has no venue assigned (can't verify, trust the match)
-	 * - Venues match exactly OR fuzzy-match (normalized comparison)
-	 *
-	 * @param string $title Event title
-	 * @param string $venue Venue name
-	 * @param string $startDate Start date (YYYY-MM-DD)
-	 * @return int|null Post ID if found, null otherwise
-	 */
-	private function findEventByExactTitle( string $title, string $venue, string $startDate ): ?int {
-		$low_confidence_title = EventIdentifierGenerator::isLowConfidenceTitle( $title );
-
-		if ( ! empty( $startDate ) ) {
-			$exact_date_only = self::extractDateForQuery( $startDate );
-			$ability         = new \DataMachineEvents\Abilities\EventDateQueryAbilities();
-			$result          = $ability->executeQueryEvents( array(
-				'date_match' => $exact_date_only,
-				'per_page'   => -1,
-				'fields'     => 'ids',
-				'status'     => 'any',
-			) );
-			// Filter to exact title match in PHP.
-			$posts = array();
-			foreach ( $result['posts'] as $candidate_id ) {
-				if ( get_the_title( $candidate_id ) === $title ) {
-					$posts[] = $candidate_id;
-					break;
-				}
-			}
-		} else {
-			$args  = array(
-				'post_type'      => Event_Post_Type::POST_TYPE,
-				'title'          => $title,
-				'posts_per_page' => 1,
-				'post_status'    => array( 'publish', 'draft', 'pending' ),
-				'fields'         => 'ids',
-			);
-			$posts = get_posts( $args );
-		}
-
-		if ( ! empty( $posts ) ) {
-			$post_id = $posts[0];
-
-			// No incoming venue — trust the title+date match only for stronger titles.
-			if ( empty( $venue ) ) {
-				if ( $low_confidence_title ) {
-					return null;
-				}
-				return $post_id;
-			}
-
-			$venue_terms = wp_get_post_terms( $post_id, 'venue', array( 'fields' => 'names' ) );
-
-			// Existing post has no venue — trust the title+date match only for stronger titles.
-			if ( empty( $venue_terms ) ) {
-				if ( $low_confidence_title ) {
-					return null;
-				}
-				return $post_id;
-			}
-
-			// Check venue: exact match first, then normalized comparison
-			foreach ( $venue_terms as $existing_venue ) {
-				if ( $venue === $existing_venue ) {
-					return $post_id;
-				}
-
-				if ( EventIdentifierGenerator::venuesMatch( $venue, $existing_venue ) ) {
-					do_action(
-						'datamachine_log',
-						'info',
-						'Event Upsert: Fuzzy venue match in exact title search',
-						array(
-							'incoming_venue' => $venue,
-							'existing_venue' => $existing_venue,
-							'post_id'        => $post_id,
-							'title'          => $title,
-						)
-					);
-					return $post_id;
-				}
-			}
-		}
-
-		return null;
-	}
-
-	/**
-	 * Find event by matching ticket URL on the same date
-	 *
-	 * Ticket URLs are stable identifiers from ticketing platforms.
-	 * Same ticket URL + same date = definitively the same event.
-	 *
-	 * @param string $ticketUrl Ticket purchase URL
-	 * @param string $startDate Start date (YYYY-MM-DD)
-	 * @return int|null Post ID if found, null otherwise
-	 */
-	private function findEventByTicketUrl( string $ticketUrl, string $startDate ): ?int {
-		if ( empty( $ticketUrl ) || empty( $startDate ) ) {
-			return null;
-		}
-
-		$normalized_url = datamachine_normalize_ticket_url( $ticketUrl );
-		if ( empty( $normalized_url ) ) {
-			return null;
-		}
-
-		// Strategy A: exact match on stored normalized URL
-		$ticket_date_only = self::extractDateForQuery( $startDate );
-		$ability          = new \DataMachineEvents\Abilities\EventDateQueryAbilities();
-		$result_a         = $ability->executeQueryEvents( array(
-			'date_match' => $ticket_date_only,
-			'per_page'   => 1,
-			'fields'     => 'ids',
-			'status'     => 'any',
-			'meta_query' => array(
-				array(
-					'key'     => EVENT_TICKET_URL_META_KEY,
-					'value'   => $normalized_url,
-					'compare' => '=',
-				),
-			),
-		) );
-		$posts            = $result_a['posts'];
-
-		if ( ! empty( $posts ) ) {
-			do_action(
-				'datamachine_log',
-				'info',
-				'Event Upsert: Found duplicate by ticket URL (exact)',
-				array(
-					'ticket_url'      => $ticketUrl,
-					'normalized_url'  => $normalized_url,
-					'matched_post_id' => $posts[0],
-					'date'            => $startDate,
-				)
-			);
-			return $posts[0];
-		}
-
-		// Strategy B: match on canonical ticket identity (unwraps affiliate URLs).
-		// This catches cases where one source provides an affiliate link and another
-		// provides the direct URL for the same event.
-		$canonical_identity = datamachine_extract_ticket_identity( $ticketUrl );
-		if ( empty( $canonical_identity ) || $canonical_identity === $normalized_url ) {
-			return null; // No different identity to check
-		}
-
-		// Search all events on the same date and compare their canonical identities
-		$result_b   = $ability->executeQueryEvents( array(
-			'date_match' => $ticket_date_only,
-			'per_page'   => 50,
-			'fields'     => 'ids',
-			'status'     => 'any',
-			'meta_query' => array(
-				array(
-					'key'     => EVENT_TICKET_URL_META_KEY,
-					'compare' => 'EXISTS',
-				),
-			),
-		) );
-		$candidates = $result_b['posts'];
-
-		foreach ( $candidates as $candidate_id ) {
-			$stored_url       = get_post_meta( $candidate_id, EVENT_TICKET_URL_META_KEY, true );
-			$stored_canonical = datamachine_extract_ticket_identity( $stored_url );
-
-			if ( $stored_canonical === $canonical_identity ) {
-				do_action(
-					'datamachine_log',
-					'info',
-					'Event Upsert: Found duplicate by ticket canonical identity',
-					array(
-						'ticket_url'         => $ticketUrl,
-						'canonical_identity' => $canonical_identity,
-						'stored_url'         => $stored_url,
-						'matched_post_id'    => $candidate_id,
-						'date'               => $startDate,
-					)
-				);
-				return $candidate_id;
-			}
-		}
-
-		return null;
-	}
-
-	/**
-	 * Find event by date and fuzzy title without venue constraint
-	 *
-	 * Last-resort deduplication for cross-source imports where the same event
-	 * appears with different venue names (e.g. "Come and Take It Live" vs
-	 * "Come and Take It Productions") or where one source omits the venue entirely.
-	 *
-	 * Queries all events on a given date and compares titles using core extraction.
-	 * More permissive than venue-scoped fuzzy matching — only fires as a final
-	 * fallback after ticket URL, venue+fuzzy, and exact title strategies all fail.
-	 *
-	 * When both the incoming event and a candidate have venue data, venue matching
-	 * is required to prevent false positives (e.g. "Open Mic Night" at two
-	 * different bars on the same date).
-	 *
-	 * @param string $title Event title to match
-	 * @param string $startDate Start date (YYYY-MM-DD)
-	 * @param string $venue Incoming venue name for confirmation (may be empty)
-	 * @return int|null Post ID if fuzzy match found, null otherwise
-	 */
-	private function findEventByDateAndFuzzyTitle( string $title, string $startDate, string $venue = '' ): ?int {
-		if ( EventIdentifierGenerator::isLowConfidenceTitle( $title ) ) {
-			return null;
-		}
-
-		$date_only  = self::extractDateForQuery( $startDate );
-		$ability    = new \DataMachineEvents\Abilities\EventDateQueryAbilities();
-		$result     = $ability->executeQueryEvents( array(
-			'date_match' => $date_only,
-			'per_page'   => 20,
-			'status'     => 'any',
-		) );
-		$candidates = $result['posts'];
-
-		if ( empty( $candidates ) ) {
-			return null;
-		}
-
-		foreach ( $candidates as $candidate ) {
-			if ( ! EventIdentifierGenerator::titlesMatch( $title, $candidate->post_title ) ) {
-				continue;
-			}
-
-			$candidate_dates   = \DataMachineEvents\Core\EventDatesTable::get( $candidate->ID );
-			$existing_datetime = $candidate_dates ? $candidate_dates->start_datetime : '';
-			if ( ! $this->isWithinTimeWindow( $startDate, $existing_datetime ) ) {
-				continue;
-			}
-
-			// When both sides have venue data, require venue match to avoid
-			// false positives on generic titles at different venues.
-			if ( ! empty( $venue ) ) {
-				$candidate_venues = wp_get_post_terms( $candidate->ID, 'venue', array( 'fields' => 'names' ) );
-				$candidate_venue  = ( ! is_wp_error( $candidate_venues ) && ! empty( $candidate_venues ) ) ? $candidate_venues[0] : '';
-
-				if ( ! empty( $candidate_venue ) && ! EventIdentifierGenerator::venuesMatch( $venue, $candidate_venue ) ) {
-					do_action(
-						'datamachine_log',
-						'debug',
-						'Event Upsert: Title matched but venues differ in venue-agnostic fallback',
-						array(
-							'incoming_title' => $title,
-							'matched_title'  => $candidate->post_title,
-							'incoming_venue' => $venue,
-							'existing_venue' => $candidate_venue,
-							'post_id'        => $candidate->ID,
-						)
-					);
-					continue;
-				}
-			}
-
-			do_action(
-				'datamachine_log',
-				'info',
-				'Event Upsert: Cross-source fuzzy match (venue-agnostic) found duplicate',
-				array(
-					'incoming_title' => $title,
-					'matched_title'  => $candidate->post_title,
-					'post_id'        => $candidate->ID,
-					'date'           => $startDate,
-				)
-			);
-			return $candidate->ID;
-		}
-
-		return null;
 	}
 
 	/**

--- a/tests/Unit/EventDuplicateStrategyTest.php
+++ b/tests/Unit/EventDuplicateStrategyTest.php
@@ -25,6 +25,8 @@ use DataMachineEvents\Core\DuplicateDetection\EventDuplicateStrategy;
 use DataMachineEvents\Core\Event_Post_Type;
 use DataMachineEvents\Core\EventDatesTable;
 use DataMachineEvents\Core\Venue_Taxonomy;
+use const DataMachineEvents\Core\EVENT_TICKET_URL_META_KEY;
+use function DataMachineEvents\Core\datamachine_normalize_ticket_url;
 
 class EventDuplicateStrategyTest extends WP_UnitTestCase {
 
@@ -270,6 +272,160 @@ class EventDuplicateStrategyTest extends WP_UnitTestCase {
 	}
 
 	// ---------------------------------------------------------------------
+	// check() — date-aware end-to-end cascade tests (#423)
+	// ---------------------------------------------------------------------
+
+	/**
+	 * Recurring series: same title, same venue, DIFFERENT date → NOT a
+	 * duplicate. The indexed strategy scopes every query by date_only,
+	 * so an event on 2026-04-22 is invisible to a lookup for 2026-05-06.
+	 *
+	 * This is the core behavior the legacy findExistingEvent() cascade
+	 * provided and that the indexed strategy must preserve now that the
+	 * legacy path is deleted. See #423, #1108.
+	 */
+	public function test_recurring_series_same_title_different_date_not_duplicate(): void {
+		$venue_name = 'Recurring Venue ' . uniqid();
+		[ $term_id, $existing_post_id ] = $this->seedVenueWithEvent(
+			'Barn Jam',
+			'2026-04-22 21:00:00',
+			$venue_name
+		);
+
+		// Same title, same venue, different date.
+		$result = EventDuplicateStrategy::check( array(
+			'title'   => 'Barn Jam',
+			'context' => array(
+				'venue'     => $venue_name,
+				'startDate' => '2026-05-06',
+				'ticketUrl' => '',
+			),
+		) );
+
+		$this->assertNull(
+			$result,
+			'Recurring series (same title, different date) must NOT be a duplicate.'
+		);
+
+		$this->cleanup( $term_id, $existing_post_id );
+	}
+
+	/**
+	 * Same title + same venue + same date, start times within the 2-hour
+	 * window → IS a duplicate.
+	 *
+	 * The seeded event starts at 21:00; the incoming event starts at
+	 * 22:30 — 1.5 hours apart, well within the 2-hour tolerance.
+	 */
+	public function test_same_title_venue_date_within_2h_is_duplicate(): void {
+		$venue_name = 'Dupe Venue ' . uniqid();
+		[ $term_id, $existing_post_id ] = $this->seedVenueWithEvent(
+			'Barn Jam',
+			'2026-04-22 21:00:00',
+			$venue_name
+		);
+
+		$result = EventDuplicateStrategy::check( array(
+			'title'   => 'Barn Jam',
+			'context' => array(
+				'venue'     => $venue_name,
+				'startDate' => '2026-04-22T22:30:00',
+				'ticketUrl' => '',
+			),
+		) );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'duplicate', $result['verdict'] );
+		$this->assertSame( $existing_post_id, $result['match']['post_id'] );
+
+		$this->cleanup( $term_id, $existing_post_id );
+	}
+
+	/**
+	 * Exact ticket-URL match on the same date → IS a duplicate.
+	 * Same ticket URL on a different date → NOT a duplicate.
+	 *
+	 * Ticket URLs are stable platform identifiers; same URL + same date
+	 * is definitively the same event. A different date means it's a
+	 * different occurrence (e.g. a multi-night run using the same
+	 * ticketing link).
+	 */
+	public function test_exact_ticket_url_match_dedups_same_date_only(): void {
+		$venue_name = 'Ticket Venue ' . uniqid();
+		$ticket_url = 'https://www.ticketmaster.com/event/12345ABCD';
+
+		[ $term_id, $existing_post_id ] = $this->seedVenueWithEvent(
+			'Concert Night',
+			'2026-04-22 20:00:00',
+			$venue_name,
+			$ticket_url
+		);
+
+		// Same ticket URL + same date → duplicate.
+		$result_same = EventDuplicateStrategy::check( array(
+			'title'   => 'Concert Night',
+			'context' => array(
+				'venue'     => $venue_name,
+				'startDate' => '2026-04-22',
+				'ticketUrl' => $ticket_url,
+			),
+		) );
+
+		$this->assertIsArray( $result_same );
+		$this->assertSame( 'duplicate', $result_same['verdict'] );
+		$this->assertSame( $existing_post_id, $result_same['match']['post_id'] );
+
+		// Same ticket URL + DIFFERENT date → NOT a duplicate.
+		$result_diff = EventDuplicateStrategy::check( array(
+			'title'   => 'Concert Night',
+			'context' => array(
+				'venue'     => $venue_name,
+				'startDate' => '2026-04-23',
+				'ticketUrl' => $ticket_url,
+			),
+		) );
+
+		$this->assertNull(
+			$result_diff,
+			'Same ticket URL on a different date must NOT be a duplicate.'
+		);
+
+		$this->cleanup( $term_id, $existing_post_id );
+	}
+
+	/**
+	 * Venue + date + fuzzy title match → IS a duplicate.
+	 *
+	 * The incoming title is a close variant of the stored title; the
+	 * SimilarityEngine's titlesMatch() should accept it. Both share the
+	 * same venue and date.
+	 */
+	public function test_venue_date_fuzzy_title_dedups(): void {
+		$venue_name = 'Fuzzy Venue ' . uniqid();
+		[ $term_id, $existing_post_id ] = $this->seedVenueWithEvent(
+			'Phish at the Pour House',
+			'2026-07-04 20:00:00',
+			$venue_name
+		);
+
+		// Incoming title is a fuzzy variant — same core identity.
+		$result = EventDuplicateStrategy::check( array(
+			'title'   => 'Phish at The Pour House',
+			'context' => array(
+				'venue'     => $venue_name,
+				'startDate' => '2026-07-04T21:00:00',
+				'ticketUrl' => '',
+			),
+		) );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'duplicate', $result['verdict'] );
+		$this->assertSame( $existing_post_id, $result['match']['post_id'] );
+
+		$this->cleanup( $term_id, $existing_post_id );
+	}
+
+	// ---------------------------------------------------------------------
 	// Helpers
 	// ---------------------------------------------------------------------
 
@@ -280,10 +436,15 @@ class EventDuplicateStrategyTest extends WP_UnitTestCase {
 	 *
 	 * @param string $title          Event title.
 	 * @param string $start_datetime MySQL datetime (e.g. '2026-05-19 21:00:00').
+	 * @param string $venue_name     Optional venue term name (defaults to 'Monks <uniqid>').
+	 * @param string $ticket_url     Optional ticket URL to seed in postmeta + index.
 	 * @return array{0:int,1:int}
 	 */
-	private function seedVenueWithEvent( string $title, string $start_datetime ): array {
-		$term = wp_insert_term( 'Monks ' . uniqid(), 'venue' );
+	private function seedVenueWithEvent( string $title, string $start_datetime, string $venue_name = '', string $ticket_url = '' ): array {
+		if ( '' === $venue_name ) {
+			$venue_name = 'Monks ' . uniqid();
+		}
+		$term = wp_insert_term( $venue_name, 'venue' );
 		$this->assertNotWPError( $term );
 		$term_id = (int) $term['term_id'];
 
@@ -304,20 +465,30 @@ class EventDuplicateStrategyTest extends WP_UnitTestCase {
 		// candidate datetime to compare against.
 		EventDatesTable::upsert( $post_id, $start_datetime );
 
+		// Seed ticket URL in postmeta (normalized, matching production
+		// event-dates-sync behavior) so canonical-identity comparison
+		// works in the ticket-URL strategy.
+		$normalized_ticket_url = '';
+		if ( '' !== $ticket_url ) {
+			$normalized_ticket_url = datamachine_normalize_ticket_url( $ticket_url );
+			update_post_meta( $post_id, EVENT_TICKET_URL_META_KEY, $normalized_ticket_url );
+		}
+
 		// Seed the identity-index row so findByExactTitle's
 		// find_by_date_and_title_hash() lookup finds this post.
 		$index      = new \DataMachine\Core\Database\PostIdentityIndex\PostIdentityIndex();
 		$date_only  = substr( $start_datetime, 0, 10 );
 		$title_hash = EventDuplicateStrategy::computeTitleHash( $title );
-		$index->upsert(
-			$post_id,
-			array(
-				'post_type'     => 'data_machine_events',
-				'event_date'    => $date_only,
-				'venue_term_id' => $term_id,
-				'title_hash'    => $title_hash,
-			)
+		$index_fields = array(
+			'post_type'     => 'data_machine_events',
+			'event_date'    => $date_only,
+			'venue_term_id' => $term_id,
+			'title_hash'    => $title_hash,
 		);
+		if ( '' !== $normalized_ticket_url ) {
+			$index_fields['ticket_url'] = $normalized_ticket_url;
+		}
+		$index->upsert( $post_id, $index_fields );
 
 		return array( $term_id, $post_id );
 	}

--- a/tests/Unit/EventUpsertTest.php
+++ b/tests/Unit/EventUpsertTest.php
@@ -47,21 +47,6 @@ class EventUpsertTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'promoter', $handlers );
 	}
 
-	public function test_find_existing_event_returns_null_for_new() {
-		$method = new \ReflectionMethod( $this->handler, 'findExistingEvent' );
-		$method->setAccessible( true );
-
-		$result = $method->invoke(
-			$this->handler,
-			'Unique Event ' . uniqid(),
-			'Test Venue',
-			'2026-12-31',
-			''
-		);
-
-		$this->assertNull( $result );
-	}
-
 	public function test_create_event_post_with_minimum_data() {
 		// Create a test event post directly
 		$post_id = wp_insert_post(
@@ -286,72 +271,6 @@ class EventUpsertTest extends WP_UnitTestCase {
 
 		$this->assertFalse( $result['success'] ?? null, 'Upsert with an unparseable startDate must not succeed.' );
 		$this->assertStringContainsString( 'startDate', $result['error'] ?? '' );
-	}
-
-	/**
-	 * Verify that recurring series events with the same title but different
-	 * dates are treated as distinct events, not duplicates.
-	 *
-	 * The legacy findExistingEvent() method correctly uses venue + date +
-	 * fuzzy title matching. This test verifies that the method returns null
-	 * for a different date at the same venue with the same title.
-	 *
-	 * @see https://github.com/Extra-Chill/data-machine/issues/1108
-	 */
-	public function test_find_existing_event_distinguishes_recurring_series_by_date(): void {
-		$method = new \ReflectionMethod( $this->handler, 'findExistingEvent' );
-		$method->setAccessible( true );
-
-		$venue_name = 'Recurring Venue ' . uniqid();
-
-		// Create venue term.
-		$venue_term = wp_insert_term( $venue_name, 'venue' );
-		$this->assertNotWPError( $venue_term );
-
-		// Create existing event: "Barn Jam" on April 22.
-		$existing_post_id = wp_insert_post(
-			array(
-				'post_title'   => 'Barn Jam',
-				'post_type'    => 'data_machine_events',
-				'post_status'  => 'publish',
-				'post_content' => '<!-- wp:data-machine-events/event-details {"startDate":"2026-04-22","venue":"' . $venue_name . '"} --><div class="wp-block-data-machine-events-event-details"></div><!-- /wp:data-machine-events/event-details -->',
-			)
-		);
-		$this->assertGreaterThan( 0, $existing_post_id );
-		wp_set_object_terms( $existing_post_id, array( $venue_term['term_id'] ), 'venue' );
-
-		// Search for "Barn Jam" at same venue but DIFFERENT date — should NOT match.
-		$result = $method->invoke(
-			$this->handler,
-			'Barn Jam',
-			$venue_name,
-			'2026-05-06',
-			''
-		);
-
-		$this->assertNull(
-			$result,
-			'findExistingEvent should NOT match same-title event on a different date (recurring series)'
-		);
-
-		// Search for "Barn Jam" at same venue and SAME date — should match.
-		$result_same_date = $method->invoke(
-			$this->handler,
-			'Barn Jam',
-			$venue_name,
-			'2026-04-22',
-			''
-		);
-
-		$this->assertSame(
-			$existing_post_id,
-			$result_same_date,
-			'findExistingEvent should match same-title event on the same date'
-		);
-
-		// Cleanup.
-		wp_delete_post( $existing_post_id, true );
-		wp_delete_term( $venue_term['term_id'], 'venue' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Closes #423.

Removes the parallel legacy dedup implementation (~513 lines) from `EventUpsert`, leaving `EventDuplicateStrategy` (indexed `PostIdentityIndex` queries) as the single source of truth for event duplicate detection.

## What existed before

Two parallel dedup implementations running the same 4-tier cascade (ticket-URL+date → venue+date+fuzzy-title → exact-title+date → date+fuzzy-title):

1. **Indexed path (kept):** `EventDuplicateStrategy::check()` — queries the `PostIdentityIndex` table with indexed columns. Already date-aware (every query scopes by `date_only`).
2. **Legacy path (deleted):** `EventUpsert::findExistingEvent()` + four helpers (`findEventByTicketUrl`, `findEventByExactTitle`, `findEventByVenueDateAndFuzzyTitle`, `findEventByDateAndFuzzyTitle`) — `meta_query` with `EXISTS` scans over `wp_postmeta`. Also included `isWithinTimeWindow()` and `normalizeDatetime()` helpers.

The legacy path was still live on the hot path: `findExistingEventViaAbility()` fell back to `findExistingEvent()` whenever the indexed check matched a title but the date differed (every recurring series — weekly barn jams, open mics, residencies).

## What was deleted

- `findExistingEvent()` — 49 lines
- `findEventByVenueDateAndFuzzyTitle()` — 96 lines
- `findEventByExactTitle()` — 77 lines
- `findEventByTicketUrl()` — 89 lines
- `findEventByDateAndFuzzyTitle()` — 68 lines
- `isWithinTimeWindow()` — 32 lines (instance method; the strategy has its own static copy)
- `normalizeDatetime()` — 4 lines
- **Total: ~513 lines removed** (including docblocks)

Kept: `extractDateForQuery()` (used by `acquireUpsertLock` and the date guard) and `extractEventData()` (used by the date guard).

## How the indexed strategy covers the recurring case

`EventDuplicateStrategy` was **already date-aware** — `check()` extracts `date_only` from `startDate` in context and passes it to every `PostIdentityIndex` query (`find_by_ticket_url_and_date`, `find_by_date_and_venue`, `find_by_date_and_title_hash`, `find_by_date`). This means:

- **Recurring series** (same title, same venue, different date): the index query for `date_only = 2026-05-06` will not return an event stored on `2026-04-22` → no match → new event created. ✓
- **Same title + venue + date within 2h window**: the index query finds the candidate, `titlesMatch()` confirms, `isWithinTimeWindow()` (2h) confirms → duplicate. ✓

The docblock now explicitly documents this date-awareness.

## `findExistingEventViaAbility()` changes

- **`class_exists` guard**: returns `null` (new event) instead of calling the deleted `findExistingEvent()`. DM core is network-pinned so this branch is unreachable in practice. Documented.
- **`! $duplicate_check` guard**: same — returns `null`.
- **Defensive date guard**: retained but now compares `date_only` (not full `startDate` strings, which could differ by format on the same date) and returns `null` instead of calling the deleted `findExistingEvent()`. This catches non-date-aware core strategies that might match on title alone — the `EventDuplicateStrategy` itself (priority 5, date-scoped) would never produce such a match.

## Behavior-preservation confirmation

The 4-tier cascade logic, affiliate-URL unwrapping (evyy.net → canonical), and 2-hour time window all survive unchanged in `EventDuplicateStrategy`. This PR consolidates **WHERE** the logic lives, not **WHAT** it decides. The bugs that motivated these behaviors (#252, #349, #367) remain covered by the indexed path.

## Test/lint results

- **`php -l`**: all 4 changed files pass ✓
- **PHPStan** (level 7): passed, 0 findings ✓
- **PHPCS**: 284 findings across the codebase — 15 in changed files, all **pre-existing** (short ternaries in untouched methods, PSR12 import ordering). No new findings introduced by this PR.
- **PHPUnit**: could not run — `homeboy review test` failed with "wp-codebox was found, but no candidate passed 'wp-codebox --version'" (sandbox unavailable on this host). Tests run in CI.

## Tests added

Removed two `EventUpsertTest` cases that tested the deleted `findExistingEvent()` directly. Added four `EventDuplicateStrategyTest` cases:

1. `test_recurring_series_same_title_different_date_not_duplicate` — same title/venue, different date → `null`
2. `test_same_title_venue_date_within_2h_is_duplicate` — same title/venue/date, times 1.5h apart → duplicate
3. `test_exact_ticket_url_match_dedups_same_date_only` — same ticket URL + same date → duplicate; same URL + different date → `null`
4. `test_venue_date_fuzzy_title_dedups` — fuzzy title variant + same venue + same date → duplicate