### PR TITLE
fix: retain nightlife scopes after midnight

### DIFF
--- a/inc/Blocks/Calendar/Query/ScopeResolver.php
+++ b/inc/Blocks/Calendar/Query/ScopeResolver.php
@@ -15,6 +15,8 @@
 
 namespace DataMachineEvents\Blocks\Calendar\Query;
 
+use DataMachineEvents\Blocks\Calendar\Grouping\LateNightCutoff;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -98,34 +100,34 @@ class ScopeResolver {
 	 * Returns null for 'current' (the default) or unrecognized scopes,
 	 * which signals the caller to use existing unscoped behavior.
 	 *
-	 * @param string $scope The scope identifier.
+	 * @param string   $scope The scope identifier.
+	 * @param int|null $now   Current site-local timestamp. Null uses the current time.
 	 * @return array|null Array with 'date_start', 'date_end', and optionally
 	 *                    'time_start', 'time_end' for sub-day precision. Null if no scope.
 	 */
-	public static function resolve( string $scope ): ?array {
+	public static function resolve( string $scope, ?int $now = null ): ?array {
 		$scope = sanitize_key( $scope );
 
 		if ( 'current' === $scope || '' === $scope ) {
 			return null;
 		}
-		$now   = current_time( 'timestamp' );
-		$today = gmdate( 'Y-m-d', $now );
+		$now         = $now ?? current_time( 'timestamp' );
+		$literal_day = gmdate( 'Y-m-d', $now );
+		$time        = gmdate( 'H:i:s', $now );
+		$display_day = LateNightCutoff::display_date_from_strings( $literal_day, $time );
 
 		switch ( $scope ) {
 			case 'today':
-				return array(
-					'date_start' => $today,
-					'date_end'   => $today,
-				);
+				return self::resolve_display_day( $display_day );
 
 			case 'tonight':
-				return self::resolve_tonight( $now, $today );
+				return self::resolve_tonight( $now, $display_day );
 
 			case 'this-weekend':
-				return self::resolve_this_weekend( $now, $today );
+				return self::resolve_this_weekend( $now, $literal_day );
 
 			case 'this-week':
-				return self::resolve_this_week( $now, $today );
+				return self::resolve_this_week( $now, $literal_day );
 
 			default:
 				return null;
@@ -143,28 +145,58 @@ class ScopeResolver {
 	}
 
 	/**
-	 * Resolve "tonight" — events starting from 5 PM today through 3:59 AM tomorrow.
+	 * Resolve the raw datetime bounds for one nightlife display day.
 	 *
-	 * Before 5 PM, tonight means today 5 PM – tomorrow 3:59 AM.
-	 * After 5 PM, tonight means now – tomorrow 3:59 AM.
+	 * When late-night bucketing is enabled, the display day starts at the
+	 * configured cutoff and ends just before that cutoff on the following
+	 * literal day. This ensures date filters select exactly the events grouped
+	 * under the same display-day heading. With bucketing disabled, the display
+	 * day remains the literal calendar day.
+	 *
+	 * @param string $display_day Display date in Y-m-d format.
+	 * @return array Resolved date boundaries with time precision when enabled.
+	 */
+	private static function resolve_display_day( string $display_day ): array {
+		$cutoff = LateNightCutoff::cutoff_hour();
+
+		if ( $cutoff <= 0 ) {
+			return array(
+				'date_start' => $display_day,
+				'date_end'   => $display_day,
+			);
+		}
+
+		return array(
+			'date_start' => $display_day,
+			'date_end'   => gmdate( 'Y-m-d', strtotime( $display_day . ' +1 day' ) ),
+			'time_start' => sprintf( '%02d:00:00', $cutoff ),
+			'time_end'   => sprintf( '%02d:59:59', $cutoff - 1 ),
+		);
+	}
+
+	/**
+	 * Resolve "tonight" — events starting from 5 PM on the active display day
+	 * through the configured late-night cutoff on its following literal day.
+	 *
+	 * Before 5 PM, tonight starts at 5 PM. After 5 PM, it starts now.
 	 *
 	 * @param int    $now   Current timestamp (site timezone).
-	 * @param string $today Today's date in Y-m-d format.
+	 * @param string $display_day Active nightlife display date in Y-m-d format.
 	 * @return array Resolved date boundaries with time precision.
 	 */
-	private static function resolve_tonight( int $now, string $today ): array {
+	private static function resolve_tonight( int $now, string $display_day ): array {
 		$current_hour = (int) gmdate( 'G', $now );
-		$tomorrow     = gmdate( 'Y-m-d', $now + DAY_IN_SECONDS );
+		$display_day_bounds = self::resolve_display_day( $display_day );
 
 		// Before 5 PM: show from 5 PM today onward.
 		// After 5 PM: show from now onward (events already in progress or starting soon).
 		$time_start = $current_hour < 17 ? '17:00:00' : gmdate( 'H:i:s', $now );
 
 		return array(
-			'date_start' => $today,
-			'date_end'   => $tomorrow,
+			'date_start' => $display_day,
+			'date_end'   => $display_day_bounds['date_end'],
 			'time_start' => $time_start,
-			'time_end'   => '03:59:59',
+			'time_end'   => $display_day_bounds['time_end'] ?? '23:59:59',
 		);
 	}
 

--- a/tests/Unit/ScopeResolverTest.php
+++ b/tests/Unit/ScopeResolverTest.php
@@ -18,6 +18,19 @@ use DataMachineEvents\Blocks\Calendar\Query\ScopeResolver;
 
 class ScopeResolverTest extends WP_UnitTestCase {
 
+	private $cutoff_filter;
+
+	public function set_up(): void {
+		parent::set_up();
+		$this->cutoff_filter = static fn() => 5;
+		add_filter( 'data_machine_events_late_night_cutoff_hour', $this->cutoff_filter );
+	}
+
+	public function tear_down(): void {
+		remove_filter( 'data_machine_events_late_night_cutoff_hour', $this->cutoff_filter );
+		parent::tear_down();
+	}
+
 	// ---------------------------------------------------------------------
 	// preset_scopes(): default / subset / order / sanitization
 	// ---------------------------------------------------------------------
@@ -97,5 +110,86 @@ class ScopeResolverTest extends WP_UnitTestCase {
 				"Scope '{$slug}' must resolve to a human label."
 			);
 		}
+	}
+
+	// ---------------------------------------------------------------------
+	// resolve(): raw query bounds follow the active display day
+	// ---------------------------------------------------------------------
+
+	public function test_resolve_today_retains_the_active_display_day_after_midnight(): void {
+		$before_midnight = ScopeResolver::resolve( 'today', strtotime( '2026-07-10 23:59:59 UTC' ) );
+		$after_midnight  = ScopeResolver::resolve( 'today', strtotime( '2026-07-11 00:00:01 UTC' ) );
+
+		$this->assertSame(
+			array(
+				'date_start' => '2026-07-10',
+				'date_end'   => '2026-07-11',
+				'time_start' => '05:00:00',
+				'time_end'   => '04:59:59',
+			),
+			$before_midnight
+		);
+		$this->assertSame( $before_midnight, $after_midnight );
+	}
+
+	public function test_resolve_tonight_retains_the_active_display_day_after_midnight(): void {
+		$this->assertSame(
+			array(
+				'date_start' => '2026-07-10',
+				'date_end'   => '2026-07-11',
+				'time_start' => '17:00:00',
+				'time_end'   => '04:59:59',
+			),
+			ScopeResolver::resolve( 'tonight', strtotime( '2026-07-11 00:00:01 UTC' ) )
+		);
+	}
+
+	public function test_resolve_uses_the_new_display_day_at_the_cutoff(): void {
+		$this->assertSame(
+			array(
+				'date_start' => '2026-07-11',
+				'date_end'   => '2026-07-12',
+				'time_start' => '05:00:00',
+				'time_end'   => '04:59:59',
+			),
+			ScopeResolver::resolve( 'today', strtotime( '2026-07-11 05:00:00 UTC' ) )
+		);
+	}
+
+	public function test_resolve_tonight_keeps_daytime_and_evening_behavior(): void {
+		$this->assertSame(
+			array(
+				'date_start' => '2026-07-11',
+				'date_end'   => '2026-07-12',
+				'time_start' => '17:00:00',
+				'time_end'   => '04:59:59',
+			),
+			ScopeResolver::resolve( 'tonight', strtotime( '2026-07-11 14:30:00 UTC' ) )
+		);
+		$this->assertSame(
+			array(
+				'date_start' => '2026-07-11',
+				'date_end'   => '2026-07-12',
+				'time_start' => '18:30:00',
+				'time_end'   => '04:59:59',
+			),
+			ScopeResolver::resolve( 'tonight', strtotime( '2026-07-11 18:30:00 UTC' ) )
+		);
+	}
+
+	public function test_resolve_uses_the_configured_cutoff_for_display_day_bounds(): void {
+		remove_filter( 'data_machine_events_late_night_cutoff_hour', $this->cutoff_filter );
+		$this->cutoff_filter = static fn() => 3;
+		add_filter( 'data_machine_events_late_night_cutoff_hour', $this->cutoff_filter );
+
+		$this->assertSame(
+			array(
+				'date_start' => '2026-07-10',
+				'date_end'   => '2026-07-11',
+				'time_start' => '03:00:00',
+				'time_end'   => '02:59:59',
+			),
+			ScopeResolver::resolve( 'today', strtotime( '2026-07-11 02:59:59 UTC' ) )
+		);
 	}
 }


### PR DESCRIPTION
## Summary
- Anchor `today` and `tonight` to `LateNightCutoff`'s active display day instead of the literal post-midnight date.
- Resolve `today` to the complete raw datetime window for that display day, so the queried events and grouped heading use identical cutoff semantics.
- Keep `tonight` on the prior evening after midnight; use the configured cutoff for both its upper bound and the `today` window.

## Root Cause
`ScopeResolver::resolve()` used the literal current date. At 12:01 a.m., `today` moved to the new date and `tonight` selected that evening's 5 p.m. start, despite `LateNightCutoff` still grouping the current early-morning events under the previous nightlife day.

## Scope Semantics
Before the cutoff, the active display day is the prior literal date. `today` queries from that date at the configured cutoff through one second before the next cutoff; `tonight` queries from 5 p.m. on that same active day through that cutoff. At and after the cutoff, both scopes advance to the current literal date. Daytime and evening `tonight` starts remain 5 p.m. and the current time respectively.

## Tests
- `php -l inc/Blocks/Calendar/Query/ScopeResolver.php`
- `php -l tests/Unit/ScopeResolverTest.php`
- `git diff --check`
- Added deterministic coverage immediately before/after midnight, at the cutoff, during daytime/evening, and with a filtered cutoff.
- Focused PHPUnit and `homeboy review ... --changed-since origin/main` were not run: Homeboy refused on the overloaded host (load average 165+ across 8 CPUs), no eligible Lab runner was connected, and no local `phpunit` binary is installed.

Fixes #452