### PR TITLE
fix(calendar): align boundaries with search and geo

### DIFF
--- a/inc/Abilities/CalendarAbilities.php
+++ b/inc/Abilities/CalendarAbilities.php
@@ -181,9 +181,9 @@ class CalendarAbilities {
 			$current_page = 1;
 		}
 
-		$scope          = $input['scope'] ?? '';
-		$scope_resolved = $scope ? ScopeResolver::resolve( $scope ) : null;
-		$date_bounds    = self::intersect_date_bounds(
+		$scope            = $input['scope'] ?? '';
+		$scope_resolved   = $scope ? ScopeResolver::resolve( $scope ) : null;
+		$date_bounds      = self::intersect_date_bounds(
 			array(
 				array(
 					'date_start' => $user_date_start,
@@ -193,12 +193,12 @@ class CalendarAbilities {
 				$scope_resolved,
 			)
 		);
-		$user_date_start   = $date_bounds['date_start'];
-		$user_date_end     = $date_bounds['date_end'];
-		$scope_time_start  = $scope_resolved && $user_date_start === ( $scope_resolved['date_start'] ?? '' )
+		$user_date_start  = $date_bounds['date_start'];
+		$user_date_end    = $date_bounds['date_end'];
+		$scope_time_start = $scope_resolved && ( $scope_resolved['date_start'] ?? '' ) === $user_date_start
 			? ( $scope_resolved['time_start'] ?? '' )
 			: '';
-		$scope_time_end   = $scope_resolved && $user_date_end === ( $scope_resolved['date_end'] ?? '' )
+		$scope_time_end   = $scope_resolved && ( $scope_resolved['date_end'] ?? '' ) === $user_date_end
 			? ( $scope_resolved['time_end'] ?? '' )
 			: '';
 
@@ -338,69 +338,8 @@ class CalendarAbilities {
 			}
 		}
 
-		// Build ability input from query_params.
-		$ability_input = array(
-			'scope'       => $query_params['show_past'] ? 'past' : 'upcoming',
-			'tax_filters' => $query_params['tax_filters'],
-			'search'      => $query_params['search_query'],
-			'order'       => $query_params['show_past'] ? 'DESC' : 'ASC',
-			'per_page'    => 500, // Safety cap — prevents loading 17K+ posts when date boundaries are empty.
-		);
-
-		// Date range overrides scope.
-		if ( ! empty( $query_params['date_start'] ) || ! empty( $query_params['date_end'] ) ) {
-			$ability_input['date_start'] = $query_params['date_start'];
-			$ability_input['date_end']   = $query_params['date_end'];
-			$ability_input['time_start'] = $query_params['time_start'] ?? '';
-			$ability_input['time_end']   = $query_params['time_end'] ?? '';
-			// When user provides explicit dates, don't add scope filter.
-			if ( $query_params['user_date_range'] ) {
-				$ability_input['scope'] = 'all';
-			}
-		}
-
-		// Taxonomy archive constraint.
-		if ( ! empty( $query_params['archive_taxonomy'] ) && ! empty( $query_params['archive_term_id'] ) ) {
-			$ability_input['tax_filters'][ $query_params['archive_taxonomy'] ] = array( (int) $query_params['archive_term_id'] );
-		}
-
-		// Apply calendar_base_query filter.
-		$tax_query_override = apply_filters(
-			'data_machine_events_calendar_base_query',
-			null,
-			array(
-				'archive_taxonomy' => $query_params['archive_taxonomy'],
-				'archive_term_id'  => $query_params['archive_term_id'],
-				'source'           => 'ability',
-			)
-		);
-		if ( $tax_query_override ) {
-			foreach ( $tax_query_override as $clause ) {
-				if ( isset( $clause['taxonomy'] ) && isset( $clause['terms'] ) ) {
-					$ability_input['tax_filters'][ $clause['taxonomy'] ] = (array) $clause['terms'];
-				}
-			}
-		}
-
-		// Geo. Skip when the request is already scoped to a single venue archive
-		// — the proximity radius cannot further filter what's already a one-venue
-		// result, and the haversine sweep over every venue's coordinates is
-		// expensive (especially under bot crawl pressure). This short-circuit
-		// intentionally only applies to `venue` archives because a venue is the
-		// only single-point archive; artist/festival/location archives can span
-		// multiple coordinates so geo+radius remain meaningful for them.
-		$skip_geo = ! empty( $query_params['archive_taxonomy'] )
-			&& 'venue' === $query_params['archive_taxonomy']
-			&& ! empty( $query_params['archive_term_id'] );
-
-		if ( ! $skip_geo && ! empty( $query_params['geo_lat'] ) && ! empty( $query_params['geo_lng'] ) ) {
-			$ability_input['geo'] = array(
-				'lat'    => (float) $query_params['geo_lat'],
-				'lng'    => (float) $query_params['geo_lng'],
-				'radius' => (float) ( $query_params['geo_radius'] ?? 25 ),
-				'unit'   => $query_params['geo_radius_unit'] ?? 'mi',
-			);
-		}
+		$ability_input             = self::build_event_query_input( $query_params );
+		$ability_input['per_page'] = 500; // Safety cap — prevents loading 17K+ posts when date boundaries are empty.
 
 		$event_date_query = new \DataMachineEvents\Abilities\EventDateQueryAbilities();
 		$query_result     = $event_date_query->executeQueryEvents( $ability_input );
@@ -726,6 +665,42 @@ class CalendarAbilities {
 		// LateNightCutoff::display_date_from_strings() at the PHP layer.
 		$start_bucket_sql = LateNightCutoff::sql_display_date_expression( 'ed.start_datetime' );
 
+		// Search and geo are already implemented canonically by the event query
+		// ability (including WordPress search semantics, geo validation, venue
+		// fallback, taxonomy composition, and consumer query-args filters). Reuse
+		// that path to select IDs, then aggregate only their indexed date rows.
+		// The broad unfiltered calendar remains on the single-table fast path.
+		if ( self::requires_canonical_boundary_query( $params ) ) {
+			$ability_input             = self::build_event_query_input( $params );
+			$ability_input['fields']   = 'ids';
+			$ability_input['per_page'] = -1;
+
+			$event_query = new EventDateQueryAbilities();
+			$event_ids   = array_map(
+				static function ( $event ): int {
+					return absint( is_object( $event ) ? $event->ID : $event );
+				},
+				$event_query->executeQueryEvents( $ability_input )['posts']
+			);
+			$event_ids   = array_values( array_unique( array_filter( $event_ids ) ) );
+
+			if ( empty( $event_ids ) ) {
+				return self::expand_date_buckets( array(), $show_past_param, $current_date );
+			}
+
+			$placeholders = implode( ', ', array_fill( 0, count( $event_ids ), '%d' ) );
+			$sql          = "SELECT {$start_bucket_sql} AS start_date, DATE(ed.end_datetime) AS end_date, COUNT(*) AS bucket_count
+					FROM {$ed_table} ed
+					WHERE ed.post_id IN ({$placeholders})
+					GROUP BY {$start_bucket_sql}, DATE(ed.end_datetime)
+					ORDER BY start_date ASC";
+
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared
+			$rows = $wpdb->get_results( $wpdb->prepare( $sql, ...$event_ids ) );
+
+			return self::expand_date_buckets( $rows, $show_past_param, $current_date );
+		}
+
 		// Fast path: no taxonomy constraint → skip posts/term joins entirely.
 		// event_dates already carries post_status, so we can aggregate against
 		// the single table + its status_start composite index.
@@ -823,6 +798,88 @@ class CalendarAbilities {
 		$rows = $wpdb->get_results( $wpdb->prepare( $sql, ...$query_values ) );
 
 		return self::expand_date_buckets( $rows, $show_past_param, $current_date );
+	}
+
+	/**
+	 * Build the canonical event-query constraints shared by buckets and rows.
+	 *
+	 * @param array $params Calendar query parameters.
+	 * @return array EventDateQueryAbilities input.
+	 */
+	private static function build_event_query_input( array $params ): array {
+		$ability_input = array(
+			'scope'       => ! empty( $params['show_past'] ) ? 'past' : 'upcoming',
+			'tax_filters' => is_array( $params['tax_filters'] ?? null ) ? $params['tax_filters'] : array(),
+			'search'      => $params['search_query'] ?? '',
+			'order'       => ! empty( $params['show_past'] ) ? 'DESC' : 'ASC',
+		);
+
+		if ( ! empty( $params['date_start'] ) || ! empty( $params['date_end'] ) ) {
+			$ability_input['date_start'] = $params['date_start'] ?? '';
+			$ability_input['date_end']   = $params['date_end'] ?? '';
+			$ability_input['time_start'] = $params['time_start'] ?? '';
+			$ability_input['time_end']   = $params['time_end'] ?? '';
+
+			if ( ! empty( $params['user_date_range'] ) ) {
+				$ability_input['scope'] = 'all';
+			}
+		}
+
+		if ( ! empty( $params['archive_taxonomy'] ) && ! empty( $params['archive_term_id'] ) ) {
+			$ability_input['tax_filters'][ $params['archive_taxonomy'] ] = array( (int) $params['archive_term_id'] );
+		}
+
+		$tax_query_override = apply_filters(
+			'data_machine_events_calendar_base_query',
+			null,
+			array(
+				'archive_taxonomy' => $params['archive_taxonomy'] ?? '',
+				'archive_term_id'  => $params['archive_term_id'] ?? 0,
+				'source'           => 'ability',
+			)
+		);
+		if ( $tax_query_override ) {
+			foreach ( $tax_query_override as $clause ) {
+				if ( isset( $clause['taxonomy'] ) && isset( $clause['terms'] ) ) {
+					$ability_input['tax_filters'][ $clause['taxonomy'] ] = (array) $clause['terms'];
+				}
+			}
+		}
+
+		// A venue archive already identifies one point, so proximity cannot
+		// narrow it and should not trigger the haversine venue lookup.
+		$skip_geo = ! empty( $params['archive_taxonomy'] )
+			&& 'venue' === $params['archive_taxonomy']
+			&& ! empty( $params['archive_term_id'] );
+
+		if ( ! $skip_geo && ! empty( $params['geo_lat'] ) && ! empty( $params['geo_lng'] ) ) {
+			$ability_input['geo'] = array(
+				'lat'    => (float) $params['geo_lat'],
+				'lng'    => (float) $params['geo_lng'],
+				'radius' => (float) ( $params['geo_radius'] ?? 25 ),
+				'unit'   => $params['geo_radius_unit'] ?? 'mi',
+			);
+		}
+
+		return $ability_input;
+	}
+
+	/**
+	 * Determine whether boundary buckets need canonical search/geo selection.
+	 *
+	 * @param array $params Calendar query parameters.
+	 * @return bool
+	 */
+	private static function requires_canonical_boundary_query( array $params ): bool {
+		if ( ! empty( $params['search_query'] ) ) {
+			return true;
+		}
+
+		$skip_geo = ! empty( $params['archive_taxonomy'] )
+			&& 'venue' === $params['archive_taxonomy']
+			&& ! empty( $params['archive_term_id'] );
+
+		return ! $skip_geo && ! empty( $params['geo_lat'] ) && ! empty( $params['geo_lng'] );
 	}
 
 	/**

--- a/inc/Abilities/CalendarAbilities.php
+++ b/inc/Abilities/CalendarAbilities.php
@@ -634,38 +634,27 @@ class CalendarAbilities {
 		// LateNightCutoff::display_date_from_strings() at the PHP layer.
 		$start_bucket_sql = LateNightCutoff::sql_display_date_expression( 'ed.start_datetime' );
 
-		// Search and geo are already implemented canonically by the event query
-		// ability (including WordPress search semantics, geo validation, venue
-		// fallback, taxonomy composition, and consumer query-args filters). Reuse
-		// that path to select IDs, then aggregate only their indexed date rows.
-		// The broad unfiltered calendar remains on the single-table fast path.
+		// Search, geo, and consumer scopes are implemented canonically by the
+		// event query ability. Capture its matching-ID SQL and aggregate it as a
+		// derived table so arbitrary WP_Query constraints remain authoritative
+		// without materializing every ID or generating placeholder-heavy IN lists.
 		if ( self::requires_canonical_boundary_query( $params ) ) {
-			$ability_input             = self::build_event_query_input( $params );
-			$ability_input['fields']   = 'ids';
-			$ability_input['per_page'] = -1;
+			$event_query  = new EventDateQueryAbilities();
+			$matching_sql = $event_query->buildMatchingPostIdsSql( self::build_event_query_input( $params ) );
 
-			$event_query = new EventDateQueryAbilities();
-			$event_ids   = array_map(
-				static function ( $event ): int {
-					return absint( is_object( $event ) ? $event->ID : $event );
-				},
-				$event_query->executeQueryEvents( $ability_input )['posts']
-			);
-			$event_ids   = array_values( array_unique( array_filter( $event_ids ) ) );
-
-			if ( empty( $event_ids ) ) {
+			if ( '' === $matching_sql ) {
 				return self::expand_date_buckets( array(), $show_past_param, $current_date );
 			}
 
-			$placeholders = implode( ', ', array_fill( 0, count( $event_ids ), '%d' ) );
-			$sql          = "SELECT {$start_bucket_sql} AS start_date, DATE(ed.end_datetime) AS end_date, COUNT(*) AS bucket_count
-					FROM {$ed_table} ed
-					WHERE ed.post_id IN ({$placeholders})
-					GROUP BY {$start_bucket_sql}, DATE(ed.end_datetime)
+			$boundary_start_bucket_sql = LateNightCutoff::sql_display_date_expression( 'boundary_ed.start_datetime' );
+			$sql                       = "SELECT STRAIGHT_JOIN {$boundary_start_bucket_sql} AS start_date, DATE(boundary_ed.end_datetime) AS end_date, COUNT(DISTINCT matching.ID) AS bucket_count
+					FROM ({$matching_sql}) matching
+					INNER JOIN {$ed_table} boundary_ed ON matching.ID = boundary_ed.post_id
+					GROUP BY {$boundary_start_bucket_sql}, DATE(boundary_ed.end_datetime)
 					ORDER BY start_date ASC";
 
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared
-			$rows = $wpdb->get_results( $wpdb->prepare( $sql, ...$event_ids ) );
+			$rows = $wpdb->get_results( $sql );
 
 			return self::expand_date_buckets( $rows, $show_past_param, $current_date );
 		}
@@ -835,13 +824,13 @@ class CalendarAbilities {
 	}
 
 	/**
-	 * Determine whether boundary buckets need canonical search/geo selection.
+	 * Determine whether boundary buckets need canonical query selection.
 	 *
 	 * @param array $params Calendar query parameters.
 	 * @return bool
 	 */
 	private static function requires_canonical_boundary_query( array $params ): bool {
-		if ( ! empty( $params['search_query'] ) ) {
+		if ( ! empty( $params['search_query'] ) || ! empty( $params['scope_token'] ) ) {
 			return true;
 		}
 
@@ -849,7 +838,9 @@ class CalendarAbilities {
 			&& 'venue' === $params['archive_taxonomy']
 			&& ! empty( $params['archive_term_id'] );
 
-		return ! $skip_geo && ! empty( $params['geo_lat'] ) && ! empty( $params['geo_lng'] );
+		$has_geo = ! $skip_geo && ! empty( $params['geo_lat'] ) && ! empty( $params['geo_lng'] );
+
+		return $has_geo || false !== has_filter( 'data_machine_events_calendar_query_args' );
 	}
 
 	/**

--- a/inc/Abilities/EventDateQueryAbilities.php
+++ b/inc/Abilities/EventDateQueryAbilities.php
@@ -26,6 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class EventDateQueryAbilities {
+	private const CAPTURE_IDS_QUERY_VAR = '_data_machine_events_capture_ids_sql';
 
 	private static bool $registered = false;
 
@@ -184,7 +185,9 @@ class EventDateQueryAbilities {
 		$exclude     = is_array( $input['exclude'] ?? null ) ? array_map( 'absint', $input['exclude'] ) : array();
 		$per_page    = (int) ( $input['per_page'] ?? -1 );
 		$fields      = $input['fields'] ?? 'all';
-		$order       = strtoupper( $input['order'] ?? 'ASC' ) === 'DESC' ? 'DESC' : 'ASC';
+		$order       = ! empty( $input[ self::CAPTURE_IDS_QUERY_VAR ] )
+			? ''
+			: ( strtoupper( $input['order'] ?? 'ASC' ) === 'DESC' ? 'DESC' : 'ASC' );
 		$status      = $input['status'] ?? 'publish';
 		$meta_query  = is_array( $input['meta_query'] ?? null ) ? $input['meta_query'] : array();
 
@@ -221,6 +224,10 @@ class EventDateQueryAbilities {
 
 		if ( 'ids' === $fields ) {
 			$query_args['fields'] = 'ids';
+		}
+
+		if ( ! empty( $input[ self::CAPTURE_IDS_QUERY_VAR ] ) ) {
+			$query_args[ self::CAPTURE_IDS_QUERY_VAR ] = true;
 		}
 
 		if ( 'count' === $fields ) {
@@ -363,6 +370,55 @@ class EventDateQueryAbilities {
 	}
 
 	/**
+	 * Build the canonical matching-post IDs SQL without executing it.
+	 *
+	 * The generated query includes the same WordPress search, taxonomy, geo,
+	 * date, and consumer-supplied query-argument constraints as the row query.
+	 * It is suitable for use as a derived table in aggregate queries, avoiding
+	 * unbounded ID arrays and large placeholder lists in PHP.
+	 *
+	 * @param array $input Query-events ability input.
+	 * @return string SQL selecting one distinct ID column, or an empty string.
+	 */
+	public function buildMatchingPostIdsSql( array $input ): string {
+		global $wpdb;
+
+		$request                              = '';
+		$input['fields']                      = 'ids';
+		$input['per_page']                    = -1;
+		$input[ self::CAPTURE_IDS_QUERY_VAR ] = true;
+
+		$capture  = static function ( $posts, $query ) use ( &$request ) {
+			if ( ! $query->get( self::CAPTURE_IDS_QUERY_VAR ) ) {
+				return $posts;
+			}
+
+			$request = $query->request;
+			return array();
+		};
+		$fields   = static function ( $sql_fields, $query ) use ( $wpdb ) {
+			return $query->get( self::CAPTURE_IDS_QUERY_VAR ) ? "{$wpdb->posts}.ID" : $sql_fields;
+		};
+		$distinct = static function ( $sql_distinct, $query ) {
+			return $query->get( self::CAPTURE_IDS_QUERY_VAR ) ? 'DISTINCT' : $sql_distinct;
+		};
+
+		add_filter( 'posts_pre_query', $capture, PHP_INT_MAX, 2 );
+		add_filter( 'posts_fields', $fields, PHP_INT_MAX, 2 );
+		add_filter( 'posts_distinct', $distinct, PHP_INT_MAX, 2 );
+
+		try {
+			$this->executeQueryEvents( $input );
+		} finally {
+			remove_filter( 'posts_pre_query', $capture, PHP_INT_MAX );
+			remove_filter( 'posts_fields', $fields, PHP_INT_MAX );
+			remove_filter( 'posts_distinct', $distinct, PHP_INT_MAX );
+		}
+
+		return $request;
+	}
+
+	/**
 	 * Build a single posts_clauses callback that handles JOIN, WHERE, and ORDER BY.
 	 *
 	 * This consolidates all date logic into one filter — no stacking, no leaks.
@@ -433,7 +489,7 @@ class EventDateQueryAbilities {
 			// 'all' scope — no date WHERE clause.
 
 			// ORDER BY — always by start_datetime unless date_match (dedup doesn't need ordering).
-			if ( empty( $date_match ) ) {
+			if ( empty( $date_match ) && '' !== $order ) {
 				$clauses['orderby'] = "ed.start_datetime {$order}";
 			}
 

--- a/inc/Abilities/FilterAbilities.php
+++ b/inc/Abilities/FilterAbilities.php
@@ -243,18 +243,6 @@ class FilterAbilities {
 				// guarantee an empty result even when the active filters (e.g. a
 				// location term) have events. See #378.
 				if ( ! empty( $nearby_venue_ids ) ) {
-					$venue_constraint = array(
-						'taxonomy' => 'venue',
-						'field'    => 'term_id',
-						'terms'    => $nearby_venue_ids,
-					);
-
-					if ( is_array( $tax_query_override ) ) {
-						$tax_query_override[] = $venue_constraint;
-					} else {
-						$tax_query_override = array( $venue_constraint );
-					}
-
 					$geo_context = array(
 						'active'      => true,
 						'venue_count' => count( $nearby_venue_ids ),

--- a/inc/Blocks/Calendar/Cache/CalendarCache.php
+++ b/inc/Blocks/Calendar/Cache/CalendarCache.php
@@ -6,9 +6,9 @@
  * Handles cache key generation, TTLs, and get/set operations.
  *
  * Two cache layers:
- * 1. Bucket caches (dates, counts) — keyed without geo params, used by
- *    EventQueryBuilder/Pagination internals. Stored as transients (which
- *    Redis object cache backs anyway on persistent-cache hosts).
+ * 1. Bucket caches (dates, counts) — keyed by every boundary constraint.
+ *    Stored as transients (which Redis object cache backs anyway on
+ *    persistent-cache hosts).
  * 2. Full-response cache (this is the calendar REST envelope itself,
  *    pre-rendered HTML included). Keyed on the COMPLETE CalendarRequest
  *    envelope INCLUDING geo params. Stored in wp_cache (dedicated group
@@ -65,8 +65,7 @@ class CalendarCache {
 	/**
 	 * Generate a cache key from query parameters (bucket caches).
 	 *
-	 * Does NOT include geo params — bucket caches operate on the broader
-	 * date/count slice and geo filtering happens downstream.
+	 * Includes every constraint that can alter the date/count slice.
 	 *
 	 * @param array  $params Query parameters.
 	 * @param string $prefix Key prefix (e.g. 'dates', 'counts').
@@ -74,16 +73,22 @@ class CalendarCache {
 	 */
 	public static function generate_key( array $params, string $prefix ): string {
 		$key_data = array(
-			'show_past'    => $params['show_past'] ?? false,
-			'search_query' => $params['search_query'] ?? '',
-			'date_start'   => $params['date_start'] ?? '',
-			'date_end'     => $params['date_end'] ?? '',
-			'tax_filters'  => $params['tax_filters'] ?? array(),
-			'archive_tax'  => $params['archive_taxonomy'] ?? '',
-			'archive_term' => $params['archive_term_id'] ?? 0,
+			'show_past'       => $params['show_past'] ?? false,
+			'search_query'    => $params['search_query'] ?? '',
+			'date_start'      => $params['date_start'] ?? '',
+			'date_end'        => $params['date_end'] ?? '',
+			'time_start'      => $params['time_start'] ?? '',
+			'time_end'        => $params['time_end'] ?? '',
+			'tax_filters'     => $params['tax_filters'] ?? array(),
+			'archive_tax'     => $params['archive_taxonomy'] ?? '',
+			'archive_term'    => $params['archive_term_id'] ?? 0,
+			'geo_lat'         => $params['geo_lat'] ?? '',
+			'geo_lng'         => $params['geo_lng'] ?? '',
+			'geo_radius'      => $params['geo_radius'] ?? 25,
+			'geo_radius_unit' => $params['geo_radius_unit'] ?? 'mi',
 			// Bucketing depends on the cutoff hour; fold it into the key so
 			// switching the filter at runtime invalidates stale buckets.
-			'cutoff_hour'  => \DataMachineEvents\Blocks\Calendar\Grouping\LateNightCutoff::cutoff_hour(),
+			'cutoff_hour'     => \DataMachineEvents\Blocks\Calendar\Grouping\LateNightCutoff::cutoff_hour(),
 		);
 
 		return self::PREFIX . $prefix . '_' . md5( wp_json_encode( $key_data ) );

--- a/inc/Blocks/Calendar/Cache/CalendarCache.php
+++ b/inc/Blocks/Calendar/Cache/CalendarCache.php
@@ -86,6 +86,9 @@ class CalendarCache {
 			'geo_lng'         => $params['geo_lng'] ?? '',
 			'geo_radius'      => $params['geo_radius'] ?? 25,
 			'geo_radius_unit' => $params['geo_radius_unit'] ?? 'mi',
+			'scope_identity'  => ! empty( $params['scope_token'] )
+				? hash( 'sha256', (string) $params['scope_token'] )
+				: '',
 			// Bucketing depends on the cutoff hour; fold it into the key so
 			// switching the filter at runtime invalidates stale buckets.
 			'cutoff_hour'     => \DataMachineEvents\Blocks\Calendar\Grouping\LateNightCutoff::cutoff_hour(),

--- a/tests/Unit/CalendarAbilitiesTest.php
+++ b/tests/Unit/CalendarAbilitiesTest.php
@@ -336,4 +336,150 @@ class CalendarAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( 4, $result['event_count'] );
 		$this->assertEqualsCanonicalizing( $last_date_ids, $this->result_post_ids( $result ) );
 	}
+
+	public function test_scope_tokens_isolate_warm_boundary_caches_and_rows(): void {
+		$first_date = new DateTimeImmutable( '+30 days' );
+		$second_date = $first_date->modify( '+1 day' );
+		$first_id = $this->seed_event( 'First scoped event', $first_date->format( 'Y-m-d 20:00:00' ), $first_date->format( 'Y-m-d 22:00:00' ) );
+		$second_id = $this->seed_event( 'Second scoped event', $second_date->format( 'Y-m-d 20:00:00' ), $second_date->format( 'Y-m-d 22:00:00' ) );
+
+		$filter = static function ( array $query_args, array $input ) use ( $first_id, $second_id ): array {
+			$allowed = array(
+				'calendar-scope-a' => $first_id,
+				'calendar-scope-b' => $second_id,
+			);
+			if ( isset( $allowed[ $input['scope_token'] ?? '' ] ) ) {
+				$query_args['post__in'] = array( $allowed[ $input['scope_token'] ] );
+			}
+			return $query_args;
+		};
+		add_filter( 'data_machine_events_calendar_query_args', $filter, 10, 2 );
+		try {
+			$first = $this->abilities->executeGetCalendarPage(
+				array( 'scope_token' => 'calendar-scope-a', 'include_html' => false )
+			);
+			$second = $this->abilities->executeGetCalendarPage(
+				array( 'scope_token' => 'calendar-scope-b', 'include_html' => false )
+			);
+			$first_warm = $this->abilities->executeGetCalendarPage(
+				array( 'scope_token' => 'calendar-scope-a', 'include_html' => false )
+			);
+		} finally {
+			remove_filter( 'data_machine_events_calendar_query_args', $filter, 10 );
+		}
+
+		$this->assertSame( 1, $first['total_event_count'] );
+		$this->assertSame( 1, $second['total_event_count'] );
+		$this->assertSame( $first_date->format( 'Y-m-d' ), $first['date_boundaries']['start_date'] );
+		$this->assertSame( $second_date->format( 'Y-m-d' ), $second['date_boundaries']['start_date'] );
+		$this->assertSame( array( $first_id ), $this->result_post_ids( $first ) );
+		$this->assertSame( array( $second_id ), $this->result_post_ids( $second ) );
+		$this->assertSame( $first['total_event_count'], $first_warm['total_event_count'] );
+		$this->assertSame( $first['date_boundaries'], $first_warm['date_boundaries'] );
+		$this->assertSame( $this->result_post_ids( $first ), $this->result_post_ids( $first_warm ) );
+	}
+
+	public function test_scope_token_keeps_pagination_counter_and_deferred_dates_aligned(): void {
+		$start       = new DateTimeImmutable( '+45 days' );
+		$allowed_ids = array();
+		for ( $day = 0; $day < 6; ++$day ) {
+			$date = $start->modify( "+{$day} days" );
+			for ( $event = 0; $event < 10; ++$event ) {
+				$allowed_ids[] = $this->seed_event( "Scoped {$day}-{$event}", $date->format( 'Y-m-d 20:00:00' ), $date->format( 'Y-m-d 22:00:00' ) );
+			}
+		}
+		$unscoped = $start->modify( '-1 day' );
+		$this->seed_event( 'Unscoped earlier event', $unscoped->format( 'Y-m-d 20:00:00' ), $unscoped->format( 'Y-m-d 22:00:00' ) );
+
+		$filter = static function ( array $query_args, array $input ) use ( $allowed_ids ): array {
+			if ( 'pagination-scope' === ( $input['scope_token'] ?? '' ) ) {
+				$query_args['post__in'] = $allowed_ids;
+			}
+			return $query_args;
+		};
+		add_filter( 'data_machine_events_calendar_query_args', $filter, 10, 2 );
+		try {
+			$result = $this->abilities->executeGetCalendarPage(
+				array(
+					'scope_token' => 'pagination-scope',
+					'progressive' => true,
+					'include_html' => true,
+				)
+			);
+		} finally {
+			remove_filter( 'data_machine_events_calendar_query_args', $filter, 10 );
+		}
+
+		$expected_deferred = array();
+		for ( $day = 1; $day < 5; ++$day ) {
+			$expected_deferred[] = $start->modify( "+{$day} days" )->format( 'Y-m-d' );
+		}
+		$this->assertSame( 60, $result['total_event_count'] );
+		$this->assertSame( 2, $result['max_pages'] );
+		$this->assertSame( $start->format( 'Y-m-d' ), $result['date_boundaries']['start_date'] );
+		$this->assertSame( $start->modify( '+4 days' )->format( 'Y-m-d' ), $result['date_boundaries']['end_date'] );
+		$this->assertSame( 10, $result['event_count'] );
+		$this->assertSame( $expected_deferred, $result['deferred_dates'] );
+		$this->assertStringContainsString( '10 of 60 Events', $result['html']['counter'] );
+	}
+
+	public function test_scope_token_preserves_multi_day_boundary_expansion(): void {
+		$start = new DateTimeImmutable( '+60 days' );
+		$end   = $start->modify( '+2 days' );
+		$allowed_id = $this->seed_event( 'Scoped multi-day event', $start->format( 'Y-m-d 20:00:00' ), $end->format( 'Y-m-d 22:00:00' ) );
+		$this->seed_event( 'Unscoped middle event', $start->modify( '+1 day' )->format( 'Y-m-d 20:00:00' ), $start->modify( '+1 day' )->format( 'Y-m-d 22:00:00' ) );
+
+		$filter = static function ( array $query_args, array $input ) use ( $allowed_id ): array {
+			if ( 'multi-day-scope' === ( $input['scope_token'] ?? '' ) ) {
+				$query_args['post__in'] = array( $allowed_id );
+			}
+			return $query_args;
+		};
+		add_filter( 'data_machine_events_calendar_query_args', $filter, 10, 2 );
+		try {
+			$result = $this->abilities->executeGetCalendarPage(
+				array( 'scope_token' => 'multi-day-scope', 'include_html' => false )
+			);
+		} finally {
+			remove_filter( 'data_machine_events_calendar_query_args', $filter, 10 );
+		}
+
+		$this->assertSame( 1, $result['total_event_count'] );
+		$this->assertSame( $start->format( 'Y-m-d' ), $result['date_boundaries']['start_date'] );
+		$this->assertSame( $end->format( 'Y-m-d' ), $result['date_boundaries']['end_date'] );
+		$this->assertSame( array( $allowed_id ), $this->result_post_ids( $result ) );
+	}
+
+	public function test_search_geo_and_consumer_scope_constraints_stay_aligned(): void {
+		$venue  = $this->seed_venue( 'Scoped search venue', '32.7765,-79.9311' );
+		$date   = new DateTimeImmutable( '+70 days' );
+		$target = $this->seed_event( 'Scoped needle target', $date->format( 'Y-m-d 20:00:00' ), $date->format( 'Y-m-d 22:00:00' ), $venue );
+		$this->seed_event( 'Scoped needle excluded', $date->format( 'Y-m-d 21:00:00' ), $date->format( 'Y-m-d 23:00:00' ), $venue );
+
+		$filter = static function ( array $query_args, array $input ) use ( $target ): array {
+			if ( 'search-geo-scope' === ( $input['scope_token'] ?? '' ) ) {
+				$query_args['post__in'] = array( $target );
+			}
+			return $query_args;
+		};
+		add_filter( 'data_machine_events_calendar_query_args', $filter, 10, 2 );
+		try {
+			$result = $this->abilities->executeGetCalendarPage(
+				array(
+					'event_search' => 'Scoped needle',
+					'geo_lat' => '32.7765',
+					'geo_lng' => '-79.9311',
+					'geo_radius' => 10,
+					'scope_token' => 'search-geo-scope',
+					'include_html' => false,
+				)
+			);
+		} finally {
+			remove_filter( 'data_machine_events_calendar_query_args', $filter, 10 );
+		}
+
+		$this->assertSame( 1, $result['total_event_count'] );
+		$this->assertSame( 1, $result['event_count'] );
+		$this->assertSame( array( $target ), $this->result_post_ids( $result ) );
+	}
 }

--- a/tests/Unit/CalendarAbilitiesTest.php
+++ b/tests/Unit/CalendarAbilitiesTest.php
@@ -27,6 +27,12 @@ class CalendarAbilitiesTest extends WP_UnitTestCase {
 		if ( ! taxonomy_exists( 'venue' ) ) {
 			Venue_Taxonomy::register();
 		}
+		if ( ! taxonomy_exists( 'calendar_test_region' ) ) {
+			register_taxonomy( 'calendar_test_region', Event_Post_Type::POST_TYPE );
+		}
+		if ( ! taxonomy_exists( 'calendar_test_style' ) ) {
+			register_taxonomy( 'calendar_test_style', Event_Post_Type::POST_TYPE );
+		}
 		if ( ! EventDatesTable::table_exists() ) {
 			EventDatesTable::create_table();
 		}
@@ -35,7 +41,7 @@ class CalendarAbilitiesTest extends WP_UnitTestCase {
 		delete_transient( 'data-machine_cal_counts' );
 	}
 
-	private function seed_event( string $title, string $start, string $end, int $venue_id = 0 ): int {
+	private function seed_event( string $title, string $start, string $end, int $venue_id = 0, array $terms = array() ): int {
 		$post_id = self::factory()->post->create(
 			array(
 				'post_title'  => $title,
@@ -48,8 +54,29 @@ class CalendarAbilitiesTest extends WP_UnitTestCase {
 		if ( $venue_id ) {
 			wp_set_object_terms( $post_id, array( $venue_id ), 'venue' );
 		}
+		foreach ( $terms as $taxonomy => $term_ids ) {
+			wp_set_object_terms( $post_id, (array) $term_ids, $taxonomy );
+		}
 
 		return $post_id;
+	}
+
+	private function seed_venue( string $name, string $coordinates ): int {
+		$term = wp_insert_term( $name . ' ' . uniqid(), 'venue' );
+		$this->assertNotWPError( $term );
+		$venue_id = (int) $term['term_id'];
+		add_term_meta( $venue_id, '_venue_coordinates', $coordinates, true );
+
+		return $venue_id;
+	}
+
+	private function result_post_ids( array $result ): array {
+		$post_ids = array();
+		foreach ( $result['paged_date_groups'] as $date_group ) {
+			$post_ids = array_merge( $post_ids, array_column( $date_group['events'], 'post_id' ) );
+		}
+
+		return $post_ids;
 	}
 
 	public function test_past_mode_returns_only_completed_events_with_chronological_boundaries(): void {
@@ -154,5 +181,159 @@ class CalendarAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( 0, $empty['event_count'] );
 		$this->assertSame( array(), $empty['paged_date_groups'] );
 		$this->assertGreaterThan( $empty['date_boundaries']['end_date'], $empty['date_boundaries']['start_date'] );
+	}
+
+	public function test_search_constrains_totals_boundaries_and_repeated_date_rows(): void {
+		$date       = new DateTimeImmutable( '+7 days' );
+		$search     = 'needle-' . uniqid();
+		$first_id   = $this->seed_event( "{$search} first", $date->format( 'Y-m-d 18:00:00' ), $date->format( 'Y-m-d 20:00:00' ) );
+		$second_id  = $this->seed_event( "{$search} second", $date->format( 'Y-m-d 21:00:00' ), $date->format( 'Y-m-d 23:00:00' ) );
+		$other_date = $date->modify( '+1 day' );
+		$this->seed_event( 'Unrelated search event', $other_date->format( 'Y-m-d 20:00:00' ), $other_date->format( 'Y-m-d 22:00:00' ) );
+
+		$result = $this->abilities->executeGetCalendarPage(
+			array(
+				'event_search' => $search,
+				'include_html' => false,
+			)
+		);
+
+		$this->assertSame( 2, $result['total_event_count'] );
+		$this->assertSame( 2, $result['event_count'] );
+		$this->assertSame( $date->format( 'Y-m-d' ), $result['date_boundaries']['start_date'] );
+		$this->assertSame( $date->format( 'Y-m-d' ), $result['date_boundaries']['end_date'] );
+		$this->assertEqualsCanonicalizing( array( $first_id, $second_id ), $this->result_post_ids( $result ) );
+	}
+
+	public function test_search_with_no_matches_returns_empty_boundaries(): void {
+		$date = new DateTimeImmutable( '+8 days' );
+		$this->seed_event( 'Existing event', $date->format( 'Y-m-d 20:00:00' ), $date->format( 'Y-m-d 22:00:00' ) );
+
+		$result = $this->abilities->executeGetCalendarPage(
+			array(
+				'event_search' => 'absent-' . uniqid(),
+				'include_html' => false,
+			)
+		);
+
+		$this->assertSame( 0, $result['total_event_count'] );
+		$this->assertSame( 0, $result['event_count'] );
+		$this->assertSame( 0, $result['max_pages'] );
+		$this->assertSame( array( 'start_date' => '', 'end_date' => '' ), $result['date_boundaries'] );
+		$this->assertSame( array(), $result['paged_date_groups'] );
+	}
+
+	public function test_geo_constrains_totals_boundaries_and_rows(): void {
+		$near_venue = $this->seed_venue( 'Nearby venue', '32.7765,-79.9311' );
+		$far_venue  = $this->seed_venue( 'Far venue', '40.7128,-74.0060' );
+		$near_date  = new DateTimeImmutable( '+9 days' );
+		$far_date   = $near_date->modify( '+1 day' );
+		$near_id    = $this->seed_event( 'Nearby event', $near_date->format( 'Y-m-d 20:00:00' ), $near_date->format( 'Y-m-d 22:00:00' ), $near_venue );
+		$this->seed_event( 'Far event', $far_date->format( 'Y-m-d 20:00:00' ), $far_date->format( 'Y-m-d 22:00:00' ), $far_venue );
+
+		$result = $this->abilities->executeGetCalendarPage(
+			array(
+				'geo_lat'         => '32.7765',
+				'geo_lng'         => '-79.9311',
+				'geo_radius'      => 10,
+				'geo_radius_unit' => 'mi',
+				'include_html'    => false,
+			)
+		);
+
+		$this->assertSame( 1, $result['total_event_count'] );
+		$this->assertSame( 1, $result['event_count'] );
+		$this->assertSame( $near_date->format( 'Y-m-d' ), $result['date_boundaries']['start_date'] );
+		$this->assertSame( array( $near_id ), $this->result_post_ids( $result ) );
+	}
+
+	public function test_combined_search_geo_taxonomy_archive_and_date_constraints_stay_aligned(): void {
+		$near_venue  = $this->seed_venue( 'Combined nearby venue', '32.7765,-79.9311' );
+		$far_venue   = $this->seed_venue( 'Combined far venue', '40.7128,-74.0060' );
+		$region      = wp_insert_term( 'Combined region ' . uniqid(), 'calendar_test_region' );
+		$other       = wp_insert_term( 'Other region ' . uniqid(), 'calendar_test_region' );
+		$style       = wp_insert_term( 'Combined style ' . uniqid(), 'calendar_test_style' );
+		$other_style = wp_insert_term( 'Other style ' . uniqid(), 'calendar_test_style' );
+		$this->assertNotWPError( $region );
+		$this->assertNotWPError( $other );
+		$this->assertNotWPError( $style );
+		$this->assertNotWPError( $other_style );
+
+		$date   = new DateTimeImmutable( '+10 days' );
+		$search = 'combined-' . uniqid();
+		$terms  = array(
+			'calendar_test_region' => (int) $region['term_id'],
+			'calendar_test_style'  => (int) $style['term_id'],
+		);
+		$match_id = $this->seed_event( "{$search} match", $date->format( 'Y-m-d 20:00:00' ), $date->format( 'Y-m-d 22:00:00' ), $near_venue, $terms );
+		$this->seed_event( "{$search} far", $date->format( 'Y-m-d 20:00:00' ), $date->format( 'Y-m-d 22:00:00' ), $far_venue, $terms );
+		$this->seed_event( "{$search} wrong archive", $date->format( 'Y-m-d 20:00:00' ), $date->format( 'Y-m-d 22:00:00' ), $near_venue, array_merge( $terms, array( 'calendar_test_region' => (int) $other['term_id'] ) ) );
+		$this->seed_event( "{$search} wrong filter", $date->format( 'Y-m-d 20:00:00' ), $date->format( 'Y-m-d 22:00:00' ), $near_venue, array_merge( $terms, array( 'calendar_test_style' => (int) $other_style['term_id'] ) ) );
+		$this->seed_event( 'Wrong search', $date->format( 'Y-m-d 20:00:00' ), $date->format( 'Y-m-d 22:00:00' ), $near_venue, $terms );
+		$outside = $date->modify( '+1 day' );
+		$this->seed_event( "{$search} outside date", $outside->format( 'Y-m-d 20:00:00' ), $outside->format( 'Y-m-d 22:00:00' ), $near_venue, $terms );
+
+		$result = $this->abilities->executeGetCalendarPage(
+			array(
+				'event_search'     => $search,
+				'geo_lat'          => '32.7765',
+				'geo_lng'          => '-79.9311',
+				'geo_radius'       => 10,
+				'geo_radius_unit'  => 'mi',
+				'archive_taxonomy' => 'calendar_test_region',
+				'archive_term_id'  => (int) $region['term_id'],
+				'tax_filter'       => array( 'calendar_test_style' => array( (int) $style['term_id'] ) ),
+				'date_start'       => $date->format( 'Y-m-d' ),
+				'date_end'         => $date->format( 'Y-m-d' ),
+				'include_html'     => false,
+			)
+		);
+
+		$this->assertSame( 1, $result['total_event_count'] );
+		$this->assertSame( 1, $result['event_count'] );
+		$this->assertSame( array( $match_id ), $this->result_post_ids( $result ) );
+		$this->assertSame( $date->format( 'Y-m-d' ), $result['date_boundaries']['start_date'] );
+		$this->assertSame( $date->format( 'Y-m-d' ), $result['date_boundaries']['end_date'] );
+	}
+
+	public function test_search_pagination_boundaries_do_not_include_unmatched_dates(): void {
+		$global_start = new DateTimeImmutable( '+12 days' );
+		$search_start = $global_start->modify( '+10 days' );
+		$search       = 'paged-' . uniqid();
+
+		for ( $day = 0; $day < 5; ++$day ) {
+			$date = $global_start->modify( "+{$day} days" );
+			for ( $event = 0; $event < 4; ++$event ) {
+				$this->seed_event( "Global {$day}-{$event}", $date->format( 'Y-m-d 20:00:00' ), $date->format( 'Y-m-d 22:00:00' ) );
+			}
+		}
+
+		$last_date_ids = array();
+		for ( $day = 0; $day < 6; ++$day ) {
+			$date = $search_start->modify( "+{$day} days" );
+			for ( $event = 0; $event < 4; ++$event ) {
+				$post_id = $this->seed_event( "{$search} {$day}-{$event}", $date->format( 'Y-m-d 20:00:00' ), $date->format( 'Y-m-d 22:00:00' ) );
+				if ( 5 === $day ) {
+					$last_date_ids[] = $post_id;
+				}
+			}
+		}
+
+		$result = $this->abilities->executeGetCalendarPage(
+			array(
+				'event_search' => $search,
+				'paged'        => 2,
+				'include_html' => false,
+			)
+		);
+
+		$last_date = $search_start->modify( '+5 days' )->format( 'Y-m-d' );
+		$this->assertSame( 24, $result['total_event_count'] );
+		$this->assertSame( 2, $result['max_pages'] );
+		$this->assertSame( 2, $result['current_page'] );
+		$this->assertSame( $last_date, $result['date_boundaries']['start_date'] );
+		$this->assertSame( $last_date, $result['date_boundaries']['end_date'] );
+		$this->assertSame( 4, $result['event_count'] );
+		$this->assertEqualsCanonicalizing( $last_date_ids, $this->result_post_ids( $result ) );
 	}
 }

--- a/tests/Unit/CalendarCacheTest.php
+++ b/tests/Unit/CalendarCacheTest.php
@@ -51,9 +51,7 @@ class CalendarCacheTest extends WP_UnitTestCase {
 
 	/**
 	 * Two requests differing only by `lat`/`lng` MUST produce distinct
-	 * cache keys. The pre-fix bug was that the bucket cache key omitted
-	 * geo params entirely, so distinct radius searches collapsed onto
-	 * one bucket. The full-response key fixes that.
+	 * full-response cache keys.
 	 */
 	public function test_full_response_key_includes_geo_params() {
 		$base_envelope = array(
@@ -97,6 +95,33 @@ class CalendarCacheTest extends WP_UnitTestCase {
 			CalendarCache::generate_full_response_key( $base_envelope ),
 			'identical envelope MUST produce identical cache key'
 		);
+	}
+
+	public function test_bucket_key_includes_geo_and_time_constraints() {
+		$params = array(
+			'show_past'       => false,
+			'search_query'    => 'calendar',
+			'date_start'      => '2026-07-19',
+			'date_end'        => '2026-07-19',
+			'time_start'      => '18:00:00',
+			'time_end'        => '23:59:59',
+			'geo_lat'         => '32.7765',
+			'geo_lng'         => '-79.9311',
+			'geo_radius'      => 25,
+			'geo_radius_unit' => 'mi',
+		);
+
+		$other_lat            = $params;
+		$other_lat['geo_lat'] = '33.7765';
+		$other_radius               = $params;
+		$other_radius['geo_radius'] = 50;
+		$other_time               = $params;
+		$other_time['time_start'] = '20:00:00';
+
+		$key = CalendarCache::generate_key( $params, 'dates' );
+		$this->assertNotSame( $key, CalendarCache::generate_key( $other_lat, 'dates' ) );
+		$this->assertNotSame( $key, CalendarCache::generate_key( $other_radius, 'dates' ) );
+		$this->assertNotSame( $key, CalendarCache::generate_key( $other_time, 'dates' ) );
 	}
 
 	/**

--- a/tests/Unit/CalendarCacheTest.php
+++ b/tests/Unit/CalendarCacheTest.php
@@ -328,4 +328,16 @@ class CalendarCacheTest extends WP_UnitTestCase {
 		);
 		$this->assertStringNotContainsString( $token, $key );
 	}
+
+	public function test_scope_tokens_isolate_boundary_cache_keys_without_leaking_contents() {
+		$first_token = 'signed.private.boundary.scope.a';
+		$second_token = 'signed.private.boundary.scope.b';
+		$first_key = CalendarCache::generate_key( array( 'scope_token' => $first_token ), 'dates' );
+		$second_key = CalendarCache::generate_key( array( 'scope_token' => $second_token ), 'dates' );
+
+		$this->assertNotSame( $first_key, $second_key );
+		$this->assertNotSame( CalendarCache::generate_key( array(), 'dates' ), $first_key );
+		$this->assertStringNotContainsString( $first_token, $first_key );
+		$this->assertStringNotContainsString( $second_token, $second_key );
+	}
 }

--- a/tests/Unit/EventDateQueryAbilitiesTest.php
+++ b/tests/Unit/EventDateQueryAbilitiesTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Event date query ability tests.
+ *
+ * @package DataMachineEvents\Tests\Unit
+ */
+
+namespace DataMachineEvents\Tests\Unit;
+
+use WP_UnitTestCase;
+use DataMachineEvents\Abilities\EventDateQueryAbilities;
+use DataMachineEvents\Core\Event_Post_Type;
+use DataMachineEvents\Core\EventDatesTable;
+
+class EventDateQueryAbilitiesTest extends WP_UnitTestCase {
+
+	public function setUp(): void {
+		parent::setUp();
+		if ( ! post_type_exists( Event_Post_Type::POST_TYPE ) ) {
+			Event_Post_Type::register();
+		}
+		if ( ! EventDatesTable::table_exists() ) {
+			EventDatesTable::create_table();
+		}
+	}
+
+	public function test_matching_ids_sql_preserves_consumer_constraints_without_querying(): void {
+		global $wpdb;
+
+		$filter = static function ( array $query_args, array $input ): array {
+			if ( 'sql-capture-scope' === ( $input['scope_token'] ?? '' ) ) {
+				$query_args['post__in'] = array( 123, 456 );
+			}
+			return $query_args;
+		};
+		add_filter( 'data_machine_events_calendar_query_args', $filter, 10, 2 );
+		$queries_before = $wpdb->num_queries;
+		try {
+			$sql = ( new EventDateQueryAbilities() )->buildMatchingPostIdsSql(
+				array(
+					'scope' => 'upcoming',
+					'scope_token' => 'sql-capture-scope',
+					'search' => 'needle',
+				)
+			);
+		} finally {
+			remove_filter( 'data_machine_events_calendar_query_args', $filter, 10 );
+		}
+
+		$this->assertSame( $queries_before, $wpdb->num_queries );
+		$this->assertStringContainsString( 'SELECT DISTINCT', $sql );
+		$this->assertStringContainsString( '123,456', str_replace( ' ', '', $sql ) );
+		$this->assertStringContainsString( 'needle', $sql );
+		$this->assertStringNotContainsString( ' LIMIT ', strtoupper( $sql ) );
+		$this->assertStringNotContainsString( ' ORDER BY ', strtoupper( $sql ) );
+	}
+
+	public function test_matching_ids_sql_handles_large_consumer_sets_without_materializing_results(): void {
+		global $wpdb;
+
+		$large_set = range( 1, 17000 );
+		$filter    = static function ( array $query_args ) use ( $large_set ): array {
+			$query_args['post__in'] = $large_set;
+			return $query_args;
+		};
+		add_filter( 'data_machine_events_calendar_query_args', $filter );
+		$queries_before = $wpdb->num_queries;
+		try {
+			$sql = ( new EventDateQueryAbilities() )->buildMatchingPostIdsSql( array( 'scope_token' => 'large-set' ) );
+		} finally {
+			remove_filter( 'data_machine_events_calendar_query_args', $filter );
+		}
+
+		$this->assertSame( $queries_before, $wpdb->num_queries );
+		$this->assertStringContainsString( '17000', $sql );
+		$this->assertStringNotContainsString( '%d', $sql );
+		$this->assertStringNotContainsString( ' LIMIT ', strtoupper( $sql ) );
+	}
+}

--- a/tests/Unit/FilterAbilitiesTest.php
+++ b/tests/Unit/FilterAbilitiesTest.php
@@ -13,6 +13,7 @@ use DataMachineEvents\Abilities\FilterAbilities;
 use DataMachineEvents\Blocks\Calendar\Query\ScopeResolver;
 use DataMachineEvents\Core\Event_Post_Type;
 use DataMachineEvents\Core\EventDatesTable;
+use DataMachineEvents\Core\Venue_Taxonomy;
 
 class FilterAbilitiesTest extends WP_UnitTestCase {
 
@@ -23,6 +24,9 @@ class FilterAbilitiesTest extends WP_UnitTestCase {
 
 		if ( ! post_type_exists( Event_Post_Type::POST_TYPE ) ) {
 			Event_Post_Type::register();
+		}
+		if ( ! taxonomy_exists( 'venue' ) ) {
+			Venue_Taxonomy::register();
 		}
 		foreach ( array( 'filter_group', 'filter_kind' ) as $taxonomy ) {
 			if ( ! taxonomy_exists( $taxonomy ) ) {
@@ -143,5 +147,36 @@ class FilterAbilitiesTest extends WP_UnitTestCase {
 		remove_filter( 'data_machine_events_calendar_query_args', $filter, 10 );
 
 		$this->assertSame( 1, $this->term_count( $result, 'filter_kind', $term_id ) );
+	}
+
+	public function test_geo_intersects_active_venue_when_counting_other_taxonomies(): void {
+		$selected_venue = $this->create_term( 'venue' );
+		$nearby_venue   = $this->create_term( 'venue' );
+		$kind_id        = $this->create_term( 'filter_kind' );
+		add_term_meta( $selected_venue, '_venue_coordinates', '32.7765,-79.9311', true );
+		add_term_meta( $nearby_venue, '_venue_coordinates', '32.7800,-79.9300', true );
+
+		$tomorrow = ( new DateTimeImmutable( current_time( 'mysql' ) ) )->modify( '+1 day' );
+		$this->seed_event(
+			'Selected nearby venue',
+			$tomorrow->format( 'Y-m-d 20:00:00' ),
+			array( 'venue' => $selected_venue, 'filter_kind' => $kind_id )
+		);
+		$this->seed_event(
+			'Unselected nearby venue',
+			$tomorrow->format( 'Y-m-d 21:00:00' ),
+			array( 'venue' => $nearby_venue, 'filter_kind' => $kind_id )
+		);
+
+		$result = $this->abilities->executeGetFilterOptions(
+			array(
+				'active_filters' => array( 'venue' => array( $selected_venue ) ),
+				'geo_lat'        => '32.7765',
+				'geo_lng'        => '-79.9311',
+				'geo_radius'     => 10,
+			)
+		);
+
+		$this->assertSame( 1, $this->term_count( $result, 'filter_kind', $kind_id ) );
 	}
 }


### PR DESCRIPTION
## Summary
- build boundary and row queries from the same canonical search, geo, taxonomy, archive, date, and scope constraints
- keep unconstrained calendars on the indexed single-table fast path while aggregating constrained event IDs without duplicate dates
- isolate date-bucket caches by geo and time constraints and add ability-level regression coverage for sparse pagination cases

## Verification
- `homeboy review lint data-machine-events --path /var/lib/datamachine/workspace/data-machine-events@fix-128-search-geo-boundaries --changed-only --summary` (pass, PHPCS clean)
- `homeboy review audit data-machine-events --path /var/lib/datamachine/workspace/data-machine-events@fix-128-search-geo-boundaries --changed-since origin/main --profile pr --json-summary` (pass, 0 findings)
- PHP syntax checks for all four changed PHP files (pass)
- `git diff --check origin/main...HEAD` (pass)
- production-volume `EXPLAIN` over 1,000 constrained IDs uses the `event_dates` primary key with `eq_ref` lookups; temporary/filesort is limited to date grouping
- focused PHPUnit was attempted through Homeboy/WP Codebox, but the host-wide Codebox runtime preflight stalled under extreme load and the run timed out before PHPUnit execution; no test result is claimed
- JavaScript/build not run because no JS or generated assets changed

Closes #128

Closes #475
Closes #476