### PR TITLE
fix: strip trailing address from venue name so find-or-create dedup works (#433)

### DIFF
--- a/inc/Core/Venue_Taxonomy.php
+++ b/inc/Core/Venue_Taxonomy.php
@@ -45,6 +45,26 @@ class Venue_Taxonomy {
 		'timezone'    => 'Timezone',
 	);
 
+	/**
+	 * US state / DC / territory postal abbreviations.
+	 *
+	 * Used by extract_address_from_name() as the conservative guard that
+	 * decides whether a trailing comma-separated segment is really a state
+	 * (and therefore the tail is an address blob) rather than two
+	 * incidental capital letters that happen to appear at the end of a
+	 * legitimate venue name.
+	 *
+	 * @var string[]
+	 */
+	private static $us_state_abbreviations = array(
+		'AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'FL', 'GA',
+		'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'ME', 'MD',
+		'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NH', 'NJ',
+		'NM', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 'PA', 'RI', 'SC',
+		'SD', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY',
+		'DC', 'PR', 'VI', 'GU', 'AS', 'MP',
+	);
+
 	public static function register() {
 		self::register_venue_taxonomy();
 
@@ -87,6 +107,10 @@ class Venue_Taxonomy {
 	 * Find or create a venue with given name and metadata
 	 *
 	 * Matching cascade:
+	 * 0. Address-in-name extraction (strips a trailing "street, city, ST zip"
+	 *    blob baked into the name — common with AI-extracted venue strings —
+	 *    and routes it into $venue_data BEFORE matching runs, so step 1 below
+	 *    can resolve it against the canonical venue by address)
 	 * 1. Address-based matching (normalized street + city comparison)
 	 * 2. Exact name match
 	 * 3. "The" prefix toggle ("The Royal American" ↔ "Royal American")
@@ -100,6 +124,21 @@ class Venue_Taxonomy {
 	 * @return array Array with keys: term_id, was_created
 	 */
 	public static function find_or_create_venue( $venue_name, $venue_data = array() ) {
+		// Strip a trailing address blob baked into the venue name (AI
+		// extraction sometimes returns "Venue Name, street, city, ST zip"
+		// as a single string). Must run first: it both cleans the name used
+		// for matching/creation below AND fills $venue_data so the
+		// address-based match immediately below can use it. See #433.
+		$extracted_address = self::extract_address_from_name( $venue_name );
+		if ( ! empty( $extracted_address ) ) {
+			$venue_name = $extracted_address['name'];
+			foreach ( array( 'address', 'city', 'state', 'zip' ) as $field ) {
+				if ( ! empty( $extracted_address[ $field ] ) && empty( $venue_data[ $field ] ) ) {
+					$venue_data[ $field ] = $extracted_address[ $field ];
+				}
+			}
+		}
+
 		// Address-based matching (source of truth)
 		$address = $venue_data['address'] ?? '';
 		$city    = $venue_data['city'] ?? '';
@@ -186,6 +225,136 @@ class Venue_Taxonomy {
 		return array(
 			'term_id'     => $term_id,
 			'was_created' => true,
+		);
+	}
+
+	/**
+	 * Detect and strip a trailing address blob baked into a venue name.
+	 *
+	 * AI-driven venue extraction (AI_DECIDES resolution) sometimes returns
+	 * the venue name and its address concatenated into ONE string, comma
+	 * separated, e.g.:
+	 *
+	 *   "The Dinghy , 8 J C Long Blvd, Isle of Palms, SC 29451"
+	 *   "Blind Tiger Pub, 36-38 Broad St, Charleston, SC 29403"
+	 *   "Lake Oconee , Greensboro, GA"
+	 *
+	 * Left alone, this becomes the taxonomy term NAME, which (a) produces
+	 * ugly terms and (b) defeats find_or_create_venue()'s dedup: the SAME
+	 * venue splits into a clean term and an address-suffixed term depending
+	 * on whether the AI happened to include the address that run. See #433.
+	 *
+	 * Heuristic (deliberately conservative — false negatives are cheap,
+	 * false positives truncate a real venue name):
+	 *
+	 * 1. Split the string on commas.
+	 * 2. A single-segment name (no commas) never matches — nothing to strip.
+	 * 3. The LAST segment must look like "<City>, <ST> <zip?>" or a bare
+	 *    "<ST> <zip>" / "<ST>" — i.e. it must end in a two-letter token that
+	 *    is a real US state/territory abbreviation (see
+	 *    self::$us_state_abbreviations), optionally followed by a 5 or
+	 *    5+4 digit ZIP. This is the load-bearing guard: legitimate venue
+	 *    names with commas ("Bar, Restaurant & Grill") never end in a state
+	 *    abbreviation, so they never match and are never truncated.
+	 * 4. Once the state-bearing tail segment is confirmed, everything from
+	 *    the SECOND segment onward is treated as the address blob (segment
+	 *    1 is the clean venue name). Within that blob, the last segment is
+	 *    parsed for a "<city>? <ST> <zip?>" pattern — if it carries its own
+	 *    leading city text (e.g. one comma-separated segment holds
+	 *    "Isle of Palms SC 29451"), that leading text becomes the city;
+	 *    otherwise the city is pulled from the next-to-last segment (e.g.
+	 *    when city and state are each their own comma segment). Anything
+	 *    remaining before the city is the street.
+	 *
+	 * Examples walked through the heuristic:
+	 * - "The Dinghy , 8 J C Long Blvd, Isle of Palms, SC 29451"
+	 *   → segments: ["The Dinghy", "8 J C Long Blvd", "Isle of Palms", "SC 29451"]
+	 *   → last segment "SC 29451" ends in state+zip, no leading city text → match.
+	 *   → name = "The Dinghy", street = "8 J C Long Blvd", city = "Isle of Palms",
+	 *     state = "SC", zip = "29451".
+	 * - "Lake Oconee , Greensboro, GA"
+	 *   → segments: ["Lake Oconee", "Greensboro", "GA"]
+	 *   → last segment "GA" is a bare state → match.
+	 *   → name = "Lake Oconee", street = "" (only 2 tail segments: city + state),
+	 *     city = "Greensboro", state = "GA".
+	 * - "Bar, Restaurant & Grill"
+	 *   → segments: ["Bar", "Restaurant & Grill"]
+	 *   → last segment "Restaurant & Grill" does not end in a state
+	 *     abbreviation → no match, name returned unchanged (empty array).
+	 * - "The Dinghy"
+	 *   → no commas → no match, name returned unchanged (empty array).
+	 *
+	 * @param string $venue_name Raw venue name, possibly with an address baked in.
+	 * @return array{name: string, address: string, city: string, state: string, zip: string}|array{}
+	 *         Empty array when no address tail was detected (name should be used as-is).
+	 */
+	public static function extract_address_from_name( string $venue_name ): array {
+		if ( false === strpos( $venue_name, ',' ) ) {
+			return array();
+		}
+
+		$segments = array_map( 'trim', explode( ',', $venue_name ) );
+		$segments = array_values( array_filter( $segments, static fn( $segment ) => '' !== $segment ) );
+
+		// Need at least "name" + one address segment to have anything to strip.
+		if ( count( $segments ) < 2 ) {
+			return array();
+		}
+
+		$last = end( $segments );
+
+		// The tail segment must end in a real state/territory abbreviation,
+		// optionally preceded by leading city text and optionally followed
+		// by a ZIP (5 or ZIP+4). This is what distinguishes an address blob
+		// from an ordinary comma-containing venue name (e.g.
+		// "Restaurant & Grill" never matches this pattern).
+		if ( ! preg_match(
+			'/^(?<city>.*?)\s*\b(?<state>[A-Z]{2})\s*(?<zip>\d{5}(?:-\d{4})?)?$/',
+			strtoupper( $last ),
+			$tail_matches
+		) ) {
+			return array();
+		}
+
+		$state = $tail_matches['state'];
+		$zip   = $tail_matches['zip'] ?? '';
+
+		if ( ! in_array( $state, self::$us_state_abbreviations, true ) ) {
+			return array();
+		}
+
+		// Confirmed: everything from the second segment onward is the
+		// address blob. First segment is the clean venue name.
+		$name         = array_shift( $segments );
+		$address_tail = $segments; // Remaining segments, ending in the state(+zip) segment just parsed.
+
+		// Drop the state(+zip) segment — already parsed above.
+		array_pop( $address_tail );
+
+		// Recover the original (non-uppercased) leading city text from
+		// inside the last segment, if any (e.g. "Isle of Palms SC 29451").
+		$city_in_last_segment = trim( mb_substr( $last, 0, mb_strlen( trim( $tail_matches['city'] ) ) ) );
+
+		if ( '' !== $city_in_last_segment ) {
+			// City was embedded in the same segment as the state/zip.
+			$city   = $city_in_last_segment;
+			$street = implode( ', ', $address_tail );
+		} else {
+			// City is its own comma-separated segment (or absent).
+			$city   = ! empty( $address_tail ) ? array_pop( $address_tail ) : '';
+			$street = implode( ', ', $address_tail );
+		}
+
+		if ( '' === $name ) {
+			return array();
+		}
+
+		return array(
+			'name'    => $name,
+			'address' => $street,
+			'city'    => $city,
+			'state'   => $state,
+			'zip'     => $zip,
 		);
 	}
 

--- a/tests/Unit/VenueNormalizationTest.php
+++ b/tests/Unit/VenueNormalizationTest.php
@@ -195,4 +195,108 @@ class VenueNormalizationTest extends WP_UnitTestCase {
 			'Suite-suffix address variant should resolve to the same venue term.'
 		);
 	}
+
+	// ---------------------------------------------------------------------
+	// Part C: address-in-name extraction (#433)
+	// ---------------------------------------------------------------------
+
+	public function test_extract_address_from_name_strips_full_address(): void {
+		$result = Venue_Taxonomy::extract_address_from_name(
+			'The Dinghy , 8 J C Long Blvd, Isle of Palms, SC 29451'
+		);
+
+		$this->assertSame( 'The Dinghy', $result['name'] );
+		$this->assertSame( '8 J C Long Blvd', $result['address'] );
+		$this->assertSame( 'Isle of Palms', $result['city'] );
+		$this->assertSame( 'SC', $result['state'] );
+		$this->assertSame( '29451', $result['zip'] );
+	}
+
+	public function test_extract_address_from_name_strips_address_no_zip(): void {
+		$result = Venue_Taxonomy::extract_address_from_name(
+			'Blind Tiger Pub, 36-38 Broad St, Charleston, SC'
+		);
+
+		$this->assertSame( 'Blind Tiger Pub', $result['name'] );
+		$this->assertSame( '36-38 Broad St', $result['address'] );
+		$this->assertSame( 'Charleston', $result['city'] );
+		$this->assertSame( 'SC', $result['state'] );
+	}
+
+	public function test_extract_address_from_name_strips_city_state_only(): void {
+		$result = Venue_Taxonomy::extract_address_from_name( 'Lake Oconee , Greensboro, GA' );
+
+		$this->assertSame( 'Lake Oconee', $result['name'] );
+		$this->assertSame( '', $result['address'] );
+		$this->assertSame( 'Greensboro', $result['city'] );
+		$this->assertSame( 'GA', $result['state'] );
+	}
+
+	public function test_extract_address_from_name_ignores_plain_name(): void {
+		$this->assertSame( array(), Venue_Taxonomy::extract_address_from_name( 'The Dinghy' ) );
+	}
+
+	public function test_extract_address_from_name_does_not_truncate_legit_comma_name(): void {
+		// "Restaurant & Grill" does not end in a state abbreviation, so the
+		// conservative guard must refuse to touch it.
+		$this->assertSame(
+			array(),
+			Venue_Taxonomy::extract_address_from_name( 'Bar, Restaurant & Grill' )
+		);
+	}
+
+	public function test_extract_address_from_name_does_not_truncate_slash_name(): void {
+		// No comma at all — nothing to strip regardless of trailing tokens.
+		$this->assertSame( array(), Venue_Taxonomy::extract_address_from_name( 'RADIO/EAST' ) );
+	}
+
+	public function test_find_or_create_venue_dedupes_clean_name_and_address_baked_name(): void {
+		// First call: clean name only (no metadata) — this is the scenario
+		// from #433 where a canonical clean-name term already exists.
+		$clean = Venue_Taxonomy::find_or_create_venue( 'The Dinghy Test ' . uniqid() );
+		$this->assertIsArray( $clean );
+		$this->assertNotNull( $clean['term_id'] );
+
+		$clean_term = get_term( $clean['term_id'], 'venue' );
+
+		// Second call: AI-style blob with the address baked into the name,
+		// but matching address metadata so it resolves via address match
+		// once extraction populates $venue_data.
+		$blob_name = $clean_term->name . ' , 8 J C Long Blvd, Isle of Palms, SC 29451';
+		$blob      = Venue_Taxonomy::find_or_create_venue(
+			$blob_name,
+			array(
+				'address' => '8 J C Long Blvd',
+				'city'    => 'Isle of Palms',
+				'state'   => 'SC',
+				'zip'     => '29451',
+			)
+		);
+
+		$this->assertIsArray( $blob );
+		$this->assertNotNull( $blob['term_id'] );
+
+		// Third call: same blob, but WITHOUT any pre-supplied address
+		// metadata — extraction must recover it from the name itself and
+		// still land on the same term via the normalized-name match
+		// (since no address meta was pre-populated on the second call's
+		// term until smart-merge runs).
+		$blob_only_name = $clean_term->name . ' , 8 J C Long Blvd, Isle of Palms, SC 29451';
+		$blob_only      = Venue_Taxonomy::find_or_create_venue( $blob_only_name );
+
+		$this->assertIsArray( $blob_only );
+		$this->assertSame(
+			$blob['term_id'],
+			$blob_only['term_id'],
+			'Extraction must recover address from the name itself even with no pre-supplied venue_data.'
+		);
+
+		// The created term's name must be the clean name — never the blob.
+		$created_term = get_term( $blob['term_id'], 'venue' );
+		$this->assertSame( $clean_term->name, $created_term->name );
+
+		// Address metadata must have landed on the term, not been discarded.
+		$saved_address = get_term_meta( $blob['term_id'], '_venue_address', true );
+		$this->assertSame( '8 J C Long Blvd', $saved_address );
+	}
 }


### PR DESCRIPTION
Fixes #433

## The bug

AI_DECIDES venue extraction often returns `"Venue Name, <street>, <City>, <ST> <zip>"` as ONE string, which becomes the taxonomy term NAME. This:

- produces ugly terms, and
- defeats `find_or_create_venue()` dedup — the SAME venue splits into a clean term and an address-suffixed term depending on whether the AI happened to bake the address into the name that run.

Confirmed prod evidence:
- `The Dinghy` vs `The Dinghy , 8 J C Long Blvd, Isle of Palms, SC 29451` became two terms even though a canonical `The Dinghy` (id 3609) already existed.
- `Blind Tiger Pub, 36-38 Broad St, Charleston, SC 29403`
- `Lake Oconee , Greensboro, GA`

## The fix

Adds `Venue_Taxonomy::extract_address_from_name()` and calls it at the very top of `find_or_create_venue()`, before the existing address-first matching cascade runs. This means the recovered address fields flow straight into the *existing* address-match / smart-merge path — no parallel normalization path, single find-or-create venue path preserved per the class's existing architecture.

### Heuristic (conservative by design)

1. Split the raw name on commas. A single-segment name (no commas) never matches — nothing to strip.
2. The **last** segment must end in a real US state/territory abbreviation (`self::$us_state_abbreviations`, all 50 states + DC + territories), optionally preceded by leading city text in that same segment, optionally followed by a ZIP (5 or ZIP+4). This is the load-bearing guard: an ordinary comma-containing venue name (`"Bar, Restaurant & Grill"`) never ends in a state abbreviation, so it's never touched.
3. Once confirmed, segment 1 is the clean venue name. The remaining segments are parsed into street / city / state / zip: if the state+zip segment carries its own leading city text (`"Isle of Palms SC 29451"` as one comma segment), that becomes the city; otherwise city is pulled from the next comma segment (`"...,  Greensboro, GA"`).
4. Extracted `address`/`city`/`state`/`zip` are merged into `$venue_data` (only filling fields not already supplied by the caller) **before** `find_venue_by_address()` runs, so a blob-named venue with a matching address resolves to the same canonical term as a clean-named one. The created/matched term's NAME is always the clean name — the address is routed into term meta via the existing smart-merge, never discarded.

### Reasoning walked through the regex, verified with a standalone harness before wiring in:

| Input | Result |
|---|---|
| `The Dinghy , 8 J C Long Blvd, Isle of Palms, SC 29451` | name=`The Dinghy`, address=`8 J C Long Blvd`, city=`Isle of Palms`, state=`SC`, zip=`29451` |
| `Blind Tiger Pub, 36-38 Broad St, Charleston, SC 29403` | name=`Blind Tiger Pub`, address=`36-38 Broad St`, city=`Charleston`, state=`SC`, zip=`29403` |
| `Lake Oconee , Greensboro, GA` | name=`Lake Oconee`, city=`Greensboro`, state=`GA` (no street segment) |
| `Bar, Restaurant & Grill` | **no match** — tail doesn't end in a state abbreviation, name untouched |
| `RADIO/EAST` | **no match** — no comma at all |
| `The Dinghy` | **no match** — no comma, nothing to strip |

### Tests

Added to `tests/Unit/VenueNormalizationTest.php` (Part C):
- Unit coverage of `extract_address_from_name()` for full address, no-zip, city+state-only, plain-name-no-op, and the two conservatism guards (legit comma name, slash name).
- Integration test: a clean-named term + a same-venue AI blob (with and without pre-supplied `venue_data`) resolve to the **same** term ID, the created/matched term's name stays clean, and the address lands in term meta.

Note: this worktree's local PHPUnit bootstrap is currently broken independent of this change (`tests/bootstrap.php` was removed in a prior "favor of homeboy's core testing system" commit and never replaced) — confirmed the same `homeboy review test` failure reproduces on unmodified `origin/main` via `git stash`. Verified this change instead via `php -l` on both touched files and a standalone extraction-only harness exercising the exact heuristic before wiring it into `Venue_Taxonomy`.

## Constraints honored

- Single find-or-create venue path — no parallel normalization path added.
- Generic substrate — no consumer-specific ("extrachill"/"artist") knowledge; `$us_state_abbreviations` is a plain US postal reference table, not tenant config.
- PR only. Not merged, not released, not deployed.