### PR TITLE
fix(calendar): clamp ongoing event boundaries

### DIFF
--- a/inc/Abilities/CalendarAbilities.php
+++ b/inc/Abilities/CalendarAbilities.php
@@ -882,7 +882,9 @@ class CalendarAbilities {
 			}
 			$total_events += $count;
 
-			$events_per_date[ $row->start_date ] = ( $events_per_date[ $row->start_date ] ?? 0 ) + $count;
+			if ( $show_past_param || $row->start_date >= $current_date ) {
+				$events_per_date[ $row->start_date ] = ( $events_per_date[ $row->start_date ] ?? 0 ) + $count;
+			}
 
 			// Multi-day: each spanned date after the start also gets +$count.
 			if ( $row->end_date && $row->end_date > $row->start_date ) {

--- a/tests/Unit/CalendarAbilitiesTest.php
+++ b/tests/Unit/CalendarAbilitiesTest.php
@@ -127,6 +127,26 @@ class CalendarAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( $past_id, $result['paged_date_groups'][0]['events'][0]['post_id'] );
 	}
 
+	public function test_upcoming_boundaries_exclude_past_dates_from_ongoing_multi_day_events(): void {
+		$today = new DateTimeImmutable( current_time( 'Y-m-d' ) . ' 12:00:00' );
+		$start = $today->modify( '-3 days' );
+		$end   = $today->modify( '+2 days' );
+
+		$event_id = $this->seed_event( 'Ongoing multi-day event', $start->format( 'Y-m-d 20:00:00' ), $end->format( 'Y-m-d 22:00:00' ) );
+
+		$result = $this->abilities->executeGetCalendarPage(
+			array(
+				'include_html' => false,
+			)
+		);
+
+		$this->assertSame( 1, $result['total_event_count'] );
+		$this->assertSame( $today->format( 'Y-m-d' ), $result['date_boundaries']['start_date'] );
+		$this->assertSame( $end->format( 'Y-m-d' ), $result['date_boundaries']['end_date'] );
+		$this->assertSame( $today->format( 'Y-m-d' ), $result['paged_date_groups'][0]['date'] );
+		$this->assertContains( $event_id, $this->result_post_ids( $result ) );
+	}
+
 	public function test_month_intersects_explicit_date_range(): void {
 		$month_start = new DateTimeImmutable( 'first day of +2 months 00:00:00' );
 		$outside     = $month_start->modify( '+4 days' );


### PR DESCRIPTION
## Summary
- exclude historical start dates from upcoming boundary buckets for ongoing multi-day events
- preserve today and future continuation dates, plus unchanged past-calendar behavior
- add regression coverage for an event that began before today and ends after today

## Verification
- `homeboy review ... --changed-since=origin/main`: audit passed with 0 findings
- PHPCS, ESLint, and PHPStan passed with 0 findings
- PHP syntax and `git diff --check` passed
- PHPUnit is blocked before test execution by the existing private `run()` collision tracked in #477

Closes #479