### PR TITLE
fix: stop 50mi metro sweep from tagging all events with one city term (#379)

### DIFF
--- a/inc/Steps/Upsert/Events/EventTaxonomyAssigner.php
+++ b/inc/Steps/Upsert/Events/EventTaxonomyAssigner.php
@@ -277,6 +277,282 @@ class EventTaxonomyAssigner {
 	}
 
 	/**
+	 * Process location taxonomy assignment for an event.
+	 *
+	 * City `location` pipelines fetch events within a discovery radius (e.g. a
+	 * 50-mile Ticketmaster/Dice sweep) but, when location is PRE_SELECTED, the
+	 * generic taxonomy pass stamps EVERY fetched event with the pipeline's
+	 * single city term — so a city archive absorbs the whole surrounding metro.
+	 * A Galveston-centered sweep tagged Houston, Sugar Land, Dallas, and even
+	 * Reno events as "Galveston". See data-machine-events#379.
+	 *
+	 * This intercepts the PRE_SELECTED location path and derives the term from
+	 * the event's actual venue city instead of the ingest center. When the
+	 * venue city resolves to a location term, that term wins. When it cannot be
+	 * resolved, the pipeline's configured term is kept as a conservative
+	 * fallback so the event stays discoverable by location. AI_DECIDES and SKIP
+	 * modes are left to the generic taxonomy pass (this returns false to signal
+	 * "not handled here").
+	 *
+	 * @param int $post_id Post ID.
+	 * @param array $parameters Event parameters.
+	 * @param EngineData $engine Engine data helper.
+	 * @param array $handler_config Handler configuration.
+	 * @return bool True when location was assigned here (caller should skip the
+	 *              generic pass for location); false when left to the generic pass.
+	 */
+	public function processLocation( int $post_id, array $parameters, EngineData $engine, array $handler_config = array() ): bool {
+		$selection = (string) ( $handler_config['taxonomy_location_selection'] ?? 'skip' );
+
+		// Only intercept PRE_SELECTED. AI_DECIDES is handled by the generic
+		// taxonomy pass (the AI picks from event data); SKIP needs no work.
+		if ( ! SelectionMode::isPreSelected( $selection ) ) {
+			return false;
+		}
+
+		if ( ! taxonomy_exists( 'location' ) ) {
+			return false;
+		}
+
+		// Resolve the pipeline-configured ingest-center term as the fallback.
+		$fallback_term_id = $this->resolveLocationSelectionTermId( $selection );
+
+		// Determine the event's actual venue city/state.
+		$venue_location = $this->getVenueLocationContext( $post_id, $parameters, $engine );
+
+		/**
+		 * Resolve the event location term from the venue's city.
+		 *
+		 * Lets a consumer layer that owns market knowledge (e.g. suburb→market
+		 * rollups like Cambridge→Boston, or state-abbreviation disambiguation)
+		 * supply a richer resolver than the substrate's generic city-name match.
+		 * Returning a WP_Term overrides the default resolution; returning null
+		 * lets the substrate fall back to its own name match, then to the
+		 * pipeline's configured term.
+		 *
+		 * @param \WP_Term|null $term    Resolved term so far (null by default).
+		 * @param string        $city    Venue city.
+		 * @param string        $state   Venue state (abbreviation or full name).
+		 * @param string        $zip     Venue zip code.
+		 * @param int           $post_id Event post ID.
+		 */
+		$resolved = apply_filters( 'data_machine_events_resolve_event_location_term', null, $venue_location['city'], $venue_location['state'], $venue_location['zip'], $post_id );
+
+		if ( ! $resolved instanceof \WP_Term ) {
+			$resolved = $this->resolveLocationTermForVenueCity( $venue_location['city'], $venue_location['state'] );
+		}
+
+		$term_id = $resolved instanceof \WP_Term ? (int) $resolved->term_id : $fallback_term_id;
+
+		if ( $term_id <= 0 ) {
+			// Neither the venue city nor the pipeline selection resolved to a
+			// usable term — nothing to assign. Still report handled so the
+			// generic pass does not re-stamp a dead selection value.
+			return true;
+		}
+
+		$result = wp_set_object_terms( $post_id, array( $term_id ), 'location' );
+
+		if ( is_wp_error( $result ) ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Event location assignment failed',
+				array(
+					'post_id' => $post_id,
+					'term_id' => $term_id,
+					'error'   => $result->get_error_message(),
+				)
+			);
+		} elseif ( $resolved instanceof \WP_Term && $fallback_term_id > 0 && (int) $resolved->term_id !== $fallback_term_id ) {
+			// Log when the venue city overrode the pipeline-center term — the
+			// exact metro-sweep mis-tag this method exists to correct.
+			do_action(
+				'datamachine_log',
+				'info',
+				'Event location derived from venue city (overrode pipeline center)',
+				array(
+					'post_id'          => $post_id,
+					'venue_city'       => $venue_location['city'],
+					'assigned_term'    => $resolved->name,
+					'pipeline_term_id' => $fallback_term_id,
+				)
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Resolve a PRE_SELECTED location selection to a term ID.
+	 *
+	 * @param string $selection Term ID, name, or slug.
+	 * @return int Term ID, or 0 when unresolvable.
+	 */
+	private function resolveLocationSelectionTermId( string $selection ): int {
+		if ( is_numeric( $selection ) ) {
+			$term = get_term( (int) $selection, 'location' );
+			return ( $term && ! is_wp_error( $term ) ) ? (int) $term->term_id : 0;
+		}
+
+		$term = get_term_by( 'name', $selection, 'location' );
+		if ( ! $term ) {
+			$term = get_term_by( 'slug', $selection, 'location' );
+		}
+
+		return ( $term && ! is_wp_error( $term ) ) ? (int) $term->term_id : 0;
+	}
+
+	/**
+	 * Gather the venue city/state/zip for an event.
+	 *
+	 * Reads from the venue term attached to the post (canonical, set earlier
+	 * in the upsert pass by processVenue), falling back to the engine/parameter
+	 * values when the venue term carries no city meta.
+	 *
+	 * @param int $post_id Post ID.
+	 * @param array $parameters Event parameters.
+	 * @param EngineData $engine Engine data helper.
+	 * @return array{city:string, state:string, zip:string}
+	 */
+	private function getVenueLocationContext( int $post_id, array $parameters, EngineData $engine ): array {
+		$venue_terms = wp_get_object_terms( $post_id, 'venue' );
+
+		if ( ! is_wp_error( $venue_terms ) && ! empty( $venue_terms ) ) {
+			$venue = $venue_terms[0];
+			$city  = trim( (string) get_term_meta( $venue->term_id, '_venue_city', true ) );
+
+			if ( '' !== $city ) {
+				return array(
+					'city'  => $city,
+					'state' => trim( (string) get_term_meta( $venue->term_id, '_venue_state', true ) ),
+					'zip'   => trim( (string) get_term_meta( $venue->term_id, '_venue_zip', true ) ),
+				);
+			}
+		}
+
+		return array(
+			'city'  => trim( (string) ( $engine->get( 'venueCity' ) ?? $parameters['venueCity'] ?? '' ) ),
+			'state' => trim( (string) ( $engine->get( 'venueState' ) ?? $parameters['venueState'] ?? '' ) ),
+			'zip'   => trim( (string) ( $engine->get( 'venueZip' ) ?? $parameters['venueZip'] ?? '' ) ),
+		);
+	}
+
+	/**
+	 * Resolve a city name to a `location` taxonomy term.
+	 *
+	 * Generic, consumer-agnostic resolution: exact (case-insensitive) city-name
+	 * match, with best-effort state disambiguation when multiple location terms
+	 * share a city name (e.g. Portland, OR vs Portland, ME — location is
+	 * hierarchical Country > State > City). No market mapping (suburb→city
+	 * rollups like Cambridge→Boston live in the consumer layer via the
+	 * data_machine_events_resolve_event_location_term filter).
+	 *
+	 * @param string $city  Venue city.
+	 * @param string $state Venue state (abbreviation or full name).
+	 * @return \WP_Term|null Resolved term, or null when unresolved.
+	 */
+	private function resolveLocationTermForVenueCity( string $city, string $state ): ?\WP_Term {
+		$city = trim( $city );
+		if ( '' === $city ) {
+			return null;
+		}
+
+		$matches = $this->getLocationTermsByName()[ strtolower( $city ) ] ?? array();
+
+		if ( 1 === count( $matches ) ) {
+			return reset( $matches );
+		}
+
+		if ( count( $matches ) > 1 ) {
+			return $this->disambiguateLocationByState( $matches, $state );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Get all location terms grouped by lowercased name (request-cached).
+	 *
+	 * @return array<string, array<int, \WP_Term>>
+	 */
+	private function getLocationTermsByName(): array {
+		static $by_name = null;
+
+		if ( null !== $by_name ) {
+			return $by_name;
+		}
+
+		$by_name = array();
+
+		if ( ! taxonomy_exists( 'location' ) ) {
+			return $by_name;
+		}
+
+		$terms = get_terms(
+			array(
+				'taxonomy'   => 'location',
+				'hide_empty' => false,
+				'number'     => 0,
+			)
+		);
+
+		if ( is_wp_error( $terms ) ) {
+			return $by_name;
+		}
+
+		foreach ( $terms as $term ) {
+			$key = strtolower( $term->name );
+			if ( ! isset( $by_name[ $key ] ) ) {
+				$by_name[ $key ] = array();
+			}
+			$by_name[ $key ][] = $term;
+		}
+
+		return $by_name;
+	}
+
+	/**
+	 * Disambiguate same-named location terms using the venue's state.
+	 *
+	 * Location terms are hierarchical (Country > State > City). Compares the
+	 * venue's state against each candidate's parent (state-level) term name,
+	 * case-insensitively. Best-effort: state-abbreviation → full-name mapping
+	 * (e.g. "SC" → "South Carolina") is intentionally NOT owned by this
+	 * substrate layer — consumers with locale knowledge should hook
+	 * data_machine_events_resolve_event_location_term for robust disambiguation.
+	 *
+	 * @param array<int, \WP_Term> $matches Location terms sharing a city name.
+	 * @param string               $state   Venue state.
+	 * @return \WP_Term|null Matched term, or null when state doesn't resolve it.
+	 */
+	private function disambiguateLocationByState( array $matches, string $state ): ?\WP_Term {
+		$state = trim( $state );
+		if ( '' === $state ) {
+			return null;
+		}
+
+		$state_lower = strtolower( $state );
+
+		foreach ( $matches as $match ) {
+			if ( $match->parent <= 0 ) {
+				continue;
+			}
+
+			$parent = get_term( $match->parent, 'location' );
+			if ( ! $parent instanceof \WP_Term ) {
+				continue;
+			}
+
+			if ( strtolower( $parent->name ) === $state_lower ) {
+				return $match;
+			}
+		}
+
+		return null;
+	}
+
+	/**
 	 * Resolve the pre-selected artist term name from handler config, if any.
 	 *
 	 * Only returns a name when `taxonomy_artist_selection` is a pre-selected

--- a/inc/Steps/Upsert/Events/EventUpsert.php
+++ b/inc/Steps/Upsert/Events/EventUpsert.php
@@ -12,7 +12,7 @@
  * are delegated to focused collaborators (see #425):
  *  - EventUpsertValidator       — pre-publish validation gate.
  *  - EventBlockContentBuilder   — event-details block / description assembly.
- *  - EventTaxonomyAssigner      — venue/promoter taxonomy assignment.
+ *  - EventTaxonomyAssigner      — venue/promoter/location taxonomy assignment.
  *
  * @package DataMachineEvents\Steps\Upsert\Events
  * @since   0.2.0
@@ -58,7 +58,7 @@ class EventUpsert extends UpsertHandler {
 	private EventBlockContentBuilder $content_builder;
 
 	/**
-	 * Venue/promoter taxonomy assignment.
+	 * Venue/promoter/location taxonomy assignment.
 	 *
 	 * @var EventTaxonomyAssigner
 	 */
@@ -297,6 +297,13 @@ class EventUpsert extends UpsertHandler {
 		$this->taxonomy_assigner->processVenue( $post_id, $parameters, $engine, $handler_config );
 		$this->taxonomy_assigner->processPromoter( $post_id, $parameters, $engine, $handler_config );
 
+		// Derive location from the event's actual venue city rather than the
+		// pipeline's ingest center. processLocation returns true when it took
+		// ownership of the location term (PRE_SELECTED mode), in which case the
+		// generic taxonomy pass below must skip location so it doesn't
+		// re-stamp the pipeline-center term. See data-machine-events#379.
+		$location_handled = $this->taxonomy_assigner->processLocation( $post_id, $parameters, $engine, $handler_config );
+
 		// Map performer to artist taxonomy if not explicitly provided.
 		if ( empty( $parameters['artist'] ) && ! empty( $event_data['performer'] ) ) {
 			$parameters['artist'] = $event_data['performer'];
@@ -305,7 +312,10 @@ class EventUpsert extends UpsertHandler {
 		$handler_config_for_tax                                = $handler_config;
 		$handler_config_for_tax['taxonomy_venue_selection']    = 'skip';
 		$handler_config_for_tax['taxonomy_promoter_selection'] = 'skip';
-		$engine_data_array                                     = $engine instanceof EngineData ? $engine->all() : array();
+		if ( $location_handled ) {
+			$handler_config_for_tax['taxonomy_location_selection'] = 'skip';
+		}
+		$engine_data_array = $engine instanceof EngineData ? $engine->all() : array();
 		$this->taxonomy_handler->processTaxonomies( $post_id, $parameters, $handler_config_for_tax, $engine_data_array );
 
 		do_action( 'datamachine_event_taxonomy_processed', $post_id );

--- a/tests/Unit/EventTaxonomyAssignerTest.php
+++ b/tests/Unit/EventTaxonomyAssignerTest.php
@@ -28,6 +28,19 @@ class EventTaxonomyAssignerTest extends WP_UnitTestCase {
 		if ( ! taxonomy_exists( 'venue' ) ) {
 			Venue_Taxonomy::register();
 		}
+		if ( ! taxonomy_exists( 'location' ) ) {
+			// The `location` taxonomy is owned by the consumer layer, not this
+			// substrate. Register a minimal hierarchical instance for tests.
+			register_taxonomy(
+				'location',
+				'data_machine_events',
+				array(
+					'hierarchical' => true,
+					'public'       => true,
+					'show_in_rest' => true,
+				)
+			);
+		}
 
 		$this->assigner = new EventTaxonomyAssigner();
 	}
@@ -112,5 +125,206 @@ class EventTaxonomyAssignerTest extends WP_UnitTestCase {
 		$this->assertCount( 0, (array) $terms, 'processPromoter must not assign when selection is skip.' );
 
 		wp_delete_post( $post_id, true );
+	}
+
+	public function test_process_location_returns_false_for_skip_mode() {
+		$post_id = $this->make_event_post();
+
+		$engine = new \DataMachine\Core\EngineData( array(), 0 );
+
+		$handled = $this->assigner->processLocation(
+			$post_id,
+			array(),
+			$engine,
+			array( 'taxonomy_location_selection' => 'skip' )
+		);
+
+		$this->assertFalse( $handled, 'processLocation must not take ownership for SKIP mode.' );
+		wp_delete_post( $post_id, true );
+	}
+
+	public function test_process_location_returns_false_for_ai_decides_mode() {
+		$post_id = $this->make_event_post();
+
+		$engine = new \DataMachine\Core\EngineData( array(), 0 );
+
+		$handled = $this->assigner->processLocation(
+			$post_id,
+			array(),
+			$engine,
+			array( 'taxonomy_location_selection' => 'ai_decides' )
+		);
+
+		$this->assertFalse( $handled, 'processLocation must defer AI_DECIDES to the generic taxonomy pass.' );
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * The core #379 bug: a Houston venue fetched inside a Galveston-centered
+	 * 50mi sweep must NOT inherit the pipeline's Galveston location term — it
+	 * must carry Houston, derived from the venue's own city.
+	 */
+	public function test_process_location_derives_term_from_venue_city_not_pipeline_center() {
+		$galveston = wp_insert_term( 'Galveston', 'location' );
+		$houston   = wp_insert_term( 'Houston', 'location' );
+		$this->assertNotWPError( $galveston );
+		$this->assertNotWPError( $houston );
+
+		$post_id = $this->make_event_post();
+
+		// Attach a venue term whose city is Houston (the event's actual city).
+		$venue = wp_insert_term( 'Toyota Center', 'venue' );
+		$this->assertNotWPError( $venue );
+		update_term_meta( $venue['term_id'], '_venue_city', 'Houston' );
+		wp_set_object_terms( $post_id, array( $venue['term_id'] ), 'venue' );
+
+		$engine = new \DataMachine\Core\EngineData( array(), 0 );
+
+		$handled = $this->assigner->processLocation(
+			$post_id,
+			array(),
+			$engine,
+			array( 'taxonomy_location_selection' => (string) $galveston['term_id'] ) // pipeline center = Galveston
+		);
+
+		$this->assertTrue( $handled, 'processLocation must take ownership for PRE_SELECTED mode.' );
+
+		$assigned = wp_get_object_terms( $post_id, 'location' );
+		$this->assertNotWPError( $assigned );
+		$this->assertCount( 1, $assigned, 'Exactly one location term must be assigned.' );
+		$this->assertSame( 'Houston', $assigned[0]->name, 'Venue-city term must override the pipeline-center term.' );
+
+		wp_delete_post( $post_id, true );
+		wp_delete_term( $venue['term_id'], 'venue' );
+		wp_delete_term( $houston['term_id'], 'location' );
+		wp_delete_term( $galveston['term_id'], 'location' );
+	}
+
+	/**
+	 * When the venue city is the pipeline's own city, the assignment is
+	 * unchanged — the fix must not regress the normal in-city case.
+	 */
+	public function test_process_location_keeps_pipeline_term_when_venue_is_in_that_city() {
+		$galveston = wp_insert_term( 'Galveston', 'location' );
+		$this->assertNotWPError( $galveston );
+
+		$post_id = $this->make_event_post();
+
+		$venue = wp_insert_term( 'The Grand 1894 Opera House', 'venue' );
+		$this->assertNotWPError( $venue );
+		update_term_meta( $venue['term_id'], '_venue_city', 'Galveston' );
+		wp_set_object_terms( $post_id, array( $venue['term_id'] ), 'venue' );
+
+		$engine = new \DataMachine\Core\EngineData( array(), 0 );
+
+		$this->assigner->processLocation(
+			$post_id,
+			array(),
+			$engine,
+			array( 'taxonomy_location_selection' => (string) $galveston['term_id'] )
+		);
+
+		$assigned = wp_get_object_terms( $post_id, 'location' );
+		$this->assertNotWPError( $assigned );
+		$this->assertCount( 1, $assigned );
+		$this->assertSame( 'Galveston', $assigned[0]->name );
+
+		wp_delete_post( $post_id, true );
+		wp_delete_term( $venue['term_id'], 'venue' );
+		wp_delete_term( $galveston['term_id'], 'location' );
+	}
+
+	/**
+	 * When the venue city has no matching location term (e.g. an unmapped
+	 * suburb), the pipeline's configured term is kept as a conservative
+	 * fallback rather than dropping the event from the location archive.
+	 */
+	public function test_process_location_falls_back_to_pipeline_term_when_venue_city_unresolved() {
+		$galveston = wp_insert_term( 'Galveston', 'location' );
+		$this->assertNotWPError( $galveston );
+
+		$post_id = $this->make_event_post();
+
+		// Venue in "Tinyburg" — no matching location term exists.
+		$venue = wp_insert_term( 'Tinyburg Hall', 'venue' );
+		$this->assertNotWPError( $venue );
+		update_term_meta( $venue['term_id'], '_venue_city', 'Tinyburg' );
+		wp_set_object_terms( $post_id, array( $venue['term_id'] ), 'venue' );
+
+		$engine = new \DataMachine\Core\EngineData( array(), 0 );
+
+		$this->assigner->processLocation(
+			$post_id,
+			array(),
+			$engine,
+			array( 'taxonomy_location_selection' => (string) $galveston['term_id'] )
+		);
+
+		$assigned = wp_get_object_terms( $post_id, 'location' );
+		$this->assertNotWPError( $assigned );
+		$this->assertCount( 1, $assigned );
+		$this->assertSame( 'Galveston', $assigned[0]->name, 'Unresolved venue city must fall back to the pipeline term.' );
+
+		wp_delete_post( $post_id, true );
+		wp_delete_term( $venue['term_id'], 'venue' );
+		wp_delete_term( $galveston['term_id'], 'location' );
+	}
+
+	/**
+	 * The data_machine_events_resolve_event_location_term filter lets a
+	 * consumer layer supply a richer resolver (e.g. suburb→market rollup).
+	 */
+	public function test_process_location_honors_consumer_filter_override() {
+		$galveston = wp_insert_term( 'Galveston', 'location' );
+		$houston   = wp_insert_term( 'Houston', 'location' );
+		$this->assertNotWPError( $galveston );
+		$this->assertNotWPError( $houston );
+
+		$post_id = $this->make_event_post();
+
+		// Venue in "Sugar Land" (a Houston suburb with no direct location term).
+		$venue = wp_insert_term( 'Smart Financial Centre', 'venue' );
+		$this->assertNotWPError( $venue );
+		update_term_meta( $venue['term_id'], '_venue_city', 'Sugar Land' );
+		wp_set_object_terms( $post_id, array( $venue['term_id'] ), 'venue' );
+
+		$engine = new \DataMachine\Core\EngineData( array(), 0 );
+
+		// Consumer filter rolls "Sugar Land" up to the Houston market.
+		$callback = function () use ( $houston ) {
+			return get_term( $houston['term_id'], 'location' );
+		};
+		add_filter( 'data_machine_events_resolve_event_location_term', $callback );
+
+		$this->assigner->processLocation(
+			$post_id,
+			array(),
+			$engine,
+			array( 'taxonomy_location_selection' => (string) $galveston['term_id'] )
+		);
+
+		remove_filter( 'data_machine_events_resolve_event_location_term', $callback );
+
+		$assigned = wp_get_object_terms( $post_id, 'location' );
+		$this->assertNotWPError( $assigned );
+		$this->assertCount( 1, $assigned );
+		$this->assertSame( 'Houston', $assigned[0]->name, 'Consumer filter override must win.' );
+
+		wp_delete_post( $post_id, true );
+		wp_delete_term( $venue['term_id'], 'venue' );
+		wp_delete_term( $houston['term_id'], 'location' );
+		wp_delete_term( $galveston['term_id'], 'location' );
+	}
+
+	private function make_event_post(): int {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Location Test ' . uniqid(),
+				'post_type'   => 'data_machine_events',
+				'post_status' => 'publish',
+			)
+		);
+		$this->assertGreaterThan( 0, $post_id );
+		return $post_id;
 	}
 }


### PR DESCRIPTION
Fixes #379

## Root cause

City `location` pipelines fetch events within a discovery radius (e.g. a 50-mile Ticketmaster/Dice sweep) but, with location in **PRE_SELECTED** mode, every fetched event was stamped with the pipeline's single city term. A Galveston-centered sweep tagged Houston, Sugar Land, Dallas, and even Reno (1571 mi) events as "Galveston".

The generic DM core `TaxonomyHandler::processPreSelectedTaxonomy()` blindly assigns the configured term, and custom taxonomy handlers only fire for `AI_DECIDES` mode — so there was no per-event override point for PRE_SELECTED location. The fetch radius (correct for discovery) and the location tag (should reflect the event's actual city) were conflated.

## Fix

Add `EventTaxonomyAssigner::processLocation()`, which intercepts the **PRE_SELECTED** location path and derives the term from the event's actual venue city (read from the venue term's `_venue_city` meta, with engine/parameter fallback) instead of the ingest center:

- **Venue city resolves to a location term** → that term wins (Houston venue → Houston term, not Galveston).
- **Venue city can't be resolved** → the pipeline's configured term is kept as a conservative fallback so the event stays discoverable by location.
- **AI_DECIDES / SKIP** → deferred to the generic taxonomy pass unchanged.

`EventUpsert` calls `processLocation()` after `processVenue()`/`processPromoter()` and, when it takes ownership (`PRE_SELECTED`), sets `taxonomy_location_selection = 'skip'` on the generic-pass config so the pipeline-center term isn't re-stamped. This mirrors how venue/promoter are already handled.

Resolution is **generic and consumer-agnostic**: case-insensitive city-name match against existing `location` terms, with best-effort state disambiguation for hierarchical locations (`Country > State > City`) when multiple terms share a city name (e.g. Portland, OR vs Portland, ME). No city names, market maps, or site-specific knowledge are hardcoded.

A new `data_machine_events_resolve_event_location_term` filter lets a consumer layer (e.g. extrachill-events) supply a richer resolver — suburb→market rollups like Cambridge→Boston, or state-abbreviation→full-name disambiguation — without this substrate owning locale-specific knowledge. This keeps layer purity intact: the substrate does generic name matching; the consumer layers market knowledge on top.

## Why this layer

The bug is in the substrate behavior (PRE_SELECTED location stamping), so the root fix lives here. The consumer layer (`extrachill-events`) already has a create-time normalizer + reconcile CLI that derives location from venue city with full market mapping — that work is complementary and remains the authority for suburb rollups; this PR makes the substrate produce the correct term in the first place so the consumer's backstop has less to correct (and sites without the consumer layer get correct behavior too).

## Verify

- `php -l` on both touched files: clean.
- PHPCS (WordPress standard) on the added code: no new categories of findings (the file's pre-existing convention warnings — camelCase method names, docblock spacing — apply equally to existing `processVenue`/`processPromoter`).
- PHPStan level 7 via `homeboy review`: passed.
- Unit tests added in `EventTaxonomyAssignerTest` covering:
  - SKIP / AI_DECIDES modes return `false` (deferred to generic pass).
  - **Core #379 case**: Houston venue under a Galveston PRE_SELECTED pipeline → assigned Houston, not Galveston.
  - In-city case unchanged (Galveston venue → Galveston term).
  - Unresolved venue city → falls back to pipeline term.
  - Consumer filter override → filter term wins.

> Note: the repo's PHPUnit suite currently can't execute — `phpunit.xml` references `tests/bootstrap.php` which was never committed (pre-existing gap, unrelated to this change). The tests are written against the existing `WP_UnitTestCase` conventions and will run once that bootstrap exists.

## Follow-ups (out of scope)

- Commit the missing `tests/bootstrap.php` so the PHPUnit suite can actually run.
- Consumer layer (extrachill-events): migrate its create-time normalizer to also hook `data_machine_events_resolve_event_location_term` to avoid double resolution.
- Backfill the ~190 existing city pipelines' already-mis-tagged events via `wp extrachill events fix-locations`.