### PR TITLE
chore: fix release-blocking ScopeResolver lint

### DIFF
--- a/inc/Blocks/Calendar/Query/ScopeResolver.php
+++ b/inc/Blocks/Calendar/Query/ScopeResolver.php
@@ -185,7 +185,7 @@ class ScopeResolver {
 	 * @return array Resolved date boundaries with time precision.
 	 */
 	private static function resolve_tonight( int $now, string $display_day ): array {
-		$current_hour = (int) gmdate( 'G', $now );
+		$current_hour       = (int) gmdate( 'G', $now );
 		$display_day_bounds = self::resolve_display_day( $display_day );
 
 		// Before 5 PM: show from 5 PM today onward.


### PR DESCRIPTION
## Summary
- align the new `ScopeResolver` assignment with the surrounding statement
- clear the auto-fixable PHPCS warning blocking the v0.49.1 release

## Verification
- direct PHPCS no longer reports the alignment warning
- `git diff --check`
- no behavioral code changed

Fixes #457