### PR TITLE
fix(tests): avoid PHPUnit run method collision

### DIFF
--- a/tests/Unit/CheckMissingVenueAddressesCommandTest.php
+++ b/tests/Unit/CheckMissingVenueAddressesCommandTest.php
@@ -73,7 +73,7 @@ class CheckMissingVenueAddressesCommandTest extends WP_UnitTestCase {
 		return $term_id;
 	}
 
-	private function run( StubbedMissingVenueAddressesCommand $cmd, array $assoc_args ): void {
+	private function run_command( StubbedMissingVenueAddressesCommand $cmd, array $assoc_args ): void {
 		ob_start();
 		$cmd( array(), $assoc_args );
 		ob_end_clean();
@@ -110,7 +110,7 @@ class CheckMissingVenueAddressesCommandTest extends WP_UnitTestCase {
 		// Note: we intentionally route through --dry-run; the stub will
 		// be called but no meta writes must result.
 
-		$this->run( $cmd, array( 'dry-run' => true ) );
+		$this->run_command( $cmd, array( 'dry-run' => true ) );
 
 		$this->assertSame( '', get_term_meta( $with_coords_a, '_venue_address', true ) );
 		$this->assertSame( '', get_term_meta( $with_coords_b, '_venue_address', true ) );
@@ -133,7 +133,7 @@ class CheckMissingVenueAddressesCommandTest extends WP_UnitTestCase {
 			'country' => 'United States',
 		);
 
-		$this->run( $cmd, array( 'apply' => true ) );
+		$this->run_command( $cmd, array( 'apply' => true ) );
 
 		$this->assertSame( '801 Red River St', get_term_meta( $term_id, '_venue_address', true ) );
 		$this->assertSame( 'Austin', get_term_meta( $term_id, '_venue_city', true ) );
@@ -164,7 +164,7 @@ class CheckMissingVenueAddressesCommandTest extends WP_UnitTestCase {
 			'display_name_short' => 'Stubbs Bar-B-Q',
 		);
 
-		$this->run( $cmd, array( 'apply' => true ) );
+		$this->run_command( $cmd, array( 'apply' => true ) );
 
 		$this->assertSame( '801 Red River St', get_term_meta( $term_id, '_venue_address', true ) );
 		$this->assertSame( 'Austin', get_term_meta( $term_id, '_venue_city', true ) );
@@ -198,7 +198,7 @@ class CheckMissingVenueAddressesCommandTest extends WP_UnitTestCase {
 			'country' => 'United States',
 		);
 
-		$this->run( $cmd, array( 'apply' => true ) );
+		$this->run_command( $cmd, array( 'apply' => true ) );
 
 		// Address WAS filled (was empty).
 		$this->assertSame( '801 Red River St', get_term_meta( $term_id, '_venue_address', true ) );
@@ -213,7 +213,7 @@ class CheckMissingVenueAddressesCommandTest extends WP_UnitTestCase {
 		$term_id = $this->make_venue( 'Phantom Venue' );
 
 		$cmd = new StubbedMissingVenueAddressesCommand();
-		$this->run( $cmd, array( 'apply' => true ) );
+		$this->run_command( $cmd, array( 'apply' => true ) );
 
 		// No writes.
 		$this->assertSame( '', get_term_meta( $term_id, '_venue_address', true ) );
@@ -244,7 +244,7 @@ class CheckMissingVenueAddressesCommandTest extends WP_UnitTestCase {
 			'display_name_short' => 'Texas Music Theater',
 		);
 
-		$this->run( $cmd, array( 'apply' => true ) );
+		$this->run_command( $cmd, array( 'apply' => true ) );
 
 		// Lookup was attempted but rejected — no writes.
 		$this->assertSame( '', get_term_meta( $term_id, '_venue_address', true ) );

--- a/tests/Unit/CheckOrphanPipelinesCommandTest.php
+++ b/tests/Unit/CheckOrphanPipelinesCommandTest.php
@@ -140,7 +140,7 @@ class CheckOrphanPipelinesCommandTest extends WP_UnitTestCase {
 		);
 	}
 
-	private function run( array $assoc_args ): void {
+	private function run_command( array $assoc_args ): void {
 		$cmd = new CheckOrphanPipelinesCommand();
 		ob_start();
 		$cmd( array(), $assoc_args );
@@ -153,7 +153,7 @@ class CheckOrphanPipelinesCommandTest extends WP_UnitTestCase {
 		$this->insert_pipeline( 20, 'Nashville Events', '' );
 		$this->insert_flow( 20, $this->sample_flow_config( 20, 128 ) );
 
-		$this->run( array( 'dry-run' => true ) );
+		$this->run_command( array( 'dry-run' => true ) );
 
 		// Config must remain empty after a dry run.
 		$this->assertSame( '', (string) $this->get_pipeline_config_raw( 20 ) );
@@ -164,7 +164,7 @@ class CheckOrphanPipelinesCommandTest extends WP_UnitTestCase {
 		$this->insert_flow( 20, $this->sample_flow_config( 20, 128 ) );
 
 		// --apply alone must not perform the opt-in rebuild.
-		$this->run( array( 'apply' => true ) );
+		$this->run_command( array( 'apply' => true ) );
 
 		$this->assertSame( '', (string) $this->get_pipeline_config_raw( 20 ) );
 	}
@@ -174,7 +174,7 @@ class CheckOrphanPipelinesCommandTest extends WP_UnitTestCase {
 		$this->insert_flow( 20, $this->sample_flow_config( 20, 128 ) );
 		$this->insert_flow( 20, $this->sample_flow_config( 20, 129 ) );
 
-		$this->run(
+		$this->run_command(
 			array(
 				'apply'          => true,
 				'rebuild-config' => true,
@@ -225,7 +225,7 @@ class CheckOrphanPipelinesCommandTest extends WP_UnitTestCase {
 		$this->insert_pipeline( 18, 'Asheville Events', $valid );
 		$this->insert_flow( 18, $this->sample_flow_config( 18, 50 ) );
 
-		$this->run(
+		$this->run_command(
 			array(
 				'apply'          => true,
 				'rebuild-config' => true,
@@ -240,7 +240,7 @@ class CheckOrphanPipelinesCommandTest extends WP_UnitTestCase {
 		// Empty config but NO flows => not a candidate (nothing erroring).
 		$this->insert_pipeline( 99, 'Abandoned', '' );
 
-		$this->run(
+		$this->run_command(
 			array(
 				'apply'          => true,
 				'rebuild-config' => true,

--- a/tests/Unit/CheckOrphanVenuesCommandTest.php
+++ b/tests/Unit/CheckOrphanVenuesCommandTest.php
@@ -132,7 +132,7 @@ class CheckOrphanVenuesCommandTest extends WP_UnitTestCase {
 		return array( $term_id, $post_id );
 	}
 
-	private function run( CheckOrphanVenuesCommand $cmd, array $assoc_args ): void {
+	private function run_command( CheckOrphanVenuesCommand $cmd, array $assoc_args ): void {
 		ob_start();
 		$cmd( array(), $assoc_args );
 		ob_end_clean();
@@ -150,7 +150,7 @@ class CheckOrphanVenuesCommandTest extends WP_UnitTestCase {
 		$this->make_event_with_venue( 'Real event', $active );
 
 		$cmd = new CheckOrphanVenuesCommand();
-		$this->run( $cmd, array( 'dry-run' => true ) );
+		$this->run_command( $cmd, array( 'dry-run' => true ) );
 
 		// No flag meta written on any candidate.
 		foreach ( array( $a, $b, $c ) as $term_id ) {
@@ -170,7 +170,7 @@ class CheckOrphanVenuesCommandTest extends WP_UnitTestCase {
 		[ $term_id ] = $this->make_stale_cached_orphan( 'Stale Cache Venue' );
 
 		$cmd = new CheckOrphanVenuesCommand();
-		$this->run( $cmd, array( 'apply' => true ) );
+		$this->run_command( $cmd, array( 'apply' => true ) );
 
 		// Term must NOT be flagged as orphan.
 		$this->assertSame(
@@ -227,7 +227,7 @@ class CheckOrphanVenuesCommandTest extends WP_UnitTestCase {
 		$this->assertSame( 0, $cached_before, 'precondition: stale cache should read 0' );
 
 		$cmd = new CheckOrphanVenuesCommand();
-		$this->run( $cmd, array( 'apply' => true ) );
+		$this->run_command( $cmd, array( 'apply' => true ) );
 
 		// Fresh DB read — must reflect the real count (2), not the stale 0.
 		$cached_after = (int) $wpdb->get_var(
@@ -274,7 +274,7 @@ class CheckOrphanVenuesCommandTest extends WP_UnitTestCase {
 		$this->assertSame( 0, (int) $primed->count, 'precondition: primed cache reads 0' );
 
 		$cmd = new CheckOrphanVenuesCommand();
-		$this->run( $cmd, array( 'apply' => true ) );
+		$this->run_command( $cmd, array( 'apply' => true ) );
 
 		// get_term() must now return the fresh value (2) — proves both
 		// the DB write AND the cache invalidation worked together.
@@ -302,7 +302,7 @@ class CheckOrphanVenuesCommandTest extends WP_UnitTestCase {
 		);
 
 		$cmd = new CheckOrphanVenuesCommand();
-		$this->run( $cmd, array( 'apply' => true ) );
+		$this->run_command( $cmd, array( 'apply' => true ) );
 
 		// protected-by-flow meta written, flag-at meta NOT written.
 		$this->assertSame(
@@ -322,7 +322,7 @@ class CheckOrphanVenuesCommandTest extends WP_UnitTestCase {
 		$term_id = $this->make_venue( 'Plain Orphan' );
 
 		$cmd = new CheckOrphanVenuesCommand();
-		$this->run( $cmd, array( 'apply' => true ) );
+		$this->run_command( $cmd, array( 'apply' => true ) );
 
 		// Flag meta written with a current-ish timestamp.
 		$flagged_at = (int) get_term_meta(
@@ -340,7 +340,7 @@ class CheckOrphanVenuesCommandTest extends WP_UnitTestCase {
 		$term_id = $this->make_venue( 'Deletable Orphan' );
 
 		$cmd = new CheckOrphanVenuesCommand();
-		$this->run(
+		$this->run_command(
 			$cmd,
 			array(
 				'apply'          => true,
@@ -365,7 +365,7 @@ class CheckOrphanVenuesCommandTest extends WP_UnitTestCase {
 		);
 
 		$cmd = new CheckOrphanVenuesCommand();
-		$this->run(
+		$this->run_command(
 			$cmd,
 			array(
 				'apply'          => true,


### PR DESCRIPTION
## Summary

- rename the private PHPUnit-colliding `run()` command helpers to `run_command()`
- update every helper call site in the three command test classes discovered by the suite
- keep the change test-only so PHPUnit can load the suite without overriding `TestCase::run()`

## Original Fatal

```text
Access level to DataMachineEvents\Tests\Unit\CheckMissingVenueAddressesCommandTest::run() must be public (as in class PHPUnit\Framework\TestCase)
at tests/Unit/CheckMissingVenueAddressesCommandTest.php:76
```

The suite also contained the same private helper name in the orphan-pipeline and orphan-venue command tests. Since `phpunit.xml` discovers every `*Test.php`, leaving those unchanged would move the same fatal to the next class.

## Verification

```bash
homeboy review test data-machine-events --path /var/lib/datamachine/workspace/data-machine-events@fix-477-phpunit-run-collision --skip-lint -- --filter CheckMissingVenueAddressesCommandTest
```

Result: PHPUnit discovered and executed all 6 focused tests, confirming the visibility fatal is gone. The tests then hit a separate WP Codebox Playground limitation, `Undefined constant \"cli\\STDOUT\"`, tracked upstream as Automattic/wp-codebox#1901. Homeboy run: `6b5b3e42-d9b6-4990-9e0e-ecc3b838da6f`.

```bash
homeboy review test data-machine-events --path /var/lib/datamachine/workspace/data-machine-events@fix-477-phpunit-run-collision --skip-lint -- --list-tests
```

Result: passed. WP Codebox loaded and listed the complete PHPUnit suite without a lifecycle-method fatal. Homeboy run: `2aa427d2-8527-407d-8e30-3b092aad105e`.

Closes #477