### PR TITLE
feat: filter calendar request defaults before parsing

### DIFF
--- a/docs/integration-api.md
+++ b/docs/integration-api.md
@@ -86,6 +86,7 @@ signatures are stable.
 | `data_machine_events_excluded_taxonomies` | `(array $excluded, string $context)` | Exclude taxonomies from badge / modal display. `$context` is `'badge'` or `'modal'`. |
 | `data_machine_events_more_info_button_classes` | `(array $classes)` | Modify CSS classes on the calendar card "More Info" link. |
 | `data_machine_events_modal_button_classes` | `(array $classes, string $variant)` | Modify CSS classes on filter modal buttons. `$variant` is `'primary'` or `'secondary'`. |
+| `data_machine_events_calendar_request_args` | `(array $query_args, array $context)` | Add contextual calendar defaults immediately before `CalendarRequest` parsing. Request and block values are already assembled, so consumers should add only missing keys; all returned values are sanitized by `CalendarRequest`. Context contains `attributes`, resolved `display_mode`, and `archive_term` (`WP_Term|null`). Parsed taxonomy and geo values automatically reach the initial query, rendered state, controls, and existing frontend REST round-trips. |
 | `data_machine_events_calendar_query_args` | `(array $args, array $params)` | Modify the WP_Query args used by the calendar block. |
 
 ### Event Details block filters

--- a/inc/Blocks/Calendar/render.php
+++ b/inc/Blocks/Calendar/render.php
@@ -122,6 +122,32 @@ if ( $is_month_grid_mode && empty( $query_args['month'] ) ) {
 	$query_args['month'] = current_time( 'Y-m' );
 }
 
+/**
+ * Filter the assembled calendar request arguments before they are parsed.
+ *
+ * Request values and built-in block defaults are already present. Consumers
+ * providing contextual defaults should therefore add only missing keys so
+ * explicit request values retain precedence. Every returned value is parsed
+ * and sanitized by CalendarRequest::fromQueryArgs(). Parsed taxonomy and geo
+ * state then follows the existing initial-query, rendered-attribute, filter,
+ * and frontend REST round-trip paths.
+ *
+ * @since 0.48.0
+ *
+ * @param array $query_args Raw calendar request arguments.
+ * @param array $context    Render context containing block `attributes`, resolved
+ *                          `display_mode`, and optional `archive_term` (WP_Term|null).
+ */
+$query_args = (array) apply_filters(
+	'data_machine_events_calendar_request_args',
+	$query_args,
+	array(
+		'attributes'   => $attributes,
+		'display_mode' => $display_mode,
+		'archive_term' => $archive_term,
+	)
+);
+
 $request = CalendarRequest::fromQueryArgs( $query_args, $archive_term );
 
 // Local aliases used by template includes / data attrs further down.

