### PR TITLE
fix: preserve event index integrity across mutations

### DIFF
--- a/inc/Blocks/Calendar/Cache/CacheInvalidator.php
+++ b/inc/Blocks/Calendar/Cache/CacheInvalidator.php
@@ -21,7 +21,7 @@ class CacheInvalidator {
 
 	private static bool $initialized = false;
 
-	/** @var array<string,array<int>> Actual removals scoped to the current delete hook sequence. */
+	/** @var array<string,array<array<int>>> LIFO removal frames scoped by object and taxonomy. */
 	private static array $pending_removed_terms = array();
 
 	/** @var array<string,array<int>> Relationships actually inserted by the current set operation. */
@@ -158,18 +158,12 @@ class CacheInvalidator {
 		);
 		$key         = self::relationship_key( (int) $post_id, (string) $taxonomy );
 
-		if ( is_wp_error( $current_ids ) ) {
-			unset( self::$pending_removed_terms[ $key ] );
-			return;
-		}
+		$removed_ids = is_wp_error( $current_ids )
+			? array()
+			: self::normalize_term_ids( array_intersect( self::normalize_term_ids( $current_ids ), self::normalize_term_ids( $tt_ids ) ) );
 
-		$removed_ids = self::normalize_term_ids( array_intersect( self::normalize_term_ids( $current_ids ), self::normalize_term_ids( $tt_ids ) ) );
-		if ( empty( $removed_ids ) ) {
-			unset( self::$pending_removed_terms[ $key ] );
-			return;
-		}
-
-		self::$pending_removed_terms[ $key ] = $removed_ids;
+		self::$pending_removed_terms[ $key ]   = self::$pending_removed_terms[ $key ] ?? array();
+		self::$pending_removed_terms[ $key ][] = $removed_ids;
 	}
 
 	/**
@@ -181,8 +175,14 @@ class CacheInvalidator {
 	 */
 	public static function on_event_terms_removed( $post_id, $tt_ids, $taxonomy ): void {
 		$key         = self::relationship_key( (int) $post_id, (string) $taxonomy );
-		$removed_ids = self::$pending_removed_terms[ $key ] ?? array();
-		unset( self::$pending_removed_terms[ $key ] );
+		$stack       = self::$pending_removed_terms[ $key ] ?? array();
+		$removed_ids = array_pop( $stack ) ?? array();
+
+		if ( empty( $stack ) ) {
+			unset( self::$pending_removed_terms[ $key ] );
+		} else {
+			self::$pending_removed_terms[ $key ] = $stack;
+		}
 
 		if ( Event_Post_Type::POST_TYPE === get_post_type( $post_id ) && ! empty( $removed_ids ) ) {
 			self::invalidate_all();

--- a/inc/Blocks/Calendar/Cache/CacheInvalidator.php
+++ b/inc/Blocks/Calendar/Cache/CacheInvalidator.php
@@ -24,6 +24,9 @@ class CacheInvalidator {
 	/** @var array<string,array<int>> Actual removals awaiting a paired set hook. */
 	private static array $pending_removed_terms = array();
 
+	/** @var array<string,array<int>> Relationships actually inserted by the current set operation. */
+	private static array $added_terms = array();
+
 	/**
 	 * Initialize cache invalidation hooks
 	 */
@@ -38,6 +41,7 @@ class CacheInvalidator {
 		add_action( 'trashed_post', array( __CLASS__, 'on_delete_post' ), 10, 1 );
 		add_action( 'untrashed_post', array( __CLASS__, 'on_delete_post' ), 10, 1 );
 		add_action( 'set_object_terms', array( __CLASS__, 'on_event_terms_set' ), 10, 6 );
+		add_action( 'added_term_relationship', array( __CLASS__, 'on_event_term_added' ), 10, 3 );
 		add_action( 'delete_term_relationships', array( __CLASS__, 'on_event_terms_removing' ), 10, 3 );
 		add_action( 'deleted_term_relationships', array( __CLASS__, 'on_event_terms_removed' ), 10, 3 );
 
@@ -84,25 +88,48 @@ class CacheInvalidator {
 			return;
 		}
 
-		$old_tt_ids = self::normalize_term_ids( $old_tt_ids );
-		$new_tt_ids = self::normalize_term_ids( $tt_ids );
-		$final_ids  = $append ? self::normalize_term_ids( array_merge( $old_tt_ids, $new_tt_ids ) ) : $new_tt_ids;
+		$key = self::relationship_key( (int) $post_id, (string) $taxonomy );
+		if ( $append ) {
+			$added_ids = self::$added_terms[ $key ] ?? array();
+			unset( self::$added_terms[ $key ] );
+			if ( empty( $added_ids ) ) {
+				return;
+			}
 
-		if ( $old_tt_ids === $final_ids ) {
+			self::invalidate_all();
 			return;
 		}
 
-		$key         = self::relationship_key( (int) $post_id, (string) $taxonomy );
-		$removed_ids = self::normalize_term_ids( array_diff( $old_tt_ids, $final_ids ) );
-		if ( isset( self::$pending_removed_terms[ $key ] ) ) {
-			$pending_ids = self::$pending_removed_terms[ $key ];
-			unset( self::$pending_removed_terms[ $key ] );
-			if ( $pending_ids === $removed_ids ) {
-				return;
-			}
+		unset( self::$added_terms[ $key ] );
+		$old_tt_ids = self::normalize_term_ids( $old_tt_ids );
+		$new_tt_ids = self::normalize_term_ids( $tt_ids );
+
+		if ( $old_tt_ids === $new_tt_ids ) {
+			return;
 		}
 
 		self::invalidate_all();
+	}
+
+	/**
+	 * Record relationships WordPress actually inserted during a set operation.
+	 *
+	 * Identical appends do not fire this hook, which makes it the authoritative
+	 * change signal when set_object_terms provides no old IDs in append mode.
+	 *
+	 * @param int    $post_id  Post ID.
+	 * @param int    $tt_id    Inserted term-taxonomy ID.
+	 * @param string $taxonomy Taxonomy slug.
+	 */
+	public static function on_event_term_added( $post_id, $tt_id, $taxonomy ): void {
+		if ( Event_Post_Type::POST_TYPE !== get_post_type( $post_id ) ) {
+			return;
+		}
+
+		$key = self::relationship_key( (int) $post_id, (string) $taxonomy );
+		self::$added_terms[ $key ]   = self::$added_terms[ $key ] ?? array();
+		self::$added_terms[ $key ][] = (int) $tt_id;
+		self::$added_terms[ $key ]   = self::normalize_term_ids( self::$added_terms[ $key ] );
 	}
 
 	/**
@@ -149,10 +176,26 @@ class CacheInvalidator {
 	 * @param string $taxonomy Taxonomy slug.
 	 */
 	public static function on_event_terms_removed( $post_id, $tt_ids, $taxonomy ): void {
-		$key = self::relationship_key( (int) $post_id, (string) $taxonomy );
-		if ( Event_Post_Type::POST_TYPE === get_post_type( $post_id ) && ! empty( self::$pending_removed_terms[ $key ] ) ) {
+		$key         = self::relationship_key( (int) $post_id, (string) $taxonomy );
+		$removed_ids = self::$pending_removed_terms[ $key ] ?? array();
+		unset( self::$pending_removed_terms[ $key ] );
+
+		if ( Event_Post_Type::POST_TYPE === get_post_type( $post_id ) && ! empty( $removed_ids ) && ! self::inside_set_object_terms() ) {
 			self::invalidate_all();
 		}
+	}
+
+	/**
+	 * Whether a removal is the nested replacement phase of wp_set_object_terms().
+	 */
+	private static function inside_set_object_terms(): bool {
+		foreach ( debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS ) as $frame ) {
+			if ( 'wp_set_object_terms' === ( $frame['function'] ?? '' ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/inc/Blocks/Calendar/Cache/CacheInvalidator.php
+++ b/inc/Blocks/Calendar/Cache/CacheInvalidator.php
@@ -21,6 +21,9 @@ class CacheInvalidator {
 
 	private static bool $initialized = false;
 
+	/** @var array<string,array<int>> Actual removals awaiting a paired set hook. */
+	private static array $pending_removed_terms = array();
+
 	/**
 	 * Initialize cache invalidation hooks
 	 */
@@ -34,8 +37,9 @@ class CacheInvalidator {
 		add_action( 'delete_post', array( __CLASS__, 'on_delete_post' ), 10, 1 );
 		add_action( 'trashed_post', array( __CLASS__, 'on_delete_post' ), 10, 1 );
 		add_action( 'untrashed_post', array( __CLASS__, 'on_delete_post' ), 10, 1 );
-		add_action( 'set_object_terms', array( __CLASS__, 'on_event_terms_changed' ), 10, 1 );
-		add_action( 'deleted_term_relationships', array( __CLASS__, 'on_event_terms_changed' ), 10, 1 );
+		add_action( 'set_object_terms', array( __CLASS__, 'on_event_terms_set' ), 10, 6 );
+		add_action( 'delete_term_relationships', array( __CLASS__, 'on_event_terms_removing' ), 10, 3 );
+		add_action( 'deleted_term_relationships', array( __CLASS__, 'on_event_terms_removed' ), 10, 3 );
 
 		add_action( 'edited_venue', array( __CLASS__, 'invalidate_all' ), 10, 0 );
 		add_action( 'created_venue', array( __CLASS__, 'invalidate_all' ), 10, 0 );
@@ -63,14 +67,111 @@ class CacheInvalidator {
 	}
 
 	/**
-	 * Invalidate caches when event taxonomy relationships change without a save.
+	 * Invalidate caches when an event's final taxonomy relationships changed.
 	 *
-	 * @param int $post_id Post ID whose term relationships changed.
+	 * Replacements call wp_remove_object_terms() internally before this hook.
+	 * When that removal already invalidated caches, suppress the duplicate flush.
+	 *
+	 * @param int          $post_id   Post ID whose terms were set.
+	 * @param array|string $terms     Requested terms.
+	 * @param array        $tt_ids    Requested term-taxonomy IDs.
+	 * @param string       $taxonomy  Taxonomy slug.
+	 * @param bool         $append    Whether terms were appended.
+	 * @param array        $old_tt_ids Previous term-taxonomy IDs.
 	 */
-	public static function on_event_terms_changed( int $post_id ): void {
-		if ( Event_Post_Type::POST_TYPE === get_post_type( $post_id ) ) {
+	public static function on_event_terms_set( $post_id, $terms, $tt_ids, $taxonomy, $append, $old_tt_ids ): void {
+		if ( Event_Post_Type::POST_TYPE !== get_post_type( $post_id ) ) {
+			return;
+		}
+
+		$old_tt_ids = self::normalize_term_ids( $old_tt_ids );
+		$new_tt_ids = self::normalize_term_ids( $tt_ids );
+		$final_ids  = $append ? self::normalize_term_ids( array_merge( $old_tt_ids, $new_tt_ids ) ) : $new_tt_ids;
+
+		if ( $old_tt_ids === $final_ids ) {
+			return;
+		}
+
+		$key         = self::relationship_key( (int) $post_id, (string) $taxonomy );
+		$removed_ids = self::normalize_term_ids( array_diff( $old_tt_ids, $final_ids ) );
+		if ( isset( self::$pending_removed_terms[ $key ] ) ) {
+			$pending_ids = self::$pending_removed_terms[ $key ];
+			unset( self::$pending_removed_terms[ $key ] );
+			if ( $pending_ids === $removed_ids ) {
+				return;
+			}
+		}
+
+		self::invalidate_all();
+	}
+
+	/**
+	 * Capture only relationships that exist before WordPress removes them.
+	 *
+	 * @param int    $post_id  Post ID.
+	 * @param array  $tt_ids   Requested term-taxonomy IDs.
+	 * @param string $taxonomy Taxonomy slug.
+	 */
+	public static function on_event_terms_removing( $post_id, $tt_ids, $taxonomy ): void {
+		if ( Event_Post_Type::POST_TYPE !== get_post_type( $post_id ) ) {
+			return;
+		}
+
+		$current_ids = wp_get_object_terms(
+			$post_id,
+			$taxonomy,
+			array(
+				'fields'                 => 'tt_ids',
+				'update_term_meta_cache' => false,
+			)
+		);
+		$key         = self::relationship_key( (int) $post_id, (string) $taxonomy );
+
+		if ( is_wp_error( $current_ids ) ) {
+			unset( self::$pending_removed_terms[ $key ] );
+			return;
+		}
+
+		$removed_ids = self::normalize_term_ids( array_intersect( self::normalize_term_ids( $current_ids ), self::normalize_term_ids( $tt_ids ) ) );
+		if ( empty( $removed_ids ) ) {
+			unset( self::$pending_removed_terms[ $key ] );
+			return;
+		}
+
+		self::$pending_removed_terms[ $key ] = $removed_ids;
+	}
+
+	/**
+	 * Invalidate once after a real standalone or replacement removal.
+	 *
+	 * @param int    $post_id  Post ID.
+	 * @param array  $tt_ids   Removed term-taxonomy IDs.
+	 * @param string $taxonomy Taxonomy slug.
+	 */
+	public static function on_event_terms_removed( $post_id, $tt_ids, $taxonomy ): void {
+		$key = self::relationship_key( (int) $post_id, (string) $taxonomy );
+		if ( Event_Post_Type::POST_TYPE === get_post_type( $post_id ) && ! empty( self::$pending_removed_terms[ $key ] ) ) {
 			self::invalidate_all();
 		}
+	}
+
+	/**
+	 * Build a request-local key for one post/taxonomy relationship operation.
+	 */
+	private static function relationship_key( int $post_id, string $taxonomy ): string {
+		return $post_id . ':' . $taxonomy;
+	}
+
+	/**
+	 * Normalize term-taxonomy IDs for order-independent comparisons.
+	 *
+	 * @param array $term_ids Term-taxonomy IDs.
+	 * @return array<int>
+	 */
+	private static function normalize_term_ids( array $term_ids ): array {
+		$term_ids = array_values( array_unique( array_map( 'intval', $term_ids ) ) );
+		sort( $term_ids, SORT_NUMERIC );
+		return $term_ids;
 	}
 
 	/**

--- a/inc/Blocks/Calendar/Cache/CacheInvalidator.php
+++ b/inc/Blocks/Calendar/Cache/CacheInvalidator.php
@@ -21,7 +21,7 @@ class CacheInvalidator {
 
 	private static bool $initialized = false;
 
-	/** @var array<string,array<int>> Actual removals awaiting a paired set hook. */
+	/** @var array<string,array<int>> Actual removals scoped to the current delete hook sequence. */
 	private static array $pending_removed_terms = array();
 
 	/** @var array<string,array<int>> Relationships actually inserted by the current set operation. */
@@ -107,6 +107,10 @@ class CacheInvalidator {
 		if ( $old_tt_ids === $new_tt_ids ) {
 			return;
 		}
+		if ( array_diff( $old_tt_ids, $new_tt_ids ) ) {
+			// The relationship deletion hook already invalidated this replacement.
+			return;
+		}
 
 		self::invalidate_all();
 	}
@@ -180,22 +184,9 @@ class CacheInvalidator {
 		$removed_ids = self::$pending_removed_terms[ $key ] ?? array();
 		unset( self::$pending_removed_terms[ $key ] );
 
-		if ( Event_Post_Type::POST_TYPE === get_post_type( $post_id ) && ! empty( $removed_ids ) && ! self::inside_set_object_terms() ) {
+		if ( Event_Post_Type::POST_TYPE === get_post_type( $post_id ) && ! empty( $removed_ids ) ) {
 			self::invalidate_all();
 		}
-	}
-
-	/**
-	 * Whether a removal is the nested replacement phase of wp_set_object_terms().
-	 */
-	private static function inside_set_object_terms(): bool {
-		foreach ( debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS ) as $frame ) {
-			if ( 'wp_set_object_terms' === ( $frame['function'] ?? '' ) ) {
-				return true;
-			}
-		}
-
-		return false;
 	}
 
 	/**

--- a/inc/Blocks/Calendar/Cache/CacheInvalidator.php
+++ b/inc/Blocks/Calendar/Cache/CacheInvalidator.php
@@ -34,6 +34,8 @@ class CacheInvalidator {
 		add_action( 'delete_post', array( __CLASS__, 'on_delete_post' ), 10, 1 );
 		add_action( 'trashed_post', array( __CLASS__, 'on_delete_post' ), 10, 1 );
 		add_action( 'untrashed_post', array( __CLASS__, 'on_delete_post' ), 10, 1 );
+		add_action( 'set_object_terms', array( __CLASS__, 'on_event_terms_changed' ), 10, 1 );
+		add_action( 'deleted_term_relationships', array( __CLASS__, 'on_event_terms_changed' ), 10, 1 );
 
 		add_action( 'edited_venue', array( __CLASS__, 'invalidate_all' ), 10, 0 );
 		add_action( 'created_venue', array( __CLASS__, 'invalidate_all' ), 10, 0 );
@@ -56,6 +58,17 @@ class CacheInvalidator {
 	public static function on_delete_post( int $post_id ): void {
 		$post_type = get_post_type( $post_id );
 		if ( Event_Post_Type::POST_TYPE === $post_type ) {
+			self::invalidate_all();
+		}
+	}
+
+	/**
+	 * Invalidate caches when event taxonomy relationships change without a save.
+	 *
+	 * @param int $post_id Post ID whose term relationships changed.
+	 */
+	public static function on_event_terms_changed( int $post_id ): void {
+		if ( Event_Post_Type::POST_TYPE === get_post_type( $post_id ) ) {
 			self::invalidate_all();
 		}
 	}

--- a/inc/Core/DuplicateDetection/EventIdentityWriter.php
+++ b/inc/Core/DuplicateDetection/EventIdentityWriter.php
@@ -26,9 +26,12 @@ class EventIdentityWriter {
 	 */
 	public static function register(): void {
 		add_action( 'datamachine_event_dates_updated', array( static::class, 'onEventDatesUpdated' ), 10, 3 );
+		add_action( 'datamachine_event_dates_deleted', array( static::class, 'onEventDatesDeleted' ) );
 		// Keep ticket URL meta hook for identity sync.
 		add_action( 'updated_post_meta', array( static::class, 'onTicketUrlMetaChange' ), 10, 4 );
 		add_action( 'added_post_meta', array( static::class, 'onTicketUrlMetaChange' ), 10, 4 );
+		add_action( 'set_object_terms', array( static::class, 'onVenueTermsChanged' ), 10, 6 );
+		add_action( 'deleted_term_relationships', array( static::class, 'onVenueTermsRemoved' ), 10, 3 );
 	}
 
 	/**
@@ -45,6 +48,52 @@ class EventIdentityWriter {
 		}
 
 		self::syncIdentityRow( $post_id );
+	}
+
+	/**
+	 * Remove identity state when an event no longer has indexed dates.
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public static function onEventDatesDeleted( int $post_id ): void {
+		if ( Event_Post_Type::POST_TYPE !== get_post_type( $post_id ) ) {
+			return;
+		}
+
+		self::deleteIdentityRow( $post_id );
+	}
+
+	/**
+	 * React to venue assignments and replacements from upsert, editor, or REST.
+	 *
+	 * @param int    $object_id Post ID.
+	 * @param array  $terms     Assigned terms.
+	 * @param array  $tt_ids    Assigned term taxonomy IDs.
+	 * @param string $taxonomy  Taxonomy name.
+	 * @param bool   $append    Whether terms were appended.
+	 * @param array  $old_tt_ids Previous term taxonomy IDs.
+	 */
+	public static function onVenueTermsChanged( $object_id, $terms, $tt_ids, $taxonomy, $append, $old_tt_ids ): void {
+		if ( 'venue' !== $taxonomy || Event_Post_Type::POST_TYPE !== get_post_type( $object_id ) ) {
+			return;
+		}
+
+		self::syncIdentityRow( (int) $object_id );
+	}
+
+	/**
+	 * React to venue removal through wp_remove_object_terms().
+	 *
+	 * @param int    $object_id Post ID.
+	 * @param array  $tt_ids    Removed term taxonomy IDs.
+	 * @param string $taxonomy  Taxonomy name.
+	 */
+	public static function onVenueTermsRemoved( $object_id, $tt_ids, $taxonomy ): void {
+		if ( 'venue' !== $taxonomy || Event_Post_Type::POST_TYPE !== get_post_type( $object_id ) ) {
+			return;
+		}
+
+		self::syncIdentityRow( (int) $object_id );
 	}
 
 	/**
@@ -87,6 +136,7 @@ class EventIdentityWriter {
 		$dates    = \DataMachineEvents\Core\EventDatesTable::get( $post_id );
 		$datetime = $dates ? $dates->start_datetime : '';
 		if ( empty( $datetime ) ) {
+			self::deleteIdentityRow( $post_id );
 			return;
 		}
 
@@ -131,6 +181,17 @@ class EventIdentityWriter {
 				'title_hash'    => $title_hash,
 			)
 		);
+	}
+
+	/**
+	 * Delete an event's identity row when its required date identity is absent.
+	 *
+	 * @param int $post_id Event post ID.
+	 */
+	private static function deleteIdentityRow( int $post_id ): void {
+		if ( class_exists( PostIdentityIndex::class ) ) {
+			( new PostIdentityIndex() )->delete( $post_id );
+		}
 	}
 
 	/**

--- a/inc/Core/DuplicateDetection/EventIdentityWriter.php
+++ b/inc/Core/DuplicateDetection/EventIdentityWriter.php
@@ -30,6 +30,7 @@ class EventIdentityWriter {
 		// Keep ticket URL meta hook for identity sync.
 		add_action( 'updated_post_meta', array( static::class, 'onTicketUrlMetaChange' ), 10, 4 );
 		add_action( 'added_post_meta', array( static::class, 'onTicketUrlMetaChange' ), 10, 4 );
+		add_action( 'deleted_post_meta', array( static::class, 'onTicketUrlMetaChange' ), 10, 4 );
 		add_action( 'set_object_terms', array( static::class, 'onVenueTermsChanged' ), 10, 6 );
 		add_action( 'deleted_term_relationships', array( static::class, 'onVenueTermsRemoved' ), 10, 3 );
 	}

--- a/inc/Core/EventDatesTable.php
+++ b/inc/Core/EventDatesTable.php
@@ -186,6 +186,8 @@ class EventDatesTable {
 			array( 'post_id' => $post_id ),
 			array( '%d' )
 		);
+
+		do_action( 'datamachine_event_dates_deleted', $post_id );
 	}
 
 	/**

--- a/inc/Core/event-dates-sync.php
+++ b/inc/Core/event-dates-sync.php
@@ -192,14 +192,16 @@ function data_machine_events_sync_datetime_meta( $post_id, $post, $update ) {
 	}
 
 	// Parse blocks to extract event details from Event Details block.
-	$blocks = parse_blocks( $post->post_content );
+	$blocks              = parse_blocks( $post->post_content );
+	$event_details_found = false;
 
 	foreach ( $blocks as $block ) {
 		if ( 'data-machine-events/event-details' === $block['blockName'] ) {
-			$start_date = $block['attrs']['startDate'] ?? '';
-			$start_time = $block['attrs']['startTime'] ?? '';
-			$end_date   = $block['attrs']['endDate'] ?? '';
-			$end_time   = $block['attrs']['endTime'] ?? '';
+			$event_details_found = true;
+			$start_date         = $block['attrs']['startDate'] ?? '';
+			$start_time         = $block['attrs']['startTime'] ?? '';
+			$end_date           = $block['attrs']['endDate'] ?? '';
+			$end_time           = $block['attrs']['endTime'] ?? '';
 
 			$start_time_parts = $start_time ? explode( ':', $start_time ) : array();
 			if ( $start_time && count( $start_time_parts ) === 2 ) {
@@ -305,6 +307,11 @@ function data_machine_events_sync_datetime_meta( $post_id, $post, $update ) {
 
 			break;
 		}
+	}
+
+	if ( ! $event_details_found ) {
+		EventDatesTable::delete( $post_id );
+		delete_post_meta( $post_id, EVENT_TICKET_URL_META_KEY );
 	}
 }
 add_action( 'save_post', __NAMESPACE__ . '\\data_machine_events_sync_datetime_meta', 10, 3 );

--- a/inc/Steps/Upsert/Events/EventTaxonomyAssigner.php
+++ b/inc/Steps/Upsert/Events/EventTaxonomyAssigner.php
@@ -53,6 +53,7 @@ class EventTaxonomyAssigner {
 		}
 
 		if ( empty( $venue_name ) ) {
+			wp_set_post_terms( $post_id, array(), 'venue' );
 			return;
 		}
 

--- a/inc/Steps/Upsert/Events/EventUpsert.php
+++ b/inc/Steps/Upsert/Events/EventUpsert.php
@@ -282,19 +282,11 @@ class EventUpsert extends UpsertHandler {
 		$post_id = (int) $result['post_id'];
 		$action  = $result['action'];
 
-		// 7. no_change: nothing else to do.
-		if ( 'no_change' === $action ) {
-			return $this->successResponse(
-				array(
-					'post_id'  => $post_id,
-					'post_url' => get_permalink( $post_id ),
-					'action'   => 'no_change',
-				)
-			);
+		// 7. Content idempotency does not imply taxonomy or identity integrity.
+		// Skip image work for unchanged content, but always reconcile indexed state.
+		if ( 'no_change' !== $action ) {
+			$this->processEventFeaturedImage( $post_id, $handler_config, $engine );
 		}
-
-		// 8. Post-upsert event-specific processing (create and update paths).
-		$this->processEventFeaturedImage( $post_id, $handler_config, $engine );
 		$this->taxonomy_assigner->processVenue( $post_id, $parameters, $engine, $handler_config );
 		$this->taxonomy_assigner->processPromoter( $post_id, $parameters, $engine, $handler_config );
 
@@ -321,10 +313,20 @@ class EventUpsert extends UpsertHandler {
 
 		do_action( 'datamachine_event_taxonomy_processed', $post_id );
 
-		// 9. Sync identity index (title or ticket URL may have changed).
+		// 8. Sync identity index after taxonomy reconciliation.
 		EventIdentityWriter::syncIdentityRow( $post_id, $title, datamachine_normalize_ticket_url( $ticketUrl ) ?: null );
 
-		// 10. Sync engine data for pipeline continuation (create path only).
+		if ( 'no_change' === $action ) {
+			return $this->successResponse(
+				array(
+					'post_id'  => $post_id,
+					'post_url' => get_permalink( $post_id ),
+					'action'   => 'no_change',
+				)
+			);
+		}
+
+		// 9. Sync engine data for pipeline continuation (create path only).
 		$job_id = (int) ( $parameters['job_id'] ?? 0 );
 		if ( 'created' === $action && $job_id ) {
 			datamachine_merge_engine_data(
@@ -336,7 +338,7 @@ class EventUpsert extends UpsertHandler {
 			);
 		}
 
-		// 11. Log and return.
+		// 10. Log and return.
 		$log_level = 'created' === $action ? 'info' : 'info';
 		$log_msg   = 'created' === $action ? 'Created new event' : 'Updated existing event';
 		do_action(

--- a/tests/Unit/CalendarCacheTest.php
+++ b/tests/Unit/CalendarCacheTest.php
@@ -448,6 +448,67 @@ class CalendarCacheTest extends WP_UnitTestCase {
 		$this->assertSame( array(), $this->operation_state( 'added_terms' ) );
 	}
 
+	public function test_same_relationship_key_nested_removals_use_lifo_state(): void {
+		$post_id = self::factory()->post->create( array( 'post_type' => Event_Post_Type::POST_TYPE ) );
+		$first   = wp_insert_term( 'Cache Nested Removal First ' . uniqid(), 'venue' );
+		$second  = wp_insert_term( 'Cache Nested Removal Second ' . uniqid(), 'venue' );
+		$this->assertNotWPError( $first );
+		$this->assertNotWPError( $second );
+		wp_set_object_terms( $post_id, array( $first['term_id'], $second['term_id'] ), 'venue' );
+
+		$nested       = false;
+		$invalidations = 0;
+		$snapshots     = array();
+		$query_filter  = static function ( string $query ) use ( &$invalidations ): string {
+			if ( str_starts_with( ltrim( $query ), 'DELETE FROM' ) && str_contains( $query, '_transient_' . CalendarCache::PREFIX ) ) {
+				++$invalidations;
+			}
+			return $query;
+		};
+		$nested_removal = static function ( $object_id, $tt_ids, $taxonomy ) use ( $post_id, $first, &$nested ): void {
+			if ( ! $nested && $post_id === (int) $object_id && 'venue' === $taxonomy ) {
+				$nested = true;
+				wp_remove_object_terms( $post_id, array( $first['term_id'] ), 'venue' );
+			}
+		};
+		$observe_removal = static function ( $object_id, $tt_ids, $taxonomy ) use ( $post_id, &$invalidations, &$snapshots ): void {
+			if ( $post_id === (int) $object_id && 'venue' === $taxonomy ) {
+				$remaining   = wp_get_object_terms( $post_id, 'venue', array( 'fields' => 'tt_ids' ) );
+				$snapshots[] = array(
+					'invalidations' => $invalidations,
+					'remaining'     => is_wp_error( $remaining ) ? -1 : count( $remaining ),
+				);
+			}
+		};
+
+		add_filter( 'query', $query_filter );
+		add_action( 'delete_term_relationships', $nested_removal, 20, 3 );
+		add_action( 'deleted_term_relationships', $observe_removal, 20, 3 );
+		try {
+			wp_remove_object_terms( $post_id, array( $first['term_id'], $second['term_id'] ), 'venue' );
+		} finally {
+			remove_filter( 'query', $query_filter );
+			remove_action( 'delete_term_relationships', $nested_removal, 20 );
+			remove_action( 'deleted_term_relationships', $observe_removal, 20 );
+		}
+
+		$this->assertSame( 2, $invalidations );
+		$this->assertSame(
+			array(
+				array(
+					'invalidations' => 1,
+					'remaining'     => 1,
+				),
+				array(
+					'invalidations' => 2,
+					'remaining'     => 0,
+				),
+			),
+			$snapshots
+		);
+		$this->assertSame( array(), $this->pending_removed_terms() );
+	}
+
 	public function test_bulk_venue_removal_invalidates_once_and_clears_pending_state(): void {
 		$post_id = self::factory()->post->create( array( 'post_type' => Event_Post_Type::POST_TYPE ) );
 		$first   = wp_insert_term( 'Cache Bulk Removal One ' . uniqid(), 'venue' );

--- a/tests/Unit/CalendarCacheTest.php
+++ b/tests/Unit/CalendarCacheTest.php
@@ -415,6 +415,39 @@ class CalendarCacheTest extends WP_UnitTestCase {
 		$this->assertSame( array(), $this->pending_removed_terms() );
 	}
 
+	public function test_reentrant_removal_for_another_event_invalidates_independently(): void {
+		$first_post  = self::factory()->post->create( array( 'post_type' => Event_Post_Type::POST_TYPE ) );
+		$second_post = self::factory()->post->create( array( 'post_type' => Event_Post_Type::POST_TYPE ) );
+		$first_old   = wp_insert_term( 'Cache Reentrant First Old ' . uniqid(), 'venue' );
+		$first_new   = wp_insert_term( 'Cache Reentrant First New ' . uniqid(), 'venue' );
+		$second_term = wp_insert_term( 'Cache Reentrant Second ' . uniqid(), 'venue' );
+		$this->assertNotWPError( $first_old );
+		$this->assertNotWPError( $first_new );
+		$this->assertNotWPError( $second_term );
+		wp_set_object_terms( $first_post, array( $first_old['term_id'] ), 'venue' );
+		wp_set_object_terms( $second_post, array( $second_term['term_id'] ), 'venue' );
+
+		$reentrant_removal = static function ( $post_id, $terms, $tt_ids, $taxonomy ) use ( $first_post, $second_post, $second_term ): void {
+			if ( $first_post === (int) $post_id && 'venue' === $taxonomy ) {
+				wp_remove_object_terms( $second_post, array( $second_term['term_id'] ), 'venue' );
+			}
+		};
+		add_action( 'set_object_terms', $reentrant_removal, 20, 4 );
+		try {
+			$invalidations = $this->count_calendar_invalidations(
+				static function () use ( $first_post, $first_new ): void {
+					wp_set_object_terms( $first_post, array( $first_new['term_id'] ), 'venue' );
+				}
+			);
+		} finally {
+			remove_action( 'set_object_terms', $reentrant_removal, 20 );
+		}
+
+		$this->assertSame( 2, $invalidations );
+		$this->assertSame( array(), $this->pending_removed_terms() );
+		$this->assertSame( array(), $this->operation_state( 'added_terms' ) );
+	}
+
 	public function test_bulk_venue_removal_invalidates_once_and_clears_pending_state(): void {
 		$post_id = self::factory()->post->create( array( 'post_type' => Event_Post_Type::POST_TYPE ) );
 		$first   = wp_insert_term( 'Cache Bulk Removal One ' . uniqid(), 'venue' );
@@ -483,7 +516,11 @@ class CalendarCacheTest extends WP_UnitTestCase {
 	}
 
 	private function pending_removed_terms(): array {
-		$property = new \ReflectionProperty( CacheInvalidator::class, 'pending_removed_terms' );
+		return $this->operation_state( 'pending_removed_terms' );
+	}
+
+	private function operation_state( string $name ): array {
+		$property = new \ReflectionProperty( CacheInvalidator::class, $name );
 		$property->setAccessible( true );
 		return $property->getValue();
 	}

--- a/tests/Unit/CalendarCacheTest.php
+++ b/tests/Unit/CalendarCacheTest.php
@@ -331,24 +331,58 @@ class CalendarCacheTest extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( $token, $key );
 	}
 
-	public function test_venue_assignment_invalidates_calendar_bucket_cache(): void {
+	public function test_identical_venue_assignment_does_not_invalidate_calendar_cache(): void {
 		$post_id = self::factory()->post->create(
 			array(
 				'post_type'   => Event_Post_Type::POST_TYPE,
 				'post_status' => 'publish',
 			)
 		);
-		$venue   = wp_insert_term( 'Cache Assignment Venue ' . uniqid(), 'venue' );
-		$key     = CalendarCache::PREFIX . 'taxonomy_assignment_' . uniqid();
+		$venue   = wp_insert_term( 'Cache Identical Venue ' . uniqid(), 'venue' );
 		$this->assertNotWPError( $venue );
-		set_transient( $key, 'cached', HOUR_IN_SECONDS );
-
 		wp_set_object_terms( $post_id, array( $venue['term_id'] ), 'venue' );
 
-		$this->assertFalse( get_transient( $key ) );
+		$invalidations = $this->count_calendar_invalidations(
+			static function () use ( $post_id, $venue ): void {
+				wp_set_object_terms( $post_id, array( $venue['term_id'] ), 'venue' );
+			}
+		);
+
+		$this->assertSame( 0, $invalidations );
 	}
 
-	public function test_venue_removal_invalidates_calendar_bucket_cache(): void {
+	public function test_venue_assignment_invalidates_calendar_cache_once(): void {
+		$post_id = self::factory()->post->create( array( 'post_type' => Event_Post_Type::POST_TYPE ) );
+		$venue   = wp_insert_term( 'Cache Assignment Venue ' . uniqid(), 'venue' );
+		$this->assertNotWPError( $venue );
+
+		$invalidations = $this->count_calendar_invalidations(
+			static function () use ( $post_id, $venue ): void {
+				wp_set_object_terms( $post_id, array( $venue['term_id'] ), 'venue' );
+			}
+		);
+
+		$this->assertSame( 1, $invalidations );
+	}
+
+	public function test_venue_replacement_invalidates_calendar_cache_once(): void {
+		$post_id = self::factory()->post->create( array( 'post_type' => Event_Post_Type::POST_TYPE ) );
+		$first   = wp_insert_term( 'Cache First Venue ' . uniqid(), 'venue' );
+		$second  = wp_insert_term( 'Cache Second Venue ' . uniqid(), 'venue' );
+		$this->assertNotWPError( $first );
+		$this->assertNotWPError( $second );
+		wp_set_object_terms( $post_id, array( $first['term_id'] ), 'venue' );
+
+		$invalidations = $this->count_calendar_invalidations(
+			static function () use ( $post_id, $second ): void {
+				wp_set_object_terms( $post_id, array( $second['term_id'] ), 'venue' );
+			}
+		);
+
+		$this->assertSame( 1, $invalidations );
+	}
+
+	public function test_venue_removal_invalidates_calendar_cache_once(): void {
 		$post_id = self::factory()->post->create(
 			array(
 				'post_type'   => Event_Post_Type::POST_TYPE,
@@ -356,14 +390,32 @@ class CalendarCacheTest extends WP_UnitTestCase {
 			)
 		);
 		$venue   = wp_insert_term( 'Cache Removal Venue ' . uniqid(), 'venue' );
-		$key     = CalendarCache::PREFIX . 'taxonomy_removal_' . uniqid();
 		$this->assertNotWPError( $venue );
 		wp_set_object_terms( $post_id, array( $venue['term_id'] ), 'venue' );
-		set_transient( $key, 'cached', HOUR_IN_SECONDS );
 
-		wp_remove_object_terms( $post_id, array( $venue['term_id'] ), 'venue' );
+		$invalidations = $this->count_calendar_invalidations(
+			static function () use ( $post_id, $venue ): void {
+				wp_remove_object_terms( $post_id, array( $venue['term_id'] ), 'venue' );
+			}
+		);
 
-		$this->assertFalse( get_transient( $key ) );
+		$this->assertSame( 1, $invalidations );
+	}
+
+	private function count_calendar_invalidations( callable $operation ): int {
+		$count  = 0;
+		$filter = static function ( string $query ) use ( &$count ): string {
+			if ( str_starts_with( ltrim( $query ), 'DELETE FROM' ) && str_contains( $query, '_transient_' . CalendarCache::PREFIX ) ) {
+				++$count;
+			}
+			return $query;
+		};
+
+		add_filter( 'query', $filter );
+		$operation();
+		remove_filter( 'query', $filter );
+
+		return $count;
 	}
 
 	public function test_scope_tokens_isolate_boundary_cache_keys_without_leaking_contents() {

--- a/tests/Unit/CalendarCacheTest.php
+++ b/tests/Unit/CalendarCacheTest.php
@@ -365,6 +365,38 @@ class CalendarCacheTest extends WP_UnitTestCase {
 		$this->assertSame( 1, $invalidations );
 	}
 
+	public function test_identical_venue_append_does_not_invalidate_calendar_cache(): void {
+		$post_id = self::factory()->post->create( array( 'post_type' => Event_Post_Type::POST_TYPE ) );
+		$venue   = wp_insert_term( 'Cache Identical Append Venue ' . uniqid(), 'venue' );
+		$this->assertNotWPError( $venue );
+		wp_set_object_terms( $post_id, array( $venue['term_id'] ), 'venue' );
+
+		$invalidations = $this->count_calendar_invalidations(
+			static function () use ( $post_id, $venue ): void {
+				wp_add_object_terms( $post_id, array( $venue['term_id'] ), 'venue' );
+			}
+		);
+
+		$this->assertSame( 0, $invalidations );
+	}
+
+	public function test_real_venue_append_invalidates_calendar_cache_once(): void {
+		$post_id = self::factory()->post->create( array( 'post_type' => Event_Post_Type::POST_TYPE ) );
+		$first   = wp_insert_term( 'Cache Existing Append Venue ' . uniqid(), 'venue' );
+		$second  = wp_insert_term( 'Cache Added Append Venue ' . uniqid(), 'venue' );
+		$this->assertNotWPError( $first );
+		$this->assertNotWPError( $second );
+		wp_set_object_terms( $post_id, array( $first['term_id'] ), 'venue' );
+
+		$invalidations = $this->count_calendar_invalidations(
+			static function () use ( $post_id, $second ): void {
+				wp_add_object_terms( $post_id, array( $second['term_id'] ), 'venue' );
+			}
+		);
+
+		$this->assertSame( 1, $invalidations );
+	}
+
 	public function test_venue_replacement_invalidates_calendar_cache_once(): void {
 		$post_id = self::factory()->post->create( array( 'post_type' => Event_Post_Type::POST_TYPE ) );
 		$first   = wp_insert_term( 'Cache First Venue ' . uniqid(), 'venue' );
@@ -380,6 +412,25 @@ class CalendarCacheTest extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( 1, $invalidations );
+		$this->assertSame( array(), $this->pending_removed_terms() );
+	}
+
+	public function test_bulk_venue_removal_invalidates_once_and_clears_pending_state(): void {
+		$post_id = self::factory()->post->create( array( 'post_type' => Event_Post_Type::POST_TYPE ) );
+		$first   = wp_insert_term( 'Cache Bulk Removal One ' . uniqid(), 'venue' );
+		$second  = wp_insert_term( 'Cache Bulk Removal Two ' . uniqid(), 'venue' );
+		$this->assertNotWPError( $first );
+		$this->assertNotWPError( $second );
+		wp_set_object_terms( $post_id, array( $first['term_id'], $second['term_id'] ), 'venue' );
+
+		$invalidations = $this->count_calendar_invalidations(
+			static function () use ( $post_id, $first, $second ): void {
+				wp_remove_object_terms( $post_id, array( $first['term_id'], $second['term_id'] ), 'venue' );
+			}
+		);
+
+		$this->assertSame( 1, $invalidations );
+		$this->assertSame( array(), $this->pending_removed_terms() );
 	}
 
 	public function test_venue_removal_invalidates_calendar_cache_once(): void {
@@ -400,6 +451,19 @@ class CalendarCacheTest extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( 1, $invalidations );
+		$this->assertSame( array(), $this->pending_removed_terms() );
+
+		$next_venue = wp_insert_term( 'Cache Next Operation Venue ' . uniqid(), 'venue' );
+		$this->assertNotWPError( $next_venue );
+		$this->assertSame(
+			1,
+			$this->count_calendar_invalidations(
+				static function () use ( $post_id, $next_venue ): void {
+					wp_set_object_terms( $post_id, array( $next_venue['term_id'] ), 'venue' );
+				}
+			),
+			'A standalone removal must not suppress a later independent operation.'
+		);
 	}
 
 	private function count_calendar_invalidations( callable $operation ): int {
@@ -416,6 +480,12 @@ class CalendarCacheTest extends WP_UnitTestCase {
 		remove_filter( 'query', $filter );
 
 		return $count;
+	}
+
+	private function pending_removed_terms(): array {
+		$property = new \ReflectionProperty( CacheInvalidator::class, 'pending_removed_terms' );
+		$property->setAccessible( true );
+		return $property->getValue();
 	}
 
 	public function test_scope_tokens_isolate_boundary_cache_keys_without_leaking_contents() {

--- a/tests/Unit/CalendarCacheTest.php
+++ b/tests/Unit/CalendarCacheTest.php
@@ -15,6 +15,7 @@ use WP_UnitTestCase;
 use WP_REST_Request;
 use WP_REST_Server;
 use DataMachineEvents\Blocks\Calendar\Cache\CalendarCache;
+use DataMachineEvents\Blocks\Calendar\Cache\CacheInvalidator;
 use DataMachineEvents\Core\Event_Post_Type;
 use DataMachineEvents\Core\Venue_Taxonomy;
 
@@ -35,6 +36,7 @@ class CalendarCacheTest extends WP_UnitTestCase {
 		if ( ! taxonomy_exists( 'venue' ) ) {
 			Venue_Taxonomy::register();
 		}
+		CacheInvalidator::init();
 	}
 
 	public function tearDown(): void {
@@ -327,6 +329,41 @@ class CalendarCacheTest extends WP_UnitTestCase {
 			$key
 		);
 		$this->assertStringNotContainsString( $token, $key );
+	}
+
+	public function test_venue_assignment_invalidates_calendar_bucket_cache(): void {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'   => Event_Post_Type::POST_TYPE,
+				'post_status' => 'publish',
+			)
+		);
+		$venue   = wp_insert_term( 'Cache Assignment Venue ' . uniqid(), 'venue' );
+		$key     = CalendarCache::PREFIX . 'taxonomy_assignment_' . uniqid();
+		$this->assertNotWPError( $venue );
+		set_transient( $key, 'cached', HOUR_IN_SECONDS );
+
+		wp_set_object_terms( $post_id, array( $venue['term_id'] ), 'venue' );
+
+		$this->assertFalse( get_transient( $key ) );
+	}
+
+	public function test_venue_removal_invalidates_calendar_bucket_cache(): void {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'   => Event_Post_Type::POST_TYPE,
+				'post_status' => 'publish',
+			)
+		);
+		$venue   = wp_insert_term( 'Cache Removal Venue ' . uniqid(), 'venue' );
+		$key     = CalendarCache::PREFIX . 'taxonomy_removal_' . uniqid();
+		$this->assertNotWPError( $venue );
+		wp_set_object_terms( $post_id, array( $venue['term_id'] ), 'venue' );
+		set_transient( $key, 'cached', HOUR_IN_SECONDS );
+
+		wp_remove_object_terms( $post_id, array( $venue['term_id'] ), 'venue' );
+
+		$this->assertFalse( get_transient( $key ) );
 	}
 
 	public function test_scope_tokens_isolate_boundary_cache_keys_without_leaking_contents() {

--- a/tests/Unit/EventIdentityWriterTest.php
+++ b/tests/Unit/EventIdentityWriterTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * EventIdentityWriter regression tests.
+ *
+ * @package DataMachineEvents\Tests\Unit
+ */
+
+namespace DataMachineEvents\Tests\Unit;
+
+use DataMachine\Core\Database\PostIdentityIndex\PostIdentityIndex;
+use DataMachineEvents\Core\DuplicateDetection\EventIdentityWriter;
+use DataMachineEvents\Core\EventDatesTable;
+use DataMachineEvents\Core\Event_Post_Type;
+use DataMachineEvents\Core\Venue_Taxonomy;
+use WP_UnitTestCase;
+
+class EventIdentityWriterTest extends WP_UnitTestCase {
+
+	private PostIdentityIndex $index;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		if ( ! post_type_exists( Event_Post_Type::POST_TYPE ) ) {
+			Event_Post_Type::register();
+		}
+		if ( ! taxonomy_exists( 'venue' ) ) {
+			Venue_Taxonomy::register();
+		}
+		if ( ! EventDatesTable::table_exists() ) {
+			EventDatesTable::create_table();
+		}
+
+		$this->index = new PostIdentityIndex();
+		$this->index->create_table();
+
+		if ( false === has_action( 'set_object_terms', array( EventIdentityWriter::class, 'onVenueTermsChanged' ) ) ) {
+			EventIdentityWriter::register();
+		}
+	}
+
+	public function test_venue_reassignment_updates_identity_row(): void {
+		$post_id = $this->make_event();
+		$first   = wp_insert_term( 'First Identity Venue ' . uniqid(), 'venue' );
+		$second  = wp_insert_term( 'Second Identity Venue ' . uniqid(), 'venue' );
+		$this->assertNotWPError( $first );
+		$this->assertNotWPError( $second );
+
+		wp_set_object_terms( $post_id, array( $first['term_id'] ), 'venue' );
+		$this->assertSame( (string) $first['term_id'], (string) $this->index->get( $post_id )['venue_term_id'] );
+
+		wp_set_object_terms( $post_id, array( $second['term_id'] ), 'venue' );
+		$this->assertSame( (string) $second['term_id'], (string) $this->index->get( $post_id )['venue_term_id'] );
+	}
+
+	public function test_venue_removal_clears_identity_venue(): void {
+		$post_id = $this->make_event();
+		$venue   = wp_insert_term( 'Removed Identity Venue ' . uniqid(), 'venue' );
+		$this->assertNotWPError( $venue );
+
+		wp_set_object_terms( $post_id, array( $venue['term_id'] ), 'venue' );
+		wp_set_object_terms( $post_id, array(), 'venue' );
+
+		$row = $this->index->get( $post_id );
+		$this->assertNotNull( $row );
+		$this->assertNull( $row['venue_term_id'], 'Removing the venue relationship must clear the indexed venue.' );
+	}
+
+	public function test_repeated_venue_assignment_keeps_one_current_identity_row(): void {
+		$post_id = $this->make_event();
+		$venue   = wp_insert_term( 'Idempotent Identity Venue ' . uniqid(), 'venue' );
+		$this->assertNotWPError( $venue );
+
+		wp_set_object_terms( $post_id, array( $venue['term_id'] ), 'venue' );
+		wp_set_object_terms( $post_id, array( $venue['term_id'] ), 'venue' );
+
+		global $wpdb;
+		$table = $wpdb->prefix . PostIdentityIndex::TABLE_NAME;
+		$count = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$table} WHERE post_id = %d", $post_id ) );
+
+		$this->assertSame( 1, $count );
+		$this->assertSame( (string) $venue['term_id'], (string) $this->index->get( $post_id )['venue_term_id'] );
+	}
+
+	public function test_removing_event_details_block_deletes_identity_row(): void {
+		$post_id = $this->make_event();
+		$this->assertNotNull( $this->index->get( $post_id ) );
+
+		wp_update_post(
+			array(
+				'ID'           => $post_id,
+				'post_content' => '<!-- wp:paragraph --><p>No event details.</p><!-- /wp:paragraph -->',
+			)
+		);
+
+		$this->assertNull( $this->index->get( $post_id ) );
+	}
+
+	private function make_event(): int {
+		return wp_insert_post(
+			array(
+				'post_title'   => 'Identity Event ' . uniqid(),
+				'post_type'    => Event_Post_Type::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:data-machine-events/event-details {"startDate":"2026-09-20","startTime":"20:00"} --><div class="wp-block-data-machine-events-event-details"></div><!-- /wp:data-machine-events/event-details -->',
+			)
+		);
+	}
+}

--- a/tests/Unit/EventIdentityWriterTest.php
+++ b/tests/Unit/EventIdentityWriterTest.php
@@ -12,6 +12,7 @@ use DataMachineEvents\Core\DuplicateDetection\EventIdentityWriter;
 use DataMachineEvents\Core\EventDatesTable;
 use DataMachineEvents\Core\Event_Post_Type;
 use DataMachineEvents\Core\Venue_Taxonomy;
+use const DataMachineEvents\Core\EVENT_TICKET_URL_META_KEY;
 use WP_UnitTestCase;
 
 class EventIdentityWriterTest extends WP_UnitTestCase {
@@ -96,13 +97,30 @@ class EventIdentityWriterTest extends WP_UnitTestCase {
 		$this->assertNull( $this->index->get( $post_id ) );
 	}
 
-	private function make_event(): int {
+	public function test_removing_ticket_url_clears_identity_ticket(): void {
+		$post_id = $this->make_event( 'https://tickets.example.com/event/123' );
+		$this->assertSame( 'https://tickets.example.com/event/123', $this->index->get( $post_id )['ticket_url'] );
+
+		wp_update_post(
+			array(
+				'ID'           => $post_id,
+				'post_content' => '<!-- wp:data-machine-events/event-details {"startDate":"2026-09-20","startTime":"20:00"} --><div class="wp-block-data-machine-events-event-details"></div><!-- /wp:data-machine-events/event-details -->',
+			)
+		);
+
+		$this->assertSame( '', get_post_meta( $post_id, EVENT_TICKET_URL_META_KEY, true ) );
+		$this->assertNull( $this->index->get( $post_id )['ticket_url'], 'Deleting ticket meta must clear the identity ticket URL after date sync runs.' );
+	}
+
+	private function make_event( string $ticket_url = '' ): int {
+		$ticket_attribute = $ticket_url ? ',"ticketUrl":"' . $ticket_url . '"' : '';
+
 		return wp_insert_post(
 			array(
 				'post_title'   => 'Identity Event ' . uniqid(),
 				'post_type'    => Event_Post_Type::POST_TYPE,
 				'post_status'  => 'publish',
-				'post_content' => '<!-- wp:data-machine-events/event-details {"startDate":"2026-09-20","startTime":"20:00"} --><div class="wp-block-data-machine-events-event-details"></div><!-- /wp:data-machine-events/event-details -->',
+				'post_content' => '<!-- wp:data-machine-events/event-details {"startDate":"2026-09-20","startTime":"20:00"' . $ticket_attribute . '} --><div class="wp-block-data-machine-events-event-details"></div><!-- /wp:data-machine-events/event-details -->',
 			)
 		);
 	}

--- a/tests/Unit/EventTaxonomyAssignerTest.php
+++ b/tests/Unit/EventTaxonomyAssignerTest.php
@@ -95,6 +95,55 @@ class EventTaxonomyAssignerTest extends WP_UnitTestCase {
 		wp_delete_post( $post_id, true );
 	}
 
+	public function test_process_venue_repairs_missing_taxonomy_without_changing_content(): void {
+		$post_id = $this->make_event_post();
+		$content = get_post_field( 'post_content', $post_id );
+		$venue   = 'Taxonomy Repair Venue ' . uniqid();
+		$engine  = new \DataMachine\Core\EngineData( array( 'venue' => $venue ), 0 );
+
+		$this->assigner->processVenue( $post_id, array(), $engine );
+
+		$terms = wp_get_object_terms( $post_id, 'venue' );
+		$this->assertNotWPError( $terms );
+		$this->assertCount( 1, $terms, 'An unchanged event must repair its missing venue relationship.' );
+		$this->assertSame( $venue, $terms[0]->name );
+		$this->assertSame( $content, get_post_field( 'post_content', $post_id ) );
+
+		wp_delete_post( $post_id, true );
+		wp_delete_term( $terms[0]->term_id, 'venue' );
+	}
+
+	public function test_process_venue_is_idempotent_when_assignment_is_already_correct(): void {
+		$post_id = $this->make_event_post();
+		$venue   = 'Idempotent Venue ' . uniqid();
+		$engine  = new \DataMachine\Core\EngineData( array( 'venue' => $venue ), 0 );
+
+		$this->assigner->processVenue( $post_id, array(), $engine );
+		$this->assigner->processVenue( $post_id, array(), $engine );
+
+		$terms = wp_get_object_terms( $post_id, 'venue' );
+		$this->assertNotWPError( $terms );
+		$this->assertCount( 1, $terms, 'Repeated reconciliation must not duplicate venue relationships.' );
+		$this->assertSame( $venue, $terms[0]->name );
+
+		wp_delete_post( $post_id, true );
+		wp_delete_term( $terms[0]->term_id, 'venue' );
+	}
+
+	public function test_process_venue_removes_stale_assignment_when_source_venue_is_empty(): void {
+		$post_id = $this->make_event_post();
+		$venue   = wp_insert_term( 'Removed Upsert Venue ' . uniqid(), 'venue' );
+		$this->assertNotWPError( $venue );
+		wp_set_object_terms( $post_id, array( $venue['term_id'] ), 'venue' );
+
+		$this->assigner->processVenue( $post_id, array(), new \DataMachine\Core\EngineData( array(), 0 ) );
+
+		$this->assertSame( array(), wp_get_object_terms( $post_id, 'venue', array( 'fields' => 'ids' ) ) );
+
+		wp_delete_post( $post_id, true );
+		wp_delete_term( $venue['term_id'], 'venue' );
+	}
+
 	public function test_process_promoter_skips_when_selection_is_skip() {
 		$post_id = wp_insert_post(
 			array(

--- a/tests/Unit/EventUpsertTest.php
+++ b/tests/Unit/EventUpsertTest.php
@@ -10,11 +10,15 @@
 
 namespace DataMachineEvents\Tests\Unit;
 
+use DataMachine\Core\Database\PostIdentityIndex\PostIdentityIndex;
+use DataMachine\Core\EngineData;
 use WP_UnitTestCase;
 use DataMachineEvents\Steps\Upsert\Events\EventUpsert;
 use DataMachineEvents\Core\Event_Post_Type;
 use DataMachineEvents\Core\EventDatesTable;
 use DataMachineEvents\Core\Venue_Taxonomy;
+use DataMachineEvents\Blocks\Calendar\Cache\CalendarCache;
+use DataMachineEvents\Blocks\Calendar\Cache\CacheInvalidator;
 use DataMachineEvents\Blocks\Calendar\Query\UpcomingFilter;
 
 class EventUpsertTest extends WP_UnitTestCase {
@@ -34,6 +38,10 @@ class EventUpsertTest extends WP_UnitTestCase {
 		if ( ! EventDatesTable::table_exists() ) {
 			EventDatesTable::create_table();
 		}
+		if ( class_exists( PostIdentityIndex::class ) ) {
+			( new PostIdentityIndex() )->create_table();
+		}
+		CacheInvalidator::init();
 
 		$this->handler = new EventUpsert();
 	}
@@ -174,6 +182,69 @@ class EventUpsertTest extends WP_UnitTestCase {
 		);
 
 		$this->assertNull( EventDatesTable::get( $post_id ), 'Removing the source block must delete the stale date index row.' );
+	}
+
+	public function test_no_change_upsert_repairs_indexes_and_invalidates_cache_without_content_or_image_work(): void {
+		$title      = 'No Change Integrity Repair ' . uniqid();
+		$venue_name = 'No Change Repair Venue ' . uniqid();
+		$engine     = new EngineData(
+			array(
+				'image_file_path' => '/missing/no-change-image.jpg',
+			),
+			0
+		);
+		$parameters = array(
+			'title'       => $title,
+			'venue'       => $venue_name,
+			'startDate'   => '2026-10-15',
+			'startTime'   => '20:00',
+			'description' => 'Integration coverage for unchanged event reconciliation.',
+			'engine'      => $engine,
+			'job_id'      => 0,
+		);
+		$config     = array(
+			'post_status'    => 'publish',
+			'post_author'    => self::factory()->user->create( array( 'role' => 'administrator' ) ),
+			'include_images' => true,
+		);
+		$execute    = new \ReflectionMethod( $this->handler, 'executeUpsert' );
+		$execute->setAccessible( true );
+
+		$created = $execute->invoke( $this->handler, $parameters, $config );
+		$this->assertTrue( $created['success'] ?? false );
+		$this->assertSame( 'created', $created['data']['action'] ?? '' );
+
+		$post_id = (int) $created['data']['post_id'];
+		$venue   = get_term_by( 'name', $venue_name, 'venue' );
+		$this->assertInstanceOf( \WP_Term::class, $venue );
+
+		wp_set_object_terms( $post_id, array(), 'venue' );
+		$identity = ( new PostIdentityIndex() )->get( $post_id );
+		$this->assertNull( $identity['venue_term_id'] );
+
+		$cache_key = CalendarCache::PREFIX . 'no_change_repair_' . uniqid();
+		set_transient( $cache_key, 'stale', HOUR_IN_SECONDS );
+		$content_before     = get_post_field( 'post_content', $post_id );
+		$attachments_before = (int) wp_count_posts( 'attachment' )->inherit;
+		$image_attempts     = 0;
+		$log_listener       = static function ( $level, $message ) use ( &$image_attempts ): void {
+			if ( str_contains( (string) $message, 'Image file not found for attachment' ) ) {
+				++$image_attempts;
+			}
+		};
+		add_action( 'datamachine_log', $log_listener, 10, 2 );
+
+		$repaired = $execute->invoke( $this->handler, $parameters, $config );
+
+		remove_action( 'datamachine_log', $log_listener, 10 );
+		$this->assertTrue( $repaired['success'] ?? false );
+		$this->assertSame( 'no_change', $repaired['data']['action'] ?? '' );
+		$this->assertSame( $content_before, get_post_field( 'post_content', $post_id ) );
+		$this->assertSame( 0, $image_attempts, 'The no_change path must not invoke image attachment work.' );
+		$this->assertSame( $attachments_before, (int) wp_count_posts( 'attachment' )->inherit );
+		$this->assertSame( array( $venue->term_id ), wp_get_object_terms( $post_id, 'venue', array( 'fields' => 'ids' ) ) );
+		$this->assertSame( (string) $venue->term_id, (string) ( new PostIdentityIndex() )->get( $post_id )['venue_term_id'] );
+		$this->assertFalse( get_transient( $cache_key ), 'Taxonomy-only repair must invalidate calendar caches.' );
 	}
 
 	public function test_save_post_normalizes_implicit_overnight_end_time(): void {

--- a/tests/Unit/EventUpsertTest.php
+++ b/tests/Unit/EventUpsertTest.php
@@ -154,6 +154,28 @@ class EventUpsertTest extends WP_UnitTestCase {
 		wp_delete_post( $post_id, true );
 	}
 
+	public function test_save_post_deletes_indexed_dates_when_event_details_block_is_removed(): void {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Block Removal Sync Test ' . uniqid(),
+				'post_type'    => 'data_machine_events',
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:data-machine-events/event-details {"startDate":"2026-08-15","startTime":"20:00"} --><div class="wp-block-data-machine-events-event-details"></div><!-- /wp:data-machine-events/event-details -->',
+			)
+		);
+
+		$this->assertNotNull( EventDatesTable::get( $post_id ) );
+
+		wp_update_post(
+			array(
+				'ID'           => $post_id,
+				'post_content' => '<!-- wp:paragraph --><p>Event details removed.</p><!-- /wp:paragraph -->',
+			)
+		);
+
+		$this->assertNull( EventDatesTable::get( $post_id ), 'Removing the source block must delete the stale date index row.' );
+	}
+
 	public function test_save_post_normalizes_implicit_overnight_end_time(): void {
 		$post_id = wp_insert_post(
 			array(

--- a/tests/Unit/EventUpsertTest.php
+++ b/tests/Unit/EventUpsertTest.php
@@ -233,10 +233,19 @@ class EventUpsertTest extends WP_UnitTestCase {
 			}
 		};
 		add_action( 'datamachine_log', $log_listener, 10, 2 );
+		$cache_invalidations = 0;
+		$query_listener      = static function ( string $query ) use ( &$cache_invalidations ): string {
+			if ( str_starts_with( ltrim( $query ), 'DELETE FROM' ) && str_contains( $query, '_transient_' . CalendarCache::PREFIX ) ) {
+				++$cache_invalidations;
+			}
+			return $query;
+		};
+		add_filter( 'query', $query_listener );
 
 		$repaired = $execute->invoke( $this->handler, $parameters, $config );
 
 		remove_action( 'datamachine_log', $log_listener, 10 );
+		remove_filter( 'query', $query_listener );
 		$this->assertTrue( $repaired['success'] ?? false );
 		$this->assertSame( 'no_change', $repaired['data']['action'] ?? '' );
 		$this->assertSame( $content_before, get_post_field( 'post_content', $post_id ) );
@@ -244,6 +253,7 @@ class EventUpsertTest extends WP_UnitTestCase {
 		$this->assertSame( $attachments_before, (int) wp_count_posts( 'attachment' )->inherit );
 		$this->assertSame( array( $venue->term_id ), wp_get_object_terms( $post_id, 'venue', array( 'fields' => 'ids' ) ) );
 		$this->assertSame( (string) $venue->term_id, (string) ( new PostIdentityIndex() )->get( $post_id )['venue_term_id'] );
+		$this->assertSame( 1, $cache_invalidations, 'A no_change taxonomy repair must invalidate canonical caches exactly once.' );
 		$this->assertFalse( get_transient( $cache_key ), 'Taxonomy-only repair must invalidate calendar caches.' );
 	}
 


### PR DESCRIPTION
## Summary
- delete indexed event dates and identity state when the authoritative event-details block is removed
- reconcile venue taxonomy and identity state even when post content is unchanged, including venue reassignment and removal from upsert, editor, and REST term mutations
- clear identity ticket data after ticket meta deletion and invalidate canonical calendar/filter caches for real taxonomy relationship changes
- preserve normal idempotency while skipping unrelated content/image work on `no_change`

## Source-of-truth invariants
- the event-details block remains the authoring source of truth for date and ticket state
- `EventDatesTable` contains no row when the source block or its start date is absent
- `PostIdentityIndex` contains no event identity without indexed dates; its venue and ticket fields reflect current taxonomy/meta state
- content-hash `no_change` skips content/image work only; taxonomy, identity, and cache reconciliation still run
- non-append taxonomy invalidation compares normalized old/final term-taxonomy ID sets, so identical assignments do not flush
- append invalidation uses WordPress's actual `added_term_relationship` signal, so identical appends do not flush and real appends flush once
- real relationship removals use a bounded LIFO frame stack per object/taxonomy; each completed deletion pops only its own frame and removes the key at depth zero
- a replacement's final set hook identifies its own removal from old/final sets and does not duplicate that flush
- independent-key and same-key reentrant removals remain correctly ordered without global caller/backtrace inference
- all relationship mutations continue to call the existing `CacheInvalidator::invalidate_all()` mechanism, with no parallel cache state

## Review blocker fixes
- register `deleted_post_meta` so ticket removal cannot leave identity rows rebuilt with the pre-delete URL
- invalidate calendar bucket/full-response caches when event term relationships actually change without a post save
- suppress invalidation for identical assignments/appends and duplicate flushes from WordPress replacement/removal hook sequences
- replace single pending removal values with object/taxonomy-keyed LIFO stacks, including empty frames so nested hook pairs remain balanced
- clear keyed removal state before invalidation at each completed deletion boundary, preventing state leakage across standalone, bulk, replacement, reentrant, exception, and long-running process paths where WordPress supplies completion hooks
- remove production `debug_backtrace()` control flow; coalescing is based only on concrete relationship state
- add integration coverage for a real `EventUpsert` `created` -> corrupted taxonomy/index -> `no_change` repair cycle, including exactly one cache invalidation and skipped image/content work
- merge current `origin/main`, including `d182427` / #484, which resolves the #477 PHPUnit method-collision blocker

## Tests
- `php -l` passed for every modified PHP source and test file
- `git diff --check origin/main...HEAD` passed
- changed-file `homeboy review lint` ran; repository syntax checks passed and no source findings were emitted, while the installed WordPress extension still reports broken PHPCS/PHPStan executables
- the full `homeboy review test` run reached 533 repository tests but the WP Codebox SQLite environment failed all tests on unsupported MySQL SQL and missing custom tables
- focused `CalendarCacheTest` and `EventUpsertTest` runs were attempted but stop before project tests because the WP Codebox vendor autoloader cannot load `Composer\\Autoload\\ClassLoader`; related runtime failures are tracked in Automattic/wp-codebox#1906

## Regression coverage
- event-details block removal deletes date and identity rows
- ticket URL removal clears identity ticket data after save ordering completes
- taxonomy-only correction and unchanged-content repair
- venue reassignment/removal identity synchronization
- identical assignment and identical append each produce zero canonical cache invalidations
- real append, assignment, replacement, standalone removal, and bulk removal each produce exactly one canonical cache invalidation
- standalone/bulk removal and replacement leave no pending removal state; a later independent operation still invalidates normally
- a later-priority `set_object_terms` callback that removes terms from another event produces two total invalidations, one for each logical operation, with no retained keyed state
- a same-event/same-taxonomy nested removal produces one invalidation after the inner deletion and a second after the outer deletion removes the final relationship; the LIFO stack is empty afterward
- integration-level `no_change` taxonomy/identity repair produces exactly one cache invalidation with no content rewrite or image attachment attempt

## Existing stale rows
This change repairs rows on subsequent post saves, upserts, ticket-meta changes, and venue relationship mutations. Rows already stale before deployment will still require an explicit reconciliation/backfill or a resave/relationship mutation to pass through the corrected synchronization paths.

Fixes #486