### PR TITLE
chore: exclude block build configs from runtime releases

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -9,6 +9,15 @@
     }
   },
   "id": "data-machine-events",
+  "scopes": {
+    "release": {
+      "exclude": [
+        "inc/Blocks/Calendar/webpack.config.js",
+        "inc/Blocks/EventDetails/webpack.config.js",
+        "inc/Blocks/EventsMap/webpack.config.js"
+      ]
+    }
+  },
   "version_targets": [
     {
       "file": "data-machine-events.php",


### PR DESCRIPTION
## Summary
- declare each block's `webpack.config.js` as build-only in the Homeboy release scope
- keep runtime artifact structure validation enabled without shipping source build configuration

## Verification
- `jq empty homeboy.json`
- `git diff --check`

Fixes #459