### PR TITLE
fix: register abilities on wp_abilities_api_init instead of firing outside the action

### DIFF
--- a/inc/Abilities/AbilityCategories.php
+++ b/inc/Abilities/AbilityCategories.php
@@ -72,10 +72,6 @@ class AbilityCategories {
 			return;
 		}
 
-		if ( did_action( 'wp_abilities_api_categories_init' ) ) {
-			self::register();
-		} else {
-			add_action( 'wp_abilities_api_categories_init', array( self::class, 'register' ) );
-		}
+		add_action( 'wp_abilities_api_categories_init', array( self::class, 'register' ) );
 	}
 }

--- a/inc/Abilities/BatchTimeFixAbilities.php
+++ b/inc/Abilities/BatchTimeFixAbilities.php
@@ -127,11 +127,7 @@ class BatchTimeFixAbilities {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		add_action( 'wp_abilities_api_init', $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/CalendarAbilities.php
+++ b/inc/Abilities/CalendarAbilities.php
@@ -145,11 +145,7 @@ class CalendarAbilities {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		add_action( 'wp_abilities_api_init', $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/DeleteEventAbilities.php
+++ b/inc/Abilities/DeleteEventAbilities.php
@@ -110,11 +110,7 @@ class DeleteEventAbilities {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		add_action( 'wp_abilities_api_init', $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/DiceFmTest.php
+++ b/inc/Abilities/DiceFmTest.php
@@ -68,11 +68,7 @@ class DiceFmTest {
 				);
 			};
 
-			if ( did_action( 'wp_abilities_api_init' ) ) {
-				$register_callback();
-			} else {
-				add_action( 'wp_abilities_api_init', $register_callback );
-			}
+			add_action( 'wp_abilities_api_init', $register_callback );
 
 			self::$registered = true;
 		}

--- a/inc/Abilities/DuplicateDetectionAbilities.php
+++ b/inc/Abilities/DuplicateDetectionAbilities.php
@@ -43,11 +43,7 @@ class DuplicateDetectionAbilities {
 			$this->registerFindDuplicateEventAbility();
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		add_action( 'wp_abilities_api_init', $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/EncodingFixAbilities.php
+++ b/inc/Abilities/EncodingFixAbilities.php
@@ -101,11 +101,7 @@ class EncodingFixAbilities {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		add_action( 'wp_abilities_api_init', $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/EventDateQueryAbilities.php
+++ b/inc/Abilities/EventDateQueryAbilities.php
@@ -160,11 +160,7 @@ class EventDateQueryAbilities {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		add_action( 'wp_abilities_api_init', $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/EventHealthAbilities.php
+++ b/inc/Abilities/EventHealthAbilities.php
@@ -133,11 +133,7 @@ class EventHealthAbilities {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		add_action( 'wp_abilities_api_init', $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/EventQualityAuditAbilities.php
+++ b/inc/Abilities/EventQualityAuditAbilities.php
@@ -93,11 +93,7 @@ class EventQualityAuditAbilities {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		add_action( 'wp_abilities_api_init', $register_callback );
 	}
 
 	public function executeAudit( array $input ): array|\WP_Error {

--- a/inc/Abilities/EventQueryAbilities.php
+++ b/inc/Abilities/EventQueryAbilities.php
@@ -113,11 +113,7 @@ class EventQueryAbilities {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		add_action( 'wp_abilities_api_init', $register_callback );
 	}
 
 	public function executeGetVenueEvents( array $input ): array|\WP_Error {

--- a/inc/Abilities/EventScraperTest.php
+++ b/inc/Abilities/EventScraperTest.php
@@ -86,11 +86,7 @@ class EventScraperTest {
 				);
 			};
 
-			if ( did_action( 'wp_abilities_api_init' ) ) {
-				$register_callback();
-			} else {
-				add_action( 'wp_abilities_api_init', $register_callback );
-			}
+			add_action( 'wp_abilities_api_init', $register_callback );
 
 			self::$registered = true;
 		}

--- a/inc/Abilities/EventUpdateAbilities.php
+++ b/inc/Abilities/EventUpdateAbilities.php
@@ -167,11 +167,7 @@ class EventUpdateAbilities {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		add_action( 'wp_abilities_api_init', $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/EventsByTermAbilities.php
+++ b/inc/Abilities/EventsByTermAbilities.php
@@ -109,11 +109,7 @@ class EventsByTermAbilities {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		add_action( 'wp_abilities_api_init', $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/FilterAbilities.php
+++ b/inc/Abilities/FilterAbilities.php
@@ -130,11 +130,7 @@ class FilterAbilities {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		add_action( 'wp_abilities_api_init', $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/GeocodingAbilities.php
+++ b/inc/Abilities/GeocodingAbilities.php
@@ -62,11 +62,7 @@ class GeocodingAbilities {
 			$this->registerAuditVenuesAbility();
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		add_action( 'wp_abilities_api_init', $register_callback );
 	}
 
 	// -------------------------------------------------------------------------

--- a/inc/Abilities/MergeEventPostsAbilities.php
+++ b/inc/Abilities/MergeEventPostsAbilities.php
@@ -69,11 +69,7 @@ class MergeEventPostsAbilities {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		add_action( 'wp_abilities_api_init', $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/MergedBillDecideAbilities.php
+++ b/inc/Abilities/MergedBillDecideAbilities.php
@@ -102,11 +102,7 @@ class MergedBillDecideAbilities {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		add_action( 'wp_abilities_api_init', $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/MergedBillDetectAbilities.php
+++ b/inc/Abilities/MergedBillDetectAbilities.php
@@ -91,11 +91,7 @@ class MergedBillDetectAbilities {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		add_action( 'wp_abilities_api_init', $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/MoveEventAbilities.php
+++ b/inc/Abilities/MoveEventAbilities.php
@@ -110,11 +110,7 @@ class MoveEventAbilities {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		add_action( 'wp_abilities_api_init', $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/SettingsAbilities.php
+++ b/inc/Abilities/SettingsAbilities.php
@@ -56,11 +56,7 @@ class SettingsAbilities {
 			$this->registerUpdateSettingAbility();
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		add_action( 'wp_abilities_api_init', $register_callback );
 	}
 
 	// -------------------------------------------------------------------------

--- a/inc/Abilities/TicketUrlResyncAbilities.php
+++ b/inc/Abilities/TicketUrlResyncAbilities.php
@@ -94,11 +94,7 @@ class TicketUrlResyncAbilities {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		add_action( 'wp_abilities_api_init', $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/TicketmasterTest.php
+++ b/inc/Abilities/TicketmasterTest.php
@@ -81,11 +81,7 @@ class TicketmasterTest {
 				);
 			};
 
-			if ( did_action( 'wp_abilities_api_init' ) ) {
-				$register_callback();
-			} else {
-				add_action( 'wp_abilities_api_init', $register_callback );
-			}
+			add_action( 'wp_abilities_api_init', $register_callback );
 
 			self::$registered = true;
 		}

--- a/inc/Abilities/TimezoneAbilities.php
+++ b/inc/Abilities/TimezoneAbilities.php
@@ -180,11 +180,7 @@ class TimezoneAbilities {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		add_action( 'wp_abilities_api_init', $register_callback );
 	}
 
 	public function executeAbility( array $input ): array {

--- a/inc/Abilities/UpcomingCountAbilities.php
+++ b/inc/Abilities/UpcomingCountAbilities.php
@@ -98,11 +98,7 @@ class UpcomingCountAbilities {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		add_action( 'wp_abilities_api_init', $register_callback );
 	}
 
 	/**

--- a/inc/Abilities/VenueAbilities.php
+++ b/inc/Abilities/VenueAbilities.php
@@ -68,11 +68,7 @@ class VenueAbilities {
 			$this->registerCheckDuplicateAbility();
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		add_action( 'wp_abilities_api_init', $register_callback );
 	}
 
 	private function registerHealthCheckAbility(): void {

--- a/inc/Abilities/VenueMapAbilities.php
+++ b/inc/Abilities/VenueMapAbilities.php
@@ -45,11 +45,7 @@ class VenueMapAbilities {
 			$this->registerListVenuesAbility();
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		add_action( 'wp_abilities_api_init', $register_callback );
 	}
 
 	private function registerListVenuesAbility(): void {

--- a/inc/Abilities/VenueStatsAbilities.php
+++ b/inc/Abilities/VenueStatsAbilities.php
@@ -86,11 +86,7 @@ class VenueStatsAbilities {
 			);
 		};
 
-		if ( did_action( 'wp_abilities_api_init' ) ) {
-			$register_callback();
-		} else {
-			add_action( 'wp_abilities_api_init', $register_callback );
-		}
+		add_action( 'wp_abilities_api_init', $register_callback );
 	}
 
 	/**


### PR DESCRIPTION
## Root cause

WordPress 6.9 `wp_register_ability()` (`wp-includes/abilities-api.php:278-291`) emits a `doing_it_wrong` notice **and returns `null` (ability not registered)** unless it is called **while** the `wp_abilities_api_init` action is firing. It gates on `doing_action(...)`, **not** `did_action(...)`.

Every ability class in `inc/Abilities/` used the same copy-pasted idiom:

```php
if ( did_action( 'wp_abilities_api_init' ) ) {
    $register_callback();   // <-- BUG: runs OUTSIDE the action
} else {
    add_action( 'wp_abilities_api_init', $register_callback );
}
```

The `did_action` immediate branch is dead-wrong: once the hook has fired, `did_action()` is true forever but `doing_action()` is false, so this branch **always** registers outside the action context — tripping the notice and failing to register. Registering after the hook is impossible-by-design and correctly forbidden by core.

## The fix

Replace the whole `if ( did_action(...) ) { ... } else { ... }` wrapper with just the deferred registration:

```diff
-	if ( did_action( 'wp_abilities_api_init' ) ) {
-		$register_callback();
-	} else {
-		add_action( 'wp_abilities_api_init', $register_callback );
-	}
+	add_action( 'wp_abilities_api_init', $register_callback );
```

The existing `private static bool $registered = false;` dedupe guard and everything else are untouched. Only the broken immediate branch is removed. No `doing_action()` OR-guard workaround is added — the clean fix matches core's contract.

`inc/Abilities/AbilityCategories.php` had the **same bug on the sibling hook** `wp_abilities_api_categories_init` (core gates it identically at `abilities-api.php:468`); fixed the same way using its `array( self::class, 'register' )` callback form.

## Why this is safe

The ability classes double as service objects `new`'d ad-hoc all over (CLI, REST, chat) purely to call `->executeX()` methods — those do **not** need registry registration, so dropping the immediate branch does not break them. The one genuine lazy consumer (`extrachill-cli` `LocationCommand`) already works by instantiating classes **before** the first `wp_has_ability()` call, which fires the hook once via `get_instance()`. Dropping the dead branch is the clean fix.

## Files changed (28)

All in `inc/Abilities/`:

`AbilityCategories.php` (categories hook), `BatchTimeFixAbilities.php`, `CalendarAbilities.php`, `DeleteEventAbilities.php`, `DiceFmTest.php`, `DuplicateDetectionAbilities.php`, `EncodingFixAbilities.php`, `EventDateQueryAbilities.php`, `EventHealthAbilities.php`, `EventQualityAuditAbilities.php`, `EventQueryAbilities.php`, `EventScraperTest.php`, `EventUpdateAbilities.php`, `EventsByTermAbilities.php`, `FilterAbilities.php`, `GeocodingAbilities.php`, `MergeEventPostsAbilities.php`, `MergedBillDecideAbilities.php`, `MergedBillDetectAbilities.php`, `MoveEventAbilities.php`, `SettingsAbilities.php`, `TicketUrlResyncAbilities.php`, `TicketmasterTest.php`, `TimezoneAbilities.php`, `UpcomingCountAbilities.php`, `VenueAbilities.php`, `VenueMapAbilities.php`, `VenueStatsAbilities.php`.

## Verification

- `grep -rn "did_action( ['\"]wp_abilities_api" inc/` → **0 matches** repo-wide (both single- and double-quote variants checked).
- `php -l` clean on all 28 changed files.
- `homeboy review data-machine-events lint` → **phpstan passed**; phpcs reports 343 findings that are **pre-existing baseline on `main`** (spread across untouched files: `Venue_Taxonomy.php`, `WebflowExtractor.php`, `render.php`, etc.). Cross-checked every finding's line number against my changed lines: **0 collisions** — this change introduces no new phpcs findings.

This eliminates a large chunk of the WordPress 6.9 `doing_it_wrong` notices currently spamming the network `debug.log`.

---

No release, no deploy, no CHANGELOG edit, no version bump — PR only.