### PR TITLE
fix: reject malformed event dates before they coerce to 0000-00-00 + audit command (#395)

### DIFF
--- a/inc/Cli/Check/CheckAllCommand.php
+++ b/inc/Cli/Check/CheckAllCommand.php
@@ -64,12 +64,13 @@ class CheckAllCommand {
 		$limit      = $assoc_args['limit'] ?? '10';
 
 		$checks = array(
-			'quality'    => 'Unified Quality Audit',
-			'times'      => 'Time Issues',
-			'venues'     => 'Venue Issues',
-			'encoding'   => 'Encoding Issues',
-			'duration'   => 'Duration Issues',
-			'duplicates' => 'Duplicate Events',
+			'quality'         => 'Unified Quality Audit',
+			'times'           => 'Time Issues',
+			'malformed-dates' => 'Malformed Dates',
+			'venues'          => 'Venue Issues',
+			'encoding'        => 'Encoding Issues',
+			'duration'        => 'Duration Issues',
+			'duplicates'      => 'Duplicate Events',
 		);
 
 		\WP_CLI::log( '=====================================' );
@@ -91,6 +92,11 @@ class CheckAllCommand {
 			// duration uses --max-days and --scope, not --days-ahead or --limit
 			if ( 'duration' === $subcommand ) {
 				$run_args = array( 'scope' => $scope );
+			}
+
+			// malformed-dates takes no scope/limit flags.
+			if ( 'malformed-dates' === $subcommand ) {
+				$run_args = array();
 			}
 
 			try {

--- a/inc/Cli/Check/CheckMalformedDatesCommand.php
+++ b/inc/Cli/Check/CheckMalformedDatesCommand.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ * Check for events with malformed/zero dates in the event_dates table.
+ *
+ * Under non-strict MySQL sql_mode, malformed date strings (e.g. "2026-07-??")
+ * are silently coerced to "0000-00-00 00:00:00" in the
+ * datamachine_event_dates table. This command finds those rows so they can
+ * be cleaned up, and also scans event-details block content for placeholder
+ * date patterns (the upstream source of the problem). See #395.
+ *
+ * Usage:
+ *   wp data-machine-events check malformed-dates
+ *   wp data-machine-events check malformed-dates --format=json
+ *   wp data-machine-events check malformed-dates --delete-zero-rows --yes
+ *
+ * @package DataMachineEvents\Cli\Check
+ * @since   0.47.4
+ */
+
+namespace DataMachineEvents\Cli\Check;
+
+use DataMachineEvents\Core\Event_Post_Type;
+use DataMachineEvents\Core\EventDatesTable;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class CheckMalformedDatesCommand {
+
+	/**
+	 * Check for events with malformed/zero dates.
+	 *
+	 * Scans the datamachine_event_dates table for rows coerced to
+	 * "0000-00-00 00:00:00" and event-details block attributes for
+	 * placeholder date patterns (e.g. "2026-07-??"). Optionally deletes
+	 * the zero rows so the event no longer appears in date-based queries.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * [--delete-zero-rows]
+	 * : Delete zero-date rows from the event_dates table. The post itself
+	 * is not modified — only the denormalized date row is removed. The row
+	 * will be re-created on the next save_post if the block has a valid date.
+	 *
+	 * [--yes]
+	 * : Skip the confirmation prompt when using --delete-zero-rows.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Audit only (read-only)
+	 *     wp data-machine-events check malformed-dates
+	 *
+	 *     # Output as JSON
+	 *     wp data-machine-events check malformed-dates --format=json
+	 *
+	 *     # Delete zero-date rows without prompting
+	 *     wp data-machine-events check malformed-dates --delete-zero-rows --yes
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Named arguments.
+	 */
+	public function __invoke( array $args, array $assoc_args ): void {
+		$format           = $assoc_args['format'] ?? 'table';
+		$delete_zero_rows = isset( $assoc_args['delete-zero-rows'] );
+		$skip_confirm     = isset( $assoc_args['yes'] );
+
+		$zero_rows      = EventDatesTable::find_zero_date_rows();
+		$block_placeholders = $this->find_placeholder_block_dates();
+
+		$total = count( $zero_rows ) + count( $block_placeholders );
+
+		if ( 'json' === $format ) {
+			\WP_CLI::log( wp_json_encode(
+				array(
+					'zero_date_rows'      => $zero_rows,
+					'block_placeholders'  => $block_placeholders,
+					'total_issues'        => $total,
+				),
+				JSON_PRETTY_PRINT
+			) );
+			return;
+		}
+
+		\WP_CLI::log( sprintf( 'Found %d malformed-date issue(s).', $total ) );
+		\WP_CLI::log( '' );
+
+		// --- Zero-date rows in the event_dates table ---
+		\WP_CLI::log( sprintf( '--- Zero-date rows in event_dates table (%d) ---', count( $zero_rows ) ) );
+
+		if ( empty( $zero_rows ) ) {
+			\WP_CLI::log( 'None.' );
+		} else {
+			$table_data = array();
+			foreach ( $zero_rows as $row ) {
+				$post = get_post( $row['post_id'] );
+				$table_data[] = array(
+					'ID'            => $row['post_id'],
+					'Title'         => $post ? mb_substr( $post->post_title, 0, 45 ) : '(deleted)',
+					'Status'        => $post ? $post->post_status : '—',
+					'Start (table)' => $row['start_datetime'],
+				);
+			}
+
+			if ( 'csv' === $format ) {
+				\WP_CLI\Utils\format_items( 'csv', $table_data, array_keys( $table_data[0] ) );
+			} else {
+				\WP_CLI\Utils\format_items( 'table', $table_data, array_keys( $table_data[0] ) );
+			}
+
+			if ( $delete_zero_rows ) {
+				if ( ! $skip_confirm ) {
+					\WP_CLI::confirm( sprintf( 'Delete %d zero-date row(s) from the event_dates table?', count( $zero_rows ) ) );
+				}
+				$deleted = 0;
+				foreach ( $zero_rows as $row ) {
+					EventDatesTable::delete( $row['post_id'] );
+					++$deleted;
+					\WP_CLI::log( sprintf( 'Deleted zero-date row: post_id %d', $row['post_id'] ) );
+				}
+				\WP_CLI::success( sprintf( 'Deleted %d zero-date row(s).', $deleted ) );
+			} else {
+				\WP_CLI::log( 'Tip: run with --delete-zero-rows to remove these rows.' );
+			}
+		}
+
+		\WP_CLI::log( '' );
+
+		// --- Placeholder dates in block content ---
+		\WP_CLI::log( sprintf( '--- Placeholder dates in block content (%d) ---', count( $block_placeholders ) ) );
+
+		if ( empty( $block_placeholders ) ) {
+			\WP_CLI::log( 'None.' );
+		} else {
+			$table_data = array();
+			foreach ( $block_placeholders as $item ) {
+				$table_data[] = array(
+					'ID'       => $item['id'],
+					'Title'    => mb_substr( $item['title'], 0, 45 ),
+					'Status'   => $item['status'],
+					'StartDate' => $item['start_date'],
+					'EndDate'  => $item['end_date'],
+				);
+			}
+
+			if ( 'csv' === $format ) {
+				\WP_CLI\Utils\format_items( 'csv', $table_data, array_keys( $table_data[0] ) );
+			} else {
+				\WP_CLI\Utils\format_items( 'table', $table_data, array_keys( $table_data[0] ) );
+			}
+
+			\WP_CLI::log( 'These events have placeholder dates (e.g. "2026-07-??") in the' );
+			\WP_CLI::log( 'event-details block. Fix the date in the editor or delete the event.' );
+		}
+
+		\WP_CLI::log( '' );
+
+		if ( 0 === $total ) {
+			\WP_CLI::success( 'No malformed dates found.' );
+		} else {
+			\WP_CLI::warning( sprintf( '%d malformed-date issue(s) found.', $total ) );
+		}
+	}
+
+	/**
+	 * Find events whose event-details block has a placeholder date pattern.
+	 *
+	 * Scans all event posts for startDate/endDate attributes containing
+	 * placeholder characters or an incomplete Y-m-d shape.
+	 *
+	 * @return array<array{id: int, title: string, status: string, start_date: string, end_date: string}>
+	 */
+	private function find_placeholder_block_dates(): array {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$posts = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT ID, post_title, post_status, post_content
+				FROM {$wpdb->posts}
+				WHERE post_type = %s
+					AND post_content REGEXP %s",
+				Event_Post_Type::POST_TYPE,
+				'startDate":"20[0-9][0-9]-[0-9?][0-9?]-[?]'
+			)
+		);
+
+		$results = array();
+		foreach ( $posts as $post ) {
+			$blocks = parse_blocks( $post->post_content );
+			foreach ( $blocks as $block ) {
+				if ( 'data-machine-events/event-details' !== $block['blockName'] ) {
+					continue;
+				}
+
+				$start_date = $block['attrs']['startDate'] ?? '';
+				$end_date   = $block['attrs']['endDate'] ?? '';
+
+				$has_placeholder = $this->is_placeholder_date( $start_date ) || $this->is_placeholder_date( $end_date );
+				if ( ! $has_placeholder ) {
+					continue;
+				}
+
+				$results[] = array(
+					'id'         => (int) $post->ID,
+					'title'      => $post->post_title,
+					'status'     => $post->post_status,
+					'start_date' => $start_date,
+					'end_date'   => $end_date,
+				);
+				break;
+			}
+		}
+
+		return $results;
+	}
+
+	/**
+	 * Check whether a date string is a placeholder/TBD value.
+	 *
+	 * @param string $date Date string from block attributes.
+	 * @return bool True if the date contains placeholder characters.
+	 */
+	private function is_placeholder_date( string $date ): bool {
+		if ( '' === $date ) {
+			return false;
+		}
+
+		return false !== strpos( $date, '?' );
+	}
+}

--- a/inc/Cli/CommandRegistry.php
+++ b/inc/Cli/CommandRegistry.php
@@ -119,6 +119,10 @@ class CommandRegistry {
 				'file'  => $cli . 'Check/CheckQualityCommand.php',
 				'class' => Check\CheckQualityCommand::class,
 			),
+			'data-machine-events check malformed-dates'   => array(
+				'file'  => $cli . 'Check/CheckMalformedDatesCommand.php',
+				'class' => Check\CheckMalformedDatesCommand::class,
+			),
 			'data-machine-events check all'              => array(
 				'file'  => $cli . 'Check/CheckAllCommand.php',
 				'class' => Check\CheckAllCommand::class,

--- a/inc/Core/EventDatesTable.php
+++ b/inc/Core/EventDatesTable.php
@@ -71,13 +71,50 @@ class EventDatesTable {
 	/**
 	 * Upsert an event's dates into the table.
 	 *
+	 * The date portion of each datetime is validated with
+	 * DateTimeParser::isValidYmd() before any write. A malformed or
+	 * placeholder value (e.g. "2026-07-??", "0000-00-00") is rejected —
+	 * logged and skipped — rather than passed to MySQL, which under
+	 * non-strict sql_mode silently coerces such strings to
+	 * "0000-00-00 00:00:00". The save_post hook already validates upstream
+	 * (#394); this guard is defense-in-depth at the storage primitive so
+	 * that backfill, CLI, or any future caller can never produce a zero-date
+	 * row. See #395.
+	 *
 	 * @param int         $post_id        Post ID.
 	 * @param string      $start_datetime MySQL datetime string.
 	 * @param string|null $end_datetime   MySQL datetime string or null.
 	 * @param string|null $post_status    Post status (auto-detected from post if null).
+	 * @return bool True on success, false if a malformed date was rejected.
 	 */
-	public static function upsert( int $post_id, string $start_datetime, ?string $end_datetime = null, ?string $post_status = null ): void {
+	public static function upsert( int $post_id, string $start_datetime, ?string $end_datetime = null, ?string $post_status = null ): bool {
 		global $wpdb;
+
+		if ( ! self::is_valid_datetime( $start_datetime ) ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'EventDatesTable::upsert rejected malformed start_datetime',
+				array(
+					'post_id'        => $post_id,
+					'start_datetime' => $start_datetime,
+				)
+			);
+			return false;
+		}
+
+		if ( null !== $end_datetime && ! self::is_valid_datetime( $end_datetime ) ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'EventDatesTable::upsert rejected malformed end_datetime',
+				array(
+					'post_id'      => $post_id,
+					'end_datetime' => $end_datetime,
+				)
+			);
+			return false;
+		}
 
 		if ( null === $post_status ) {
 			$post_status = get_post_status( $post_id ) ?: 'publish';
@@ -93,6 +130,25 @@ class EventDatesTable {
 			),
 			array( '%d', '%s', $end_datetime ? '%s' : null, '%s' )
 		);
+
+		return true;
+	}
+
+	/**
+	 * Validate that a datetime string has a real Y-m-d date prefix.
+	 *
+	 * Rejects placeholder/TBD strings ("2026-07-??"), the MySQL zero date
+	 * ("0000-00-00 00:00:00"), out-of-range values, and impossible calendar
+	 * dates. The time-of-day suffix is not validated — only the leading
+	 * Y-m-d must be a genuine calendar date.
+	 *
+	 * @param string $datetime Datetime string (at least 10 chars of Y-m-d).
+	 * @return bool True when the date portion is a valid calendar date.
+	 */
+	private static function is_valid_datetime( string $datetime ): bool {
+		$date = substr( $datetime, 0, 10 );
+
+		return DateTimeParser::isValidYmd( $date );
 	}
 
 	/**
@@ -150,6 +206,45 @@ class EventDatesTable {
 	}
 
 	/**
+	 * Find rows with a MySQL zero date in the event_dates table.
+	 *
+	 * Under non-strict sql_mode, malformed date strings (e.g. "2026-07-??")
+	 * are silently coerced to "0000-00-00 00:00:00". This method surfaces
+	 * those rows for the audit/cleanup command. See #395.
+	 *
+	 * @return array<array{post_id: int, start_datetime: string, end_datetime: string|null}> Rows with a zero start_datetime.
+	 */
+	public static function find_zero_date_rows(): array {
+		global $wpdb;
+
+		$table = self::table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results(
+			"SELECT post_id, start_datetime, end_datetime
+			FROM {$table}
+			WHERE start_datetime = '0000-00-00 00:00:00'
+				OR start_datetime LIKE '0000-%'",
+			ARRAY_A
+		);
+
+		if ( empty( $rows ) ) {
+			return array();
+		}
+
+		return array_map(
+			static function ( array $row ) {
+				return array(
+					'post_id'        => (int) $row['post_id'],
+					'start_datetime' => $row['start_datetime'],
+					'end_datetime'   => isset( $row['end_datetime'] ) ? (string) $row['end_datetime'] : null,
+				);
+			},
+			$rows
+		);
+	}
+
+	/**
 	 * Backfill the event dates table from legacy postmeta.
 	 *
 	 * One-time migration: populates the table for events that still have
@@ -195,13 +290,15 @@ class EventDatesTable {
 			}
 
 			foreach ( $rows as $row ) {
-				self::upsert(
+				$written = self::upsert(
 					(int) $row->post_id,
 					$row->start_datetime,
 					$row->end_datetime ?: null,
 					$row->post_status
 				);
-				++$total;
+				if ( $written ) {
+					++$total;
+				}
 			}
 
 			if ( $progress ) {

--- a/tests/Unit/EventDatesTableMalformedDateTest.php
+++ b/tests/Unit/EventDatesTableMalformedDateTest.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * EventDatesTable malformed-date guardrail tests.
+ *
+ * Verifies that EventDatesTable::upsert() rejects malformed/placeholder
+ * date strings instead of letting MySQL coerce them to 0000-00-00.
+ * Covers issue #395.
+ *
+ * @package DataMachineEvents\Tests\Unit
+ * @since   0.47.4
+ */
+
+namespace DataMachineEvents\Tests\Unit;
+
+use WP_UnitTestCase;
+use DataMachineEvents\Core\Event_Post_Type;
+use DataMachineEvents\Core\EventDatesTable;
+
+class EventDatesTableMalformedDateTest extends WP_UnitTestCase {
+
+	public function setUp(): void {
+		parent::setUp();
+
+		if ( ! post_type_exists( 'data_machine_events' ) ) {
+			Event_Post_Type::register();
+		}
+
+		EventDatesTable::create_table();
+	}
+
+	private function create_event(): int {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Malformed Date Test ' . uniqid(),
+				'post_type'   => 'data_machine_events',
+				'post_status' => 'draft',
+			)
+		);
+
+		$this->assertGreaterThan( 0, $post_id );
+
+		return $post_id;
+	}
+
+	public function test_upsert_accepts_valid_datetime(): void {
+		$post_id  = $this->create_event();
+		$datetime = '2026-07-15 19:30:00';
+
+		$result = EventDatesTable::upsert( $post_id, $datetime );
+
+		$this->assertTrue( $result );
+
+		$stored = EventDatesTable::get( $post_id );
+		$this->assertNotNull( $stored );
+		$this->assertEquals( $datetime, $stored->start_datetime );
+	}
+
+	public function test_upsert_rejects_placeholder_day(): void {
+		$post_id  = $this->create_event();
+		$datetime = '2026-07-?? 00:00:00';
+
+		$result = EventDatesTable::upsert( $post_id, $datetime );
+
+		$this->assertFalse( $result );
+		$this->assertNull( EventDatesTable::get( $post_id ) );
+	}
+
+	public function test_upsert_rejects_placeholder_month_and_day(): void {
+		$post_id  = $this->create_event();
+		$datetime = '2026-??-?? 00:00:00';
+
+		$result = EventDatesTable::upsert( $post_id, $datetime );
+
+		$this->assertFalse( $result );
+		$this->assertNull( EventDatesTable::get( $post_id ) );
+	}
+
+	public function test_upsert_rejects_mysql_zero_date(): void {
+		$post_id  = $this->create_event();
+		$datetime = '0000-00-00 00:00:00';
+
+		$result = EventDatesTable::upsert( $post_id, $datetime );
+
+		$this->assertFalse( $result );
+		$this->assertNull( EventDatesTable::get( $post_id ) );
+	}
+
+	public function test_upsert_rejects_impossible_calendar_date(): void {
+		$post_id  = $this->create_event();
+		$datetime = '2026-02-30 00:00:00';
+
+		$result = EventDatesTable::upsert( $post_id, $datetime );
+
+		$this->assertFalse( $result );
+		$this->assertNull( EventDatesTable::get( $post_id ) );
+	}
+
+	public function test_upsert_rejects_malformed_end_datetime(): void {
+		$post_id      = $this->create_event();
+		$start        = '2026-07-15 19:30:00';
+		$bad_end      = '2026-07-?? 23:59:59';
+
+		$result = EventDatesTable::upsert( $post_id, $start, $bad_end );
+
+		$this->assertFalse( $result );
+		$this->assertNull( EventDatesTable::get( $post_id ) );
+	}
+
+	public function test_upsert_accepts_null_end_datetime(): void {
+		$post_id = $this->create_event();
+		$start   = '2026-07-15 19:30:00';
+
+		$result = EventDatesTable::upsert( $post_id, $start, null );
+
+		$this->assertTrue( $result );
+
+		$stored = EventDatesTable::get( $post_id );
+		$this->assertNotNull( $stored );
+		$this->assertEquals( $start, $stored->start_datetime );
+	}
+
+	public function test_find_zero_date_rows_finds_existing_zero_rows(): void {
+		global $wpdb;
+
+		$post_id = $this->create_event();
+		$table   = EventDatesTable::table_name();
+
+		// Bypass the guardrail to simulate a pre-existing zero-date row
+		// (the state that existed before this fix was deployed).
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		$wpdb->replace(
+			$table,
+			array(
+				'post_id'        => $post_id,
+				'start_datetime' => '0000-00-00 00:00:00',
+				'end_datetime'   => '0000-00-00 00:00:00',
+				'post_status'    => 'draft',
+			),
+			array( '%d', '%s', '%s', '%s' )
+		);
+
+		$rows = EventDatesTable::find_zero_date_rows();
+
+		$this->assertNotEmpty( $rows );
+
+		$found = false;
+		foreach ( $rows as $row ) {
+			if ( $row['post_id'] === $post_id ) {
+				$found = true;
+				$this->assertEquals( '0000-00-00 00:00:00', $row['start_datetime'] );
+				break;
+			}
+		}
+
+		$this->assertTrue( $found, 'find_zero_date_rows must surface the zero-date row' );
+	}
+
+	public function test_find_zero_date_rows_empty_when_all_valid(): void {
+		$post_id = $this->create_event();
+		EventDatesTable::upsert( $post_id, '2026-07-15 19:30:00' );
+
+		$rows = EventDatesTable::find_zero_date_rows();
+
+		// No zero-date rows should exist after a valid upsert.
+		foreach ( $rows as $row ) {
+			$this->assertNotEquals( $post_id, $row['post_id'] );
+		}
+	}
+}


### PR DESCRIPTION
Addresses #395.

## Summary

Adds a **defense-in-depth guardrail at the storage primitive** (`EventDatesTable::upsert()`) so malformed/placeholder date strings can never silently coerce to `0000-00-00 00:00:00` in the `datamachine_event_dates` table — regardless of which code path feeds them in. Also adds an **audit command** to find and clean up existing zero-date rows.

### The problem

7 events on blog 7 stored incomplete dates (`2026-07-??`, `2026-??-??`) in the event-details block. Under non-strict MySQL `sql_mode`, these strings were silently zeroed to `0000-00-00 00:00:00` in the custom table. The published one (261090) was a live fatal trigger on the render path.

The `save_post` hook was already guarded upstream by #394 (`DateTimeParser::isValidYmd` at the parsing chokepoint in `event-dates-sync.php`). But `EventDatesTable::upsert()` itself — the single storage primitive that all write paths funnel through — was **unguarded**. Any caller bypassing `save_post` (backfill, CLI, future code) could still write a zero-date row.

### What this PR does

1. **`EventDatesTable::upsert()` guardrail** — validates the Y-m-d prefix of both `start_datetime` and `end_datetime` via `DateTimeParser::isValidYmd()` before any write. Rejects placeholders (`2026-07-??`), the MySQL zero date (`0000-00-00`), out-of-range values (`2026-13-01`), and impossible calendar dates (`2026-02-30`). Returns `bool` (false = rejected) and logs a `datamachine_log` warning. Malformed rows are **skipped, not stored**.

2. **`EventDatesTable::backfill()`** — now only counts successfully written rows (uses the bool return), so a malformed postmeta value doesn't inflate the count.

3. **`EventDatesTable::find_zero_date_rows()`** — new method that surfaces existing `0000-00-00` rows for audit/cleanup.

4. **`wp data-machine-events check malformed-dates`** — new audit command that:
   - Finds zero-date rows in the `datamachine_event_dates` table
   - Scans event-details block content for placeholder date patterns (the upstream source)
   - Supports `--format=table|json|csv`
   - Optional `--delete-zero-rows --yes` to remove zero rows (the post is untouched; the row gets re-created on next `save_post` if the block has a valid date, or stays gone if it doesn't)
   - Included in `wp data-machine-events check all`

5. **Tests** — `EventDatesTableMalformedDateTest` covers rejection of placeholders, zero dates, impossible calendar dates, malformed end datetimes, valid accepts, and the `find_zero_date_rows` audit path.

### Trace

A malformed date string (`2026-07-?? 00:00:00`) passed to `upsert()`:
- `is_valid_datetime()` extracts `substr('2026-07-??', 0, 10)` = `'2026-07-??'`
- `DateTimeParser::isValidYmd('2026-07-??')` returns `false` (regex fails on `?`)
- `upsert()` logs warning, returns `false`, **no `$wpdb->replace()` call is made**
- `get()` returns `null` — no zero-date row exists

## Ops steps for the 7 existing rows (#395 data cleanup)

After this PR is merged and deployed, run against the events site:

```bash
# 1. Audit — find the 7 zero-date rows + any block placeholders
wp --path=/var/www/extrachill.com --url=events.extrachill.com data-machine-events check malformed-dates

# 2. Delete the zero rows (post content is untouched)
wp --path=/var/www/extrachill.com --url=events.extrachill.com data-machine-events check malformed-dates --delete-zero-rows --yes

# 3. Decide per-event: fix the date in the editor, or trash the draft
#    (event 261090 is published — un-publish or resolve its date first)
```

The 7 affected events (from #395): 261090, 222758, 224284, 253597, 256872, 257930, 258783.

## Related

- #394 — systemic fix (the `save_post` validating chokepoint, already merged)
- #393 — the `2026-07-??` fatal PR