### PR TITLE
fix(calendar): synchronize month-grid filter state

### DIFF
--- a/docs/calendar-data-schema.md
+++ b/docs/calendar-data-schema.md
@@ -5,7 +5,8 @@ Status: **phase 1 of the refactor in [Extra-Chill/data-machine-events#298](https
 The canonical calendar REST response remains the legacy HTML-string envelope
 returned by `/wp-json/datamachine/v1/events/calendar`. This document describes
 the **opt-in** data-only envelope introduced in phase 1: a server-rendered
-JSON shape with **zero HTML strings**, intended to become the canonical
+JSON shape with structured event data and one canonical server-rendered
+empty-state recovery fragment, intended to become the canonical
 contract once the consumers in `inc/Blocks/Calendar/src/` are ported in
 subsequent phases.
 
@@ -42,7 +43,7 @@ full-response cache key (`CalendarCache::generate_full_response_key()`).
   "success": true,
   "schema": {
     "name": "calendar-data",
-    "version": 2,
+    "version": 3,
     "phase": 1,
     "issue": 298
   },
@@ -74,14 +75,15 @@ full-response cache key (`CalendarCache::generate_full_response_key()`).
     "future_count": 834,
     "has_past":     true,
     "has_future":   true
-  }
+  },
+  "empty_html": ""
 }
 ```
 
 ### `schema`
 
 Identifies the schema for forward compatibility. Clients should check
-`schema.name === 'calendar-data'` and `schema.version === 2` before
+`schema.name === 'calendar-data'` and `schema.version === 3` before
 reading the rest. Future phases bump `phase`; backward-incompatible
 shape changes bump `version`.
 
@@ -98,6 +100,10 @@ time / date / unicode formatting in JavaScript, making
 (PHP template, lazy-render hydration, and the client event renderer).
 This closed the badge- and time-format drift bugs where client-rendered
 (Load More) cards diverged from server-rendered ones.
+
+**v3 ([#465](https://github.com/Extra-Chill/data-machine-events/issues/465)):** empty
+responses carry `empty_html`, rendered from the existing `no-events.php`
+template. Non-empty responses carry an empty string.
 
 ### `events`
 
@@ -212,12 +218,15 @@ Clients should render these verbatim and must **not** re-derive time,
 date, or unicode formatting locally — doing so reintroduces the
 server/client drift this block exists to eliminate.
 
-### `pagination`, `counter`, `navigation`
+### `pagination`, `counter`, `navigation`, `empty_html`
 
-Pure metadata — no HTML strings. Field meanings mirror the legacy
+Pagination, counter, and navigation are pure metadata. Field meanings mirror the legacy
 envelope's metadata fields (`pagination.current_page`,
 `navigation.past_count`, etc.), with the HTML-rendering fields
 (`pagination.html`, `counter` as string, `navigation.html`) removed.
+`empty_html` is empty for non-empty results. For an empty result it contains
+the translated output of the canonical `no-events.php` template, including
+the existing Today recovery control, so clients do not duplicate that copy.
 
 ## What this phase does NOT change
 

--- a/inc/Abilities/CalendarAbilities.php
+++ b/inc/Abilities/CalendarAbilities.php
@@ -92,7 +92,7 @@ class CalendarAbilities {
 							),
 							'scope'            => array(
 								'type'        => 'string',
-								'description' => 'Time scope: today, tonight, this-weekend, this-week (overrides date_start/date_end when set)',
+								'description' => 'Time scope: today, tonight, this-weekend, this-week (intersects date_start/date_end and month when set)',
 							),
 							'month'            => array(
 								'type'        => 'string',
@@ -167,38 +167,40 @@ class CalendarAbilities {
 		$user_date_end   = $input['date_end'] ?? '';
 		$tax_filters     = is_array( $input['tax_filter'] ?? null ) ? $input['tax_filter'] : array();
 
-		// #318: month-grid mode short-circuits scope/paged semantics. When
-		// a `YYYY-MM` month is supplied, expand it to first-of-month →
-		// last-of-month and flip `show_past` on so past dates within the
-		// month are included (grid mode displays both past and future
-		// inside one window — the locked-design decision is "no past/
-		// upcoming toggle in grid; users navigate months freely"). The
-		// existing user_date_range branch downstream collapses pagination
-		// to a single page automatically.
+		// Month-grid displays past and future dates inside one visible month.
+		// Month, explicit date, and resolved scope windows are independent
+		// constraints, so compose them by intersection instead of allowing one
+		// input to overwrite another.
 		$month_input = '';
 		if ( isset( $input['month'] ) && is_string( $input['month'] ) ) {
 			$month_input = self::normalize_month_input( $input['month'] );
 		}
-		if ( '' !== $month_input ) {
-			$month_bounds = self::month_to_date_bounds( $month_input );
-			if ( $month_bounds ) {
-				$user_date_start = $month_bounds['date_start'];
-				$user_date_end   = $month_bounds['date_end'];
-				$show_past       = true; // Include past dates that fall inside the visible month.
-				$current_page    = 1;
-			}
+		$month_bounds = '' !== $month_input ? self::month_to_date_bounds( $month_input ) : null;
+		if ( $month_bounds ) {
+			$show_past    = true;
+			$current_page = 1;
 		}
 
-		// Resolve scope to date boundaries when user hasn't set explicit dates.
 		$scope          = $input['scope'] ?? '';
-		$scope_resolved = null;
-		if ( $scope && empty( $user_date_start ) && empty( $user_date_end ) ) {
-			$scope_resolved = ScopeResolver::resolve( $scope );
-			if ( $scope_resolved ) {
-				$user_date_start = $scope_resolved['date_start'];
-				$user_date_end   = $scope_resolved['date_end'];
-			}
-		}
+		$scope_resolved = $scope ? ScopeResolver::resolve( $scope ) : null;
+		$date_bounds    = self::intersect_date_bounds(
+			array(
+				array(
+					'date_start' => $user_date_start,
+					'date_end'   => $user_date_end,
+				),
+				$month_bounds,
+				$scope_resolved,
+			)
+		);
+		$user_date_start   = $date_bounds['date_start'];
+		$user_date_end     = $date_bounds['date_end'];
+		$scope_time_start  = $scope_resolved && $user_date_start === ( $scope_resolved['date_start'] ?? '' )
+			? ( $scope_resolved['time_start'] ?? '' )
+			: '';
+		$scope_time_end   = $scope_resolved && $user_date_end === ( $scope_resolved['date_end'] ?? '' )
+			? ( $scope_resolved['time_end'] ?? '' )
+			: '';
 
 		$archive_taxonomy = sanitize_key( $input['archive_taxonomy'] ?? '' );
 		$archive_term_id  = absint( $input['archive_term_id'] ?? 0 );
@@ -219,8 +221,8 @@ class CalendarAbilities {
 			'search_query'       => $search_query,
 			'date_start'         => $user_date_start,
 			'date_end'           => $user_date_end,
-			'time_start'         => $scope_resolved['time_start'] ?? '',
-			'time_end'           => $scope_resolved['time_end'] ?? '',
+			'time_start'         => $scope_time_start,
+			'time_end'           => $scope_time_end,
 			'tax_filters'        => $tax_filters,
 			'tax_query_override' => $tax_query_override,
 			'archive_taxonomy'   => $archive_taxonomy,
@@ -467,6 +469,39 @@ class CalendarAbilities {
 		wp_reset_postdata();
 
 		return $result;
+	}
+
+	/**
+	 * Intersect inclusive date windows, preserving one-sided constraints.
+	 *
+	 * An empty intersection intentionally returns a lower bound after the upper
+	 * bound; the canonical event-date query then returns zero rows.
+	 *
+	 * @param array $windows Date windows with optional date_start/date_end keys.
+	 * @return array{date_start:string,date_end:string}
+	 */
+	private static function intersect_date_bounds( array $windows ): array {
+		$starts = array();
+		$ends   = array();
+
+		foreach ( $windows as $window ) {
+			if ( ! is_array( $window ) ) {
+				continue;
+			}
+			$start = (string) ( $window['date_start'] ?? '' );
+			$end   = (string) ( $window['date_end'] ?? '' );
+			if ( '' !== $start ) {
+				$starts[] = $start;
+			}
+			if ( '' !== $end ) {
+				$ends[] = $end;
+			}
+		}
+
+		return array(
+			'date_start' => $starts ? max( $starts ) : '',
+			'date_end'   => $ends ? min( $ends ) : '',
+		);
 	}
 
 	/**

--- a/inc/Api/Controllers/Calendar.php
+++ b/inc/Api/Controllers/Calendar.php
@@ -22,7 +22,8 @@
  * - `?format=data`: the structured data-only envelope introduced in
  *   phase 1 of refactor #298. Returns event objects, pagination /
  *   counter / navigation metadata, gap map, and a `by_date` grouping
- *   index — zero HTML strings. See `docs/calendar-data-schema.md`.
+ *   index. Empty results include the canonical server-rendered recovery
+ *   fragment. See `docs/calendar-data-schema.md`.
  *
  * Both envelopes are cached independently via
  * `CalendarCache::generate_full_response_key()`, which includes
@@ -38,8 +39,10 @@ use DataMachineEvents\Abilities\CalendarAbilities;
 use DataMachineEvents\Api\BrowserNavigationGuard;
 use DataMachineEvents\Blocks\Calendar\Cache\CalendarCache;
 use DataMachineEvents\Blocks\Calendar\Display\DisplayVars;
+use DataMachineEvents\Blocks\Calendar\Display\EventRenderer;
 use DataMachineEvents\Blocks\Calendar\Query\CalendarRequest;
 use DataMachineEvents\Blocks\Calendar\Taxonomy\Badges;
+use DataMachineEvents\Blocks\Calendar\Template_Loader;
 
 /**
  * Calendar API controller
@@ -55,8 +58,9 @@ class Calendar {
 	 * envelope to the newer client (and vice-versa) for the cache TTL window.
 	 *
 	 * v2 (#381): per-occurrence `display` block added to `grouping.by_date`.
+	 * v3 (#465): canonical server-rendered empty-state fragment added.
 	 */
-	const DATA_SCHEMA_VERSION = 2;
+	const DATA_SCHEMA_VERSION = 3;
 
 	/**
 	 * Calendar endpoint implementation
@@ -161,13 +165,13 @@ class Calendar {
 	 * Build the data-only response envelope (phase 1 of refactor #298).
 	 *
 	 * Returns structured event objects, pagination / counter / navigation
-	 * metadata, gap map, and a `by_date` grouping index. NO HTML strings.
+	 * metadata, gap map, and a `by_date` grouping index. The only HTML is the
+	 * canonical no-events recovery fragment when the result is empty.
 	 *
-	 * Performance note: this path NEVER calls `ob_start()` or any template
-	 * loader. `CalendarAbilities::executeGetCalendarPage()` was already
-	 * invoked with `include_html: false`, so the ability skipped its
-	 * `renderHtml()` branch entirely. The work here is pure array
-	 * restructuring on top of `paged_date_groups`.
+	 * Performance note: non-empty responses never call a template loader.
+	 * `CalendarAbilities::executeGetCalendarPage()` was invoked with
+	 * `include_html: false`, so the ability skipped its full `renderHtml()`
+	 * branch. Empty responses render only the canonical recovery fragment.
 	 *
 	 * Schema: see `docs/calendar-data-schema.md`.
 	 *
@@ -240,6 +244,11 @@ class Calendar {
 		}
 
 		$events = array_values( $events_by_id );
+		$empty_html = '';
+		if ( empty( $ordered_dates ) ) {
+			Template_Loader::init();
+			$empty_html = EventRenderer::render_date_groups( array() );
+		}
 
 		$show_past = $req->past();
 
@@ -281,6 +290,7 @@ class Calendar {
 				'has_past'     => (int) ( $result['event_counts']['past'] ?? 0 ) > 0,
 				'has_future'   => (int) ( $result['event_counts']['future'] ?? 0 ) > 0,
 			),
+			'empty_html' => $empty_html,
 		);
 	}
 

--- a/inc/Blocks/Calendar/src/frontend.test.ts
+++ b/inc/Blocks/Calendar/src/frontend.test.ts
@@ -1,0 +1,275 @@
+jest.mock( './modules/carousel', () => ( {
+	initCarousel: jest.fn(),
+	destroyCarousel: jest.fn(),
+} ) );
+jest.mock( './modules/date-picker', () => ( {
+	initDatePicker: jest.fn(),
+	destroyDatePicker: jest.fn(),
+	getDatePicker: jest.fn( () => mockPicker ),
+} ) );
+jest.mock( './modules/filter-modal', () => ( {
+	initFilterModal: jest.fn( ( _calendar, _apply, reset ) => {
+		mockResetCallback = reset;
+	} ),
+	destroyFilterModal: jest.fn(),
+} ) );
+jest.mock( './modules/navigation', () => ( {
+	initNavigation: jest.fn(),
+} ) );
+jest.mock( './modules/lazy-render', () => ( {
+	initLazyRender: jest.fn(),
+	destroyLazyRender: jest.fn(),
+} ) );
+jest.mock( './modules/day-loader', () => ( {
+	initDayLoader: jest.fn(),
+	destroyDayLoader: jest.fn(),
+} ) );
+jest.mock( './modules/load-more', () => ( {
+	initLoadMore: jest.fn(),
+	destroyLoadMore: jest.fn(),
+} ) );
+jest.mock( './modules/scope-presets', () => ( {
+	initScopePresets: jest.fn(),
+} ) );
+jest.mock( './modules/month-grid-response-renderer', () => ( {
+	renderMonthGridResponse: jest.fn(
+		( calendar: HTMLElement, month: string ) => {
+			const grid = global.document.createElement( 'div' );
+			grid.className = 'data-machine-month-grid';
+			grid.dataset.month = month;
+			grid.innerHTML =
+				'<a class="data-machine-month-grid__nav-next" data-month="2026-09" href="#">Next</a>';
+			calendar
+				.querySelector( '.data-machine-month-grid' )
+				?.replaceWith( grid );
+			calendar.querySelector(
+				'.data-machine-events-content'
+			)!.textContent = `mobile:${ month }`;
+		}
+	),
+} ) );
+
+import { renderMonthGridResponse } from './modules/month-grid-response-renderer';
+import { initCalendarInstance } from './frontend';
+
+import type { FlatpickrInstance } from './types';
+
+let mockResetCallback: ( params: URLSearchParams ) => void;
+const mockPicker: FlatpickrInstance = {
+	selectedDates: [ new Date( 2026, 7, 10 ), new Date( 2026, 7, 12 ) ],
+	clear: jest.fn(),
+	setDate: jest.fn(),
+	destroy: jest.fn(),
+};
+const mockFetch = jest.fn();
+const mockRenderMonthGridResponse = renderMonthGridResponse as jest.Mock;
+
+function successfulResponse(): Promise< Response > {
+	return Promise.resolve( {
+		ok: true,
+		json: async () => ( { success: true } ),
+	} as Response );
+}
+
+function requestedParams( call: number ): URLSearchParams {
+	return new URL( mockFetch.mock.calls[ call ][ 0 ], window.location.origin )
+		.searchParams;
+}
+
+function deferredResponse(): {
+	promise: Promise< Response >;
+	resolve: () => void;
+} {
+	let resolvePromise!: ( response: Response ) => void;
+	const promise = new Promise< Response >( ( resolve ) => {
+		resolvePromise = resolve;
+	} );
+	return {
+		promise,
+		resolve: () =>
+			resolvePromise( {
+				ok: true,
+				json: async () => ( { success: true } ),
+			} as Response ),
+	};
+}
+
+function calendarMarkup( withMap = false, mode = 'month-grid' ): string {
+	return `
+		${ withMap ? '<div class="data-machine-events-map-root"></div>' : '' }
+		<div class="data-machine-events-calendar" data-display-mode="${ mode }"
+			data-scope="tonight" data-scope-token="opaque-token"
+			data-archive-taxonomy="location" data-archive-term-id="12">
+			<div class="data-machine-events-filter-bar">
+				<input class="data-machine-events-search-input" value="new search">
+				<button class="data-machine-events-search-btn"></button>
+				<div class="data-machine-taxonomy-filters-inline">
+					<input type="checkbox" data-taxonomy="venue" value="42" checked>
+				</div>
+			</div>
+			<div class="data-machine-month-grid" data-month="2026-08"></div>
+			<div class="data-machine-events-content">old mobile</div>
+		</div>`;
+}
+
+async function flush(): Promise< void > {
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+describe( 'calendar frontend month-grid integration', () => {
+	beforeEach( () => {
+		window.history.replaceState( {}, '', '/events/' );
+		document.body.innerHTML = calendarMarkup();
+		mockFetch.mockReset();
+		mockFetch.mockImplementation( successfulResponse );
+		global.fetch = mockFetch;
+		mockRenderMonthGridResponse.mockClear();
+		mockPicker.selectedDates = [
+			new Date( 2026, 7, 10 ),
+			new Date( 2026, 7, 12 ),
+		];
+	} );
+
+	afterEach( () => {
+		window.dispatchEvent( new Event( 'beforeunload' ) );
+		jest.useRealTimers();
+	} );
+
+	it( 'submits real controls, default scope, archive, and opaque token', async () => {
+		const calendar = document.querySelector< HTMLElement >(
+			'.data-machine-events-calendar'
+		)!;
+		initCalendarInstance( calendar );
+
+		calendar
+			.querySelector< HTMLButtonElement >(
+				'.data-machine-events-search-btn'
+			)!
+			.click();
+		await flush();
+
+		const request = requestedParams( 0 );
+		expect( request.get( 'event_search' ) ).toBe( 'new search' );
+		expect( request.get( 'date_start' ) ).toBe( '2026-08-10' );
+		expect( request.get( 'date_end' ) ).toBe( '2026-08-12' );
+		expect( request.getAll( 'tax_filter[venue][]' ) ).toEqual( [ '42' ] );
+		expect( request.get( 'scope' ) ).toBe( 'tonight' );
+		expect( request.get( 'archive_taxonomy' ) ).toBe( 'location' );
+		expect( request.get( 'scope_token' ) ).toBe( 'opaque-token' );
+		expect(
+			calendar.querySelector( '.data-machine-events-content' )!
+				.textContent
+		).toBe( 'mobile:2026-08' );
+	} );
+
+	it( 'keeps reset, month navigation, and popstate on the controller path', async () => {
+		const calendar = document.querySelector< HTMLElement >(
+			'.data-machine-events-calendar'
+		)!;
+		initCalendarInstance( calendar );
+		mockResetCallback( new URLSearchParams() );
+		await flush();
+		expect( requestedParams( 0 ).get( 'event_search' ) ).toBeNull();
+		expect( requestedParams( 0 ).get( 'scope' ) ).toBe( 'tonight' );
+
+		calendar
+			.querySelector< HTMLAnchorElement >(
+				'.data-machine-month-grid__nav-next'
+			)!
+			.click();
+		await flush();
+		expect( requestedParams( 1 ).get( 'month' ) ).toBe( '2026-09' );
+
+		window.history.replaceState(
+			{},
+			'',
+			'/events/?event_search=back&month=2026-07'
+		);
+		window.dispatchEvent( new PopStateEvent( 'popstate' ) );
+		await flush();
+		expect( requestedParams( 2 ).get( 'event_search' ) ).toBe( 'back' );
+		expect( requestedParams( 2 ).get( 'month' ) ).toBe( '2026-07' );
+	} );
+
+	it( 'sequences overlapping geo and filter requests globally', async () => {
+		jest.useFakeTimers();
+		document.body.innerHTML = calendarMarkup( true );
+		const geo = deferredResponse();
+		const filter = deferredResponse();
+		mockFetch
+			.mockImplementationOnce( () => geo.promise )
+			.mockImplementationOnce( () => filter.promise );
+		const calendar = document.querySelector< HTMLElement >(
+			'.data-machine-events-calendar'
+		)!;
+		initCalendarInstance( calendar );
+
+		document.dispatchEvent(
+			new CustomEvent( 'data-machine-map-bounds-changed', {
+				detail: {
+					bounds: { swLat: 32, swLng: -80, neLat: 33, neLng: -79 },
+					zoom: 10,
+					center: { lat: 32.78, lng: -79.93 },
+				},
+			} )
+		);
+		jest.advanceTimersByTime( 300 );
+		calendar
+			.querySelector< HTMLButtonElement >(
+				'.data-machine-events-search-btn'
+			)!
+			.click();
+
+		filter.resolve();
+		await flush();
+		geo.resolve();
+		await flush();
+
+		expect( requestedParams( 0 ).get( 'lat' ) ).toBe( '32.78' );
+		expect( requestedParams( 1 ).get( 'event_search' ) ).toBe(
+			'new search'
+		);
+		expect( mockRenderMonthGridResponse ).toHaveBeenCalledTimes( 1 );
+		expect( window.location.search ).toContain( 'event_search=new+search' );
+		expect( window.location.search ).not.toContain( 'lat=' );
+	} );
+
+	it( 'leaves list-mode geo updates on the existing HTML response path', async () => {
+		jest.useFakeTimers();
+		document.body.innerHTML = calendarMarkup( true, 'date-groups' );
+		mockFetch.mockResolvedValueOnce( {
+			ok: true,
+			json: async () => ( {
+				success: true,
+				html: '<p>updated list</p>',
+				pagination: null,
+				counter: null,
+				navigation: null,
+			} ),
+		} as Response );
+		const calendar = document.querySelector< HTMLElement >(
+			'.data-machine-events-calendar'
+		)!;
+		initCalendarInstance( calendar );
+
+		document.dispatchEvent(
+			new CustomEvent( 'data-machine-map-bounds-changed', {
+				detail: {
+					bounds: { swLat: 32, swLng: -80, neLat: 33, neLng: -79 },
+					zoom: 10,
+					center: { lat: 32.78, lng: -79.93 },
+				},
+			} )
+		);
+		jest.advanceTimersByTime( 300 );
+		await flush();
+
+		expect( requestedParams( 0 ).has( 'format' ) ).toBe( false );
+		expect(
+			calendar.querySelector( '.data-machine-events-content' )!
+				.textContent
+		).toBe( 'updated list' );
+		expect( mockRenderMonthGridResponse ).not.toHaveBeenCalled();
+	} );
+} );

--- a/inc/Blocks/Calendar/src/frontend.ts
+++ b/inc/Blocks/Calendar/src/frontend.ts
@@ -93,7 +93,12 @@ function initCalendarInstance( calendar: HTMLElement ): void {
 		// the carousel which is list-specific UX.
 		initLazyRender( calendar );
 		initDayLoader( calendar );
-		initMonthGridNav( calendar );
+		initMonthGridNav( calendar, function ( params ) {
+			const currentFilterState = getFilterState( calendar );
+			currentFilterState.applyParams( params, getDatePicker( calendar ) );
+			currentFilterState.saveToStorage( params );
+			currentFilterState.updateFilterCountBadge();
+		} );
 	} else {
 		initLazyRender( calendar );
 		initDayLoader( calendar );
@@ -112,7 +117,16 @@ function initCalendarInstance( calendar: HTMLElement ): void {
 			handleFilterChange( calendar );
 		},
 		function ( params: URLSearchParams ) {
-			navigateToUrl( params );
+			if ( isMonthGridMode( calendar ) ) {
+				const currentFilterState = getFilterState( calendar );
+				currentFilterState.applyParams(
+					params,
+					getDatePicker( calendar )
+				);
+			}
+			if ( ! handleMonthGridChange( calendar, params ) ) {
+				navigateToUrl( params );
+			}
 		}
 	);
 
@@ -261,15 +275,28 @@ function handleFilterChange( calendar: HTMLElement ): void {
 
 	filterState.saveToStorage( params );
 
-	if ( isMonthGridMode( calendar ) ) {
-		const controller = getMonthGridController( calendar );
-		if ( controller ) {
-			void controller.handleFilterChange();
-			return;
-		}
+	if ( handleMonthGridChange( calendar, params ) ) {
+		return;
 	}
 
 	navigateToUrl( params );
+}
+
+function handleMonthGridChange(
+	calendar: HTMLElement,
+	params: URLSearchParams
+): boolean {
+	if ( ! isMonthGridMode( calendar ) ) {
+		return false;
+	}
+	const controller = getMonthGridController( calendar );
+	if ( ! controller ) {
+		return false;
+	}
+	void controller.handleFilterChange( params ).then( function () {
+		getFilterState( calendar ).updateFilterCountBadge();
+	} );
+	return true;
 }
 
 /**

--- a/inc/Blocks/Calendar/src/frontend.ts
+++ b/inc/Blocks/Calendar/src/frontend.ts
@@ -66,7 +66,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		.forEach( initCalendarInstance );
 } );
 
-function initCalendarInstance( calendar: HTMLElement ): void {
+export function initCalendarInstance( calendar: HTMLElement ): void {
 	if ( calendarInstances.has( calendar ) ) {
 		return;
 	}
@@ -145,7 +145,27 @@ function initCalendarInstance( calendar: HTMLElement ): void {
 
 	// Auto-detect map block on page and enable geo sync.
 	if ( hasMapBlockOnPage() ) {
-		initGeoSync( calendar );
+		if ( gridMode ) {
+			initGeoSync( calendar, async function ( geo ) {
+				const params = getFilterState( calendar ).buildParams(
+					getDatePicker( calendar )
+				);
+				params.set( 'lat', geo.lat );
+				params.set( 'lng', geo.lng );
+				if ( geo.radius !== undefined ) {
+					params.set( 'radius', String( geo.radius ) );
+				}
+				if ( geo.radius_unit ) {
+					params.set( 'radius_unit', geo.radius_unit );
+				}
+				const controller = getMonthGridController( calendar );
+				return controller
+					? controller.handleFilterChange( params )
+					: false;
+			} );
+		} else {
+			initGeoSync( calendar );
+		}
 	}
 
 	// Replace numbered pagination with a "Load More Events" button on
@@ -293,8 +313,10 @@ function handleMonthGridChange(
 	if ( ! controller ) {
 		return false;
 	}
-	void controller.handleFilterChange( params ).then( function () {
-		getFilterState( calendar ).updateFilterCountBadge();
+	void controller.handleFilterChange( params ).then( function ( updated ) {
+		if ( updated ) {
+			getFilterState( calendar ).updateFilterCountBadge();
+		}
 	} );
 	return true;
 }

--- a/inc/Blocks/Calendar/src/modules/api-client.ts
+++ b/inc/Blocks/Calendar/src/modules/api-client.ts
@@ -54,8 +54,8 @@ const CALENDAR_PASSTHROUGH_KEYS: ( keyof CalendarRequest )[] = [
  * fetches but got dropped by geo-sync re-fetches).
  *
  * Order of operations:
- *   1. Passthrough every canonical calendar param from
- *      `window.location.search` (one source of truth).
+ *   1. Passthrough every canonical calendar param from the explicit
+ *      `source`, or `window.location.search` by default.
  *   2. Passthrough every `tax_filter[*]` entry from the URL.
  *   3. Apply `archiveContext` (sets `archive_taxonomy` /
  *      `archive_term_id` if both present).
@@ -71,13 +71,18 @@ const CALENDAR_PASSTHROUGH_KEYS: ( keyof CalendarRequest )[] = [
  * the returned object — the helper intentionally does not encode
  * deletion semantics so the override semantics stay simple.
  */
-export function buildCalendarRequest( opts: {
-	archiveContext?: Partial< ArchiveContext >;
-	geoContext?: Partial< GeoContext >;
-	overrides?: Partial< CalendarRequest >;
-} = {} ): URLSearchParams {
+export function buildCalendarRequest(
+	opts: {
+		archiveContext?: Partial< ArchiveContext >;
+		geoContext?: Partial< GeoContext >;
+		overrides?: Partial< CalendarRequest >;
+		source?: URLSearchParams;
+	} = {}
+): URLSearchParams {
 	const params = new URLSearchParams();
-	const urlParams = new URLSearchParams( window.location.search );
+	const urlParams = opts.source
+		? new URLSearchParams( opts.source )
+		: new URLSearchParams( window.location.search );
 
 	// 1. Canonical passthrough.
 	CALENDAR_PASSTHROUGH_KEYS.forEach( ( key ) => {

--- a/inc/Blocks/Calendar/src/modules/filter-modal.ts
+++ b/inc/Blocks/Calendar/src/modules/filter-modal.ts
@@ -130,7 +130,6 @@ export function initFilterModal(
 
 	const resetHandler = function (): void {
 		filterState.clearStorage();
-		window.history.pushState( {}, '', window.location.pathname );
 
 		const checkboxes = modal.querySelectorAll< HTMLInputElement >(
 			'input[type="checkbox"]:checked'

--- a/inc/Blocks/Calendar/src/modules/filter-state.test.ts
+++ b/inc/Blocks/Calendar/src/modules/filter-state.test.ts
@@ -168,4 +168,22 @@ describe( 'stored calendar filters', () => {
 			)!.value
 		).toBe( '50' );
 	} );
+
+	it( 'preserves the server default scope when no scope chips exist', () => {
+		calendar.dataset.scope = 'tonight';
+
+		expect( getFilterState( calendar ).buildParams().get( 'scope' ) ).toBe(
+			'tonight'
+		);
+	} );
+
+	it( 'allows an active All chip to clear the server default scope', () => {
+		calendar.dataset.scope = 'tonight';
+		calendar.innerHTML =
+			'<button class="data-machine-events-scope-chip data-machine-events-scope-chip-active" data-scope=""></button>';
+
+		expect( getFilterState( calendar ).buildParams().has( 'scope' ) ).toBe(
+			false
+		);
+	} );
 } );

--- a/inc/Blocks/Calendar/src/modules/filter-state.test.ts
+++ b/inc/Blocks/Calendar/src/modules/filter-state.test.ts
@@ -114,4 +114,58 @@ describe( 'stored calendar filters', () => {
 		).toBe( false );
 		expect( navigate ).not.toHaveBeenCalled();
 	} );
+
+	it( 'applies popstate parameters back to every filter control', () => {
+		document.body.innerHTML = `
+			<div class="data-machine-events-calendar" data-filter-persistence="1">
+				<input class="data-machine-events-search-input" value="old">
+				<button class="data-machine-events-scope-chip data-machine-events-scope-chip-active" data-scope="" aria-pressed="true"></button>
+				<button class="data-machine-events-scope-chip" data-scope="tonight" aria-pressed="false"></button>
+				<input type="checkbox" data-taxonomy="venue" value="42">
+				<input class="data-machine-events-location-search" data-geo-lat="1" data-geo-lng="2" value="Old place">
+				<select class="data-machine-events-radius-select" data-radius-unit="mi"><option value="25">25</option><option value="50">50</option></select>
+			</div>`;
+		calendar = document.querySelector< HTMLElement >(
+			'.data-machine-events-calendar'
+		)!;
+		const picker = {
+			selectedDates: [],
+			clear: jest.fn(),
+			setDate: jest.fn(),
+			destroy: jest.fn(),
+		};
+		const params = new URLSearchParams(
+			'event_search=new&scope=tonight&date_start=2026-08-10&date_end=2026-08-12&tax_filter%5Bvenue%5D%5B%5D=42&lat=32.78&lng=-79.93&radius=50&radius_unit=mi'
+		);
+
+		getFilterState( calendar ).applyParams( params, picker );
+		const tonightChip = calendar.querySelector< HTMLButtonElement >(
+			'[data-scope="tonight"]'
+		)!;
+		const venueCheckbox = calendar.querySelector< HTMLInputElement >(
+			'[data-taxonomy="venue"]'
+		)!;
+
+		expect(
+			calendar.querySelector< HTMLInputElement >(
+				'.data-machine-events-search-input'
+			)!.value
+		).toBe( 'new' );
+		expect( tonightChip.getAttribute( 'aria-pressed' ) ).toBe( 'true' );
+		expect( venueCheckbox.checked ).toBe( true );
+		expect( picker.setDate ).toHaveBeenCalledWith(
+			[ '2026-08-10', '2026-08-12' ],
+			false
+		);
+		expect(
+			calendar.querySelector< HTMLInputElement >(
+				'.data-machine-events-location-search'
+			)!.dataset.geoLat
+		).toBe( '32.78' );
+		expect(
+			calendar.querySelector< HTMLSelectElement >(
+				'.data-machine-events-radius-select'
+			)!.value
+		).toBe( '50' );
+	} );
 } );

--- a/inc/Blocks/Calendar/src/modules/filter-state.ts
+++ b/inc/Blocks/Calendar/src/modules/filter-state.ts
@@ -277,6 +277,86 @@ class FilterStateManager {
 	}
 
 	/**
+	 * Apply shareable URL state back to controls after history navigation.
+	 */
+	applyParams(
+		params: URLSearchParams,
+		datePicker: FlatpickrInstance | null = null
+	): void {
+		const searchInput = this.calendar.querySelector< HTMLInputElement >(
+			'.data-machine-events-search-input'
+		);
+		if ( searchInput ) {
+			searchInput.value = params.get( 'event_search' ) || '';
+		}
+
+		const scope = params.get( 'scope' ) || '';
+		this.calendar
+			.querySelectorAll< HTMLButtonElement >(
+				'.data-machine-events-scope-chip[data-scope]'
+			)
+			.forEach( ( chip ) => {
+				const active = ( chip.dataset.scope || '' ) === scope;
+				chip.classList.toggle(
+					'data-machine-events-scope-chip-active',
+					active
+				);
+				chip.setAttribute( 'aria-pressed', active ? 'true' : 'false' );
+			} );
+
+		const selectedTerms = new Set< string >();
+		for ( const [ key, value ] of params.entries() ) {
+			const match = key.match( /^tax_filter\[([^\]]+)\]\[(?:\d+)?\]$/ );
+			if ( match ) {
+				selectedTerms.add( `${ match[ 1 ] }:${ value }` );
+			}
+		}
+		this.calendar
+			.querySelectorAll< HTMLInputElement >(
+				'input[type="checkbox"][data-taxonomy]'
+			)
+			.forEach( ( checkbox ) => {
+				if ( checkbox.dataset.locked !== 'true' ) {
+					checkbox.checked = selectedTerms.has(
+						`${ checkbox.dataset.taxonomy }:${ checkbox.value }`
+					);
+				}
+			} );
+
+		if ( datePicker ) {
+			const start = params.get( 'date_start' );
+			const end = params.get( 'date_end' );
+			datePicker.setDate(
+				start ? ( end ? [ start, end ] : start ) : [],
+				false
+			);
+			this.calendar
+				.querySelector( '.data-machine-events-date-clear-btn' )
+				?.classList.toggle( 'visible', Boolean( start ) );
+		}
+
+		const locationInput = this.calendar.querySelector< HTMLInputElement >(
+			'.data-machine-events-location-search'
+		);
+		if ( locationInput ) {
+			const lat = params.get( 'lat' ) || '';
+			const lng = params.get( 'lng' ) || '';
+			locationInput.dataset.geoLat = lat;
+			locationInput.dataset.geoLng = lng;
+			locationInput.value = lat && lng ? `${ lat }, ${ lng }` : '';
+		}
+
+		const radiusSelect = this.calendar.querySelector< HTMLSelectElement >(
+			'.data-machine-events-radius-select'
+		);
+		if ( radiusSelect && params.get( 'radius' ) ) {
+			radiusSelect.value = params.get( 'radius' )!;
+			radiusSelect.dataset.radiusUnit =
+				params.get( 'radius_unit' ) || 'mi';
+		}
+	}
+
+	/**
 	 * Update URL via History API and save state to localStorage.
 	 */
 	updateUrl( params: URLSearchParams ): void {

--- a/inc/Blocks/Calendar/src/modules/filter-state.ts
+++ b/inc/Blocks/Calendar/src/modules/filter-state.ts
@@ -203,6 +203,11 @@ class FilterStateManager {
 			if ( scopeSlug && scopeSlug !== 'current' ) {
 				params.set( 'scope', scopeSlug );
 			}
+		} else {
+			const defaultScope = this.calendar.dataset.scope || '';
+			if ( defaultScope && defaultScope !== 'current' ) {
+				params.set( 'scope', defaultScope );
+			}
 		}
 
 		if ( datePicker?.selectedDates?.length && datePicker.selectedDates.length > 0 ) {

--- a/inc/Blocks/Calendar/src/modules/geo-sync.ts
+++ b/inc/Blocks/Calendar/src/modules/geo-sync.ts
@@ -38,6 +38,7 @@ interface BoundsChangedDetail {
 interface GeoSyncState {
 	handler: ( e: Event ) => void;
 	currentGeo: GeoContext | null;
+	onGridUpdate?: ( geo: GeoContext ) => Promise< boolean >;
 }
 
 const instances = new WeakMap< HTMLElement, GeoSyncState >();
@@ -48,7 +49,10 @@ const instances = new WeakMap< HTMLElement, GeoSyncState >();
  * Listens for map bounds-changed events and re-fetches the calendar
  * via REST, updating the DOM in-place.
  */
-export function initGeoSync( calendar: HTMLElement ): void {
+export function initGeoSync(
+	calendar: HTMLElement,
+	onGridUpdate?: ( geo: GeoContext ) => Promise< boolean >
+): void {
 	if ( instances.has( calendar ) ) {
 		return;
 	}
@@ -56,6 +60,7 @@ export function initGeoSync( calendar: HTMLElement ): void {
 	const state: GeoSyncState = {
 		handler: createBoundsHandler( calendar ),
 		currentGeo: null,
+		onGridUpdate,
 	};
 
 	instances.set( calendar, state );
@@ -103,7 +108,7 @@ export function updateCalendarGeo(
 		state.currentGeo = geo;
 	}
 
-	fetchAndUpdate( calendar, geo );
+	void fetchAndUpdate( calendar, geo );
 }
 
 /* ------------------------------------------------------------------ */
@@ -139,7 +144,7 @@ function createBoundsHandler(
 				state.currentGeo = geo;
 			}
 
-			fetchAndUpdate( calendar, geo );
+			void fetchAndUpdate( calendar, geo );
 		}, 300 );
 	};
 }
@@ -152,6 +157,20 @@ async function fetchAndUpdate(
 	geo: GeoContext
 ): Promise< void > {
 	const filterState = getFilterState( calendar );
+	const state = instances.get( calendar );
+	if ( state?.onGridUpdate ) {
+		const updated = await state.onGridUpdate( geo );
+		if ( updated ) {
+			filterState.saveGeoToStorage( {
+				lat: geo.lat,
+				lng: geo.lng,
+				radius: geo.radius,
+				radius_unit: geo.radius_unit,
+				label: '',
+			} );
+		}
+		return;
+	}
 	const archiveContext = filterState.getArchiveContext();
 
 	// Build via the shared helper so passthrough stays consistent with
@@ -227,5 +246,4 @@ function boundsToRadius(
 	// Clamp to reasonable range.
 	return Math.max( 1, Math.min( 500, Math.round( distance ) ) );
 }
-
 

--- a/inc/Blocks/Calendar/src/modules/month-grid-nav.test.ts
+++ b/inc/Blocks/Calendar/src/modules/month-grid-nav.test.ts
@@ -1,22 +1,26 @@
-jest.mock( './month-grid-renderer', () => ( {
-	renderMonthGrid: jest.fn( ( month: string, _data, baseUrl: string ) => {
-		const grid = global.document.createElement( 'div' );
-		grid.className = 'data-machine-month-grid';
-		grid.dataset.month = month;
-		grid.dataset.baseUrl = baseUrl;
-		grid.innerHTML = `<a class="data-machine-month-grid__nav-next" data-month="2026-09" href="#">Next</a>`;
-		return grid;
-	} ),
+jest.mock( './month-grid-response-renderer', () => ( {
+	renderMonthGridResponse: jest.fn(
+		( calendar: HTMLElement, month: string, _data, baseUrl: string ) => {
+			const grid = global.document.createElement( 'div' );
+			grid.className = 'data-machine-month-grid';
+			grid.dataset.month = month;
+			grid.dataset.baseUrl = baseUrl;
+			grid.innerHTML = `<a class="data-machine-month-grid__nav-next" data-month="2026-09" href="#">Next</a>`;
+			calendar
+				.querySelector( '.data-machine-month-grid' )
+				?.replaceWith( grid );
+		}
+	),
 } ) );
 
-import { renderMonthGrid } from './month-grid-renderer';
+import { renderMonthGridResponse } from './month-grid-response-renderer';
 import {
 	destroyMonthGridNav,
 	getMonthGridController,
 	initMonthGridNav,
 } from './month-grid-nav';
 
-const mockRenderMonthGrid = renderMonthGrid as jest.Mock;
+const mockRenderMonthGridResponse = renderMonthGridResponse as jest.Mock;
 const mockFetch = jest.fn();
 
 function successfulResponse(): Promise< Response > {
@@ -73,7 +77,7 @@ describe( 'month-grid state synchronization', () => {
 		mockFetch.mockReset();
 		mockFetch.mockImplementation( successfulResponse );
 		global.fetch = mockFetch;
-		mockRenderMonthGrid.mockClear();
+		mockRenderMonthGridResponse.mockClear();
 	} );
 
 	afterEach( () => {
@@ -113,7 +117,7 @@ describe( 'month-grid state synchronization', () => {
 		expect( window.location.search ).toContain( 'month=2026-08' );
 		expect( window.location.search ).not.toContain( 'event_search=old' );
 		expect( window.location.search ).not.toContain( 'archive_' );
-		expect( mockRenderMonthGrid.mock.calls[ 0 ][ 2 ] ).toContain(
+		expect( mockRenderMonthGridResponse.mock.calls[ 0 ][ 3 ] ).toContain(
 			'event_search=new+search'
 		);
 	} );
@@ -225,7 +229,7 @@ describe( 'month-grid state synchronization', () => {
 		stale.resolve();
 		await staleRequest;
 
-		expect( mockRenderMonthGrid ).toHaveBeenCalledTimes( 1 );
+		expect( mockRenderMonthGridResponse ).toHaveBeenCalledTimes( 1 );
 		expect( window.location.search ).toContain( 'event_search=latest' );
 		expect( window.location.search ).not.toContain( 'event_search=stale' );
 	} );

--- a/inc/Blocks/Calendar/src/modules/month-grid-nav.test.ts
+++ b/inc/Blocks/Calendar/src/modules/month-grid-nav.test.ts
@@ -1,0 +1,232 @@
+jest.mock( './month-grid-renderer', () => ( {
+	renderMonthGrid: jest.fn( ( month: string, _data, baseUrl: string ) => {
+		const grid = global.document.createElement( 'div' );
+		grid.className = 'data-machine-month-grid';
+		grid.dataset.month = month;
+		grid.dataset.baseUrl = baseUrl;
+		grid.innerHTML = `<a class="data-machine-month-grid__nav-next" data-month="2026-09" href="#">Next</a>`;
+		return grid;
+	} ),
+} ) );
+
+import { renderMonthGrid } from './month-grid-renderer';
+import {
+	destroyMonthGridNav,
+	getMonthGridController,
+	initMonthGridNav,
+} from './month-grid-nav';
+
+const mockRenderMonthGrid = renderMonthGrid as jest.Mock;
+const mockFetch = jest.fn();
+
+function successfulResponse(): Promise< Response > {
+	return Promise.resolve( {
+		ok: true,
+		json: async () => ( { success: true } ),
+	} as Response );
+}
+
+function requestedParams( call = 0 ): URLSearchParams {
+	return new URL( mockFetch.mock.calls[ call ][ 0 ], window.location.origin )
+		.searchParams;
+}
+
+function deferredResponse(): {
+	promise: Promise< Response >;
+	resolve: () => void;
+} {
+	let resolvePromise!: ( response: Response ) => void;
+	const promise = new Promise< Response >( ( resolve ) => {
+		resolvePromise = resolve;
+	} );
+	return {
+		promise,
+		resolve: () => {
+			resolvePromise( {
+				ok: true,
+				json: async () => ( { success: true } ),
+			} as Response );
+		},
+	};
+}
+
+describe( 'month-grid state synchronization', () => {
+	let calendar: HTMLElement;
+
+	beforeEach( () => {
+		window.history.replaceState(
+			{},
+			'',
+			'/events/?event_search=old&month=2026-07'
+		);
+		document.body.innerHTML = `
+			<div class="data-machine-events-calendar"
+				data-archive-taxonomy="location"
+				data-archive-term-id="12">
+				<div class="data-machine-month-grid" data-month="2026-08">
+					<a class="data-machine-month-grid__nav-next" data-month="2026-09" href="#">Next</a>
+				</div>
+			</div>`;
+		calendar = document.querySelector< HTMLElement >(
+			'.data-machine-events-calendar'
+		)!;
+		mockFetch.mockReset();
+		mockFetch.mockImplementation( successfulResponse );
+		global.fetch = mockFetch;
+		mockRenderMonthGrid.mockClear();
+	} );
+
+	afterEach( () => {
+		destroyMonthGridNav( calendar );
+		jest.restoreAllMocks();
+	} );
+
+	it( 'uses one current parameter set for filters, request, links, and URL', async () => {
+		initMonthGridNav( calendar );
+		const params = new URLSearchParams();
+		params.set( 'event_search', 'new search' );
+		params.set( 'date_start', '2026-08-10' );
+		params.set( 'date_end', '2026-08-12' );
+		params.set( 'scope', 'this-week' );
+		params.append( 'tax_filter[venue][]', '42' );
+		params.set( 'lat', '32.78' );
+		params.set( 'lng', '-79.93' );
+		params.set( 'radius', '50' );
+		params.set( 'radius_unit', 'mi' );
+
+		await getMonthGridController( calendar )!.handleFilterChange( params );
+
+		const request = requestedParams();
+		expect( request.get( 'event_search' ) ).toBe( 'new search' );
+		expect( request.get( 'date_start' ) ).toBe( '2026-08-10' );
+		expect( request.get( 'date_end' ) ).toBe( '2026-08-12' );
+		expect( request.get( 'scope' ) ).toBe( 'this-week' );
+		expect( request.getAll( 'tax_filter[venue][]' ) ).toEqual( [ '42' ] );
+		expect( request.get( 'lat' ) ).toBe( '32.78' );
+		expect( request.get( 'lng' ) ).toBe( '-79.93' );
+		expect( request.get( 'archive_taxonomy' ) ).toBe( 'location' );
+		expect( request.get( 'archive_term_id' ) ).toBe( '12' );
+		expect( request.get( 'month' ) ).toBe( '2026-08' );
+		expect( request.get( 'format' ) ).toBe( 'data' );
+
+		expect( window.location.search ).toContain( 'event_search=new+search' );
+		expect( window.location.search ).toContain( 'month=2026-08' );
+		expect( window.location.search ).not.toContain( 'event_search=old' );
+		expect( window.location.search ).not.toContain( 'archive_' );
+		expect( mockRenderMonthGrid.mock.calls[ 0 ][ 2 ] ).toContain(
+			'event_search=new+search'
+		);
+	} );
+
+	it( 'clears stale filters without adding duplicate history entries', async () => {
+		const pushState = jest.spyOn( window.history, 'pushState' );
+		calendar.dataset.geoLat = '1';
+		calendar.dataset.geoLng = '2';
+		initMonthGridNav( calendar );
+
+		await getMonthGridController( calendar )!.handleFilterChange(
+			new URLSearchParams()
+		);
+
+		expect( requestedParams().get( 'event_search' ) ).toBeNull();
+		expect( requestedParams().get( 'lat' ) ).toBeNull();
+		expect( window.location.search ).toBe( '?month=2026-08' );
+		expect( pushState ).toHaveBeenCalledTimes( 1 );
+		expect( calendar.dataset.geoLat ).toBeUndefined();
+		await getMonthGridController( calendar )!.handleFilterChange(
+			new URLSearchParams()
+		);
+		expect( pushState ).toHaveBeenCalledTimes( 1 );
+
+		calendar
+			.querySelector< HTMLAnchorElement >(
+				'.data-machine-month-grid__nav-next'
+			)!
+			.click();
+		await Promise.resolve();
+		await Promise.resolve();
+		expect( requestedParams( 2 ).get( 'lat' ) ).toBeNull();
+		expect( pushState ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'preserves synchronized filters during subsequent month navigation', async () => {
+		initMonthGridNav( calendar );
+		await getMonthGridController( calendar )!.handleFilterChange(
+			new URLSearchParams( 'event_search=jam&scope=this-weekend' )
+		);
+
+		calendar
+			.querySelector< HTMLAnchorElement >(
+				'.data-machine-month-grid__nav-next'
+			)!
+			.click();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		const request = requestedParams( 1 );
+		expect( request.get( 'event_search' ) ).toBe( 'jam' );
+		expect( request.get( 'scope' ) ).toBe( 'this-weekend' );
+		expect( request.get( 'month' ) ).toBe( '2026-09' );
+	} );
+
+	it( 'keeps embedded scope tokens in requests and out of public URLs', async () => {
+		calendar.dataset.scopeToken = 'signed-consumer-scope';
+		initMonthGridNav( calendar );
+
+		await getMonthGridController( calendar )!.handleFilterChange(
+			new URLSearchParams( 'event_search=artist' )
+		);
+
+		expect( requestedParams().get( 'scope_token' ) ).toBe(
+			'signed-consumer-scope'
+		);
+		expect( window.location.search ).not.toContain( 'scope_token' );
+	} );
+
+	it( 're-fetches popstate without pushing another history entry', async () => {
+		const onPopState = jest.fn();
+		const pushState = jest.spyOn( window.history, 'pushState' );
+		initMonthGridNav( calendar, onPopState );
+		window.history.replaceState(
+			{},
+			'',
+			'/events/?event_search=back&scope=tonight&month=2026-06'
+		);
+
+		window.dispatchEvent( new PopStateEvent( 'popstate' ) );
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect( onPopState ).toHaveBeenCalledWith(
+			expect.objectContaining( {} )
+		);
+		expect( requestedParams().get( 'event_search' ) ).toBe( 'back' );
+		expect( requestedParams().get( 'month' ) ).toBe( '2026-06' );
+		expect( pushState ).not.toHaveBeenCalled();
+	} );
+
+	it( 'ignores a stale response when rapid filter requests overlap', async () => {
+		const stale = deferredResponse();
+		const latest = deferredResponse();
+		mockFetch
+			.mockImplementationOnce( () => stale.promise )
+			.mockImplementationOnce( () => latest.promise );
+		initMonthGridNav( calendar );
+		const controller = getMonthGridController( calendar )!;
+
+		const staleRequest = controller.handleFilterChange(
+			new URLSearchParams( 'event_search=stale' )
+		);
+		const latestRequest = controller.handleFilterChange(
+			new URLSearchParams( 'event_search=latest' )
+		);
+		latest.resolve();
+		await latestRequest;
+		stale.resolve();
+		await staleRequest;
+
+		expect( mockRenderMonthGrid ).toHaveBeenCalledTimes( 1 );
+		expect( window.location.search ).toContain( 'event_search=latest' );
+		expect( window.location.search ).not.toContain( 'event_search=stale' );
+	} );
+} );

--- a/inc/Blocks/Calendar/src/modules/month-grid-nav.ts
+++ b/inc/Blocks/Calendar/src/modules/month-grid-nav.ts
@@ -24,14 +24,25 @@ import type {
 const controllers = new WeakMap< HTMLElement, MonthGridController >();
 
 class MonthGridController {
-	constructor( private readonly calendar: HTMLElement ) {}
+	private requestSequence = 0;
+	private readonly initialMonth: string;
+
+	constructor(
+		private readonly calendar: HTMLElement,
+		private readonly onPopState?: ( params: URLSearchParams ) => void
+	) {
+		this.initialMonth = this.getCurrentMonth();
+	}
 
 	init(): void {
 		this.bindNavLinks();
+		window.addEventListener( 'popstate', this.handlePopState );
 	}
 
 	destroy(): void {
 		this.unbindNavLinks();
+		window.removeEventListener( 'popstate', this.handlePopState );
+		this.requestSequence++;
 	}
 
 	private getCurrentMonth(): string {
@@ -82,25 +93,54 @@ class MonthGridController {
 		void this.navigateToMonth( month );
 	};
 
+	private readonly handlePopState = (): void => {
+		const params = new URLSearchParams( window.location.search );
+		this.onPopState?.( params );
+		const month = params.get( 'month' );
+		void this.navigateToMonth(
+			month && /^\d{4}-\d{2}$/.test( month )
+				? month
+				: this.initialMonth,
+			params,
+			false
+		);
+	};
+
 	/**
 	 * Public entry point called by frontend.ts when a filter changes
 	 * in grid mode.
 	 */
-	async handleFilterChange(): Promise< void > {
-		await this.navigateToMonth( this.getCurrentMonth() );
+	async handleFilterChange( params: URLSearchParams ): Promise< void > {
+		await this.navigateToMonth(
+			this.getCurrentMonth(),
+			params,
+			true,
+			true
+		);
 	}
 
 	/**
 	 * Public entry point for callers that want to jump to a specific
 	 * month (kept narrow so future external callers can re-use it).
 	 */
-	async navigateToMonth( month: string ): Promise< void > {
+	async navigateToMonth(
+		month: string,
+		source: URLSearchParams = new URLSearchParams( window.location.search ),
+		pushHistory = true,
+		syncGeoState = false
+	): Promise< void > {
+		const requestId = ++this.requestSequence;
+		const publicParams = this.buildPublicParams( source, month );
 		const archiveContext = this.readArchiveContext();
-		const geoContext = this.readGeoContext();
+		const geoContext = this.readGeoContext(
+			publicParams,
+			pushHistory && ! syncGeoState
+		);
 
 		const params = buildCalendarRequest( {
 			archiveContext,
 			geoContext,
+			source: publicParams,
 			overrides: {
 				// `format=data` activates the data-only REST envelope
 				// (phase 1 of #298). Grid mode is the first consumer.
@@ -157,8 +197,11 @@ class MonthGridController {
 			if ( ! data?.success ) {
 				throw new Error( 'Calendar response not successful' );
 			}
+			if ( requestId !== this.requestSequence ) {
+				return;
+			}
 
-			const baseUrl = this.buildBaseUrl();
+			const baseUrl = this.buildBaseUrl( publicParams );
 			const newGrid = renderMonthGrid( month, data, baseUrl );
 
 			if ( grid ) {
@@ -180,11 +223,12 @@ class MonthGridController {
 
 			// Sync URL via pushState so prev/next history works and the
 			// month is shareable. Preserve all other query params.
-			const url = new URL( window.location.href );
-			url.searchParams.set( 'month', month );
-			url.searchParams.delete( 'paged' );
-			url.searchParams.delete( 'past' );
-			window.history.pushState( null, '', url.toString() );
+			if ( pushHistory ) {
+				this.pushUrl( publicParams );
+			}
+			if ( syncGeoState ) {
+				this.syncGeoState( publicParams );
+			}
 
 			this.calendar.dispatchEvent(
 				new CustomEvent( 'data-machine-month-grid-updated', {
@@ -193,24 +237,70 @@ class MonthGridController {
 				} )
 			);
 		} catch ( error ) {
-			console.error( 'Month-grid fetch failed:', error );
+			if ( requestId === this.requestSequence ) {
+				console.error( 'Month-grid fetch failed:', error );
+			}
 		} finally {
-			const refreshedGrid = this.calendar.querySelector(
-				'.data-machine-month-grid'
-			);
-			refreshedGrid?.classList.remove( 'is-loading' );
+			if ( requestId === this.requestSequence ) {
+				const refreshedGrid = this.calendar.querySelector(
+					'.data-machine-month-grid'
+				);
+				refreshedGrid?.classList.remove( 'is-loading' );
+			}
 		}
+	}
+
+	private buildPublicParams(
+		source: URLSearchParams,
+		month: string
+	): URLSearchParams {
+		const params = new URLSearchParams( source );
+		[
+			'format',
+			'archive_taxonomy',
+			'archive_term_id',
+			'scope_token',
+			'paged',
+			'past',
+		].forEach( ( key ) => params.delete( key ) );
+		params.set( 'month', month );
+		return params;
+	}
+
+	private pushUrl( params: URLSearchParams ): void {
+		const url = new URL( window.location.href );
+		url.search = params.toString();
+		const current = `${ window.location.pathname }${ window.location.search }${ window.location.hash }`;
+		const next = `${ url.pathname }${ url.search }${ url.hash }`;
+		if ( next !== current ) {
+			window.history.pushState( null, '', next );
+		}
+	}
+
+	private syncGeoState( params: URLSearchParams ): void {
+		const geoAttributes = {
+			geoLat: params.get( 'lat' ) || '',
+			geoLng: params.get( 'lng' ) || '',
+			geoRadius: params.get( 'radius' ) || '',
+			geoRadiusUnit: params.get( 'radius_unit' ) || '',
+		};
+		Object.entries( geoAttributes ).forEach( ( [ key, value ] ) => {
+			if ( value ) {
+				this.calendar.dataset[ key ] = value;
+			} else {
+				delete this.calendar.dataset[ key ];
+			}
+		} );
 	}
 
 	/**
 	 * Base URL used by the renderer for prev/next/today hrefs.
 	 * Preserves every URL param except `month`/`paged`/`past`.
 	 */
-	private buildBaseUrl(): string {
+	private buildBaseUrl( params: URLSearchParams ): string {
 		const url = new URL( window.location.href );
+		url.search = params.toString();
 		url.searchParams.delete( 'month' );
-		url.searchParams.delete( 'paged' );
-		url.searchParams.delete( 'past' );
 		return `${ url.pathname }${
 			url.searchParams.toString() ? '?' + url.searchParams.toString() : ''
 		}`;
@@ -236,7 +326,28 @@ class MonthGridController {
 		return this.calendar.getAttribute( 'data-scope-token' ) ?? '';
 	}
 
-	private readGeoContext(): Partial< GeoContext > {
+	private readGeoContext(
+		params: URLSearchParams,
+		allowDomFallback: boolean
+	): Partial< GeoContext > {
+		const urlLat = params.get( 'lat' );
+		const urlLng = params.get( 'lng' );
+		if ( urlLat && urlLng ) {
+			const radius = params.get( 'radius' );
+			const radiusUnit = params.get( 'radius_unit' );
+			return {
+				lat: urlLat,
+				lng: urlLng,
+				radius: radius ? Number( radius ) : undefined,
+				radius_unit:
+					radiusUnit === 'mi' || radiusUnit === 'km'
+						? radiusUnit
+						: undefined,
+			};
+		}
+		if ( ! allowDomFallback ) {
+			return {};
+		}
 		const lat = this.calendar.getAttribute( 'data-geo-lat' );
 		const lng = this.calendar.getAttribute( 'data-geo-lng' );
 		if ( ! lat || ! lng ) {
@@ -256,11 +367,14 @@ class MonthGridController {
 	}
 }
 
-export function initMonthGridNav( calendar: HTMLElement ): void {
+export function initMonthGridNav(
+	calendar: HTMLElement,
+	onPopState?: ( params: URLSearchParams ) => void
+): void {
 	if ( controllers.has( calendar ) ) {
 		return;
 	}
-	const controller = new MonthGridController( calendar );
+	const controller = new MonthGridController( calendar, onPopState );
 	controllers.set( calendar, controller );
 	controller.init();
 }

--- a/inc/Blocks/Calendar/src/modules/month-grid-nav.ts
+++ b/inc/Blocks/Calendar/src/modules/month-grid-nav.ts
@@ -13,7 +13,7 @@
  */
 
 import { buildCalendarRequest } from './api-client';
-import { renderMonthGrid } from './month-grid-renderer';
+import { renderMonthGridResponse } from './month-grid-response-renderer';
 
 import type {
 	ArchiveContext,
@@ -110,8 +110,8 @@ class MonthGridController {
 	 * Public entry point called by frontend.ts when a filter changes
 	 * in grid mode.
 	 */
-	async handleFilterChange( params: URLSearchParams ): Promise< void > {
-		await this.navigateToMonth(
+	async handleFilterChange( params: URLSearchParams ): Promise< boolean > {
+		return this.navigateToMonth(
 			this.getCurrentMonth(),
 			params,
 			true,
@@ -128,7 +128,7 @@ class MonthGridController {
 		source: URLSearchParams = new URLSearchParams( window.location.search ),
 		pushHistory = true,
 		syncGeoState = false
-	): Promise< void > {
+	): Promise< boolean > {
 		const requestId = ++this.requestSequence;
 		const publicParams = this.buildPublicParams( source, month );
 		const archiveContext = this.readArchiveContext();
@@ -198,28 +198,17 @@ class MonthGridController {
 				throw new Error( 'Calendar response not successful' );
 			}
 			if ( requestId !== this.requestSequence ) {
-				return;
+				return false;
 			}
 
 			const baseUrl = this.buildBaseUrl( publicParams );
-			const newGrid = renderMonthGrid( month, data, baseUrl );
-
-			if ( grid ) {
-				grid.replaceWith( newGrid );
-			} else {
-				// First-time mount — append after the filter bar.
-				const filterBar = this.calendar.querySelector(
-					'.data-machine-events-filter-bar'
-				);
-				if ( filterBar?.parentElement ) {
-					filterBar.parentElement.insertBefore(
-						newGrid,
-						filterBar.nextSibling
-					);
-				} else {
-					this.calendar.prepend( newGrid );
-				}
-			}
+			renderMonthGridResponse(
+				this.calendar,
+				month,
+				data,
+				baseUrl,
+				publicParams
+			);
 
 			// Sync URL via pushState so prev/next history works and the
 			// month is shareable. Preserve all other query params.
@@ -236,10 +225,12 @@ class MonthGridController {
 					detail: { month },
 				} )
 			);
+			return true;
 		} catch ( error ) {
 			if ( requestId === this.requestSequence ) {
 				console.error( 'Month-grid fetch failed:', error );
 			}
+			return false;
 		} finally {
 			if ( requestId === this.requestSequence ) {
 				const refreshedGrid = this.calendar.querySelector(
@@ -255,6 +246,17 @@ class MonthGridController {
 		month: string
 	): URLSearchParams {
 		const params = new URLSearchParams( source );
+		const hasScopeControls = Boolean(
+			this.calendar.querySelector(
+				'.data-machine-events-scope-chip[data-scope]'
+			)
+		);
+		if ( ! params.has( 'scope' ) && ! hasScopeControls ) {
+			const defaultScope = this.calendar.dataset.scope || '';
+			if ( defaultScope && defaultScope !== 'current' ) {
+				params.set( 'scope', defaultScope );
+			}
+		}
 		[
 			'format',
 			'archive_taxonomy',

--- a/inc/Blocks/Calendar/src/modules/month-grid-response-renderer.test.ts
+++ b/inc/Blocks/Calendar/src/modules/month-grid-response-renderer.test.ts
@@ -1,0 +1,112 @@
+jest.mock( './month-grid-renderer', () => ( {
+	renderMonthGrid: jest.fn( ( month: string ) => {
+		const grid = global.document.createElement( 'div' );
+		grid.className = 'data-machine-month-grid';
+		grid.dataset.month = month;
+		return grid;
+	} ),
+} ) );
+
+jest.mock( './date-group-renderer', () => ( {
+	renderDateGroup: jest.fn( ( date: string ) => {
+		const group = global.document.createElement( 'div' );
+		group.className = 'data-machine-date-group';
+		group.dataset.date = date;
+		return group;
+	} ),
+} ) );
+
+import { renderMonthGridResponse } from './month-grid-response-renderer';
+
+import type { CalendarDataResponse } from '../types';
+
+function response(): CalendarDataResponse {
+	return {
+		success: true,
+		schema: {
+			name: 'calendar-data',
+			version: 1,
+			phase: 1,
+			issue: 298,
+		},
+		events: [],
+		grouping: {
+			ordered_dates: [ '2026-08-10' ],
+			by_date: {
+				'2026-08-10': [
+					{
+						post_id: 7,
+						display_context: {} as never,
+						display: {} as never,
+					},
+				],
+			},
+			gaps: {},
+		},
+		pagination: {
+			current_page: 1,
+			total_pages: 2,
+			total_items: 15,
+			page_items: 10,
+		},
+		counter: {
+			showing_count: 10,
+			total_count: 15,
+			page_start_date: '2026-08-10',
+			page_end_date: '2026-08-12',
+		},
+		navigation: {
+			show_past: false,
+			past_count: 0,
+			future_count: 15,
+			has_past: false,
+			has_future: true,
+		},
+	};
+}
+
+describe( 'month-grid response rendering', () => {
+	it( 'updates desktop, mobile, counter, and pagination together', () => {
+		document.body.innerHTML = `
+			<div class="data-machine-events-calendar">
+				<div class="data-machine-month-grid" data-month="2026-07"></div>
+				<div class="data-machine-events-content"><p>Old mobile events</p></div>
+				<div class="data-machine-events-results-counter">Old counter</div>
+				<nav class="data-machine-events-pagination">Old pagination</nav>
+			</div>`;
+		const calendar = document.querySelector< HTMLElement >(
+			'.data-machine-events-calendar'
+		)!;
+		const updated = jest.fn();
+		calendar.addEventListener(
+			'data-machine-calendar-content-updated',
+			updated
+		);
+
+		renderMonthGridResponse(
+			calendar,
+			'2026-08',
+			response(),
+			'/events/?event_search=new',
+			new URLSearchParams( 'event_search=new&month=2026-08' )
+		);
+
+		expect(
+			calendar.querySelector< HTMLElement >( '.data-machine-month-grid' )!
+				.dataset.month
+		).toBe( '2026-08' );
+		expect(
+			calendar.querySelector< HTMLElement >( '.data-machine-date-group' )!
+				.dataset.date
+		).toBe( '2026-08-10' );
+		expect( calendar.textContent ).not.toContain( 'Old mobile events' );
+		expect(
+			calendar.querySelector( '.data-machine-events-results-counter' )!
+				.textContent
+		).toContain( '10 of 15 Events' );
+		expect(
+			calendar.querySelectorAll( '.data-machine-events-pagination a' )
+		).toHaveLength( 2 );
+		expect( updated ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/inc/Blocks/Calendar/src/modules/month-grid-response-renderer.test.ts
+++ b/inc/Blocks/Calendar/src/modules/month-grid-response-renderer.test.ts
@@ -25,7 +25,7 @@ function response(): CalendarDataResponse {
 		success: true,
 		schema: {
 			name: 'calendar-data',
-			version: 1,
+			version: 3,
 			phase: 1,
 			issue: 298,
 		},
@@ -62,6 +62,7 @@ function response(): CalendarDataResponse {
 			has_past: false,
 			has_future: true,
 		},
+		empty_html: '',
 	};
 }
 
@@ -108,5 +109,46 @@ describe( 'month-grid response rendering', () => {
 			calendar.querySelectorAll( '.data-machine-events-pagination a' )
 		).toHaveLength( 2 );
 		expect( updated ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'renders the canonical recovery state for empty mobile results', () => {
+		document.body.innerHTML = `
+				<div class="data-machine-events-calendar">
+					<div class="data-machine-month-grid" data-month="2026-07"></div>
+					<div class="data-machine-events-content"><p>Old events</p></div>
+				</div>`;
+		const calendar = document.querySelector< HTMLElement >(
+			'.data-machine-events-calendar'
+		)!;
+		const data = response();
+		data.events = [];
+		data.grouping.ordered_dates = [];
+		data.grouping.by_date = {};
+		data.counter.showing_count = 0;
+		data.counter.total_count = 0;
+		data.pagination.total_pages = 1;
+		data.empty_html = `
+				<div class="data-machine-events-no-events">
+					<p>No events found.</p>
+					<button type="button" class="data-machine-events-no-events-today-link">Show events from Today</button>
+				</div>`;
+
+		renderMonthGridResponse(
+			calendar,
+			'2026-08',
+			data,
+			'/events/',
+			new URLSearchParams( 'month=2026-08' )
+		);
+
+		expect(
+			calendar.querySelector( '.data-machine-events-no-events' )
+		).not.toBeNull();
+		expect(
+			calendar.querySelector< HTMLButtonElement >(
+				'.data-machine-events-no-events-today-link'
+			)!.type
+		).toBe( 'button' );
+		expect( calendar.textContent ).not.toContain( 'Old events' );
 	} );
 } );

--- a/inc/Blocks/Calendar/src/modules/month-grid-response-renderer.ts
+++ b/inc/Blocks/Calendar/src/modules/month-grid-response-renderer.ts
@@ -1,0 +1,172 @@
+/**
+ * Synchronize every month-grid presentation from one data response.
+ */
+
+import { renderDateGroup } from './date-group-renderer';
+import { renderGapSeparator } from './gap-renderer';
+import { renderMonthGrid } from './month-grid-renderer';
+
+import type {
+	CalendarDataCounter,
+	CalendarDataPagination,
+	CalendarDataResponse,
+	CalendarEventItem,
+} from '../types';
+
+export function renderMonthGridResponse(
+	calendar: HTMLElement,
+	month: string,
+	data: CalendarDataResponse,
+	baseUrl: string,
+	publicParams: URLSearchParams
+): void {
+	const grid = calendar.querySelector< HTMLElement >(
+		'.data-machine-month-grid'
+	);
+	const newGrid = renderMonthGrid( month, data, baseUrl );
+	if ( grid ) {
+		grid.replaceWith( newGrid );
+	} else {
+		const filterBar = calendar.querySelector(
+			'.data-machine-events-filter-bar'
+		);
+		if ( filterBar?.parentElement ) {
+			filterBar.parentElement.insertBefore(
+				newGrid,
+				filterBar.nextSibling
+			);
+		} else {
+			calendar.prepend( newGrid );
+		}
+	}
+
+	const content = calendar.querySelector< HTMLElement >(
+		'.data-machine-events-content'
+	);
+	if ( content ) {
+		content.replaceChildren();
+		const eventsById = new Map< number, CalendarEventItem >();
+		data.events.forEach( ( event ) => eventsById.set( event.id, event ) );
+		data.grouping.ordered_dates.forEach( ( date ) => {
+			const occurrences = data.grouping.by_date[ date ] || [];
+			if ( occurrences.length === 0 ) {
+				return;
+			}
+			const gap = data.grouping.gaps[ date ];
+			if ( gap && gap >= 2 ) {
+				content.appendChild( renderGapSeparator( gap ) );
+			}
+			content.appendChild(
+				renderDateGroup( date, occurrences, eventsById )
+			);
+		} );
+	}
+
+	updateCounter( calendar, content, data.counter );
+	updatePagination( calendar, content, data.pagination, publicParams );
+
+	calendar.dispatchEvent(
+		new CustomEvent( 'data-machine-calendar-content-updated', {
+			bubbles: false,
+		} )
+	);
+}
+
+function updateCounter(
+	calendar: HTMLElement,
+	content: HTMLElement | null,
+	counter: CalendarDataCounter
+): void {
+	const current = calendar.querySelector< HTMLElement >(
+		'.data-machine-events-results-counter'
+	);
+	if (
+		! counter.page_start_date ||
+		! counter.page_end_date ||
+		counter.showing_count < 1
+	) {
+		current?.remove();
+		return;
+	}
+
+	const replacement = document.createElement( 'div' );
+	replacement.className = 'data-machine-events-results-counter';
+	const start = formatCounterDate( counter.page_start_date );
+	const end = formatCounterDate( counter.page_end_date );
+	const range =
+		counter.page_start_date === counter.page_end_date
+			? start
+			: `${ start } - ${ end }`;
+	const label = counter.total_count === 1 ? 'Event' : 'Events';
+	const count =
+		counter.showing_count < counter.total_count
+			? `${ counter.showing_count } of ${ counter.total_count }`
+			: String( counter.showing_count );
+	replacement.textContent = `Viewing ${ range } (${ count } ${ label })`;
+
+	if ( current ) {
+		current.replaceWith( replacement );
+	} else {
+		content?.insertAdjacentElement( 'afterend', replacement );
+	}
+}
+
+function updatePagination(
+	calendar: HTMLElement,
+	content: HTMLElement | null,
+	pagination: CalendarDataPagination,
+	publicParams: URLSearchParams
+): void {
+	const current = calendar.querySelector< HTMLElement >(
+		'.data-machine-events-pagination'
+	);
+	if ( pagination.total_pages <= 1 ) {
+		current?.remove();
+		return;
+	}
+
+	const nav = document.createElement( 'nav' );
+	nav.className = 'data-machine-events-pagination';
+	nav.setAttribute( 'aria-label', 'Events pagination' );
+	for ( let page = 1; page <= pagination.total_pages; page++ ) {
+		const link = document.createElement( 'a' );
+		const params = new URLSearchParams( publicParams );
+		if ( page === 1 ) {
+			params.delete( 'paged' );
+		} else {
+			params.set( 'paged', String( page ) );
+		}
+		link.href = `${ window.location.pathname }?${ params.toString() }`;
+		link.textContent = String( page );
+		if ( page === pagination.current_page ) {
+			link.classList.add( 'current' );
+			link.setAttribute( 'aria-current', 'page' );
+		}
+		nav.appendChild( link );
+	}
+
+	if ( current ) {
+		current.replaceWith( nav );
+		return;
+	}
+	const counter = calendar.querySelector(
+		'.data-machine-events-results-counter'
+	);
+	( counter || content )?.insertAdjacentElement( 'afterend', nav );
+}
+
+function formatCounterDate( date: string ): string {
+	const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec( date );
+	if ( ! match ) {
+		return date;
+	}
+	const value = new Date(
+		Number( match[ 1 ] ),
+		Number( match[ 2 ] ) - 1,
+		Number( match[ 3 ] )
+	);
+	return value.toLocaleDateString( undefined, {
+		month: 'short',
+		day: 'numeric',
+	} );
+}

--- a/inc/Blocks/Calendar/src/modules/month-grid-response-renderer.ts
+++ b/inc/Blocks/Calendar/src/modules/month-grid-response-renderer.ts
@@ -45,6 +45,9 @@ export function renderMonthGridResponse(
 	);
 	if ( content ) {
 		content.replaceChildren();
+		if ( data.grouping.ordered_dates.length === 0 ) {
+			content.innerHTML = data.empty_html;
+		}
 		const eventsById = new Map< number, CalendarEventItem >();
 		data.events.forEach( ( event ) => eventsById.set( event.id, event ) );
 		data.grouping.ordered_dates.forEach( ( date ) => {

--- a/inc/Blocks/Calendar/src/types.ts
+++ b/inc/Blocks/Calendar/src/types.ts
@@ -135,7 +135,7 @@ export interface CalendarResponse {
 /** Identifies the schema version + phase the server returned. */
 export interface CalendarDataSchemaMeta {
 	name: 'calendar-data';
-	version: 1;
+	version: 3;
 	phase: 1;
 	issue: 298;
 }
@@ -298,6 +298,7 @@ export interface CalendarDataResponse {
 	pagination: CalendarDataPagination;
 	counter: CalendarDataCounter;
 	navigation: CalendarDataNavigation;
+	empty_html: string;
 }
 
 export interface FilterResponse {

--- a/inc/Blocks/Calendar/src/types.ts
+++ b/inc/Blocks/Calendar/src/types.ts
@@ -342,6 +342,10 @@ export interface EventPlaceholderData {
 export interface FlatpickrInstance {
 	selectedDates: Date[];
 	clear: () => void;
+	setDate: (
+		date: string | string[] | Date | Date[],
+		triggerChange?: boolean
+	) => void;
 	destroy: () => void;
 }
 

--- a/tests/Unit/CalendarAbilitiesTest.php
+++ b/tests/Unit/CalendarAbilitiesTest.php
@@ -99,4 +99,60 @@ class CalendarAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( 1, $result['event_count'] );
 		$this->assertSame( $past_id, $result['paged_date_groups'][0]['events'][0]['post_id'] );
 	}
+
+	public function test_month_intersects_explicit_date_range(): void {
+		$month_start = new DateTimeImmutable( 'first day of +2 months 00:00:00' );
+		$outside     = $month_start->modify( '+4 days' );
+		$inside      = $month_start->modify( '+9 days' );
+		$this->seed_event( 'Outside explicit range', $outside->format( 'Y-m-d 20:00:00' ), $outside->format( 'Y-m-d 22:00:00' ) );
+		$inside_id = $this->seed_event( 'Inside explicit range', $inside->format( 'Y-m-d 20:00:00' ), $inside->format( 'Y-m-d 22:00:00' ) );
+
+		$result = $this->abilities->executeGetCalendarPage(
+			array(
+				'month'        => $month_start->format( 'Y-m' ),
+				'date_start'   => $inside->format( 'Y-m-d' ),
+				'date_end'     => $inside->format( 'Y-m-d' ),
+				'include_html' => false,
+			)
+		);
+
+		$this->assertSame( 1, $result['event_count'] );
+		$this->assertSame( $inside->format( 'Y-m-d' ), $result['date_boundaries']['start_date'] );
+		$this->assertSame( $inside->format( 'Y-m-d' ), $result['date_boundaries']['end_date'] );
+		$this->assertSame( $inside_id, $result['paged_date_groups'][0]['events'][0]['post_id'] );
+	}
+
+	public function test_month_intersects_resolved_scope_and_can_be_empty(): void {
+		$today         = new DateTimeImmutable( current_time( 'Y-m-d' ) . ' 12:00:00' );
+		$tomorrow      = $today->modify( '+1 day' );
+		$today_id      = $this->seed_event( 'Today scoped event', $today->format( 'Y-m-d 12:00:00' ), $today->format( 'Y-m-d 14:00:00' ) );
+		$future_id     = $this->seed_event( 'Tomorrow unscoped event', $tomorrow->format( 'Y-m-d 12:00:00' ), $tomorrow->format( 'Y-m-d 14:00:00' ) );
+		$current_month = $today->format( 'Y-m' );
+
+		$scoped = $this->abilities->executeGetCalendarPage(
+			array(
+				'month'        => $current_month,
+				'scope'        => 'today',
+				'date_start'   => $today->format( 'Y-m-d' ),
+				'date_end'     => $today->format( 'Y-m-d' ),
+				'include_html' => false,
+			)
+		);
+		$scoped_ids = array_column( $scoped['paged_date_groups'][0]['events'], 'post_id' );
+		$this->assertSame( $today->format( 'Y-m-d' ), $scoped['date_boundaries']['start_date'] );
+		$this->assertSame( $today->format( 'Y-m-d' ), $scoped['date_boundaries']['end_date'] );
+		$this->assertContains( $today_id, $scoped_ids );
+		$this->assertNotContains( $future_id, $scoped_ids );
+
+		$empty = $this->abilities->executeGetCalendarPage(
+			array(
+				'month'        => $today->modify( '+2 months' )->format( 'Y-m' ),
+				'scope'        => 'today',
+				'include_html' => false,
+			)
+		);
+		$this->assertSame( 0, $empty['event_count'] );
+		$this->assertSame( array(), $empty['paged_date_groups'] );
+		$this->assertGreaterThan( $empty['date_boundaries']['end_date'], $empty['date_boundaries']['start_date'] );
+	}
 }

--- a/tests/Unit/EventRestControllerTest.php
+++ b/tests/Unit/EventRestControllerTest.php
@@ -147,6 +147,21 @@ class EventRestControllerTest extends WP_UnitTestCase {
 		$this->assertIsArray( $data );
 	}
 
+	public function test_calendar_data_response_uses_canonical_empty_state(): void {
+		$request = new WP_REST_Request( 'GET', '/datamachine/v1/events/calendar' );
+		$request->set_header( 'X-Requested-With', 'XMLHttpRequest' );
+		$request->set_param( 'format', 'data' );
+		$request->set_param( 'month', '2999-12' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 3, $data['schema']['version'] );
+		$this->assertSame( array(), $data['grouping']['ordered_dates'] );
+		$this->assertStringContainsString( 'data-machine-events-no-events', $data['empty_html'] );
+		$this->assertStringContainsString( 'data-machine-events-no-events-today-link', $data['empty_html'] );
+	}
+
 	public function test_filters_endpoint_returns_taxonomies() {
 		$request  = new WP_REST_Request( 'GET', '/datamachine/v1/events/filters' );
 		$response = $this->server->dispatch( $request );


### PR DESCRIPTION
## Summary
- pass control-built state through month-grid requests, navigation links, URL updates, and global latest-request sequencing
- render desktop grid, mobile list fallback, results counter, and pagination from one authoritative response
- intersect visible month bounds with explicit date ranges and resolved scope date/time bounds in the canonical calendar ability
- preserve server/default scope, opaque consumer scope tokens, archive, search, taxonomy, and geo behavior
- serve empty mobile results from the translated canonical `no-events.php` recovery template through data schema v3
- add frontend, renderer, ability, and REST integration coverage for controls, responsive targets, geo races, history, date/scope intersections, and empty results

## Verification
- `npm test -- --runInBand` (26 tests passed)
- `npm run build` (production build passed)
- PHP syntax checks passed for modified ability, REST controller, and focused tests
- `git diff --check`

## Backend coverage
- month plus explicit date intersection returns only the bounded event
- month plus resolved scope and explicit date returns only scoped events
- disjoint month and scope bounds return an empty result
- data REST schema v3 returns the canonical no-events recovery fragment

## Limitations
- standalone lint/typecheck remain blocked by #462 (`wp-scripts`/ESLint 9 incompatibility and missing WordPress, React, and Jest declarations)
- local PHPUnit/Homeboy test and audit execution safely refused on the hot host because no eligible offload runner was available; PR CI is the supported offloaded test/audit surface

Closes #465