### PR TITLE
style(calendar): align controller assignments

### DIFF
--- a/inc/Api/Controllers/Calendar.php
+++ b/inc/Api/Controllers/Calendar.php
@@ -243,7 +243,7 @@ class Calendar {
 			}
 		}
 
-		$events = array_values( $events_by_id );
+		$events     = array_values( $events_by_id );
 		$empty_html = '';
 		if ( empty( $ordered_dates ) ) {
 			Template_Loader::init();


### PR DESCRIPTION
## Summary
- Resolve `Generic.Formatting.MultipleStatementAlignment.NotSameWarning: Equals sign not aligned with surrounding assignments; expected 5 spaces but found 1 space.` at `inc/Api/Controllers/Calendar.php:246`.
- Add only the four missing spaces before the assignment operator so the local assignments follow project alignment style.

## Verification
- Focused PHPCS: `homeboy review lint data-machine-events --file inc/Api/Controllers/Calendar.php --sniffs Generic.Formatting.MultipleStatementAlignment --placement local` (passed, zero findings)
- Homeboy changed-file lint gate: `homeboy review lint data-machine-events --changed-only --placement local` (passed, zero findings)
- Repository-wide Homeboy lint confirmed PHPCS passes; its unrelated ESLint phase exited without producing a lint finding in this repository, which has no package manifest.

Closes #481