### PR TITLE
fix: scoped-count capability + single-day flat-list for location scope pages (#428)

### DIFF
--- a/inc/Abilities/EventDateQueryAbilities.php
+++ b/inc/Abilities/EventDateQueryAbilities.php
@@ -18,6 +18,7 @@ namespace DataMachineEvents\Abilities;
 use WP_Query;
 use DataMachineEvents\Core\Event_Post_Type;
 use DataMachineEvents\Core\EventDatesTable;
+use DataMachineEvents\Blocks\Calendar\Query\ScopeResolver;
 use DataMachineEvents\Blocks\Calendar\Query\UpcomingFilter;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -74,6 +75,11 @@ class EventDateQueryAbilities {
 							'time_end'    => array(
 								'type'        => 'string',
 								'description' => 'Time bound end (HH:MM:SS). Used with date_end.',
+							),
+							'time_scope'  => array(
+								'type'        => 'string',
+								'enum'        => array( 'today', 'tonight', 'this-weekend', 'this-week' ),
+								'description' => 'Named time scope that resolves to a concrete date/time window via ScopeResolver (today, tonight, this-weekend, this-week). The resolved window is applied through the same UpcomingFilter date-range path the calendar list uses, so count and list never drift. Explicit date_start/date_end take precedence and skip resolution. #428.',
 							),
 							'tax_filters' => array(
 								'type'        => 'object',
@@ -175,6 +181,7 @@ class EventDateQueryAbilities {
 		$days_ahead  = (int) ( $input['days_ahead'] ?? 0 );
 		$time_start  = $input['time_start'] ?? '';
 		$time_end    = $input['time_end'] ?? '';
+		$time_scope  = isset( $input['time_scope'] ) ? sanitize_key( $input['time_scope'] ) : '';
 		$tax_filters = is_array( $input['tax_filters'] ?? null ) ? $input['tax_filters'] : array();
 		$search      = $input['search'] ?? '';
 		$geo         = is_array( $input['geo'] ?? null ) ? $input['geo'] : array();
@@ -184,6 +191,28 @@ class EventDateQueryAbilities {
 		$order       = strtoupper( $input['order'] ?? 'ASC' ) === 'DESC' ? 'DESC' : 'ASC';
 		$status      = $input['status'] ?? 'publish';
 		$meta_query  = is_array( $input['meta_query'] ?? null ) ? $input['meta_query'] : array();
+
+		// #428: resolve a named time scope (today/tonight/this-weekend/
+		// this-week) to concrete date/time boundaries via ScopeResolver —
+		// the same source of truth the calendar LIST uses in
+		// CalendarAbilities::executeGetCalendarPage(). The resolved window
+		// flows into the existing date-range WHERE branch (buildDateClauses),
+		// which applies UpcomingFilter::range_start_where + start_datetime
+		// upper bound, so the count is constrained by the SAME primitive the
+		// list uses and the two can never drift. Explicit date_start/date_end
+		// from the caller take precedence (mirrors the list path, which only
+		// resolves scope "when user hasn't set explicit dates"), so a caller
+		// can still pin a precise window. Bare/unscoped requests (no
+		// time_scope) are untouched and keep reporting total upcoming.
+		if ( '' !== $time_scope && empty( $date_start ) && empty( $date_end ) ) {
+			$resolved = ScopeResolver::resolve( $time_scope );
+			if ( is_array( $resolved ) ) {
+				$date_start = $resolved['date_start'] ?? '';
+				$date_end   = $resolved['date_end'] ?? '';
+				$time_start = $resolved['time_start'] ?? '';
+				$time_end   = $resolved['time_end'] ?? '';
+			}
+		}
 
 		// Build WP_Query args.
 		$query_args = array(

--- a/inc/Blocks/Calendar/src/frontend.ts
+++ b/inc/Blocks/Calendar/src/frontend.ts
@@ -43,6 +43,21 @@ function isMonthGridMode( calendar: HTMLElement ): boolean {
 	return calendar.getAttribute( 'data-display-mode' ) === 'month-grid';
 }
 
+/**
+ * Whether the calendar is scoped to a single-day time window.
+ *
+ * Single-day scopes (tonight/today) render a flat vertical list — the
+ * horizontal carousel is poor UX when the whole result set fits one day.
+ * Mirrors the month-grid carousel skip: the `data-scope` attribute is
+ * emitted server-side in render.php and read here the same way
+ * `isMonthGridMode` reads `data-display-mode`. Multi-day scopes
+ * (this-week/this-weekend) keep the carousel. #428.
+ */
+function isSingleDayScope( calendar: HTMLElement ): boolean {
+	const scope = calendar.getAttribute( 'data-scope' );
+	return scope === 'tonight' || scope === 'today';
+}
+
 const calendarInstances = new WeakMap< HTMLElement, true >();
 
 document.addEventListener( 'DOMContentLoaded', function () {
@@ -63,6 +78,12 @@ function initCalendarInstance( calendar: HTMLElement ): void {
 
 	const gridMode = isMonthGridMode( calendar );
 
+	// #428: skip the horizontal carousel for single-day scopes (tonight/
+	// today) and render a flat vertical list instead. Mirrors the month-grid
+	// skip — `useCarousel` is the single gate for carousel init/destroy so
+	// both the initial mount and the content-updated re-init stay in sync.
+	const useCarousel = ! gridMode && ! isSingleDayScope( calendar );
+
 	if ( gridMode ) {
 		// In grid mode the list view is the mobile fallback and the
 		// progressive-render modules (lazy-render, day-loader) target
@@ -74,7 +95,9 @@ function initCalendarInstance( calendar: HTMLElement ): void {
 	} else {
 		initLazyRender( calendar );
 		initDayLoader( calendar );
-		initCarousel( calendar );
+		if ( useCarousel ) {
+			initCarousel( calendar );
+		}
 	}
 
 	initDatePicker( calendar, function () {
@@ -138,12 +161,12 @@ function initCalendarInstance( calendar: HTMLElement ): void {
 		function () {
 			destroyLazyRender( calendar );
 			destroyDayLoader( calendar );
-			if ( ! gridMode ) {
+			if ( useCarousel ) {
 				destroyCarousel( calendar );
 			}
 			initLazyRender( calendar );
 			initDayLoader( calendar );
-			if ( ! gridMode ) {
+			if ( useCarousel ) {
 				initCarousel( calendar );
 			}
 

--- a/inc/public-api.php
+++ b/inc/public-api.php
@@ -171,6 +171,13 @@ if ( ! function_exists( 'data_machine_events_query_events' ) ) {
 	 * - `order`        (string)  `'ASC'` | `'DESC'`.
 	 * - `date_start`   (string)  ISO date.
 	 * - `date_end`     (string)  ISO date.
+	 * - `time_scope`   (string)  Named window: `'today'`, `'tonight'`,
+	 *                            `'this-weekend'`, `'this-week'`. Resolves via
+	 *                            ScopeResolver and constrains the query to
+	 *                            that window through the same UpcomingFilter
+	 *                            path the calendar list uses, so a scoped
+	 *                            count matches the scoped list. Explicit
+	 *                            date_start/date_end take precedence. #428.
 	 *
 	 * @since 0.32.0
 	 *


### PR DESCRIPTION
Closes #428 (substrate half).

## What's fixed in this PR

### 1. Scoped-count capability for the substrate
The canonical event query ability (`data-machine-events/query-events`) now accepts an explicit, generic `time_scope` parameter (`today`, `tonight`, `this-weekend`, `this-week`). The value is resolved through the same `ScopeResolver` the calendar LIST uses, and the resulting date/time window flows into the existing `UpcomingFilter` date-range path. This lets callers request a scoped count without the substrate ever reading consumer query variables like `event_scope`.

- `inc/Abilities/EventDateQueryAbilities.php`: adds `time_scope` to input schema and resolves it to `date_start`/`date_end`/`time_start`/`time_end` before building the query. Explicit `date_start`/`date_end` take precedence; bare requests remain unchanged.
- `inc/public-api.php`: documents the new `time_scope` param in the `data_machine_events_query_events()` wrapper.

### 2. Single-day scopes render a flat list instead of a carousel
In `inc/Blocks/Calendar/src/frontend.ts`, single-day scopes (`today`, `tonight`) now skip the horizontal carousel and render a flat vertical list. Multi-day scopes (`this-week`, `this-weekend`) keep the carousel. This mirrors the existing month-grid carousel skip pattern and reads the server-emitted `data-scope` attribute the same way `isMonthGridMode()` reads `data-display-mode`.

## What's intentionally NOT in this PR
The consumer wiring that reads `event_scope` in `extrachill-events` and passes `time_scope` into the query ability is a follow-up in the `extrachill-events` repo. That layer owns the `event_scope` query variable; this substrate change stays layer-pure and knows nothing about it.

## Verification
- `php -l` passes on `inc/Abilities/EventDateQueryAbilities.php` and `inc/public-api.php`.
- `npm run build` in `inc/Blocks/Calendar` succeeded; `frontend.js` was regenerated (build artifacts are `.gitignore`d, source change is the committed delta).
- `grep -rn \"event_scope\" inc/` returns nothing — no consumer query-var leakage into the substrate.

## Files changed
- `inc/Abilities/EventDateQueryAbilities.php`
- `inc/Blocks/Calendar/src/frontend.ts`
- `inc/public-api.php`