### PR TITLE
fix(calendar): align optimized upcoming boundaries

### DIFF
--- a/inc/Abilities/CalendarAbilities.php
+++ b/inc/Abilities/CalendarAbilities.php
@@ -671,8 +671,7 @@ class CalendarAbilities {
 				// scope used by EventDateQueryAbilities.
 				$where_clauses[] = UpcomingFilter::past_where( $current_time );
 			} else {
-				$where_clauses[] = 'ed.start_datetime >= %s';
-				$query_values[]  = $current_date . ' 00:00:00';
+				$where_clauses[] = UpcomingFilter::upcoming_where( $current_time );
 			}
 
 			$where = implode( ' AND ', $where_clauses );
@@ -703,8 +702,7 @@ class CalendarAbilities {
 		if ( $show_past_param ) {
 			$where_clauses[] = UpcomingFilter::past_where( $current_time );
 		} else {
-			$where_clauses[] = 'ed.start_datetime >= %s';
-			$query_values[]  = $current_date . ' 00:00:00';
+			$where_clauses[] = UpcomingFilter::upcoming_where( $current_time );
 		}
 
 		if ( $archive_taxonomy && $archive_term_id ) {

--- a/tests/Unit/CalendarAbilitiesTest.php
+++ b/tests/Unit/CalendarAbilitiesTest.php
@@ -141,10 +141,37 @@ class CalendarAbilitiesTest extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( 1, $result['total_event_count'] );
+		$this->assertSame( 1, $result['event_count'] );
 		$this->assertSame( $today->format( 'Y-m-d' ), $result['date_boundaries']['start_date'] );
 		$this->assertSame( $end->format( 'Y-m-d' ), $result['date_boundaries']['end_date'] );
 		$this->assertSame( $today->format( 'Y-m-d' ), $result['paged_date_groups'][0]['date'] );
-		$this->assertContains( $event_id, $this->result_post_ids( $result ) );
+		$this->assertSame( array( $event_id ), $this->result_post_ids( $result ) );
+	}
+
+	public function test_taxonomy_filtered_upcoming_boundaries_include_ongoing_multi_day_events(): void {
+		$term = wp_insert_term( 'Ongoing calendar venue ' . uniqid(), 'venue' );
+		$this->assertNotWPError( $term );
+		$venue_id = (int) $term['term_id'];
+		$today    = new DateTimeImmutable( current_time( 'Y-m-d' ) . ' 12:00:00' );
+		$start    = $today->modify( '-3 days' );
+		$end      = $today->modify( '+2 days' );
+
+		$event_id = $this->seed_event( 'Taxonomy-filtered ongoing event', $start->format( 'Y-m-d 20:00:00' ), $end->format( 'Y-m-d 22:00:00' ), $venue_id );
+
+		$result = $this->abilities->executeGetCalendarPage(
+			array(
+				'archive_taxonomy' => 'venue',
+				'archive_term_id'  => $venue_id,
+				'include_html'     => false,
+			)
+		);
+
+		$this->assertSame( 1, $result['total_event_count'] );
+		$this->assertSame( 1, $result['event_count'] );
+		$this->assertSame( $today->format( 'Y-m-d' ), $result['date_boundaries']['start_date'] );
+		$this->assertSame( $end->format( 'Y-m-d' ), $result['date_boundaries']['end_date'] );
+		$this->assertSame( $today->format( 'Y-m-d' ), $result['paged_date_groups'][0]['date'] );
+		$this->assertSame( array( $event_id ), $this->result_post_ids( $result ) );
 	}
 
 	public function test_month_intersects_explicit_date_range(): void {


### PR DESCRIPTION
## Summary
- delegate both optimized calendar boundary predicates to `UpcomingFilter::upcoming_where()` so ongoing events use the same canonical semantics as returned rows
- preserve the existing no-taxonomy and taxonomy aggregation query shapes rather than consolidating them into a slower generic path
- cover ongoing multi-day boundary, count, and row parity for unfiltered and taxonomy-filtered calendars

## Why
The canonical `EventDateQueryAbilities` path defines upcoming events as `start_datetime >= now OR end_datetime >= now`. The optimized boundary paths had drifted to `start_datetime >= today`, so ongoing events appeared in row queries but disappeared from boundary buckets and totals. Delegating only the duplicated predicate restores the existing source of truth without introducing infrastructure or sacrificing the optimized query shapes.

A same-day already-started event does not need separate regression coverage for this defect because the previous midnight predicate already selected it; ongoing events that began before today exercise the missing `end_datetime` branch.

## Testing
- `homeboy review lint --placement local --summary --path /var/lib/datamachine/workspace/data-machine-events@fix-482-upcoming-boundary-parity --file inc/Abilities/CalendarAbilities.php data-machine-events`
- `homeboy review lint --placement local --summary --path /var/lib/datamachine/workspace/data-machine-events@fix-482-upcoming-boundary-parity --file tests/Unit/CalendarAbilitiesTest.php data-machine-events`
- `php -l inc/Abilities/CalendarAbilities.php`
- `php -l tests/Unit/CalendarAbilitiesTest.php`
- Focused WP Codebox PHPUnit was attempted. Main first hits the #477 discovery blocker because three test helpers declare private `run()` methods that conflict with `PHPUnit\\Framework\\TestCase::run()`. After locally renaming those helpers only for verification, Codebox ran the suite but 14 calendar tests failed because its SQLite runtime did not create `wptests_datamachine_event_dates`. Those temporary helper renames are not included in this PR.

Closes #482