### PR TITLE
feat: support local term IDs in events-by-term

### DIFF
--- a/inc/Abilities/EventsByTermAbilities.php
+++ b/inc/Abilities/EventsByTermAbilities.php
@@ -2,12 +2,8 @@
 /**
  * Events By Term Abilities
  *
- * Cross-site-callable primitive that returns the LIST of events tagged to a
- * term in any taxonomy on the events site. The whole point is the CONSUMER
- * (e.g. the artist profile hub on a different blog) can call this ability even
- * though this plugin's PHP is NOT loaded there — switch_to_blog() changes the
- * DB context, not the loaded code, so a consumer on another blog cannot call
- * data_machine_events_query_events() directly. The ability is the bridge.
+ * Returns the list of events assigned to a term in any registered taxonomy on
+ * the configured events site.
  *
  * It internally switches to the configured events blog (the current site by
  * default), reads the datamachine_event_dates
@@ -16,11 +12,7 @@
  * time) pre-resolved while still in events-blog context — because the caller
  * renders on a DIFFERENT blog and cannot resolve those afterward.
  *
- * Layer purity: this ability is generic "events for term X in taxonomy Y on
- * this events site". It carries no consumer-specific identity and returns data,
- * not markup — presentation is the consumer's job. The taxonomy is supplied by
- * the caller, so the generic plugin never hardcodes a consumer taxonomy such as
- * "artist".
+ * The ability is taxonomy-agnostic and returns data rather than markup.
  *
  * @package DataMachineEvents\Abilities
  */