--- a/tests/Unit/CalendarBlockTest.php
+++ b/tests/Unit/CalendarBlockTest.php
@@ -16,6 +16,12 @@ use DataMachineEvents\Blocks\Calendar\Pagination\Renderer as Pagination;
 
 class CalendarBlockTest extends WP_UnitTestCase {
 
+	private function render_calendar( array $attributes = array() ): string {
+		$block = \WP_Block_Type_Registry::get_instance()->get_registered( 'data-machine-events/calendar' );
+
+		return (string) call_user_func( $block->render_callback, $attributes, '', $block );
+	}
+
 	public function test_calendar_block_registered() {
 		$block_registry = \WP_Block_Type_Registry::get_instance();
 		$block          = $block_registry->get_registered( 'data-machine-events/calendar' );
@@ -74,6 +80,97 @@ class CalendarBlockTest extends WP_UnitTestCase {
 
 		$this->assertTrue( $modified );
 		$this->assertEquals( 'data_machine_events', $args['post_type'] );
+	}
+
+	public function test_calendar_request_args_filter_injects_sanitized_defaults_and_context() {
+		$original_get = $_GET;
+		$_GET        = array();
+		$context      = null;
+		$parsed_input = null;
+
+		add_filter(
+			'data_machine_events_calendar_request_args',
+			function ( $args, $render_context ) use ( &$context ) {
+				$context                  = $render_context;
+				$args['lat']              = '32.7765<script>';
+				$args['lng']              = '-79.9311';
+				$args['radius']           = '25px';
+				$args['radius_unit']      = 'MI<script>';
+				$args['tax_filter']       = array(
+					'Festival<script>' => array( '42', '-3', 'invalid' ),
+				);
+
+				return $args;
+			},
+			10,
+			2
+		);
+		add_filter(
+			'data_machine_events_calendar_query_args',
+			function ( $args, $input ) use ( &$parsed_input ) {
+				$parsed_input = $input;
+				return $args;
+			},
+			10,
+			2
+		);
+
+		$html = $this->render_calendar( array( 'displayMode' => 'date-groups', 'showSearch' => false ) );
+
+		$this->assertSame( array(), $_GET, 'Consumers do not need to mutate request globals.' );
+		$this->assertSame( 'date-groups', $context['display_mode'] );
+		$this->assertSame( false, $context['attributes']['showSearch'] );
+		$this->assertArrayHasKey( 'archive_term', $context );
+		$this->assertNull( $context['archive_term'] );
+		$this->assertSame( array( 'festivalscript' => array( 42, 3 ) ), $parsed_input['tax_filter'] );
+		$this->assertSame( '32.7765', $parsed_input['geo_lat'] );
+		$this->assertSame( 25, $parsed_input['geo_radius'] );
+		$this->assertSame( 'miscript', $parsed_input['geo_radius_unit'] );
+		$this->assertStringContainsString( 'data-geo-lat="32.7765"', $html );
+
+		$_GET = $original_get;
+	}
+
+	public function test_calendar_request_defaults_preserve_explicit_values_and_reject_invalid_state() {
+		$original_get = $_GET;
+		$_GET        = array(
+			'lat'        => '40.7128',
+			'lng'        => '-74.0060',
+			'tax_filter' => array( 'venue' => array( '9' ) ),
+		);
+		$parsed_input = null;
+
+		add_filter(
+			'data_machine_events_calendar_request_args',
+			function ( $args ) {
+				$args += array(
+					'lat'        => 'invalid-default',
+					'lng'        => 'invalid-default',
+					'tax_filter' => array( 'festival' => array( 42 ) ),
+					'month'     => 'not-a-month',
+				);
+				return $args;
+			}
+		);
+		add_filter(
+			'data_machine_events_calendar_query_args',
+			function ( $args, $input ) use ( &$parsed_input ) {
+				$parsed_input = $input;
+				return $args;
+			},
+			10,
+			2
+		);
+
+		$this->render_calendar();
+
+		$this->assertSame( '40.7128', $parsed_input['geo_lat'] );
+		$this->assertSame( '-74.0060', $parsed_input['geo_lng'] );
+		$this->assertSame( array( 'venue' => array( 9 ) ), $parsed_input['tax_filter'] );
+		$this->assertSame( '', $parsed_input['month'] );
+		$this->assertSame( '40.7128', $_GET['lat'] );
+
+		$_GET = $original_get;
 	}
 
 	public function test_calendar_renders_no_events_state() {


### PR DESCRIPTION
## Summary
- add `data_machine_events_calendar_request_args` over assembled request arguments immediately before `CalendarRequest::fromQueryArgs( $query_args, $archive_term )`
- provide generic render context through `(array $query_args, array $context)`, where context contains block `attributes`, resolved `display_mode`, and `archive_term`
- document and test contextual geo/taxonomy defaults without request-global mutation

## Contract
Request values and built-in block defaults are assembled before this filter. Consumers should add only missing keys (for example with `$query_args += $defaults`) so explicit URL/request values retain precedence.

The filtered array still passes through `CalendarRequest::fromQueryArgs()`, so injected values receive the same sanitization and rejection behavior as URL values. The resulting request object continues through the existing initial query, rendered geo attributes, taxonomy filter controls, and frontend REST request restoration paths.

## Migration for Extra-Chill/extrachill-events#231
Replace the temporary `$_GET` mutation around block rendering with a `data_machine_events_calendar_request_args` callback. When the consumer context applies, add the account-derived `tax_filter` and/or geo keys only when those keys are absent; explicit calendar request state will continue to win.

## Tests
- geo and taxonomy defaults reach the parsed ability input and rendered geo state
- explicit request values survive a missing-default merge
- invalid taxonomy IDs and month values are sanitized/rejected
- block attributes, display mode, and archive context are available
- callbacks can provide defaults without mutating `$_GET`

## Verification
- `php -l inc/Blocks/Calendar/render.php`
- `php -l tests/Unit/CalendarBlockTest.php`
- `git diff --check`
- `homeboy review data-machine-events build` (passed)
- `homeboy review data-machine-events test` could not start because the installed Homeboy runtime cannot locate a WP Codebox recipe-builder export
- lint/audit currently report existing repository-wide findings; changed-only invocation still scanned the whole component

Closes #444