### PR TITLE
fix: drop dangling phpunit.xml bootstrap attribute pointing at deleted tests/bootstrap.php

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,4 @@
 <phpunit
-	bootstrap="tests/bootstrap.php"
 	backupGlobals="false"
 	colors="true"
 	convertErrorsToExceptions="true"


### PR DESCRIPTION
## The bug

`tests/bootstrap.php` was added in fef9417, then deleted in the very next commit (1ea74c7, `release: v0.9.13`) with the message *"will also be removing test bootstrap in favor of homeboy's core testing system."* `phpunit.xml` was never updated to match — it still declared `bootstrap="tests/bootstrap.php"`.

The repo migrated to `homeboy-action v2` (WP Codebox-based CI) in March 2026, which is the "homeboy's core testing system" the Jan commit referenced. But nothing exercised local/PR-triggered PHPUnit runs against this dangling attribute until now.

## Why it broke `homeboy review test`

Homeboy's WP Codebox PHPUnit runner (`test-runner-wp-codebox.sh`) auto-detects bootstrap mode by regex-scanning `phpunit.xml` for a `bootstrap=` attribute:

- attribute present → commits to **project mode**, requires that exact file to exist on disk, hard-fails if not.
- attribute absent → falls through to **managed mode**, uses homeboy's own bootstrap.

Since the attribute was still there pointing at a file deleted 4 months prior, every `homeboy review test` / `homeboy test` run against this repo failed immediately with:

```
Error: project PHPUnit bootstrap file not found: <path>/tests/bootstrap.php
```

This is not a homeboy bug — homeboy correctly refuses to silently substitute a different bootstrap than the one a project explicitly declares. The fix is removing the stale declaration so auto-detect does what the 2026-01-19 commit already intended.

## The fix

One line: drop `bootstrap="tests/bootstrap.php"` from `phpunit.xml`.

## Verification

- `php -l phpunit.xml` — no syntax errors.
- Simulated homeboy's exact detection regex against the fixed file — confirms no match, correctly falls through to managed mode.
- `homeboy review data-machine-events test --path <worktree>` — confirms the run now advances **past** `WP Codebox PHPUnit bootstrap mode setup` (previously the first and only failure) to a later, unrelated environment step (`Preparing WordPress PHPUnit plugin source: composer`, which then hits a missing WP Codebox recipe-builder module local to this sandbox — an unrelated environment gap, not a repo config issue).

PR only, not merged/released/deployed.