### PR TITLE
fix(tests): create calendar table before transactions

### DIFF
--- a/tests/Unit/CalendarAbilitiesTest.php
+++ b/tests/Unit/CalendarAbilitiesTest.php
@@ -19,6 +19,11 @@ class CalendarAbilitiesTest extends WP_UnitTestCase {
 	private CalendarAbilities $abilities;
 
 	public function setUp(): void {
+		// Create the table before WP_UnitTestCase rewrites CREATE TABLE as temporary.
+		if ( ! EventDatesTable::table_exists() ) {
+			EventDatesTable::create_table();
+		}
+
 		parent::setUp();
 
 		if ( ! post_type_exists( Event_Post_Type::POST_TYPE ) ) {
@@ -33,10 +38,6 @@ class CalendarAbilitiesTest extends WP_UnitTestCase {
 		if ( ! taxonomy_exists( 'calendar_test_style' ) ) {
 			register_taxonomy( 'calendar_test_style', Event_Post_Type::POST_TYPE );
 		}
-		if ( ! EventDatesTable::table_exists() ) {
-			EventDatesTable::create_table();
-		}
-
 		$this->abilities = new CalendarAbilities();
 		delete_transient( 'data-machine_cal_counts' );
 	}


### PR DESCRIPTION
## Summary
- create the calendar test table before `WP_UnitTestCase::setUp()` installs its temporary-table query rewrite
- keep the fix isolated to `CalendarAbilitiesTest`; production `EventDatesTable` behavior is unchanged
- allow the SQLite runtime to reach the calendar assertions, including both ongoing-boundary regressions from #485

## Root cause

`WP_UnitTestCase::setUp()` starts the test transaction and installs `_create_temporary_tables`, which rewrites subsequent `CREATE TABLE` statements to `CREATE TEMPORARY TABLE`. `EventDatesTable::create_table()` therefore passed rewritten DDL through `dbDelta()` after the parent setup, and the WP Codebox SQLite compatibility layer did not establish `wptests_datamachine_event_dates`.

WordPress core's own custom-table tests create their fixture table before the parent setup for the same reason. Moving this test fixture setup ahead of `parent::setUp()` uses that existing test-runtime pattern rather than adding MySQL/SQLite branches to production schema creation.

## Verification

- `php -l tests/Unit/CalendarAbilitiesTest.php`: pass
- targeted Homeboy project lint: pass, no findings
- focused Homeboy/WP Codebox `CalendarAbilitiesTest`: all 15 tests now create and query `wptests_datamachine_event_dates`; the prior missing-table failure is gone
- the #485 methods `test_upcoming_boundaries_exclude_past_dates_from_ongoing_multi_day_events` and `test_taxonomy_filtered_upcoming_boundaries_include_ongoing_multi_day_events` both execute into `CalendarAbilities::compute_unique_event_dates()`

The focused run remains red on separate SQLite translator limitations after table setup succeeds: MySQL `DATE(... - INTERVAL 5 HOUR)` date arithmetic and geo scalar functions are unsupported. Those compatibility-layer gaps are tracked upstream in WordPress/sqlite-database-integration#454 and WordPress/sqlite-database-integration#455; no production SQL workaround is included here.

Closes #489