### PR TITLE
fix(calendar): keep filter options in query parity

### DIFF
--- a/inc/Abilities/CalendarAbilities.php
+++ b/inc/Abilities/CalendarAbilities.php
@@ -183,7 +183,7 @@ class CalendarAbilities {
 
 		$scope          = $input['scope'] ?? '';
 		$scope_resolved = $scope ? ScopeResolver::resolve( $scope ) : null;
-		$date_bounds    = self::intersect_date_bounds(
+		$date_bounds    = ScopeResolver::intersect_date_bounds(
 			array(
 				array(
 					'date_start' => $user_date_start,
@@ -193,12 +193,13 @@ class CalendarAbilities {
 				$scope_resolved,
 			)
 		);
-		$user_date_start   = $date_bounds['date_start'];
-		$user_date_end     = $date_bounds['date_end'];
-		$scope_time_start  = $scope_resolved && $user_date_start === ( $scope_resolved['date_start'] ?? '' )
+
+		$user_date_start  = $date_bounds['date_start'];
+		$user_date_end    = $date_bounds['date_end'];
+		$scope_time_start = $scope_resolved && ( $scope_resolved['date_start'] ?? '' ) === $user_date_start
 			? ( $scope_resolved['time_start'] ?? '' )
 			: '';
-		$scope_time_end   = $scope_resolved && $user_date_end === ( $scope_resolved['date_end'] ?? '' )
+		$scope_time_end   = $scope_resolved && ( $scope_resolved['date_end'] ?? '' ) === $user_date_end
 			? ( $scope_resolved['time_end'] ?? '' )
 			: '';
 
@@ -233,6 +234,7 @@ class CalendarAbilities {
 			'geo_lng'            => $input['geo_lng'] ?? '',
 			'geo_radius'         => $input['geo_radius'] ?? 25,
 			'geo_radius_unit'    => $input['geo_radius_unit'] ?? 'mi',
+			'scope_token'        => sanitize_text_field( $input['scope_token'] ?? '' ),
 		);
 
 		$date_data         = self::get_unique_event_dates( $base_params );
@@ -345,6 +347,7 @@ class CalendarAbilities {
 			'search'      => $query_params['search_query'],
 			'order'       => $query_params['show_past'] ? 'DESC' : 'ASC',
 			'per_page'    => 500, // Safety cap — prevents loading 17K+ posts when date boundaries are empty.
+			'scope_token' => $query_params['scope_token'] ?? '',
 		);
 
 		// Date range overrides scope.
@@ -469,39 +472,6 @@ class CalendarAbilities {
 		wp_reset_postdata();
 
 		return $result;
-	}
-
-	/**
-	 * Intersect inclusive date windows, preserving one-sided constraints.
-	 *
-	 * An empty intersection intentionally returns a lower bound after the upper
-	 * bound; the canonical event-date query then returns zero rows.
-	 *
-	 * @param array $windows Date windows with optional date_start/date_end keys.
-	 * @return array{date_start:string,date_end:string}
-	 */
-	private static function intersect_date_bounds( array $windows ): array {
-		$starts = array();
-		$ends   = array();
-
-		foreach ( $windows as $window ) {
-			if ( ! is_array( $window ) ) {
-				continue;
-			}
-			$start = (string) ( $window['date_start'] ?? '' );
-			$end   = (string) ( $window['date_end'] ?? '' );
-			if ( '' !== $start ) {
-				$starts[] = $start;
-			}
-			if ( '' !== $end ) {
-				$ends[] = $end;
-			}
-		}
-
-		return array(
-			'date_start' => $starts ? max( $starts ) : '',
-			'date_end'   => $ends ? min( $ends ) : '',
-		);
 	}
 
 	/**

--- a/inc/Abilities/FilterAbilities.php
+++ b/inc/Abilities/FilterAbilities.php
@@ -17,8 +17,8 @@
 namespace DataMachineEvents\Abilities;
 
 use DataMachineEvents\Blocks\Calendar\Geo_Query;
+use DataMachineEvents\Blocks\Calendar\Query\ScopeResolver;
 use DataMachineEvents\Core\Event_Post_Type;
-use DataMachineEvents\Core\EventDatesTable;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -85,6 +85,18 @@ class FilterAbilities {
 							'context'          => array(
 								'type'        => 'string',
 								'description' => 'Filter context: modal, inline, badge (default: modal)',
+							),
+							'event_search'     => array(
+								'type'        => 'string',
+								'description' => 'Search query string',
+							),
+							'scope'            => array(
+								'type'        => 'string',
+								'description' => 'Time scope: today, tonight, this-weekend, this-week',
+							),
+							'scope_token'      => array(
+								'type'        => 'string',
+								'description' => 'Opaque consumer-minted scope token passed to the authoritative event query',
 							),
 						),
 					),
@@ -156,6 +168,19 @@ class FilterAbilities {
 			'date_end'   => $input['date_context']['date_end'] ?? '',
 			'past'       => $input['date_context']['past'] ?? '',
 		);
+
+		$scope          = sanitize_key( $input['scope'] ?? '' );
+		$scope_resolved = ScopeResolver::is_valid( $scope ) ? ScopeResolver::resolve( $scope ) : null;
+		$date_bounds    = ScopeResolver::intersect_date_bounds( array( $date_context, $scope_resolved ) );
+
+		$date_context['date_start'] = $date_bounds['date_start'];
+		$date_context['date_end']   = $date_bounds['date_end'];
+		$date_context['time_start'] = $scope_resolved && ( $scope_resolved['date_start'] ?? '' ) === $date_bounds['date_start']
+			? ( $scope_resolved['time_start'] ?? '' )
+			: '';
+		$date_context['time_end']   = $scope_resolved && ( $scope_resolved['date_end'] ?? '' ) === $date_bounds['date_end']
+			? ( $scope_resolved['time_end'] ?? '' )
+			: '';
 
 		// Build archive constraint.
 		$archive_taxonomy = sanitize_key( $input['archive_taxonomy'] ?? '' );
@@ -242,7 +267,18 @@ class FilterAbilities {
 			}
 		}
 
-		$taxonomies_data = $this->get_all_taxonomies_with_counts( $active_filters, $date_context, $tax_query_override );
+		$query_context = array(
+			'event_search' => sanitize_text_field( $input['event_search'] ?? '' ),
+			'scope_token'  => sanitize_text_field( $input['scope_token'] ?? '' ),
+			'geo'          => $geo_context['active'] ? array(
+				'lat'    => $geo_context['lat'],
+				'lng'    => $geo_context['lng'],
+				'radius' => $geo_context['radius'],
+				'unit'   => $geo_context['radius_unit'],
+			) : array(),
+		);
+
+		$taxonomies_data = $this->get_all_taxonomies_with_counts( $active_filters, $date_context, $tax_query_override, $query_context );
 
 		return array(
 			'success'         => true,
@@ -253,6 +289,8 @@ class FilterAbilities {
 				'context'        => $context,
 				'active_filters' => $active_filters,
 				'date_context'   => $date_context,
+				'event_search'   => $query_context['event_search'],
+				'scope'          => $scope,
 			),
 		);
 	}
@@ -263,9 +301,10 @@ class FilterAbilities {
 	 * @param array      $active_filters    Active filter selections keyed by taxonomy slug.
 	 * @param array      $date_context      Optional date filtering context (date_start, date_end, past).
 	 * @param array|null $tax_query_override Optional taxonomy query override.
+	 * @param array      $query_context     Search, geo, and opaque scope-token context.
 	 * @return array Structured taxonomy data with hierarchy and event counts.
 	 */
-	private function get_all_taxonomies_with_counts( $active_filters = array(), $date_context = array(), $tax_query_override = null ) {
+	private function get_all_taxonomies_with_counts( $active_filters = array(), $date_context = array(), $tax_query_override = null, $query_context = array() ) {
 		$taxonomies_data = array();
 
 		$taxonomies = get_object_taxonomies( Event_Post_Type::POST_TYPE, 'objects' );
@@ -281,7 +320,7 @@ class FilterAbilities {
 				continue;
 			}
 
-			$terms_hierarchy = $this->get_taxonomy_hierarchy( $taxonomy->name, null, $date_context, $active_filters, $tax_query_override );
+			$terms_hierarchy = $this->get_taxonomy_hierarchy( $taxonomy->name, null, $date_context, $active_filters, $tax_query_override, $query_context );
 
 			if ( ! empty( $terms_hierarchy ) ) {
 				$taxonomies_data[ $taxonomy->name ] = array(
@@ -304,9 +343,10 @@ class FilterAbilities {
 	 * @param array      $date_context    Optional date filtering context.
 	 * @param array      $active_filters  Optional active taxonomy filters for cross-filtering.
 	 * @param array|null $tax_query_override Optional taxonomy query override.
+	 * @param array      $query_context   Search, geo, and opaque scope-token context.
 	 * @return array Hierarchical term structure with event counts.
 	 */
-	private function get_taxonomy_hierarchy( $taxonomy_slug, $allowed_term_ids = null, $date_context = array(), $active_filters = array(), $tax_query_override = null ) {
+	private function get_taxonomy_hierarchy( $taxonomy_slug, $allowed_term_ids = null, $date_context = array(), $active_filters = array(), $tax_query_override = null, $query_context = array() ) {
 		$terms = get_terms(
 			array(
 				'taxonomy'   => $taxonomy_slug,
@@ -324,7 +364,7 @@ class FilterAbilities {
 			return array();
 		}
 
-		$term_counts = $this->get_batch_term_counts( $taxonomy_slug, $date_context, $active_filters, $tax_query_override );
+		$term_counts = $this->get_batch_term_counts( $taxonomy_slug, $date_context, $active_filters, $tax_query_override, $query_context );
 
 		$terms_with_events = array();
 		foreach ( $terms as $term ) {
@@ -364,123 +404,56 @@ class FilterAbilities {
 	}
 
 	/**
-	 * Get event counts for all terms in a taxonomy with a single query.
+	 * Get event counts for all terms in a taxonomy.
 	 *
-	 * Joins term_relationships → event_dates directly. The posts table is
-	 * NOT joined because event_dates already carries post_status (synced
-	 * on upsert) and only event-typed posts ever get rows in that table.
-	 * Filtering on ed.post_status = 'publish' eliminates stale/trashed
-	 * rows and guarantees the post_type constraint transitively.
+	 * Queries matching event IDs through EventDateQueryAbilities, the same
+	 * primitive used by calendar results, then tallies their terms.
 	 *
 	 * @param string     $taxonomy_slug     Taxonomy to count events for.
 	 * @param array      $date_context      Optional date filtering context.
 	 * @param array      $active_filters    Optional active taxonomy filters for cross-filtering.
 	 * @param array|null $tax_query_override Optional taxonomy query override.
+	 * @param array      $query_context     Search, geo, and opaque scope-token context.
 	 * @return array Term ID => event count mapping.
 	 */
-	private function get_batch_term_counts( $taxonomy_slug, $date_context = array(), $active_filters = array(), $tax_query_override = null ) {
-		global $wpdb;
-
-		$ed_table = EventDatesTable::table_name();
-
-		// Join event_dates directly onto tr.object_id — no posts table hop.
-		// event_dates.post_status is authoritative and already indexed.
-		$joins         = "INNER JOIN {$ed_table} ed ON tr.object_id = ed.post_id";
-		$where_clauses = " AND ed.post_status = 'publish'";
-		$params        = array( $taxonomy_slug );
-
-		if ( ! empty( $date_context ) ) {
-			$date_start       = $date_context['date_start'] ?? '';
-			$date_end         = $date_context['date_end'] ?? '';
-			$show_past        = ! empty( $date_context['past'] ) && '1' === $date_context['past'];
-			$current_datetime = current_time( 'mysql' );
-
-			if ( ! empty( $date_start ) && ! empty( $date_end ) ) {
-				$where_clauses .= ' AND (ed.start_datetime >= %s AND ed.start_datetime <= %s)';
-				$params[]       = $date_start . ' 00:00:00';
-				$params[]       = $date_end . ' 23:59:59';
-			} elseif ( $show_past ) {
-				$where_clauses .= ' AND (ed.start_datetime < %s AND (ed.end_datetime < %s OR ed.end_datetime IS NULL))';
-				$params[]       = $current_datetime;
-				$params[]       = $current_datetime;
-			} else {
-				$where_clauses .= ' AND (ed.start_datetime >= %s OR ed.end_datetime >= %s)';
-				$params[]       = $current_datetime;
-				$params[]       = $current_datetime;
+	private function get_batch_term_counts( $taxonomy_slug, $date_context = array(), $active_filters = array(), $tax_query_override = null, $query_context = array() ) {
+		$tax_filters = array_diff_key( $active_filters, array( $taxonomy_slug => true ) );
+		foreach ( (array) $tax_query_override as $clause ) {
+			$taxonomy = sanitize_key( $clause['taxonomy'] ?? '' );
+			$terms    = array_map( 'absint', (array) ( $clause['terms'] ?? array() ) );
+			if ( $taxonomy && $terms ) {
+				$tax_filters[ $taxonomy ] = $terms;
 			}
 		}
 
-		if ( ! empty( $tax_query_override ) && is_array( $tax_query_override ) ) {
-			$base_join_index = 0;
-			foreach ( $tax_query_override as $clause ) {
-				$base_taxonomy = sanitize_key( $clause['taxonomy'] ?? '' );
-				$base_terms    = array_map( 'absint', (array) ( $clause['terms'] ?? array() ) );
-
-				if ( ! $base_taxonomy || empty( $base_terms ) ) {
-					continue;
-				}
-
-				$placeholders = implode( ',', array_fill( 0, count( $base_terms ), '%d' ) );
-				$alias_tr     = "base_tr_{$base_join_index}";
-				$alias_tt     = "base_tt_{$base_join_index}";
-
-				$joins .= " INNER JOIN {$wpdb->term_relationships} {$alias_tr} ON tr.object_id = {$alias_tr}.object_id";
-				$joins .= " INNER JOIN {$wpdb->term_taxonomy} {$alias_tt} ON {$alias_tr}.term_taxonomy_id = {$alias_tt}.term_taxonomy_id";
-
-				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-				$where_clauses .= " AND {$alias_tt}.taxonomy = %s AND {$alias_tt}.term_id IN ($placeholders)";
-				$params[]       = $base_taxonomy;
-				$params         = array_merge( $params, $base_terms );
-
-				++$base_join_index;
-			}
-		}
-
-		// Cross-taxonomy filtering (exclude current taxonomy from cross-filter).
-		$cross_filters = array_diff_key( $active_filters, array( $taxonomy_slug => true ) );
-		$join_index    = 0;
-		foreach ( $cross_filters as $filter_taxonomy => $term_ids ) {
-			if ( empty( $term_ids ) ) {
-				continue;
-			}
-
-			$term_ids     = array_map( 'intval', (array) $term_ids );
-			$placeholders = implode( ',', array_fill( 0, count( $term_ids ), '%d' ) );
-
-			$alias_tr = "cross_tr_{$join_index}";
-			$alias_tt = "cross_tt_{$join_index}";
-
-			$joins .= " INNER JOIN {$wpdb->term_relationships} {$alias_tr} ON tr.object_id = {$alias_tr}.object_id";
-			$joins .= " INNER JOIN {$wpdb->term_taxonomy} {$alias_tt} ON {$alias_tr}.term_taxonomy_id = {$alias_tt}.term_taxonomy_id";
-
-			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			$where_clauses .= " AND {$alias_tt}.taxonomy = %s AND {$alias_tt}.term_id IN ($placeholders)";
-			$params[]       = $filter_taxonomy;
-			$params         = array_merge( $params, $term_ids );
-
-			++$join_index;
-		}
-
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Join and where fragments contain generated aliases and placeholders; values are passed separately to prepare().
-		$query = $wpdb->prepare(
-			"SELECT tt.term_id, COUNT(DISTINCT tr.object_id) as event_count
-            FROM {$wpdb->term_relationships} tr
-            INNER JOIN {$wpdb->term_taxonomy} tt
-                ON tr.term_taxonomy_id = tt.term_taxonomy_id
-            {$joins}
-            WHERE tt.taxonomy = %s
-            {$where_clauses}
-            GROUP BY tt.term_id",
-			$params
+		$query_input = array(
+			'scope'       => ! empty( $date_context['past'] ) && '1' === $date_context['past'] ? 'past' : 'upcoming',
+			'date_start'  => $date_context['date_start'] ?? '',
+			'date_end'    => $date_context['date_end'] ?? '',
+			'time_start'  => $date_context['time_start'] ?? '',
+			'time_end'    => $date_context['time_end'] ?? '',
+			'tax_filters' => $tax_filters,
+			'search'      => $query_context['event_search'] ?? '',
+			'geo'         => $query_context['geo'] ?? array(),
+			'scope_token' => $query_context['scope_token'] ?? '',
+			'fields'      => 'ids',
+			'per_page'    => -1,
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-		$results = $wpdb->get_results( $query );
+		$result   = ( new EventDateQueryAbilities() )->executeQueryEvents( $query_input );
+		$post_ids = array_map( 'absint', $result['posts'] );
+		$counts   = array();
+		if ( empty( $post_ids ) ) {
+			return $counts;
+		}
 
-		$counts = array();
-		foreach ( $results as $row ) {
-			$counts[ (int) $row->term_id ] = (int) $row->event_count;
+		$terms = wp_get_object_terms( $post_ids, $taxonomy_slug, array( 'fields' => 'all_with_object_id' ) );
+		if ( is_wp_error( $terms ) ) {
+			return $counts;
+		}
+		foreach ( $terms as $term ) {
+			$term_id            = (int) $term->term_id;
+			$counts[ $term_id ] = ( $counts[ $term_id ] ?? 0 ) + 1;
 		}
 
 		return $counts;

--- a/inc/Api/Controllers/Filters.php
+++ b/inc/Api/Controllers/Filters.php
@@ -53,6 +53,9 @@ class Filters {
 				'geo_lng'          => $request->get_param( 'lng' ) ?? '',
 				'geo_radius'       => $request->get_param( 'radius' ) ?? 25,
 				'geo_radius_unit'  => $request->get_param( 'radius_unit' ) ?? 'mi',
+				'event_search'     => $request->get_param( 'event_search' ) ?? '',
+				'scope'            => $request->get_param( 'scope' ) ?? '',
+				'scope_token'      => $request->get_param( 'scope_token' ) ?? '',
 			)
 		);
 

--- a/inc/Api/Routes.php
+++ b/inc/Api/Routes.php
@@ -240,6 +240,20 @@ function register_routes() {
 					'type'              => 'string',
 					'sanitize_callback' => 'sanitize_text_field',
 				),
+				'event_search'     => array(
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_text_field',
+				),
+				'scope'            => array(
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_key',
+				),
+				'scope_token'      => array(
+					'type'              => 'string',
+					'default'           => '',
+					'sanitize_callback' => 'sanitize_text_field',
+					'description'       => 'Opaque consumer-minted scope token passed through to the authoritative event query.',
+				),
 				'archive_taxonomy' => array(
 					'type'              => 'string',
 					'sanitize_callback' => 'sanitize_key',

--- a/inc/Blocks/Calendar/Query/ScopeResolver.php
+++ b/inc/Blocks/Calendar/Query/ScopeResolver.php
@@ -145,6 +145,39 @@ class ScopeResolver {
 	}
 
 	/**
+	 * Intersect inclusive date windows, preserving one-sided constraints.
+	 *
+	 * An empty intersection intentionally returns a lower bound after the upper
+	 * bound so the canonical event-date query returns zero rows.
+	 *
+	 * @param array $windows Date windows with optional date_start/date_end keys.
+	 * @return array{date_start:string,date_end:string}
+	 */
+	public static function intersect_date_bounds( array $windows ): array {
+		$starts = array();
+		$ends   = array();
+
+		foreach ( $windows as $window ) {
+			if ( ! is_array( $window ) ) {
+				continue;
+			}
+			$start = (string) ( $window['date_start'] ?? '' );
+			$end   = (string) ( $window['date_end'] ?? '' );
+			if ( '' !== $start ) {
+				$starts[] = $start;
+			}
+			if ( '' !== $end ) {
+				$ends[] = $end;
+			}
+		}
+
+		return array(
+			'date_start' => $starts ? max( $starts ) : '',
+			'date_end'   => $ends ? min( $ends ) : '',
+		);
+	}
+
+	/**
 	 * Resolve the raw datetime bounds for one nightlife display day.
 	 *
 	 * When late-night bucketing is enabled, the display day starts at the

--- a/inc/Blocks/Calendar/src/modules/api-client.ts
+++ b/inc/Blocks/Calendar/src/modules/api-client.ts
@@ -8,6 +8,7 @@ import type {
 	CalendarResponse,
 	DateContext,
 	FilterResponse,
+	FilterRequestContext,
 	GeoContext,
 	TaxFilters,
 } from '../types';
@@ -222,7 +223,9 @@ export async function fetchFilters(
 	activeFilters: TaxFilters = {},
 	dateContext: Partial< DateContext > = {},
 	archiveContext: Partial< ArchiveContext > = {},
-	geoContext: Partial< GeoContext > = {}
+	geoContext: Partial< GeoContext > = {},
+	requestContext: Partial< FilterRequestContext > = {},
+	signal?: AbortSignal
 ): Promise< FilterResponse > {
 	const params = new URLSearchParams();
 
@@ -260,10 +263,21 @@ export async function fetchFilters(
 		}
 	}
 
+	if ( requestContext.event_search ) {
+		params.set( 'event_search', requestContext.event_search );
+	}
+	if ( requestContext.scope ) {
+		params.set( 'scope', requestContext.scope );
+	}
+	if ( requestContext.scope_token ) {
+		params.set( 'scope_token', requestContext.scope_token );
+	}
+
 	const apiUrl = `/wp-json/datamachine/v1/events/filters?${ params.toString() }`;
 
 	const response = await fetch( apiUrl, {
 		method: 'GET',
+		signal,
 		headers: {
 			'Content-Type': 'application/json',
 			Accept: 'application/json',

--- a/inc/Blocks/Calendar/src/modules/filter-modal.test.ts
+++ b/inc/Blocks/Calendar/src/modules/filter-modal.test.ts
@@ -1,0 +1,133 @@
+import { destroyFilterModal, initFilterModal } from './filter-modal';
+import { destroyFilterState } from './filter-state';
+
+const mockFetch = jest.fn();
+
+function response( name: string, count = 1 ): Response {
+	return {
+		ok: true,
+		json: async () => ( {
+			success: true,
+			taxonomies: {
+				venue: {
+					label: 'Venues',
+					terms: [
+						{
+							term_id: count,
+							name,
+							slug: name.toLowerCase(),
+							event_count: count,
+							children: [],
+						},
+					],
+				},
+			},
+		} ),
+	} as Response;
+}
+
+function deferred(): {
+	promise: Promise< Response >;
+	resolve: ( value: Response ) => void;
+} {
+	let resolve!: ( value: Response ) => void;
+	return {
+		promise: new Promise< Response >( ( done ) => {
+			resolve = done;
+		} ),
+		resolve: ( value ) => resolve( value ),
+	};
+}
+
+function flush(): Promise< void > {
+	return new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+}
+
+describe( 'dynamic filter modal requests', () => {
+	let calendar: HTMLElement;
+
+	beforeEach( () => {
+		window.history.replaceState(
+			{},
+			'',
+			'/events/?event_search=jam&scope=this-week&date_start=2026-07-19&date_end=2026-07-20'
+		);
+		document.body.innerHTML = `
+			<div class="data-machine-events-calendar" data-scope-token="opaque.signed.token" data-geo-lat="32.78" data-geo-lng="-79.93" data-geo-radius="25" data-geo-radius-unit="mi">
+				<button class="data-machine-taxonomy-filter-btn"></button>
+				<div class="data-machine-taxonomy-modal">
+					<div class="data-machine-filter-loading" style="display:none"></div>
+					<div class="data-machine-filter-taxonomies"></div>
+				</div>
+			</div>`;
+		calendar = document.querySelector< HTMLElement >(
+			'.data-machine-events-calendar'
+		)!;
+		mockFetch.mockReset();
+		global.fetch = mockFetch;
+	} );
+
+	afterEach( () => {
+		destroyFilterModal( calendar );
+		destroyFilterState( calendar );
+		jest.restoreAllMocks();
+	} );
+
+	it( 'sends search, scope, date, geo, and opaque scope token constraints', async () => {
+		mockFetch.mockResolvedValue( response( 'Matching venue' ) );
+		initFilterModal( calendar, jest.fn(), jest.fn() );
+		calendar.querySelector< HTMLButtonElement >( '.data-machine-taxonomy-filter-btn' )!.click();
+		await flush();
+
+		const url = new URL( mockFetch.mock.calls[ 0 ][ 0 ], window.location.origin );
+		expect( url.searchParams.get( 'event_search' ) ).toBe( 'jam' );
+		expect( url.searchParams.get( 'scope' ) ).toBe( 'this-week' );
+		expect( url.searchParams.get( 'date_start' ) ).toBe( '2026-07-19' );
+		expect( url.searchParams.get( 'date_end' ) ).toBe( '2026-07-20' );
+		expect( url.searchParams.get( 'lat' ) ).toBe( '32.78' );
+		expect( url.searchParams.get( 'scope_token' ) ).toBe( 'opaque.signed.token' );
+	} );
+
+	it( 'aborts the previous request and ignores its out-of-order response', async () => {
+		const stale = deferred();
+		const latest = deferred();
+		mockFetch
+			.mockImplementationOnce( () => stale.promise )
+			.mockImplementationOnce( () => latest.promise );
+		initFilterModal( calendar, jest.fn(), jest.fn() );
+		const trigger = calendar.querySelector< HTMLButtonElement >(
+			'.data-machine-taxonomy-filter-btn'
+		)!;
+		trigger.click();
+		trigger.click();
+
+		const firstSignal = mockFetch.mock.calls[ 0 ][ 1 ].signal as AbortSignal;
+		expect( firstSignal.aborted ).toBe( true );
+		latest.resolve( response( 'Latest venue', 2 ) );
+		await flush();
+		stale.resolve( response( 'Stale venue', 3 ) );
+		await flush();
+
+		expect( calendar.textContent ).toContain( 'Latest venue' );
+		expect( calendar.textContent ).not.toContain( 'Stale venue' );
+		expect(
+			calendar.querySelector< HTMLElement >( '.data-machine-filter-loading' )!
+				.style.display
+		).toBe( 'none' );
+	} );
+
+	it( 'retains prior options and offers retry after a refresh failure', async () => {
+		mockFetch.mockResolvedValueOnce( response( 'Usable venue' ) );
+		initFilterModal( calendar, jest.fn(), jest.fn() );
+		calendar.querySelector< HTMLButtonElement >( '.data-machine-taxonomy-filter-btn' )!.click();
+		await flush();
+
+		mockFetch.mockRejectedValueOnce( new Error( 'network failure' ) );
+		calendar.querySelector< HTMLInputElement >( '.data-machine-term-checkbox' )!.click();
+		await flush();
+
+		expect( calendar.textContent ).toContain( 'Usable venue' );
+		expect( calendar.textContent ).toContain( 'Previous options are still available' );
+		expect( calendar.querySelector( '.data-machine-filter-retry' ) ).not.toBeNull();
+	} );
+} );

--- a/inc/Blocks/Calendar/src/modules/filter-modal.ts
+++ b/inc/Blocks/Calendar/src/modules/filter-modal.ts
@@ -11,6 +11,8 @@ import type {
 	ArchiveContext,
 	DateContext,
 	FlatTaxonomyTerm,
+	FilterRequestContext,
+	GeoContext,
 	TaxFilters,
 	TaxonomyData,
 	TaxonomyTerm,
@@ -29,6 +31,8 @@ interface ModalElement extends HTMLElement {
 	_applyBtn?: HTMLElement;
 	_resetHandler?: () => void;
 	_resetBtn?: HTMLElement;
+	_filterAbortController?: AbortController;
+	_filterRequestGeneration?: number;
 }
 
 export function initFilterModal(
@@ -72,6 +76,7 @@ export function initFilterModal(
 	);
 
 	const closeModal = function (): void {
+		cancelFilterRequest( modal );
 		modal.classList.remove( 'data-machine-modal-active' );
 		document.body.classList.remove( 'data-machine-modal-active' );
 		if ( filterBtn ) {
@@ -87,11 +92,21 @@ export function initFilterModal(
 		document.body.classList.add( 'data-machine-modal-active' );
 		filterBtn?.setAttribute( 'aria-expanded', 'true' );
 
+		const params = filterState.buildParams();
+		const urlParams = new URLSearchParams( window.location.search );
 		await loadFilters(
 			modal,
 			filterState.getTaxFilters(),
 			filterState.getDateContext(),
-			archiveContext
+			archiveContext,
+			filterState.getGeoContext(),
+			{
+				event_search:
+					params.get( 'event_search' ) ||
+					filterState.getSearchQuery(),
+				scope: params.get( 'scope' ) || urlParams.get( 'scope' ) || '',
+				scope_token: calendar.dataset.scopeToken || '',
+			}
 		);
 	};
 
@@ -193,6 +208,8 @@ export function destroyFilterModal( calendar: HTMLElement ): void {
 		return;
 	}
 
+	cancelFilterRequest( modal );
+
 	const filterBtn = calendar.querySelector< HTMLElement >(
 		'.data-machine-taxonomy-filter-btn, .data-machine-taxonomy-modal-trigger, .data-machine-events-filter-btn'
 	);
@@ -244,6 +261,8 @@ export function destroyFilterModal( calendar: HTMLElement ): void {
 	delete modal._applyBtn;
 	delete modal._resetHandler;
 	delete modal._resetBtn;
+	delete modal._filterAbortController;
+	delete modal._filterRequestGeneration;
 
 	modal.dataset.dmListenersAttached = 'false';
 }
@@ -266,10 +285,12 @@ function getArchiveContextFromModal(
 }
 
 async function loadFilters(
-	modal: HTMLElement,
+	modal: ModalElement,
 	activeFilters: TaxFilters = {},
 	dateContext: Partial< DateContext > = {},
-	archiveContext: Partial< ArchiveContext > = {}
+	archiveContext: Partial< ArchiveContext > = {},
+	geoContext: Partial< GeoContext > = {},
+	requestContext: Partial< FilterRequestContext > = {}
 ): Promise< void > {
 	const container = modal.querySelector< HTMLElement >(
 		'.data-machine-filter-taxonomies'
@@ -282,37 +303,98 @@ async function loadFilters(
 		return;
 	}
 
+	modal._filterAbortController?.abort();
+	const controller = new AbortController();
+	const generation = ( modal._filterRequestGeneration ?? 0 ) + 1;
+	modal._filterAbortController = controller;
+	modal._filterRequestGeneration = generation;
+
 	if ( loading ) {
 		loading.style.display = 'flex';
 	}
-	container.innerHTML = '';
 
 	try {
 		const data = await fetchFilters(
 			activeFilters,
 			dateContext,
-			archiveContext
+			archiveContext,
+			geoContext,
+			requestContext,
+			controller.signal
 		);
+		if ( generation !== modal._filterRequestGeneration ) {
+			return;
+		}
 
 		if ( ! data.success ) {
 			throw new Error( 'API returned unsuccessful response' );
 		}
 
+		container.innerHTML = '';
 		renderTaxonomies(
 			container,
 			data.taxonomies,
 			activeFilters,
 			data.archive_context || {}
 		);
-		attachFilterChangeListeners( modal, dateContext, archiveContext );
-	} catch {
-		container.innerHTML =
-			'<div class="data-machine-filter-error"><p>Error loading filters. Please try again.</p></div>';
+		attachFilterChangeListeners(
+			modal,
+			dateContext,
+			archiveContext,
+			geoContext,
+			requestContext
+		);
+	} catch ( error ) {
+		if (
+			generation !== modal._filterRequestGeneration ||
+			( error as Error ).name === 'AbortError'
+		) {
+			return;
+		}
+		renderFilterError( container, () => {
+			void loadFilters(
+				modal,
+				activeFilters,
+				dateContext,
+				archiveContext,
+				geoContext,
+				requestContext
+			);
+		} );
 	} finally {
-		if ( loading ) {
+		if ( generation === modal._filterRequestGeneration && loading ) {
 			loading.style.display = 'none';
 		}
 	}
+}
+
+function cancelFilterRequest( modal: ModalElement ): void {
+	modal._filterAbortController?.abort();
+	modal._filterAbortController = undefined;
+	modal._filterRequestGeneration = ( modal._filterRequestGeneration ?? 0 ) + 1;
+	const loading = modal.querySelector< HTMLElement >(
+		'.data-machine-filter-loading'
+	);
+	if ( loading ) {
+		loading.style.display = 'none';
+	}
+}
+
+function renderFilterError(
+	container: HTMLElement,
+	onRetry: () => void
+): void {
+	container.querySelector( '.data-machine-filter-error' )?.remove();
+	const error = document.createElement( 'div' );
+	error.className = 'data-machine-filter-error';
+	error.innerHTML = '<p>Could not refresh filters. Previous options are still available.</p>';
+	const retry = document.createElement( 'button' );
+	retry.type = 'button';
+	retry.className = 'data-machine-filter-retry';
+	retry.textContent = 'Try again';
+	retry.addEventListener( 'click', onRetry, { once: true } );
+	error.appendChild( retry );
+	container.appendChild( error );
 }
 
 function renderTaxonomies(
@@ -429,9 +511,11 @@ function flattenHierarchy(
 }
 
 function attachFilterChangeListeners(
-	modal: HTMLElement,
+	modal: ModalElement,
 	dateContext: Partial< DateContext > = {},
-	archiveContext: Partial< ArchiveContext > = {}
+	archiveContext: Partial< ArchiveContext > = {},
+	geoContext: Partial< GeoContext > = {},
+	requestContext: Partial< FilterRequestContext > = {}
 ): void {
 	const checkboxes = modal.querySelectorAll< HTMLInputElement >(
 		'input[type="checkbox"]:not([data-locked="true"])'
@@ -444,7 +528,9 @@ function attachFilterChangeListeners(
 				modal,
 				activeFilters,
 				dateContext,
-				archiveContext
+				archiveContext,
+				geoContext,
+				requestContext
 			);
 		} );
 	} );

--- a/inc/Blocks/Calendar/src/types.ts
+++ b/inc/Blocks/Calendar/src/types.ts
@@ -108,6 +108,12 @@ export interface CalendarRequest {
 	scope_token: string;
 }
 
+export interface FilterRequestContext {
+	event_search: string;
+	scope: string;
+	scope_token: string;
+}
+
 /* ------------------------------------------------------------------ */
 /*  REST API responses                                                 */
 /* ------------------------------------------------------------------ */

--- a/tests/Unit/CalendarCacheTest.php
+++ b/tests/Unit/CalendarCacheTest.php
@@ -292,4 +292,15 @@ class CalendarCacheTest extends WP_UnitTestCase {
 
 		wp_set_current_user( 0 );
 	}
+
+	public function test_scope_tokens_isolate_cache_keys_without_leaking_token_contents() {
+		$token = 'signed.private.scope.payload';
+		$key   = CalendarCache::generate_full_response_key( array( 'scope_token' => $token ) );
+
+		$this->assertNotSame(
+			CalendarCache::generate_full_response_key( array() ),
+			$key
+		);
+		$this->assertStringNotContainsString( $token, $key );
+	}
 }

--- a/tests/Unit/FilterAbilitiesTest.php
+++ b/tests/Unit/FilterAbilitiesTest.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Filter option ability tests.
+ *
+ * @package DataMachineEvents\Tests\Unit
+ */
+
+namespace DataMachineEvents\Tests\Unit;
+
+use DateTimeImmutable;
+use WP_UnitTestCase;
+use DataMachineEvents\Abilities\FilterAbilities;
+use DataMachineEvents\Blocks\Calendar\Query\ScopeResolver;
+use DataMachineEvents\Core\Event_Post_Type;
+use DataMachineEvents\Core\EventDatesTable;
+
+class FilterAbilitiesTest extends WP_UnitTestCase {
+
+	private FilterAbilities $abilities;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		if ( ! post_type_exists( Event_Post_Type::POST_TYPE ) ) {
+			Event_Post_Type::register();
+		}
+		foreach ( array( 'filter_group', 'filter_kind' ) as $taxonomy ) {
+			if ( ! taxonomy_exists( $taxonomy ) ) {
+				register_taxonomy( $taxonomy, Event_Post_Type::POST_TYPE, array( 'public' => true ) );
+			}
+		}
+		if ( ! EventDatesTable::table_exists() ) {
+			EventDatesTable::create_table();
+		}
+
+		$this->abilities = new FilterAbilities();
+	}
+
+	private function seed_event( string $title, string $start, array $terms ): int {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'  => $title,
+				'post_type'   => Event_Post_Type::POST_TYPE,
+				'post_status' => 'publish',
+			)
+		);
+		EventDatesTable::upsert( $post_id, $start, ( new DateTimeImmutable( $start ) )->modify( '+2 hours' )->format( 'Y-m-d H:i:s' ), 'publish' );
+		foreach ( $terms as $taxonomy => $term_ids ) {
+			wp_set_object_terms( $post_id, (array) $term_ids, $taxonomy );
+		}
+		return $post_id;
+	}
+
+	private function create_term( string $taxonomy ): int {
+		$term = wp_insert_term( $taxonomy . ' ' . uniqid(), $taxonomy );
+		$this->assertNotWPError( $term );
+		return (int) $term['term_id'];
+	}
+
+	private function term_count( array $result, string $taxonomy, int $term_id ): int {
+		$terms = FilterAbilities::flatten_hierarchy( $result['taxonomies'][ $taxonomy ]['terms'] ?? array() );
+		foreach ( $terms as $term ) {
+			if ( $term_id === (int) $term['term_id'] ) {
+				return (int) $term['event_count'];
+			}
+		}
+		return 0;
+	}
+
+	public function test_search_limits_offered_term_counts(): void {
+		$term_id  = $this->create_term( 'filter_kind' );
+		$tomorrow = ( new DateTimeImmutable( current_time( 'mysql' ) ) )->modify( '+1 day' );
+		$this->seed_event( 'Needle performance', $tomorrow->format( 'Y-m-d 20:00:00' ), array( 'filter_kind' => $term_id ) );
+		$this->seed_event( 'Different performance', $tomorrow->format( 'Y-m-d 21:00:00' ), array( 'filter_kind' => $term_id ) );
+
+		$result = $this->abilities->executeGetFilterOptions( array( 'event_search' => 'Needle' ) );
+
+		$this->assertSame( 1, $this->term_count( $result, 'filter_kind', $term_id ) );
+	}
+
+	/**
+	 * @dataProvider named_scope_provider
+	 */
+	public function test_each_named_scope_limits_offered_terms( string $scope ): void {
+		$resolved = ScopeResolver::resolve( $scope );
+		$this->assertIsArray( $resolved );
+		$term_id = $this->create_term( 'filter_kind' );
+		$time    = $resolved['time_start'] ?? '12:00:00';
+		$this->seed_event( "{$scope} match", $resolved['date_start'] . ' ' . $time, array( 'filter_kind' => $term_id ) );
+		$this->seed_event( "{$scope} outside", '2035-01-01 12:00:00', array( 'filter_kind' => $term_id ) );
+
+		$result = $this->abilities->executeGetFilterOptions( array( 'scope' => $scope ) );
+
+		$this->assertSame( 1, $this->term_count( $result, 'filter_kind', $term_id ) );
+	}
+
+	public static function named_scope_provider(): array {
+		return array(
+			'today'        => array( 'today' ),
+			'tonight'      => array( 'tonight' ),
+			'this weekend' => array( 'this-weekend' ),
+			'this week'    => array( 'this-week' ),
+		);
+	}
+
+	public function test_combined_search_scope_date_archive_and_taxonomy_constraints(): void {
+		$scope       = ScopeResolver::resolve( 'this-week' );
+		$group_id    = $this->create_term( 'filter_group' );
+		$other_group = $this->create_term( 'filter_group' );
+		$kind_id     = $this->create_term( 'filter_kind' );
+		$date        = $scope['date_start'];
+		$this->seed_event( 'Combined needle', "{$date} 12:00:00", array( 'filter_group' => $group_id, 'filter_kind' => $kind_id ) );
+		$this->seed_event( 'Combined needle wrong archive', "{$date} 13:00:00", array( 'filter_group' => $other_group, 'filter_kind' => $kind_id ) );
+		$this->seed_event( 'Wrong search', "{$date} 14:00:00", array( 'filter_group' => $group_id, 'filter_kind' => $kind_id ) );
+
+		$result = $this->abilities->executeGetFilterOptions(
+			array(
+				'event_search'     => 'Combined needle',
+				'scope'            => 'this-week',
+				'date_context'     => array( 'date_start' => $date, 'date_end' => $date ),
+				'archive_taxonomy' => 'filter_group',
+				'archive_term_id'  => $group_id,
+			)
+		);
+
+		$this->assertSame( 1, $this->term_count( $result, 'filter_kind', $kind_id ) );
+	}
+
+	public function test_opaque_scope_token_reaches_authoritative_query_filter(): void {
+		$term_id  = $this->create_term( 'filter_kind' );
+		$tomorrow = ( new DateTimeImmutable( current_time( 'mysql' ) ) )->modify( '+1 day' );
+		$allowed  = $this->seed_event( 'Allowed scoped event', $tomorrow->format( 'Y-m-d 20:00:00' ), array( 'filter_kind' => $term_id ) );
+		$this->seed_event( 'Excluded scoped event', $tomorrow->format( 'Y-m-d 21:00:00' ), array( 'filter_kind' => $term_id ) );
+
+		$filter = static function ( array $query_args, array $input ) use ( $allowed ): array {
+			if ( 'signed-scope' === ( $input['scope_token'] ?? '' ) ) {
+				$query_args['post__in'] = array( $allowed );
+			}
+			return $query_args;
+		};
+		add_filter( 'data_machine_events_calendar_query_args', $filter, 10, 2 );
+		$result = $this->abilities->executeGetFilterOptions( array( 'scope_token' => 'signed-scope' ) );
+		remove_filter( 'data_machine_events_calendar_query_args', $filter, 10 );
+
+		$this->assertSame( 1, $this->term_count( $result, 'filter_kind', $term_id ) );
+	}
+}


### PR DESCRIPTION
## Summary
- resolve dynamic filter option counts through the same event query primitive as calendar results, including search, named scope, date, taxonomy, archive, geo, and opaque consumer scope constraints
- pass signed scope tokens through without interpreting them and keep token-isolated cache keys hashed
- abort superseded modal requests, generation-guard responses and loading state, and retain prior options with a retry action after failures
- add WordPress ability coverage and executable jsdom coverage for parity, rapid changes, out-of-order responses, aborts, and failures

## Verification
- `npm test -- --runInBand` (29 tests passed)
- `npm run build`
- `homeboy --placement local review lint data-machine-events --path /var/lib/datamachine/workspace/data-machine-events@fix-464-filter-option-parity --changed-only --summary`
- `homeboy --placement local review audit data-machine-events --path /var/lib/datamachine/workspace/data-machine-events@fix-464-filter-option-parity --profile pr --changed-since origin/main --json-summary`
- PHP syntax checks for all changed PHP files
- `git diff --check`

The database-backed local Homeboy test run was deferred to isolated PR CI because the production host resource policy rejected it at load average 145+ with no connected Lab runner.

Closes #464