### PR TITLE
fix: prevent cross-city venue identity collisions

### DIFF
--- a/inc/Core/DuplicateDetection/EventDuplicateStrategy.php
+++ b/inc/Core/DuplicateDetection/EventDuplicateStrategy.php
@@ -70,7 +70,7 @@ class EventDuplicateStrategy {
 	 * @param array $input {
 	 *     @type string $title      Event title.
 	 *     @type string $post_type  Post type (data_machine_events).
-	 *     @type array  $context    { venue, startDate, ticketUrl, address, city }
+	 *     @type array  $context    { venue, startDate, ticketUrl, address, city, state, country }
 	 * }
 	 * @return array|null Duplicate result or null if clear.
 	 */
@@ -82,6 +82,8 @@ class EventDuplicateStrategy {
 		$ticketUrl = $context['ticketUrl'] ?? '';
 		$address   = $context['address'] ?? '';
 		$city      = $context['city'] ?? '';
+		$state     = $context['state'] ?? '';
+		$country   = $context['country'] ?? '';
 
 		if ( empty( $title ) || empty( $startDate ) ) {
 			return null;
@@ -94,7 +96,8 @@ class EventDuplicateStrategy {
 		// Venue_Taxonomy::find_or_create_venue (address-first, then name).
 		// Reused across strategies so dedup matches the canonicalization
 		// that the upsert path will perform.
-		$venue_term = self::resolveVenueTerm( $venue, $address, $city );
+		$venue_identity = self::resolveVenueIdentity( $venue, $address, $city, $state, $country );
+		$venue_term     = $venue_identity['term'];
 
 		// Strategy 1: Ticket URL + date (most reliable).
 		if ( ! empty( $ticketUrl ) ) {
@@ -102,6 +105,13 @@ class EventDuplicateStrategy {
 			if ( $match ) {
 				return $match;
 			}
+		}
+
+		// A geographically conflicting venue name must not fall through to the
+		// later name-only confirmations. Ticket identity remains authoritative,
+		// but venue/title strategies cannot safely mark this event duplicate.
+		if ( 'ambiguous' === $venue_identity['match_status'] ) {
+			return null;
 		}
 
 		// Strategy 2: Venue + date + fuzzy title.
@@ -508,60 +518,53 @@ class EventDuplicateStrategy {
 	}
 
 	/**
-	 * Resolve a venue name to a WP_Term with cascading lookup.
-	 *
-	 * Mirrors the address-first cascade used by
-	 * Venue_Taxonomy::find_or_create_venue() so that dedup resolves the
-	 * same canonical term the upsert path will land on:
-	 *
-	 * 1. Address + city match (most authoritative — survives venue rename/alias)
-	 * 2. Exact name match
-	 * 3. Slug-based match (catches minor name variations)
-	 * 4. Normalized name match (strips punctuation, dashes, apostrophes, case)
-	 *
-	 * Without step 1, dedup misses cases where the incoming venue string
-	 * differs from the canonical term name but matches by address — e.g.
-	 * "Monks Jazz" vs term "Monks", "Humphreys Backstage Live" vs term
-	 * "Humphreys Concerts By the Bay". See issue #252.
+	 * Resolve a venue using the venue taxonomy's canonical identity rules.
 	 *
 	 * @param string $venue   Venue name from import source.
 	 * @param string $address Optional street address (enables address-first lookup).
 	 * @param string $city    Optional city name (required alongside address).
+	 * @param string $state   Optional state or region.
+	 * @param string $country Optional country.
 	 * @return \WP_Term|null Resolved venue term or null.
 	 */
-	private static function resolveVenueTerm( string $venue, string $address = '', string $city = '' ): ?\WP_Term {
-		// 1. Address + city match (mirrors find_or_create_venue).
-		if ( '' !== $address && '' !== $city ) {
-			$venue_term = \DataMachineEvents\Core\Venue_Taxonomy::find_venue_by_address_public( $address, $city );
-			if ( $venue_term ) {
-				return $venue_term;
-			}
-		}
+	private static function resolveVenueTerm(
+		string $venue,
+		string $address = '',
+		string $city = '',
+		string $state = '',
+		string $country = ''
+	): ?\WP_Term {
+		$identity = self::resolveVenueIdentity( $venue, $address, $city, $state, $country );
 
-		if ( '' === $venue ) {
-			return null;
-		}
+		return $identity['term'];
+	}
 
-		// 2. Exact name match.
-		$venue_term = get_term_by( 'name', $venue, 'venue' );
-		if ( $venue_term ) {
-			return $venue_term;
-		}
-
-		// 3. Slug-based lookup.
-		$venue_slug = sanitize_title( $venue );
-		$venue_term = get_term_by( 'slug', $venue_slug, 'venue' );
-		if ( $venue_term ) {
-			return $venue_term;
-		}
-
-		// 4. Normalized name match via Venue_Taxonomy.
-		$venue_term = \DataMachineEvents\Core\Venue_Taxonomy::find_venue_by_normalized_name_public( $venue );
-		if ( $venue_term ) {
-			return $venue_term;
-		}
-
-		return null;
+	/**
+	 * Resolve a venue while retaining ambiguity for duplicate-check control flow.
+	 *
+	 * @param string $venue   Venue name from import source.
+	 * @param string $address Optional street address.
+	 * @param string $city    Optional city.
+	 * @param string $state   Optional state or region.
+	 * @param string $country Optional country.
+	 * @return array{term: \WP_Term|null, term_id: int|null, match_status: string, venue_name: string}
+	 */
+	private static function resolveVenueIdentity(
+		string $venue,
+		string $address = '',
+		string $city = '',
+		string $state = '',
+		string $country = ''
+	): array {
+		return \DataMachineEvents\Core\Venue_Taxonomy::resolve_venue_identity(
+			$venue,
+			array(
+				'address' => $address,
+				'city'    => $city,
+				'state'   => $state,
+				'country' => $country,
+			)
+		);
 	}
 
 	/**

--- a/inc/Core/DuplicateDetection/PreAIEventDedupGate.php
+++ b/inc/Core/DuplicateDetection/PreAIEventDedupGate.php
@@ -62,6 +62,10 @@ class PreAIEventDedupGate {
 		$venue     = $engine->get( 'venue' ) ?? '';
 		$startDate = $engine->get( 'startDate' ) ?? '';
 		$ticketUrl = $engine->get( 'ticketUrl' ) ?? '';
+		$address   = $engine->get( 'venueAddress' ) ?? '';
+		$city      = $engine->get( 'venueCity' ) ?? '';
+		$state     = $engine->get( 'venueState' ) ?? '';
+		$country   = $engine->get( 'venueCountry' ) ?? '';
 
 		// Need at least title + startDate for a meaningful lookup.
 		// Without these, let the AI step run normally.
@@ -76,6 +80,10 @@ class PreAIEventDedupGate {
 				'venue'     => $venue,
 				'startDate' => $startDate,
 				'ticketUrl' => $ticketUrl,
+				'address'   => $address,
+				'city'      => $city,
+				'state'     => $state,
+				'country'   => $country,
 			),
 		) );
 

--- a/inc/Core/Venue_Taxonomy.php
+++ b/inc/Core/Venue_Taxonomy.php
@@ -162,17 +162,20 @@ class Venue_Taxonomy {
 	 *    blob baked into the name — common with AI-extracted venue strings —
 	 *    and routes it into $venue_data BEFORE matching runs, so step 1 below
 	 *    can resolve it against the canonical venue by address)
-	 * 1. Address-based matching (normalized street + city comparison)
-	 * 2. Exact name match
-	 * 3. "The" prefix toggle ("The Royal American" ↔ "Royal American")
-	 * 4. Normalized name matching (strips punctuation, dashes, case, articles)
+	 * 1. Address-based matching (normalized street + city comparison, qualified
+	 *    by state/country when both the incoming and stored venue supply them)
+	 * 2. Exact name match, qualified by supplied geographic evidence
+	 * 3. "The" prefix toggle ("The Royal American" ↔ "Royal American"),
+	 *    qualified by supplied geographic evidence
+	 * 4. Normalized name matching (strips punctuation, dashes, case, articles),
+	 *    qualified by supplied geographic evidence
 	 *    Catches: "Saturn - Birmingham" = "Saturn Birmingham",
 	 *             "Reggie's Rock Club" = "Reggies Rock Club",
 	 *             "RADIO/EAST" = "Radio East"
 	 *
 	 * @param string $venue_name Venue name
 	 * @param array $venue_data Venue metadata (address, city, state, etc.)
-	 * @return array Array with keys: term_id, was_created
+	 * @return array Array with keys: term_id, was_created, and match_status.
 	 */
 	public static function find_or_create_venue( $venue_name, $venue_data = array() ) {
 		// Strip a trailing address blob baked into the venue name (AI
@@ -193,47 +196,27 @@ class Venue_Taxonomy {
 		// Address-based matching (source of truth)
 		$address = $venue_data['address'] ?? '';
 		$city    = $venue_data['city'] ?? '';
+		$state   = $venue_data['state'] ?? '';
+		$country = $venue_data['country'] ?? '';
 
-		$address_match = self::find_venue_by_address( $address, $city );
+		$address_match = self::find_venue_by_address( $address, $city, $state, $country );
 		if ( $address_match ) {
 			if ( ! empty( $venue_data ) ) {
 				self::smart_merge_venue_meta( $address_match, $venue_data );
 			}
 
 			return array(
-				'term_id'     => $address_match,
-				'was_created' => false,
+				'term_id'      => $address_match,
+				'was_created'  => false,
+				'match_status' => 'matched',
 			);
 		}
 
 		// Allow normalization of venue name (e.g. aliases, corrections)
 		$venue_name = apply_filters( 'data_machine_events_normalize_venue_name', $venue_name );
 
-		// Check if venue already exists by name
-		$existing = get_term_by( 'name', $venue_name, 'venue' );
-
-		// Smart Lookup: If exact match fails, try variations with/without "The"
-		if ( ! $existing ) {
-			$alt_name = '';
-			if ( stripos( $venue_name, 'The ' ) === 0 ) {
-				// Remove "The " prefix
-				$alt_name = substr( $venue_name, 4 );
-			} else {
-				// Add "The " prefix
-				$alt_name = 'The ' . $venue_name;
-			}
-
-			if ( ! empty( $alt_name ) ) {
-				$existing = get_term_by( 'name', $alt_name, 'venue' );
-			}
-		}
-
-		// Normalized name matching: catches punctuation, dash, and case variants.
-		// e.g. "Saturn - Birmingham" = "Saturn Birmingham",
-		//      "Reggie's Rock Club" = "Reggies Rock Club"
-		if ( ! $existing ) {
-			$existing = self::find_venue_by_normalized_name( $venue_name );
-		}
+		$name_match = self::find_venue_by_qualified_name( $venue_name, $venue_data );
+		$existing   = $name_match['term'];
 
 		if ( $existing ) {
 			$term_id = $existing->term_id;
@@ -244,8 +227,27 @@ class Venue_Taxonomy {
 			}
 
 			return array(
-				'term_id'     => $term_id,
-				'was_created' => false,
+				'term_id'      => $term_id,
+				'was_created'  => false,
+				'match_status' => 'matched',
+			);
+		}
+
+		if ( $name_match['ambiguous'] ) {
+			do_action(
+				'datamachine_log',
+				'warning',
+				'Venue name match rejected due to ambiguous or conflicting geographic evidence',
+				array(
+					'venue_name' => $venue_name,
+					'venue_data' => $venue_data,
+				)
+			);
+
+			return array(
+				'term_id'      => null,
+				'was_created'  => false,
+				'match_status' => 'ambiguous',
 			);
 		}
 
@@ -263,8 +265,9 @@ class Venue_Taxonomy {
 				)
 			);
 			return array(
-				'term_id'     => null,
-				'was_created' => false,
+				'term_id'      => null,
+				'was_created'  => false,
+				'match_status' => 'error',
 			);
 		}
 
@@ -274,9 +277,139 @@ class Venue_Taxonomy {
 		self::update_venue_meta( $term_id, $venue_data );
 
 		return array(
-			'term_id'     => $term_id,
-			'was_created' => true,
+			'term_id'      => $term_id,
+			'was_created'  => true,
+			'match_status' => 'created',
 		);
+	}
+
+	/**
+	 * Resolve name variants without crossing conflicting geographic evidence.
+	 *
+	 * Exact, article-toggle, and normalized matches retain their precedence. A
+	 * tier with one compatible candidate wins; multiple compatible candidates
+	 * or candidates rejected by supplied geography produce an ambiguous result.
+	 *
+	 * @param string $venue_name Venue name to resolve.
+	 * @param array  $venue_data Incoming venue metadata.
+	 * @return array{term: \WP_Term|null, ambiguous: bool}
+	 */
+	private static function find_venue_by_qualified_name( string $venue_name, array $venue_data ): array {
+		$venues = get_terms(
+			array(
+				'taxonomy'   => 'venue',
+				'hide_empty' => false,
+				'number'     => 0,
+			)
+		);
+
+		if ( is_wp_error( $venues ) || empty( $venues ) ) {
+			return array(
+				'term'      => null,
+				'ambiguous' => false,
+			);
+		}
+
+		$alt_name              = 0 === stripos( $venue_name, 'The ' ) ? substr( $venue_name, 4 ) : 'The ' . $venue_name;
+		$normalized_name       = self::normalize_venue_name_for_matching( $venue_name );
+		$normalized_candidates = strlen( $normalized_name ) < 3
+			? array()
+			: array_filter(
+				$venues,
+				static fn( $venue ) => $normalized_name === self::normalize_venue_name_for_matching( $venue->name )
+			);
+		$tiers = array(
+			array_filter(
+				$venues,
+				static fn( $venue ) => 0 === strcasecmp( trim( $venue->name ), trim( $venue_name ) )
+			),
+			array_filter(
+				$venues,
+				static fn( $venue ) => 0 === strcasecmp( trim( $venue->name ), trim( $alt_name ) )
+			),
+			$normalized_candidates,
+		);
+		$had_candidates = false;
+
+		foreach ( $tiers as $candidates ) {
+			if ( empty( $candidates ) ) {
+				continue;
+			}
+
+			$had_candidates = true;
+			$compatible     = array_values(
+				array_filter(
+					$candidates,
+					static fn( $venue ) => ! self::has_geographic_conflict( $venue->term_id, $venue_data )
+				)
+			);
+
+			if ( 1 === count( $compatible ) ) {
+				return array(
+					'term'      => $compatible[0],
+					'ambiguous' => false,
+				);
+			}
+
+			if ( count( $compatible ) > 1 ) {
+				return array(
+					'term'      => null,
+					'ambiguous' => true,
+				);
+			}
+		}
+
+		return array(
+			'term'      => null,
+			'ambiguous' => $had_candidates,
+		);
+	}
+
+	/**
+	 * Determine whether supplied geography contradicts stored venue evidence.
+	 *
+	 * Missing values on either side are incomplete evidence, not a conflict.
+	 *
+	 * @param int   $term_id    Venue term ID.
+	 * @param array $venue_data Incoming venue metadata.
+	 * @return bool
+	 */
+	private static function has_geographic_conflict( int $term_id, array $venue_data ): bool {
+		foreach ( array( 'address', 'city', 'state', 'country' ) as $field ) {
+			$incoming = $venue_data[ $field ] ?? '';
+			$stored   = get_term_meta( $term_id, self::$meta_fields[ $field ], true );
+
+			if ( '' === trim( (string) $incoming ) || '' === trim( (string) $stored ) ) {
+				continue;
+			}
+
+			$incoming = 'address' === $field
+				? self::normalize_address_for_matching( (string) $incoming )
+				: self::normalize_geographic_value( (string) $incoming );
+			$stored   = 'address' === $field
+				? self::normalize_address_for_matching( (string) $stored )
+				: self::normalize_geographic_value( (string) $stored );
+
+			if ( $incoming !== $stored ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Normalize a city, state, or country value for identity comparison.
+	 *
+	 * @param string $value Geographic value.
+	 * @return string
+	 */
+	private static function normalize_geographic_value( string $value ): string {
+		$value = html_entity_decode( $value, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+		$value = strtolower( remove_accents( $value ) );
+		$value = preg_replace( '/[^a-z0-9]+/', ' ', $value );
+
+		return trim( preg_replace( '/\s+/', ' ', $value ) );
 	}
 
 	/**
@@ -990,13 +1123,20 @@ class Venue_Taxonomy {
 	}
 
 	/**
-	 * Find existing venue by address and city
+	 * Find existing venue by address and geographic context.
 	 *
-	 * @param string $address Street address
-	 * @param string $city City name
+	 * @param string $address Street address.
+	 * @param string $city City name.
+	 * @param string $state State or region, when supplied.
+	 * @param string $country Country, when supplied.
 	 * @return int|null Term ID if found, null otherwise
 	 */
-	public static function find_venue_by_address( string $address, string $city ): ?int {
+	public static function find_venue_by_address(
+		string $address,
+		string $city,
+		string $state = '',
+		string $country = ''
+	): ?int {
 		if ( empty( $address ) || empty( $city ) ) {
 			return null;
 		}
@@ -1021,6 +1161,8 @@ class Venue_Taxonomy {
 			return null;
 		}
 
+		$matches = array();
+
 		foreach ( $venues as $venue ) {
 			$venue_address = get_term_meta( $venue->term_id, '_venue_address', true );
 			$venue_city    = get_term_meta( $venue->term_id, '_venue_city', true );
@@ -1033,12 +1175,21 @@ class Venue_Taxonomy {
 			$venue_normalized_city    = strtolower( trim( $venue_city ) );
 
 			if ( $venue_normalized_address === $normalized_address &&
-				$venue_normalized_city === $normalized_city ) {
-				return $venue->term_id;
+				$venue_normalized_city === $normalized_city &&
+				! self::has_geographic_conflict(
+					$venue->term_id,
+					array(
+						'address' => $address,
+						'city'    => $city,
+						'state'   => $state,
+						'country' => $country,
+					)
+				) ) {
+				$matches[] = $venue->term_id;
 			}
 		}
 
-		return null;
+		return 1 === count( $matches ) ? $matches[0] : null;
 	}
 
 	/**

--- a/inc/Core/Venue_Taxonomy.php
+++ b/inc/Core/Venue_Taxonomy.php
@@ -116,6 +116,74 @@ class Venue_Taxonomy {
 		'MP',
 	);
 
+	/**
+	 * US state / DC / territory names keyed by postal abbreviation.
+	 *
+	 * Import sources provide both full region names and postal abbreviations.
+	 * This bounded map keeps those generic representations equivalent during
+	 * venue identity comparison.
+	 *
+	 * @var array<string, string>
+	 */
+	private static $us_state_names = array(
+		'AL' => 'Alabama',
+		'AK' => 'Alaska',
+		'AZ' => 'Arizona',
+		'AR' => 'Arkansas',
+		'CA' => 'California',
+		'CO' => 'Colorado',
+		'CT' => 'Connecticut',
+		'DE' => 'Delaware',
+		'FL' => 'Florida',
+		'GA' => 'Georgia',
+		'HI' => 'Hawaii',
+		'ID' => 'Idaho',
+		'IL' => 'Illinois',
+		'IN' => 'Indiana',
+		'IA' => 'Iowa',
+		'KS' => 'Kansas',
+		'KY' => 'Kentucky',
+		'LA' => 'Louisiana',
+		'ME' => 'Maine',
+		'MD' => 'Maryland',
+		'MA' => 'Massachusetts',
+		'MI' => 'Michigan',
+		'MN' => 'Minnesota',
+		'MS' => 'Mississippi',
+		'MO' => 'Missouri',
+		'MT' => 'Montana',
+		'NE' => 'Nebraska',
+		'NV' => 'Nevada',
+		'NH' => 'New Hampshire',
+		'NJ' => 'New Jersey',
+		'NM' => 'New Mexico',
+		'NY' => 'New York',
+		'NC' => 'North Carolina',
+		'ND' => 'North Dakota',
+		'OH' => 'Ohio',
+		'OK' => 'Oklahoma',
+		'OR' => 'Oregon',
+		'PA' => 'Pennsylvania',
+		'RI' => 'Rhode Island',
+		'SC' => 'South Carolina',
+		'SD' => 'South Dakota',
+		'TN' => 'Tennessee',
+		'TX' => 'Texas',
+		'UT' => 'Utah',
+		'VT' => 'Vermont',
+		'VA' => 'Virginia',
+		'WA' => 'Washington',
+		'WV' => 'West Virginia',
+		'WI' => 'Wisconsin',
+		'WY' => 'Wyoming',
+		'DC' => 'District of Columbia',
+		'PR' => 'Puerto Rico',
+		'VI' => 'U.S. Virgin Islands',
+		'GU' => 'Guam',
+		'AS' => 'American Samoa',
+		'MP' => 'Northern Mariana Islands',
+	);
+
 	public static function register() {
 		self::register_venue_taxonomy();
 
@@ -193,35 +261,12 @@ class Venue_Taxonomy {
 			}
 		}
 
-		// Address-based matching (source of truth)
-		$address = $venue_data['address'] ?? '';
-		$city    = $venue_data['city'] ?? '';
-		$state   = $venue_data['state'] ?? '';
-		$country = $venue_data['country'] ?? '';
+		$identity   = self::resolve_venue_identity( $venue_name, $venue_data );
+		$venue_name = $identity['venue_name'];
 
-		$address_match = self::find_venue_by_address( $address, $city, $state, $country );
-		if ( $address_match ) {
-			if ( ! empty( $venue_data ) ) {
-				self::smart_merge_venue_meta( $address_match, $venue_data );
-			}
+		if ( $identity['term'] ) {
+			$term_id = $identity['term_id'];
 
-			return array(
-				'term_id'      => $address_match,
-				'was_created'  => false,
-				'match_status' => 'matched',
-			);
-		}
-
-		// Allow normalization of venue name (e.g. aliases, corrections)
-		$venue_name = apply_filters( 'data_machine_events_normalize_venue_name', $venue_name );
-
-		$name_match = self::find_venue_by_qualified_name( $venue_name, $venue_data );
-		$existing   = $name_match['term'];
-
-		if ( $existing ) {
-			$term_id = $existing->term_id;
-
-			// Smart Merge: Fill in any missing metadata fields
 			if ( ! empty( $venue_data ) ) {
 				self::smart_merge_venue_meta( $term_id, $venue_data );
 			}
@@ -233,7 +278,7 @@ class Venue_Taxonomy {
 			);
 		}
 
-		if ( $name_match['ambiguous'] ) {
+		if ( 'ambiguous' === $identity['match_status'] ) {
 			do_action(
 				'datamachine_log',
 				'warning',
@@ -280,6 +325,59 @@ class Venue_Taxonomy {
 			'term_id'      => $term_id,
 			'was_created'  => true,
 			'match_status' => 'created',
+		);
+	}
+
+	/**
+	 * Resolve an existing venue without creating a term or merging metadata.
+	 *
+	 * This exposes the same address-first and geographically qualified name
+	 * rules to duplicate detection without introducing a separate identity
+	 * service or mutating the venue taxonomy during a read.
+	 *
+	 * @param string $venue_name Venue name.
+	 * @param array  $venue_data Venue metadata.
+	 * @return array{term: \WP_Term|null, term_id: int|null, match_status: string, venue_name: string}
+	 */
+	public static function resolve_venue_identity( string $venue_name, array $venue_data = array() ): array {
+		$extracted_address = self::extract_address_from_name( $venue_name );
+		if ( ! empty( $extracted_address ) ) {
+			$venue_name = $extracted_address['name'];
+			foreach ( array( 'address', 'city', 'state', 'zip' ) as $field ) {
+				if ( ! empty( $extracted_address[ $field ] ) && empty( $venue_data[ $field ] ) ) {
+					$venue_data[ $field ] = $extracted_address[ $field ];
+				}
+			}
+		}
+
+		$address_match = self::find_venue_by_address(
+			$venue_data['address'] ?? '',
+			$venue_data['city'] ?? '',
+			$venue_data['state'] ?? '',
+			$venue_data['country'] ?? ''
+		);
+
+		if ( $address_match ) {
+			$term = get_term( $address_match, 'venue' );
+			if ( $term instanceof \WP_Term ) {
+				return array(
+					'term'         => $term,
+					'term_id'      => (int) $term->term_id,
+					'match_status' => 'matched',
+					'venue_name'   => $venue_name,
+				);
+			}
+		}
+
+		$venue_name = apply_filters( 'data_machine_events_normalize_venue_name', $venue_name );
+		$name_match = self::find_venue_by_qualified_name( $venue_name, $venue_data );
+		$term       = $name_match['term'];
+
+		return array(
+			'term'         => $term,
+			'term_id'      => $term ? (int) $term->term_id : null,
+			'match_status' => $name_match['ambiguous'] ? 'ambiguous' : ( $term ? 'matched' : 'no_match' ),
+			'venue_name'   => $venue_name,
 		);
 	}
 
@@ -385,10 +483,10 @@ class Venue_Taxonomy {
 
 			$incoming = 'address' === $field
 				? self::normalize_address_for_matching( (string) $incoming )
-				: self::normalize_geographic_value( (string) $incoming );
+				: self::normalize_geographic_value( (string) $incoming, $field );
 			$stored   = 'address' === $field
 				? self::normalize_address_for_matching( (string) $stored )
-				: self::normalize_geographic_value( (string) $stored );
+				: self::normalize_geographic_value( (string) $stored, $field );
 
 			if ( $incoming !== $stored ) {
 				return true;
@@ -402,14 +500,30 @@ class Venue_Taxonomy {
 	 * Normalize a city, state, or country value for identity comparison.
 	 *
 	 * @param string $value Geographic value.
+	 * @param string $field Geographic field name.
 	 * @return string
 	 */
-	private static function normalize_geographic_value( string $value ): string {
+	private static function normalize_geographic_value( string $value, string $field ): string {
 		$value = html_entity_decode( $value, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
 		$value = strtolower( remove_accents( $value ) );
 		$value = preg_replace( '/[^a-z0-9]+/', ' ', $value );
+		$value = trim( preg_replace( '/\s+/', ' ', $value ) );
 
-		return trim( preg_replace( '/\s+/', ' ', $value ) );
+		$us_country_aliases = array( 'us', 'u s', 'usa', 'u s a', 'united states', 'united states of america' );
+		if ( 'country' === $field && in_array( $value, $us_country_aliases, true ) ) {
+			return 'us';
+		}
+
+		if ( 'state' === $field ) {
+			foreach ( self::$us_state_names as $abbreviation => $state_name ) {
+				$normalized_state_name = self::normalize_geographic_value( $state_name, '' );
+				if ( strtolower( $abbreviation ) === $value || $normalized_state_name === $value ) {
+					return strtolower( $abbreviation );
+				}
+			}
+		}
+
+		return $value;
 	}
 
 	/**

--- a/inc/Steps/Upsert/Events/EventUpsert.php
+++ b/inc/Steps/Upsert/Events/EventUpsert.php
@@ -224,7 +224,7 @@ class EventUpsert extends UpsertHandler {
 		EngineData $engine
 	): array {
 		// 1. Find existing event via domain-specific duplicate detection.
-		// Pass venue address + city so dedup can resolve the incoming venue
+		// Pass complete venue geography so dedup can resolve the incoming venue
 		// via the same address-first cascade the upsert path uses
 		// (Venue_Taxonomy::find_or_create_venue). Without this, dupes slip
 		// through whenever the incoming venue string differs from the
@@ -233,7 +233,18 @@ class EventUpsert extends UpsertHandler {
 		// Normalize to int (0 = no match) so downstream type contracts hold.
 		$venueAddress     = (string) ( $engine->get( 'venueAddress' ) ?? $parameters['venueAddress'] ?? '' );
 		$venueCity        = (string) ( $engine->get( 'venueCity' ) ?? $parameters['venueCity'] ?? '' );
-		$existing_post_id = (int) $this->findExistingEventViaAbility( $title, $venue, $startDate, $ticketUrl, $venueAddress, $venueCity );
+		$venueState       = (string) ( $engine->get( 'venueState' ) ?? $parameters['venueState'] ?? '' );
+		$venueCountry     = (string) ( $engine->get( 'venueCountry' ) ?? $parameters['venueCountry'] ?? '' );
+		$existing_post_id = (int) $this->findExistingEventViaAbility(
+			$title,
+			$venue,
+			$startDate,
+			$ticketUrl,
+			$venueAddress,
+			$venueCity,
+			$venueState,
+			$venueCountry
+		);
 
 		// 2. Build event data.
 		$event_data = $this->buildEventData( $parameters, $handler_config, $engine, $existing_post_id );
@@ -371,7 +382,7 @@ class EventUpsert extends UpsertHandler {
 	 * so recurring series (same title/venue, different date) are never
 	 * falsely matched. See #423.
 	 *
-	 * The `address` and `city` context fields let EventDuplicateStrategy
+	 * The geographic context fields let EventDuplicateStrategy
 	 * resolve the incoming venue via the same address-first cascade the
 	 * upsert path uses (Venue_Taxonomy::find_or_create_venue). See #252.
 	 *
@@ -381,9 +392,20 @@ class EventUpsert extends UpsertHandler {
 	 * @param string $ticketUrl Ticket URL.
 	 * @param string $address   Venue street address (for address-aware venue resolution).
 	 * @param string $city      Venue city (required alongside address).
+	 * @param string $state     Venue state or region.
+	 * @param string $country   Venue country.
 	 * @return int|null Post ID if found, null otherwise.
 	 */
-	private function findExistingEventViaAbility( string $title, string $venue, string $startDate, string $ticketUrl, string $address = '', string $city = '' ): ?int {
+	private function findExistingEventViaAbility(
+		string $title,
+		string $venue,
+		string $startDate,
+		string $ticketUrl,
+		string $address = '',
+		string $city = '',
+		string $state = '',
+		string $country = ''
+	): ?int {
 		// The indexed EventDuplicateStrategy owns all event duplicate
 		// detection. If the index class or ability is unavailable (DM core
 		// too old), there is no safe fallback — return null so a new event
@@ -412,6 +434,8 @@ class EventUpsert extends UpsertHandler {
 					'ticketUrl' => $ticketUrl,
 					'address'   => $address,
 					'city'      => $city,
+					'state'     => $state,
+					'country'   => $country,
 				),
 			)
 		);

--- a/tests/Unit/EventDuplicateStrategyTest.php
+++ b/tests/Unit/EventDuplicateStrategyTest.php
@@ -143,6 +143,70 @@ class EventDuplicateStrategyTest extends WP_UnitTestCase {
 		wp_delete_term( $term_id, 'venue' );
 	}
 
+	public function test_geographic_conflict_cannot_fall_through_to_name_only_duplicate_match(): void {
+		$venue_name = 'Cross City Duplicate Guard ' . uniqid();
+		[ $term_id, $existing_post_id ] = $this->seedVenueWithEvent(
+			'Same Night Show',
+			'2026-08-15 20:00:00',
+			$venue_name
+		);
+		update_term_meta( $term_id, '_venue_address', '100 Main Street' );
+		update_term_meta( $term_id, '_venue_city', 'Charleston' );
+		update_term_meta( $term_id, '_venue_state', 'SC' );
+		update_term_meta( $term_id, '_venue_country', 'US' );
+
+		$result = EventDuplicateStrategy::check(
+			array(
+				'title'   => 'Same Night Show',
+				'context' => array(
+					'venue'     => $venue_name,
+					'startDate' => '2026-08-15T20:30:00',
+					'ticketUrl' => '',
+					'address'   => '200 Main Street',
+					'city'      => 'Atlanta',
+					'state'     => 'GA',
+					'country'   => 'US',
+				),
+			)
+		);
+
+		$this->assertNull( $result, 'Conflicting geography must block all name-only duplicate fallbacks.' );
+		$this->cleanup( $term_id, $existing_post_id );
+	}
+
+	public function test_equivalent_geography_forms_still_allow_duplicate_match(): void {
+		$venue_name = 'Equivalent Geography Venue ' . uniqid();
+		[ $term_id, $existing_post_id ] = $this->seedVenueWithEvent(
+			'Equivalent Geography Show',
+			'2026-08-16 20:00:00',
+			$venue_name
+		);
+		update_term_meta( $term_id, '_venue_address', '300 King Street' );
+		update_term_meta( $term_id, '_venue_city', 'Charleston' );
+		update_term_meta( $term_id, '_venue_state', 'SC' );
+		update_term_meta( $term_id, '_venue_country', 'US' );
+
+		$result = EventDuplicateStrategy::check(
+			array(
+				'title'   => 'Equivalent Geography Show',
+				'context' => array(
+					'venue'     => $venue_name,
+					'startDate' => '2026-08-16T20:30:00',
+					'ticketUrl' => '',
+					'address'   => '300 King St.',
+					'city'      => 'Charleston',
+					'state'     => 'South Carolina',
+					'country'   => 'USA',
+				),
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'duplicate', $result['verdict'] );
+		$this->assertSame( $existing_post_id, $result['match']['post_id'] );
+		$this->cleanup( $term_id, $existing_post_id );
+	}
+
 	// ---------------------------------------------------------------------
 	// findByExactTitle() — term-id short-circuit + 2-hour time-window guard
 	// ---------------------------------------------------------------------

--- a/tests/Unit/VenueNormalizationTest.php
+++ b/tests/Unit/VenueNormalizationTest.php
@@ -196,6 +196,171 @@ class VenueNormalizationTest extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_same_name_in_different_city_returns_ambiguity_without_merging(): void {
+		$name  = 'The Foundry Collision ' . uniqid();
+		$first = Venue_Taxonomy::find_or_create_venue(
+			$name,
+			array(
+				'address' => '100 Main Street',
+				'city'    => 'Charleston',
+				'state'   => 'SC',
+				'country' => 'US',
+			)
+		);
+		$result = Venue_Taxonomy::find_or_create_venue(
+			$name,
+			array(
+				'address' => '200 Main Street',
+				'city'    => 'Atlanta',
+				'state'   => 'GA',
+				'country' => 'US',
+				'phone'   => '555-0100',
+			)
+		);
+
+		$this->assertNull( $result['term_id'] );
+		$this->assertSame( 'ambiguous', $result['match_status'] );
+		$this->assertSame( '', get_term_meta( $first['term_id'], '_venue_phone', true ) );
+	}
+
+	public function test_missing_address_preserves_safe_name_match(): void {
+		$name  = 'Incomplete Evidence Venue ' . uniqid();
+		$first = Venue_Taxonomy::find_or_create_venue(
+			$name,
+			array(
+				'address' => '300 King Street',
+				'city'    => 'Charleston',
+				'state'   => 'SC',
+			)
+		);
+		$result = Venue_Taxonomy::find_or_create_venue(
+			$name,
+			array(
+				'city'  => 'Charleston',
+				'phone' => '555-0101',
+			)
+		);
+
+		$this->assertSame( $first['term_id'], $result['term_id'] );
+		$this->assertSame( '555-0101', get_term_meta( $first['term_id'], '_venue_phone', true ) );
+	}
+
+	public function test_state_and_country_conflicts_reject_address_identity(): void {
+		$name  = 'Border Venue ' . uniqid();
+		$first = Venue_Taxonomy::find_or_create_venue(
+			$name,
+			array(
+				'address' => '400 State Street',
+				'city'    => 'Springfield',
+				'state'   => 'IL',
+				'country' => 'US',
+			)
+		);
+
+		$state_conflict = Venue_Taxonomy::find_or_create_venue(
+			$name,
+			array(
+				'address' => '400 State Street',
+				'city'    => 'Springfield',
+				'state'   => 'MO',
+				'country' => 'US',
+			)
+		);
+		$country_conflict = Venue_Taxonomy::find_or_create_venue(
+			$name,
+			array(
+				'address' => '400 State Street',
+				'city'    => 'Springfield',
+				'state'   => 'IL',
+				'country' => 'CA',
+			)
+		);
+
+		$this->assertNotNull( $first['term_id'] );
+		$this->assertNull(
+			Venue_Taxonomy::find_venue_by_address( '400 State St.', 'Springfield', 'MO', 'US' )
+		);
+		$this->assertNull(
+			Venue_Taxonomy::find_venue_by_address( '400 State St.', 'Springfield', 'IL', 'CA' )
+		);
+		$this->assertNull( $state_conflict['term_id'] );
+		$this->assertNull( $country_conflict['term_id'] );
+		$this->assertSame( 'ambiguous', $state_conflict['match_status'] );
+		$this->assertSame( 'ambiguous', $country_conflict['match_status'] );
+	}
+
+	public function test_article_toggle_does_not_cross_city_boundaries(): void {
+		$base  = 'Article Collision ' . uniqid();
+		$first = Venue_Taxonomy::find_or_create_venue(
+			'The ' . $base,
+			array(
+				'city'  => 'Nashville',
+				'state' => 'TN',
+			)
+		);
+		$result = Venue_Taxonomy::find_or_create_venue(
+			$base,
+			array(
+				'city'  => 'Austin',
+				'state' => 'TX',
+			)
+		);
+
+		$this->assertNotNull( $first['term_id'] );
+		$this->assertNull( $result['term_id'] );
+		$this->assertSame( 'ambiguous', $result['match_status'] );
+	}
+
+	public function test_normalized_name_collision_does_not_cross_city_boundaries(): void {
+		$suffix = uniqid();
+		$first  = Venue_Taxonomy::find_or_create_venue(
+			'Rock - House ' . $suffix,
+			array(
+				'city'  => 'Denver',
+				'state' => 'CO',
+			)
+		);
+		$result = Venue_Taxonomy::find_or_create_venue(
+			'Rock House ' . $suffix,
+			array(
+				'city'  => 'Phoenix',
+				'state' => 'AZ',
+			)
+		);
+
+		$this->assertNotNull( $first['term_id'] );
+		$this->assertNull( $result['term_id'] );
+		$this->assertSame( 'ambiguous', $result['match_status'] );
+	}
+
+	public function test_compatible_identity_fills_empty_metadata_without_overwriting(): void {
+		$name    = 'Metadata Merge Venue ' . uniqid();
+		$created = Venue_Taxonomy::find_or_create_venue(
+			$name,
+			array(
+				'address'     => '500 Market Street',
+				'city'        => 'Philadelphia',
+				'website'     => 'https://existing.example',
+				'coordinates' => '39.9526,-75.1652',
+			)
+		);
+		$result  = Venue_Taxonomy::find_or_create_venue(
+			$name,
+			array(
+				'address' => '500 Market St.',
+				'city'    => 'Philadelphia',
+				'state'   => 'PA',
+				'country' => 'US',
+				'website' => 'https://incoming.example',
+			)
+		);
+
+		$this->assertSame( $created['term_id'], $result['term_id'] );
+		$this->assertSame( 'PA', get_term_meta( $created['term_id'], '_venue_state', true ) );
+		$this->assertSame( 'US', get_term_meta( $created['term_id'], '_venue_country', true ) );
+		$this->assertSame( 'https://existing.example', get_term_meta( $created['term_id'], '_venue_website', true ) );
+	}
+
 	// ---------------------------------------------------------------------
 	// Part C: address-in-name extraction (#433)
 	// ---------------------------------------------------------------------

--- a/tests/Unit/VenueNormalizationTest.php
+++ b/tests/Unit/VenueNormalizationTest.php
@@ -289,6 +289,41 @@ class VenueNormalizationTest extends WP_UnitTestCase {
 		$this->assertSame( 'ambiguous', $country_conflict['match_status'] );
 	}
 
+	public function test_equivalent_state_and_country_forms_preserve_identity(): void {
+		$name  = 'Geography Alias Venue ' . uniqid();
+		$first = Venue_Taxonomy::find_or_create_venue(
+			$name,
+			array(
+				'address' => '600 Meeting Street',
+				'city'    => 'Charleston',
+				'state'   => 'SC',
+				'country' => 'US',
+			)
+		);
+		$full_names = Venue_Taxonomy::find_or_create_venue(
+			$name,
+			array(
+				'address' => '600 Meeting St.',
+				'city'    => 'Charleston',
+				'state'   => 'South Carolina',
+				'country' => 'United States',
+			)
+		);
+		$country_code = Venue_Taxonomy::find_or_create_venue(
+			$name,
+			array(
+				'city'    => 'Charleston',
+				'state'   => 'SC',
+				'country' => 'USA',
+			)
+		);
+
+		$this->assertSame( $first['term_id'], $full_names['term_id'] );
+		$this->assertSame( $first['term_id'], $country_code['term_id'] );
+		$this->assertSame( 'matched', $full_names['match_status'] );
+		$this->assertSame( 'matched', $country_code['match_status'] );
+	}
+
 	public function test_article_toggle_does_not_cross_city_boundaries(): void {
 		$base  = 'Article Collision ' . uniqid();
 		$first = Venue_Taxonomy::find_or_create_venue(


### PR DESCRIPTION
## Summary
- qualify address, exact-name, article-toggle, and normalized-name venue matches with non-conflicting geographic evidence
- return an explicit ambiguity result instead of attaching events or merging metadata across conflicting venues
- route event duplicate detection through the same non-mutating venue taxonomy resolver and pass address, city, state, and country from both upsert and pre-AI paths
- prevent ambiguous venue identity from falling through to exact/slug/normalized or later title-based duplicate matches
- canonicalize bounded generic US geography forms such as `SC` / `South Carolina` and `US` / `USA` / `United States`

## Identity rules
- the venue taxonomy remains the source of truth; no identity service was added
- missing geography on either side remains incomplete evidence and does not reject a safe match
- populated address, city, state, or country values must agree after normalization and bounded alias canonicalization
- exact, article-toggle, and normalized-name precedence remains intact among geographically compatible candidates
- multiple compatible candidates or only geographically conflicting candidates return `term_id: null` with `match_status: ambiguous`
- duplicate detection may still honor an authoritative matching ticket URL, but ambiguous venue identity blocks all venue/title fallback strategies

## Tests
- same-name venues across cities
- missing-address incomplete evidence
- true state and country conflicts
- equivalent state/country representations
- article-toggle and normalized-name collisions
- metadata fill-empty and no-merge-on-conflict behavior
- end-to-end duplicate detection conflict bypass and equivalent-geography matching

## Verification
- PHP syntax checks pass for all changed PHP files
- `git diff --check` passes
- focused Homeboy run reached 33 tests and 64 assertions, then all tests hit the sandbox's missing `SebastianBergmann\\Comparator\\ExceptionComparator` dependency
- full Homeboy run attempted; sandbox-wide failures remain from that missing comparator and existing MySQL `INTERVAL` queries unsupported by its SQLite runtime
- changed-file Homeboy lint attempted; PHPCS ruleset initialization and PHPStan binary are broken in the installed Homeboy extension, while syntax validation passed

Fixes #487