@@ -55,19 +47,24 @@ class EventsByTermAbilities {
 				'data-machine-events/events-by-term',
 				array(
 					'label'               => __( 'Events By Term', 'data-machine-events' ),
-					'description'         => __( 'Return the list of events for a term in a taxonomy on the events site, split into upcoming and past. Cross-site callable: resolves everything (permalinks, venue names, formatted dates) on the events blog so consumers on any other site can render the result directly.', 'data-machine-events' ),
+					'description'         => __( 'Return the list of events for a local term in any registered taxonomy, split into upcoming and past.', 'data-machine-events' ),
 					'category'            => 'datamachine-events-events',
 					'input_schema'        => array(
 						'type'       => 'object',
-						'required'   => array( 'taxonomy', 'term_slug' ),
+						'required'   => array( 'taxonomy' ),
 						'properties' => array(
 							'taxonomy'  => array(
 								'type'        => 'string',
-								'description' => __( 'Taxonomy name on the events site (e.g. "artist"). Must be registered there.', 'data-machine-events' ),
+								'description' => __( 'Registered taxonomy name on the events site.', 'data-machine-events' ),
+							),
+							'term_id'   => array(
+								'type'        => 'integer',
+								'minimum'     => 1,
+								'description' => __( 'Positive local term ID. When supplied, this takes precedence over term_slug.', 'data-machine-events' ),
 							),
 							'term_slug' => array(
 								'type'        => 'string',
-								'description' => __( 'Term slug (the canonical cross-blog join key) to look up on the events site.', 'data-machine-events' ),
+								'description' => __( 'Local term slug. Required when term_id is omitted.', 'data-machine-events' ),
 							),
 							'scope'     => array(
 								'type'        => 'string',
@@ -84,6 +81,7 @@ class EventsByTermAbilities {
 						'type'       => 'object',
 						'properties' => array(
 							'taxonomy'  => array( 'type' => 'string' ),
+							'term_id'   => array( 'type' => 'integer' ),
 							'term_slug' => array( 'type' => 'string' ),
 							'found'     => array( 'type' => 'boolean' ),
 							'upcoming'  => array(
@@ -115,17 +113,19 @@ class EventsByTermAbilities {
 	/**
 	 * Execute the events-by-term ability.
 	 *
-	 * Switches to the events blog, resolves the term by slug in the requested
+	 * Switches to the events blog, resolves the local term in the requested
 	 * taxonomy, queries the event_dates table for that term split by now, and
 	 * returns a plain structured array with presentational strings pre-resolved.
 	 *
 	 * @param array $input Input parameters.
-	 * @return array|\WP_Error { taxonomy, term_slug, found, upcoming: [...], past: [...] }
+	 * @return array|\WP_Error { taxonomy, term_id, term_slug, found, upcoming: [...], past: [...] }
 	 */
 	public function executeEventsByTerm( array $input ): array|\WP_Error {
-		$taxonomy  = isset( $input['taxonomy'] ) ? sanitize_key( (string) $input['taxonomy'] ) : '';
-		$term_slug = isset( $input['term_slug'] ) ? sanitize_title( (string) $input['term_slug'] ) : '';
-		$scope     = $input['scope'] ?? 'all';
+		$taxonomy         = isset( $input['taxonomy'] ) ? sanitize_key( (string) $input['taxonomy'] ) : '';
+		$term_id_supplied = array_key_exists( 'term_id', $input );
+		$term_id          = $term_id_supplied ? (int) $input['term_id'] : 0;
+		$term_slug        = isset( $input['term_slug'] ) ? sanitize_title( (string) $input['term_slug'] ) : '';
+		$scope            = $input['scope'] ?? 'all';
 		if ( ! in_array( $scope, array( 'upcoming', 'past', 'all' ), true ) ) {
 			$scope = 'all';
 		}
@@ -142,10 +142,18 @@ class EventsByTermAbilities {
 			);
 		}
 
-		if ( '' === $term_slug ) {
+		if ( $term_id_supplied && $term_id < 1 ) {
+			return new \WP_Error(
+				'invalid_term_id',
+				__( 'term_id must be a positive local term ID.', 'data-machine-events' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( ! $term_id_supplied && '' === $term_slug ) {
 			return new \WP_Error(
 				'invalid_term_slug',
-				__( 'A non-empty term_slug is required.', 'data-machine-events' ),
+				__( 'A non-empty term_slug is required when term_id is omitted.', 'data-machine-events' ),
 				array( 'status' => 400 )
 			);
 		}
@@ -161,7 +169,10 @@ class EventsByTermAbilities {
 
 		switch_to_blog( $events_blog_id );
 		try {
-			$result = $this->collectEventsForTerm( $taxonomy, $term_slug, $scope, $limit );
+			$result = $this->collectEventsForTerm( $taxonomy, $term_id, $term_slug, $scope, $limit );
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
 
 			/**
 			 * Filter events-by-term results in the canonical events-site context.
@@ -214,14 +225,16 @@ class EventsByTermAbilities {
 	 * presentational string per event.
 	 *
 	 * @param string $taxonomy  Taxonomy name on the events site.
-	 * @param string $term_slug Term slug to look up.
+	 * @param int    $term_id   Local term ID, or zero when resolving by slug.
+	 * @param string $term_slug Local term slug to look up when no ID is supplied.
 	 * @param string $scope     upcoming|past|all.
 	 * @param int    $limit     Per-scope result limit.
-	 * @return array Structured result.
+	 * @return array|\WP_Error Structured result or invalid-term error.
 	 */
-	private function collectEventsForTerm( string $taxonomy, string $term_slug, string $scope, int $limit ): array {
+	private function collectEventsForTerm( string $taxonomy, int $term_id, string $term_slug, string $scope, int $limit ): array|\WP_Error {
 		$empty = array(
 			'taxonomy'  => $taxonomy,
+			'term_id'   => 0,
 			'term_slug' => $term_slug,
 			'found'     => false,
 			'upcoming'  => array(),
@@ -232,14 +245,26 @@ class EventsByTermAbilities {
 			return $empty;
 		}
 
-		$term = get_term_by( 'slug', $term_slug, $taxonomy );
+		$term = $term_id > 0
+			? get_term( $term_id, $taxonomy )
+			: get_term_by( 'slug', $term_slug, $taxonomy );
+
+		if ( $term_id > 0 && ( ! $term || is_wp_error( $term ) ) ) {
+			return new \WP_Error(
+				'invalid_term_id',
+				__( 'term_id does not exist in the requested taxonomy.', 'data-machine-events' ),
+				array( 'status' => 400 )
+			);
+		}
+
 		if ( ! $term || is_wp_error( $term ) ) {
 			return $empty;
 		}
 
 		$result = array(
 			'taxonomy'  => $taxonomy,
-			'term_slug' => $term_slug,
+			'term_id'   => (int) $term->term_id,
+			'term_slug' => (string) $term->slug,
 			'found'     => true,
 			'upcoming'  => array(),
 			'past'      => array(),

--- a/tests/Unit/EventsByTermAbilitiesTest.php
+++ b/tests/Unit/EventsByTermAbilitiesTest.php
@@ -8,16 +8,39 @@
 namespace DataMachineEvents\Tests\Unit;
 
 use DataMachineEvents\Abilities\EventsByTermAbilities;
+use DataMachineEvents\Core\EventDatesTable;
 use WP_UnitTestCase;
 
 class EventsByTermAbilitiesTest extends WP_UnitTestCase {
+	private EventsByTermAbilities $abilities;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		EventDatesTable::create_table();
+		$this->abilities = new EventsByTermAbilities();
+	}
+
+	private function create_term( string $taxonomy, string $slug ): int {
+		$term = wp_insert_term(
+			ucwords( str_replace( '-', ' ', $slug ) ),
+			$taxonomy,
+			array( 'slug' => $slug )
+		);
+		$this->assertNotWPError( $term );
+
+		return (int) $term['term_id'];
+	}
+
+	private function execute( array $input ): array|\WP_Error {
+		return $this->abilities->executeEventsByTerm( $input );
+	}
 
 	public function test_events_blog_defaults_to_current_site(): void {
-		$abilities = new EventsByTermAbilities();
-		$method    = new \ReflectionMethod( $abilities, 'resolveEventsBlogId' );
+		$method = new \ReflectionMethod( $this->abilities, 'resolveEventsBlogId' );
 		$method->setAccessible( true );
 
-		$this->assertSame( get_current_blog_id(), $method->invoke( $abilities ) );
+		$this->assertSame( get_current_blog_id(), $method->invoke( $this->abilities ) );
 	}
 
 	public function test_events_blog_can_be_configured_by_consumer(): void {
@@ -26,11 +49,140 @@ class EventsByTermAbilitiesTest extends WP_UnitTestCase {
 		};
 		add_filter( 'data_machine_events_events_blog_id', $callback );
 
-		$abilities = new EventsByTermAbilities();
-		$method    = new \ReflectionMethod( $abilities, 'resolveEventsBlogId' );
+		$method = new \ReflectionMethod( $this->abilities, 'resolveEventsBlogId' );
 		$method->setAccessible( true );
 
-		$this->assertSame( get_current_blog_id() + 1, $method->invoke( $abilities ) );
+		$this->assertSame( get_current_blog_id() + 1, $method->invoke( $this->abilities ) );
 		remove_filter( 'data_machine_events_events_blog_id', $callback );
+	}
+
+	public function test_resolves_local_term_ids_for_multiple_taxonomies(): void {
+		foreach ( array( 'category', 'post_tag' ) as $taxonomy ) {
+			$slug    = 'local-' . $taxonomy . '-' . wp_generate_uuid4();
+			$term_id = $this->create_term( $taxonomy, $slug );
+			$result  = $this->execute(
+				array(
+					'taxonomy' => $taxonomy,
+					'term_id'  => $term_id,
+				)
+			);
+
+			$this->assertNotWPError( $result );
+			$this->assertTrue( $result['found'] );
+			$this->assertSame( $term_id, $result['term_id'] );
+			$this->assertSame( $slug, $result['term_slug'] );
+		}
+	}
+
+	public function test_term_id_returns_current_slug_after_rename(): void {
+		$term_id = $this->create_term( 'category', 'before-rename' );
+		$updated = wp_update_term( $term_id, 'category', array( 'slug' => 'after-rename' ) );
+		$this->assertNotWPError( $updated );
+
+		$result = $this->execute(
+			array(
+				'taxonomy' => 'category',
+				'term_id'  => $term_id,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertSame( $term_id, $result['term_id'] );
+		$this->assertSame( 'after-rename', $result['term_slug'] );
+	}
+
+	public function test_term_id_must_belong_to_requested_taxonomy(): void {
+		$term_id = $this->create_term( 'category', 'taxonomy-owner' );
+		$result  = $this->execute(
+			array(
+				'taxonomy' => 'post_tag',
+				'term_id'  => $term_id,
+			)
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_term_id', $result->get_error_code() );
+	}
+
+	public function test_deleted_term_id_is_rejected(): void {
+		$term_id = $this->create_term( 'category', 'deleted-term' );
+		$deleted = wp_delete_term( $term_id, 'category' );
+		$this->assertNotWPError( $deleted );
+
+		$result = $this->execute(
+			array(
+				'taxonomy' => 'category',
+				'term_id'  => $term_id,
+			)
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_term_id', $result->get_error_code() );
+	}
+
+	public function test_missing_term_id_is_rejected(): void {
+		$result = $this->execute(
+			array(
+				'taxonomy' => 'category',
+				'term_id'  => 999999999,
+			)
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_term_id', $result->get_error_code() );
+	}
+
+	/**
+	 * @dataProvider invalid_non_positive_term_ids
+	 */
+	public function test_non_positive_term_id_is_rejected( int $term_id ): void {
+		$result = $this->execute(
+			array(
+				'taxonomy' => 'category',
+				'term_id'  => $term_id,
+			)
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_term_id', $result->get_error_code() );
+	}
+
+	public static function invalid_non_positive_term_ids(): array {
+		return array(
+			'zero'     => array( 0 ),
+			'negative' => array( -1 ),
+		);
+	}
+
+	public function test_term_id_is_authoritative_over_disagreeing_slug(): void {
+		$authoritative_id = $this->create_term( 'category', 'authoritative-term' );
+		$this->create_term( 'category', 'different-term' );
+
+		$result = $this->execute(
+			array(
+				'taxonomy'  => 'category',
+				'term_id'   => $authoritative_id,
+				'term_slug' => 'different-term',
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertSame( $authoritative_id, $result['term_id'] );
+		$this->assertSame( 'authoritative-term', $result['term_slug'] );
+	}
+
+	public function test_legacy_term_slug_lookup_remains_supported(): void {
+		$term_id = $this->create_term( 'post_tag', 'legacy-slug' );
+		$result  = $this->execute(
+			array(
+				'taxonomy'  => 'post_tag',
+				'term_slug' => 'legacy-slug',
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertTrue( $result['found'] );
+		$this->assertSame( $term_id, $result['term_id'] );
+		$this->assertSame( 'legacy-slug', $result['term_slug'] );
 	}
 }


### PR DESCRIPTION
## Summary
- accept a positive site-local `term_id` for any registered taxonomy and validate taxonomy membership
- make `term_id` authoritative when both ID and slug are supplied, returning the resolved ID and current slug
- cover two ordinary taxonomies plus renamed, mismatched, deleted, missing, non-positive, disagreement, and legacy-slug cases

## Compatibility
- existing `taxonomy` + `term_slug` callers remain supported
- successful responses now also include `term_id`; `term_slug` reflects the resolved term's current slug
- supplied IDs that are non-positive, missing, deleted, or outside the requested taxonomy return `invalid_term_id`

## Layer Purity
This remains a strictly site-local, taxonomy-agnostic primitive. The source, schemas, comments, and tests contain no consumer-specific taxonomy semantics, identity mappings, migration behavior, term metadata, admin hooks, or additional blog switching.

## Test Evidence
- Homeboy: `0.298.0+204d86414988`
- focused test run `06b18169-a1bb-491c-8a82-d8d24c0edd91`: infrastructure-blocked before test discovery because the staged Composer autoloader could not load `Composer\\Autoload\\ClassLoader`
- full test run `3d346f21-513a-4943-bb74-f6e564c63d18`: same pre-discovery infrastructure failure
- lint run `9af93e19-2ca9-487f-a659-e303c472fd38`: PHPCS and PHPStan could not start because the Homeboy WordPress extension Composer autoloader is broken; the outer command incorrectly reported no findings
- direct `php -l` passed for both changed PHP files
- `git diff --check` passed
- prohibited-domain scan passed for the changed source and test files

Fixes #494