### PR TITLE
fix: harden public event query semantics

### DIFF
--- a/inc/Abilities/EventDateQueryAbilities.php
+++ b/inc/Abilities/EventDateQueryAbilities.php
@@ -27,6 +27,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class EventDateQueryAbilities {
 	private const CAPTURE_IDS_QUERY_VAR = '_data_machine_events_capture_ids_sql';
+	private const MAX_PUBLIC_RESULTS = 100;
+	private const DEFAULT_PUBLIC_RESULTS = 50;
 
 	private static bool $registered = false;
 
@@ -100,6 +102,11 @@ class EventDateQueryAbilities {
 										'type' => 'string',
 										'enum' => array( 'mi', 'km' ),
 									),
+									'empty_result_behavior' => array(
+										'type'        => 'string',
+										'enum'        => array( 'empty', 'ignore_geo' ),
+										'description' => 'Behavior when no venues are inside the radius. Default: empty. Use ignore_geo to explicitly fall back to the remaining filters.',
+									),
 								),
 							),
 							'exclude'     => array(
@@ -109,25 +116,19 @@ class EventDateQueryAbilities {
 							),
 							'per_page'    => array(
 								'type'        => 'integer',
-								'description' => 'Posts per page. -1 for all. Default: -1.',
+								'minimum'     => 1,
+								'maximum'     => self::MAX_PUBLIC_RESULTS,
+								'description' => 'Events per page. Default: 50. Maximum: 100.',
 							),
 							'fields'      => array(
 								'type'        => 'string',
 								'enum'        => array( 'all', 'ids', 'count' ),
-								'description' => 'Return format: all (WP_Post objects), ids (post IDs), count (just total). Default: all.',
+								'description' => 'Return format: all (structured events), ids (post IDs), count (just total). Default: all.',
 							),
 							'order'       => array(
 								'type'        => 'string',
 								'enum'        => array( 'ASC', 'DESC' ),
 								'description' => 'Sort direction for event start_datetime. Default: ASC.',
-							),
-							'status'      => array(
-								'type'        => 'string',
-								'description' => 'Post status. Default: publish.',
-							),
-							'meta_query'  => array(
-								'type'        => 'array',
-								'description' => 'Additional meta_query clauses (for non-date meta like ticket_url, flow_id).',
 							),
 						),
 					),
@@ -136,7 +137,22 @@ class EventDateQueryAbilities {
 						'properties' => array(
 							'posts'      => array(
 								'type'        => 'array',
-								'description' => 'WP_Post objects, post IDs, or empty (for count mode).',
+								'description' => 'Structured published events, post IDs, or empty (for count mode).',
+								'items'       => array(
+									'oneOf' => array(
+										array( 'type' => 'integer' ),
+										array(
+											'type'       => 'object',
+											'properties' => array(
+												'event_id'       => array( 'type' => 'integer' ),
+												'title'          => array( 'type' => 'string' ),
+												'permalink'      => array( 'type' => 'string' ),
+												'start_datetime' => array( 'type' => 'string' ),
+												'end_datetime'   => array( 'type' => array( 'string', 'null' ) ),
+											),
+										),
+									),
+								),
 							),
 							'total'      => array(
 								'type'        => 'integer',
@@ -148,7 +164,7 @@ class EventDateQueryAbilities {
 							),
 						),
 					),
-					'execute_callback'    => array( $this, 'executeQueryEvents' ),
+					'execute_callback'    => array( $this, 'executePublicQueryEvents' ),
 					'permission_callback' => '__return_true',
 					'meta'                => array(
 						'show_in_rest' => true,
@@ -162,6 +178,41 @@ class EventDateQueryAbilities {
 		};
 
 		add_action( 'wp_abilities_api_init', $register_callback );
+	}
+
+	/**
+	 * Execute the REST-visible, publish-only event query.
+	 *
+	 * The internal executeQueryEvents() method intentionally retains status and
+	 * meta controls for authorized operational abilities and PHP callers. This
+	 * public boundary strips those controls, caps hydration, and never exposes
+	 * WP_Post objects.
+	 *
+	 * @param array $input Public input parameters.
+	 * @return array { posts: array, total: int, post_count: int }
+	 */
+	public function executePublicQueryEvents( array $input ): array {
+		unset( $input['status'], $input['meta_query'] );
+
+		$input['status']   = 'publish';
+		$input['per_page'] = min(
+			self::MAX_PUBLIC_RESULTS,
+			max( 1, (int) ( $input['per_page'] ?? self::DEFAULT_PUBLIC_RESULTS ) )
+		);
+
+		$result = $this->executeQueryEvents( $input );
+		if ( 'all' !== ( $input['fields'] ?? 'all' ) ) {
+			return $result;
+		}
+
+		$result['posts'] = array_values(
+			array_filter(
+				array_map( array( $this, 'serializePublicEvent' ), $result['posts'] )
+			)
+		);
+		$result['post_count'] = count( $result['posts'] );
+
+		return $result;
 	}
 
 	/**
@@ -265,7 +316,7 @@ class EventDateQueryAbilities {
 		}
 
 		// Geo filter (venue proximity).
-		if ( ! empty( $geo['lat'] ) && ! empty( $geo['lng'] ) ) {
+		if ( array_key_exists( 'lat', $geo ) && array_key_exists( 'lng', $geo ) ) {
 			$geo_lat    = (float) $geo['lat'];
 			$geo_lng    = (float) $geo['lng'];
 			$geo_radius = (float) ( $geo['radius'] ?? 25 );
@@ -281,19 +332,14 @@ class EventDateQueryAbilities {
 					$geo_unit
 				);
 
-				// Only constrain by venue proximity when the haversine actually
-				// found venues in radius. An empty match means "no additional
-				// geo signal" — drop the geo constraint and fall back to the
-				// other constraints (e.g. the location term + date filters)
-				// instead of forcing terms => [0], which would guarantee an
-				// empty result even when the location term has events. See #378.
-				if ( ! empty( $nearby_venue_ids ) ) {
+				$ignore_empty_geo = 'ignore_geo' === ( $geo['empty_result_behavior'] ?? 'empty' );
+				if ( ! empty( $nearby_venue_ids ) || ! $ignore_empty_geo ) {
 					$tax_query             = isset( $query_args['tax_query'] ) ? $query_args['tax_query'] : array();
 					$tax_query['relation'] = 'AND';
 					$tax_query[]           = array(
 						'taxonomy' => 'venue',
 						'field'    => 'term_id',
-						'terms'    => $nearby_venue_ids,
+						'terms'    => empty( $nearby_venue_ids ) ? array( 0 ) : $nearby_venue_ids,
 						'operator' => 'IN',
 					);
 
@@ -477,7 +523,7 @@ class EventDateQueryAbilities {
 			} elseif ( 'upcoming' === $scope ) {
 				// Canonical upcoming — delegates to UpcomingFilter.
 				if ( $days_ahead > 0 ) {
-					$end_date          = gmdate( 'Y-m-d 23:59:59', strtotime( "+{$days_ahead} days" ) );
+					$end_date          = current_datetime()->modify( "+{$days_ahead} days" )->setTime( 23, 59, 59 )->format( 'Y-m-d H:i:s' );
 					$clauses['where'] .= ' AND ' . UpcomingFilter::upcoming_bounded_where( $now, $end_date );
 				} else {
 					$clauses['where'] .= ' AND ' . UpcomingFilter::upcoming_where( $now );
@@ -495,6 +541,32 @@ class EventDateQueryAbilities {
 
 			return $clauses;
 		};
+	}
+
+	/**
+	 * Serialize one published event into the bounded public contract.
+	 *
+	 * @param mixed $post Event post returned by WP_Query.
+	 * @return array|null Structured event, or null when unavailable.
+	 */
+	private function serializePublicEvent( $post ): ?array {
+		if ( ! $post instanceof \WP_Post || 'publish' !== $post->post_status ) {
+			return null;
+		}
+
+		$dates     = EventDatesTable::get( (int) $post->ID );
+		$permalink = get_permalink( $post );
+		if ( ! $dates || ! is_string( $permalink ) ) {
+			return null;
+		}
+
+		return array(
+			'event_id'       => (int) $post->ID,
+			'title'          => html_entity_decode( get_the_title( $post ), ENT_QUOTES, 'UTF-8' ),
+			'permalink'      => $permalink,
+			'start_datetime' => (string) $dates->start_datetime,
+			'end_datetime'   => null === $dates->end_datetime ? null : (string) $dates->end_datetime,
+		);
 	}
 
 	/**

--- a/inc/Abilities/EventDateQueryAbilities.php
+++ b/inc/Abilities/EventDateQueryAbilities.php
@@ -94,9 +94,26 @@ class EventDateQueryAbilities {
 							),
 							'geo'         => array(
 								'type'       => 'object',
+								'anyOf'      => array(
+									array( 'required' => array( 'lat', 'lng' ) ),
+									array(
+										'required'   => array( 'empty_result_behavior' ),
+										'properties' => array(
+											'empty_result_behavior' => array( 'enum' => array( 'ignore_geo' ) ),
+										),
+									),
+								),
 								'properties' => array(
-									'lat'    => array( 'type' => 'number' ),
-									'lng'    => array( 'type' => 'number' ),
+									'lat'    => array(
+										'type'    => 'number',
+										'minimum' => -90,
+										'maximum' => 90,
+									),
+									'lng'    => array(
+										'type'    => 'number',
+										'minimum' => -180,
+										'maximum' => 180,
+									),
 									'radius' => array( 'type' => 'number' ),
 									'unit'   => array(
 										'type' => 'string',
@@ -193,6 +210,23 @@ class EventDateQueryAbilities {
 	 */
 	public function executePublicQueryEvents( array $input ): array {
 		unset( $input['status'], $input['meta_query'] );
+
+		if ( array_key_exists( 'geo', $input ) ) {
+			$geo        = is_array( $input['geo'] ) ? $input['geo'] : array();
+			$ignore_geo = 'ignore_geo' === ( $geo['empty_result_behavior'] ?? 'empty' );
+			$valid_geo  = array_key_exists( 'lat', $geo )
+				&& array_key_exists( 'lng', $geo )
+				&& class_exists( 'DataMachineEvents\\Blocks\\Calendar\\Geo_Query' )
+				&& \DataMachineEvents\Blocks\Calendar\Geo_Query::validate_params( $geo['lat'], $geo['lng'], $geo['radius'] ?? 25 );
+
+			if ( ! $valid_geo && ! $ignore_geo ) {
+				return array(
+					'posts'      => array(),
+					'total'      => 0,
+					'post_count' => 0,
+				);
+			}
+		}
 
 		$input['status']   = 'publish';
 		$input['per_page'] = min(
@@ -315,36 +349,37 @@ class EventDateQueryAbilities {
 			$query_args['tax_query'] = $tax_query;
 		}
 
-		// Geo filter (venue proximity).
-		if ( array_key_exists( 'lat', $geo ) && array_key_exists( 'lng', $geo ) ) {
-			$geo_lat    = (float) $geo['lat'];
-			$geo_lng    = (float) $geo['lng'];
-			$geo_radius = (float) ( $geo['radius'] ?? 25 );
-			$geo_unit   = $geo['unit'] ?? 'mi';
+		// Geo filter (venue proximity). Any non-empty invalid geo envelope fails
+		// closed unless the caller explicitly requests the documented fallback.
+		if ( ! empty( $geo ) ) {
+			$nearby_venue_ids = array();
+			$ignore_empty_geo = 'ignore_geo' === ( $geo['empty_result_behavior'] ?? 'empty' );
+			$has_coordinates  = array_key_exists( 'lat', $geo ) && array_key_exists( 'lng', $geo );
+			$geo_radius       = $geo['radius'] ?? 25;
+			$valid_geo        = $has_coordinates
+				&& class_exists( 'DataMachineEvents\\Blocks\\Calendar\\Geo_Query' )
+				&& \DataMachineEvents\Blocks\Calendar\Geo_Query::validate_params( $geo['lat'], $geo['lng'], $geo_radius );
 
-			if ( class_exists( 'DataMachineEvents\\Blocks\\Calendar\\Geo_Query' )
-				&& \DataMachineEvents\Blocks\Calendar\Geo_Query::validate_params( $geo_lat, $geo_lng, $geo_radius ) ) {
-
+			if ( $valid_geo ) {
 				$nearby_venue_ids = \DataMachineEvents\Blocks\Calendar\Geo_Query::get_venue_ids_within_radius(
-					$geo_lat,
-					$geo_lng,
-					$geo_radius,
-					$geo_unit
+					(float) $geo['lat'],
+					(float) $geo['lng'],
+					(float) $geo_radius,
+					$geo['unit'] ?? 'mi'
+				);
+			}
+
+			if ( ! empty( $nearby_venue_ids ) || ! $ignore_empty_geo ) {
+				$tax_query             = isset( $query_args['tax_query'] ) ? $query_args['tax_query'] : array();
+				$tax_query['relation'] = 'AND';
+				$tax_query[]           = array(
+					'taxonomy' => 'venue',
+					'field'    => 'term_id',
+					'terms'    => empty( $nearby_venue_ids ) ? array( 0 ) : $nearby_venue_ids,
+					'operator' => 'IN',
 				);
 
-				$ignore_empty_geo = 'ignore_geo' === ( $geo['empty_result_behavior'] ?? 'empty' );
-				if ( ! empty( $nearby_venue_ids ) || ! $ignore_empty_geo ) {
-					$tax_query             = isset( $query_args['tax_query'] ) ? $query_args['tax_query'] : array();
-					$tax_query['relation'] = 'AND';
-					$tax_query[]           = array(
-						'taxonomy' => 'venue',
-						'field'    => 'term_id',
-						'terms'    => empty( $nearby_venue_ids ) ? array( 0 ) : $nearby_venue_ids,
-						'operator' => 'IN',
-					);
-
-					$query_args['tax_query'] = $tax_query;
-				}
+				$query_args['tax_query'] = $tax_query;
 			}
 		}
 

--- a/inc/Abilities/EventsByTermAbilities.php
+++ b/inc/Abilities/EventsByTermAbilities.php
@@ -19,6 +19,7 @@
 
 namespace DataMachineEvents\Abilities;
 
+use DataMachineEvents\Blocks\Calendar\Query\UpcomingFilter;
 use DataMachineEvents\Core\EventDatesTable;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -301,53 +302,30 @@ class EventsByTermAbilities {
 		$ed_table = EventDatesTable::table_name();
 		$now      = current_time( 'mysql' );
 
-		// Two fully-literal query strings keep the date comparator and sort
-		// direction out of variable interpolation so $wpdb->prepare() sees a
-		// stable placeholder count. The only interpolated token is the table
-		// name (a trusted internal constant); the taxonomy is passed as a %s
-		// placeholder, matching the sibling UpcomingCountAbilities pattern.
 		$timing = ( 'upcoming' === $scope ) ? 'upcoming' : 'past';
+		$where  = 'upcoming' === $scope
+			? UpcomingFilter::upcoming_where( $now )
+			: UpcomingFilter::past_where( $now );
 
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $ed_table is a trusted internal constant; the two literal query strings keep placeholder counts stable.
-		if ( 'upcoming' === $scope ) {
-			$rows = $wpdb->get_results(
-				$wpdb->prepare(
-					"SELECT ed.post_id AS post_id, ed.start_datetime AS start_datetime
-					FROM {$ed_table} ed
-					INNER JOIN {$wpdb->term_relationships} tr ON tr.object_id = ed.post_id
-					INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
-					WHERE tt.taxonomy = %s
-					AND tt.term_id = %d
-					AND ed.post_status = 'publish'
-					AND ed.start_datetime >= %s
-					ORDER BY ed.start_datetime ASC
-					LIMIT %d",
-					$taxonomy,
-					$term_id,
-					$now,
-					$limit
-				)
-			);
-		} else {
-			$rows = $wpdb->get_results(
-				$wpdb->prepare(
-					"SELECT ed.post_id AS post_id, ed.start_datetime AS start_datetime
-					FROM {$ed_table} ed
-					INNER JOIN {$wpdb->term_relationships} tr ON tr.object_id = ed.post_id
-					INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
-					WHERE tt.taxonomy = %s
-					AND tt.term_id = %d
-					AND ed.post_status = 'publish'
-					AND ed.start_datetime < %s
-					ORDER BY ed.start_datetime DESC
-					LIMIT %d",
-					$taxonomy,
-					$term_id,
-					$now,
-					$limit
-				)
-			);
-		}
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Trusted table, prepared canonical predicate, and fixed sort values are interpolated.
+		$order = 'upcoming' === $scope ? 'ASC' : 'DESC';
+		$rows  = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT ed.post_id AS post_id, ed.start_datetime AS start_datetime
+				FROM {$ed_table} ed
+				INNER JOIN {$wpdb->term_relationships} tr ON tr.object_id = ed.post_id
+				INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
+				WHERE tt.taxonomy = %s
+				AND tt.term_id = %d
+				AND ed.post_status = 'publish'
+				AND {$where}
+				ORDER BY ed.start_datetime {$order}
+				LIMIT %d",
+				$taxonomy,
+				$term_id,
+				$limit
+			)
+		);
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 		if ( empty( $rows ) ) {

--- a/inc/Abilities/VenueMapAbilities.php
+++ b/inc/Abilities/VenueMapAbilities.php
@@ -19,6 +19,7 @@
 namespace DataMachineEvents\Abilities;
 
 use DataMachineEvents\Blocks\Calendar\Geo_Query;
+use DataMachineEvents\Blocks\Calendar\Query\UpcomingFilter;
 use DataMachineEvents\Core\Event_Post_Type;
 use DataMachineEvents\Core\Venue_Taxonomy;
 
@@ -550,7 +551,8 @@ class VenueMapAbilities {
 	 *
 	 * Single batched query keyed by the IDs being rendered, returning a
 	 * `term_id => count` map. "Upcoming" means events with a
-	 * `start_datetime >= today` row in the event_dates table — matching
+	 * canonical upcoming event row in the event_dates table, including events
+	 * still in progress and excluding events that already ended today. This matches
 	 * the semantics of the venue popup label ("X upcoming events") and
 	 * the location-archive venue badge graph (Extra-Chill/extrachill-events#88).
 	 *
@@ -569,7 +571,7 @@ class VenueMapAbilities {
 		global $wpdb;
 
 		$post_type = Event_Post_Type::POST_TYPE;
-		$today     = gmdate( 'Y-m-d 00:00:00' );
+		$upcoming  = UpcomingFilter::upcoming_where( current_time( 'mysql' ) );
 
 		$placeholders = implode( ',', array_fill( 0, count( $venue_ids ), '%d' ) );
 
@@ -587,9 +589,9 @@ class VenueMapAbilities {
 			AND tt.term_id IN ($placeholders)
 			AND p.post_type = %s
 			AND p.post_status = 'publish'
-			AND ed.start_datetime >= %s
+			AND {$upcoming}
 			GROUP BY tt.term_id",
-			array_merge( $venue_ids, array( $post_type, $today ) )
+			array_merge( $venue_ids, array( $post_type ) )
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
@@ -635,7 +637,7 @@ class VenueMapAbilities {
 		global $wpdb;
 
 		$post_type = Event_Post_Type::POST_TYPE;
-		$today     = gmdate( 'Y-m-d 00:00:00' );
+		$upcoming  = UpcomingFilter::upcoming_where( current_time( 'mysql' ) );
 
 		$placeholders = implode( ',', array_fill( 0, count( $venue_ids ), '%d' ) );
 
@@ -661,13 +663,13 @@ class VenueMapAbilities {
 			AND venue_tt.term_id IN ($placeholders)
 			AND p.post_type = %s
 			AND p.post_status = 'publish'
-			AND ed.start_datetime >= %s
+			AND {$upcoming}
 			AND filter_tt.taxonomy = %s
 			AND filter_tt.term_id = %d
 			ORDER BY venue_tt.term_id ASC, ed.start_datetime ASC",
 			array_merge(
 				$venue_ids,
-				array( $post_type, $today, $filter_taxonomy, $filter_term_id )
+				array( $post_type, $filter_taxonomy, $filter_term_id )
 			)
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared

--- a/inc/Blocks/Calendar/Geo_Query.php
+++ b/inc/Blocks/Calendar/Geo_Query.php
@@ -159,6 +159,10 @@ class Geo_Query {
 		$lat = (float) $lat;
 		$lng = (float) $lng;
 
+		if ( ! is_finite( $lat ) || ! is_finite( $lng ) ) {
+			return false;
+		}
+
 		if ( $lat < -90 || $lat > 90 ) {
 			return false;
 		}
@@ -168,7 +172,7 @@ class Geo_Query {
 		}
 
 		if ( null !== $radius ) {
-			if ( ! is_numeric( $radius ) || (float) $radius <= 0 ) {
+			if ( ! is_numeric( $radius ) || ! is_finite( (float) $radius ) || (float) $radius <= 0 ) {
 				return false;
 			}
 		}

--- a/tests/Unit/EventDateQueryAbilitiesTest.php
+++ b/tests/Unit/EventDateQueryAbilitiesTest.php
@@ -119,6 +119,46 @@ class EventDateQueryAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( array( $event_id ), array_column( $fallback['posts'], 'event_id' ) );
 	}
 
+	/**
+	 * @dataProvider invalid_geo_inputs
+	 */
+	public function test_invalid_geo_never_falls_back_to_unrestricted_results( array $geo ): void {
+		$this->seed_event( 'Unrelated published event', 'publish', current_datetime()->modify( '+1 day' )->format( 'Y-m-d H:i:s' ) );
+
+		$result = ( new EventDateQueryAbilities() )->executePublicQueryEvents( array( 'geo' => $geo ) );
+
+		$this->assertSame( 0, $result['post_count'] );
+		$this->assertSame( array(), $result['posts'] );
+	}
+
+	public static function invalid_geo_inputs(): array {
+		return array(
+			'empty geo object'       => array( array() ),
+			'latitude only'          => array( array( 'lat' => 32.7765 ) ),
+			'longitude only'         => array( array( 'lng' => -79.9311 ) ),
+			'nonnumeric latitude'    => array( array( 'lat' => 'north', 'lng' => -79.9311 ) ),
+			'nonnumeric longitude'   => array( array( 'lat' => 32.7765, 'lng' => 'west' ) ),
+			'NaN-like latitude'      => array( array( 'lat' => 'NaN', 'lng' => -79.9311 ) ),
+			'actual NaN latitude'    => array( array( 'lat' => NAN, 'lng' => -79.9311 ) ),
+			'latitude out of range'  => array( array( 'lat' => 90.1, 'lng' => -79.9311 ) ),
+			'longitude out of range' => array( array( 'lat' => 32.7765, 'lng' => -180.1 ) ),
+		);
+	}
+
+	public function test_invalid_geo_can_only_fall_back_when_explicitly_requested(): void {
+		$event_id = $this->seed_event( 'Explicit fallback event', 'publish', current_datetime()->modify( '+1 day' )->format( 'Y-m-d H:i:s' ) );
+
+		$result = ( new EventDateQueryAbilities() )->executePublicQueryEvents(
+			array(
+				'geo' => array(
+					'empty_result_behavior' => 'ignore_geo',
+				),
+			)
+		);
+
+		$this->assertSame( array( $event_id ), array_column( $result['posts'], 'event_id' ) );
+	}
+
 	public function test_upcoming_preserves_ongoing_and_excludes_events_ended_earlier_today(): void {
 		$old_timezone = get_option( 'timezone_string' );
 		update_option( 'timezone_string', 'America/New_York' );

--- a/tests/Unit/EventDateQueryAbilitiesTest.php
+++ b/tests/Unit/EventDateQueryAbilitiesTest.php
@@ -11,6 +11,7 @@ use WP_UnitTestCase;
 use DataMachineEvents\Abilities\EventDateQueryAbilities;
 use DataMachineEvents\Core\Event_Post_Type;
 use DataMachineEvents\Core\EventDatesTable;
+use DataMachineEvents\Core\Venue_Taxonomy;
 
 class EventDateQueryAbilitiesTest extends WP_UnitTestCase {
 
@@ -21,6 +22,158 @@ class EventDateQueryAbilitiesTest extends WP_UnitTestCase {
 		}
 		if ( ! EventDatesTable::table_exists() ) {
 			EventDatesTable::create_table();
+		}
+		if ( ! taxonomy_exists( 'venue' ) ) {
+			Venue_Taxonomy::register();
+		}
+	}
+
+	private function seed_event( string $title, string $status, string $start, ?string $end = null, int $venue_id = 0 ): int {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'  => $title,
+				'post_type'   => Event_Post_Type::POST_TYPE,
+				'post_status' => $status,
+			)
+		);
+		EventDatesTable::upsert( $post_id, $start, $end, $status );
+
+		if ( $venue_id > 0 ) {
+			wp_set_object_terms( $post_id, array( $venue_id ), 'venue' );
+		}
+
+		return $post_id;
+	}
+
+	public function test_public_query_is_publish_only_for_anonymous_callers_and_returns_structured_events(): void {
+		$now       = current_datetime();
+		$published = $this->seed_event( 'Published event', 'publish', $now->modify( '+1 day' )->format( 'Y-m-d H:i:s' ) );
+		$this->seed_event( 'Draft event', 'draft', $now->modify( '+2 days' )->format( 'Y-m-d H:i:s' ) );
+		$this->seed_event( 'Private event', 'private', $now->modify( '+3 days' )->format( 'Y-m-d H:i:s' ) );
+		wp_set_current_user( 0 );
+
+		$result = ( new EventDateQueryAbilities() )->executePublicQueryEvents(
+			array(
+				'scope'      => 'upcoming',
+				'status'     => 'any',
+				'meta_query' => array( array( 'key' => '_private_control' ) ),
+			)
+		);
+
+		$this->assertSame( 1, $result['post_count'] );
+		$this->assertSame( $published, $result['posts'][0]['event_id'] );
+		$this->assertSame(
+			array( 'event_id', 'title', 'permalink', 'start_datetime', 'end_datetime' ),
+			array_keys( $result['posts'][0] )
+		);
+		$this->assertNotInstanceOf( \WP_Post::class, $result['posts'][0] );
+	}
+
+	public function test_internal_query_contract_preserves_privileged_callers(): void {
+		$draft = $this->seed_event( 'Operational draft', 'draft', current_datetime()->modify( '+1 day' )->format( 'Y-m-d H:i:s' ) );
+		update_post_meta( $draft, '_operational_scope', 'yes' );
+
+		$result = ( new EventDateQueryAbilities() )->executeQueryEvents(
+			array(
+				'scope'      => 'upcoming',
+				'status'     => 'any',
+				'meta_query' => array(
+					array(
+						'key'   => '_operational_scope',
+						'value' => 'yes',
+					),
+				),
+			)
+		);
+
+		$this->assertSame( 1, $result['post_count'] );
+		$this->assertInstanceOf( \WP_Post::class, $result['posts'][0] );
+		$this->assertSame( $draft, $result['posts'][0]->ID );
+	}
+
+	public function test_empty_geo_match_returns_zero_unless_fallback_is_explicit(): void {
+		$venue = wp_insert_term( 'Far venue ' . uniqid(), 'venue' );
+		$this->assertNotWPError( $venue );
+		$venue_id = (int) $venue['term_id'];
+		add_term_meta( $venue_id, '_venue_coordinates', '40.7128,-74.0060', true );
+		$event_id = $this->seed_event(
+			'Far event',
+			'publish',
+			current_datetime()->modify( '+1 day' )->format( 'Y-m-d H:i:s' ),
+			null,
+			$venue_id
+		);
+		$ability = new EventDateQueryAbilities();
+		$geo     = array(
+			'lat'    => 0,
+			'lng'    => 0,
+			'radius' => 1,
+			'unit'   => 'mi',
+		);
+
+		$empty = $ability->executePublicQueryEvents( array( 'geo' => $geo ) );
+		$this->assertSame( 0, $empty['post_count'] );
+
+		$geo['empty_result_behavior'] = 'ignore_geo';
+		$fallback                     = $ability->executePublicQueryEvents( array( 'geo' => $geo ) );
+		$this->assertSame( array( $event_id ), array_column( $fallback['posts'], 'event_id' ) );
+	}
+
+	public function test_upcoming_preserves_ongoing_and_excludes_events_ended_earlier_today(): void {
+		$old_timezone = get_option( 'timezone_string' );
+		update_option( 'timezone_string', 'America/New_York' );
+
+		try {
+			$now       = current_datetime();
+			$ongoing   = $this->seed_event(
+				'Ongoing event',
+				'publish',
+				$now->modify( '-1 day' )->format( 'Y-m-d H:i:s' ),
+				$now->modify( '+1 hour' )->format( 'Y-m-d H:i:s' )
+			);
+			$completed = $this->seed_event(
+				'Ended today',
+				'publish',
+				$now->setTime( 0, 0 )->format( 'Y-m-d H:i:s' ),
+				$now->modify( '-1 minute' )->format( 'Y-m-d H:i:s' )
+			);
+
+			$ability  = new EventDateQueryAbilities();
+			$upcoming = $ability->executeQueryEvents( array( 'scope' => 'upcoming', 'fields' => 'ids' ) );
+			$past     = $ability->executeQueryEvents( array( 'scope' => 'past', 'fields' => 'ids' ) );
+
+			$this->assertContains( $ongoing, $upcoming['posts'] );
+			$this->assertNotContains( $completed, $upcoming['posts'] );
+			$this->assertContains( $completed, $past['posts'] );
+			$this->assertNotContains( $ongoing, $past['posts'] );
+		} finally {
+			update_option( 'timezone_string', $old_timezone );
+		}
+	}
+
+	public function test_days_ahead_uses_site_timezone_calendar_boundary(): void {
+		$old_timezone = get_option( 'timezone_string' );
+		$utc_hour     = (int) gmdate( 'G' );
+		$timezone     = $utc_hour < 10 ? 'Pacific/Pago_Pago' : 'Pacific/Kiritimati';
+		update_option( 'timezone_string', $timezone );
+
+		try {
+			$site_now = current_datetime();
+			$inside   = $this->seed_event( 'Inside site boundary', 'publish', $site_now->modify( '+1 day' )->setTime( 23, 0 )->format( 'Y-m-d H:i:s' ) );
+			$outside  = $this->seed_event( 'Outside site boundary', 'publish', $site_now->modify( '+2 days' )->setTime( 1, 0 )->format( 'Y-m-d H:i:s' ) );
+
+			$result = ( new EventDateQueryAbilities() )->executeQueryEvents(
+				array(
+					'scope'      => 'upcoming',
+					'days_ahead' => 1,
+					'fields'     => 'ids',
+				)
+			);
+
+			$this->assertContains( $inside, $result['posts'] );
+			$this->assertNotContains( $outside, $result['posts'] );
+		} finally {
+			update_option( 'timezone_string', $old_timezone );
 		}
 	}
 

--- a/tests/Unit/EventsByTermAbilitiesTest.php
+++ b/tests/Unit/EventsByTermAbilitiesTest.php
@@ -9,6 +9,7 @@ namespace DataMachineEvents\Tests\Unit;
 
 use DataMachineEvents\Abilities\EventsByTermAbilities;
 use DataMachineEvents\Core\EventDatesTable;
+use DataMachineEvents\Core\Event_Post_Type;
 use WP_UnitTestCase;
 
 class EventsByTermAbilitiesTest extends WP_UnitTestCase {
@@ -18,6 +19,12 @@ class EventsByTermAbilitiesTest extends WP_UnitTestCase {
 		parent::setUp();
 
 		EventDatesTable::create_table();
+		if ( ! post_type_exists( Event_Post_Type::POST_TYPE ) ) {
+			Event_Post_Type::register();
+		}
+		if ( ! taxonomy_exists( 'term_timing_test' ) ) {
+			register_taxonomy( 'term_timing_test', Event_Post_Type::POST_TYPE );
+		}
 		$this->abilities = new EventsByTermAbilities();
 	}
 
@@ -34,6 +41,20 @@ class EventsByTermAbilitiesTest extends WP_UnitTestCase {
 
 	private function execute( array $input ): array|\WP_Error {
 		return $this->abilities->executeEventsByTerm( $input );
+	}
+
+	private function seed_event( string $title, int $term_id, string $start, string $end ): int {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'  => $title,
+				'post_type'   => Event_Post_Type::POST_TYPE,
+				'post_status' => 'publish',
+			)
+		);
+		EventDatesTable::upsert( $post_id, $start, $end, 'publish' );
+		wp_set_object_terms( $post_id, array( $term_id ), 'term_timing_test' );
+
+		return $post_id;
 	}
 
 	public function test_events_blog_defaults_to_current_site(): void {
@@ -184,5 +205,33 @@ class EventsByTermAbilitiesTest extends WP_UnitTestCase {
 		$this->assertTrue( $result['found'] );
 		$this->assertSame( $term_id, $result['term_id'] );
 		$this->assertSame( 'legacy-slug', $result['term_slug'] );
+	}
+
+	public function test_term_scopes_use_canonical_ongoing_and_completed_predicates(): void {
+		$term_id   = $this->create_term( 'term_timing_test', 'timing-' . uniqid() );
+		$now       = current_datetime();
+		$ongoing   = $this->seed_event(
+			'Ongoing term event',
+			$term_id,
+			$now->modify( '-1 day' )->format( 'Y-m-d H:i:s' ),
+			$now->modify( '+1 hour' )->format( 'Y-m-d H:i:s' )
+		);
+		$completed = $this->seed_event(
+			'Completed term event',
+			$term_id,
+			$now->modify( '-2 hours' )->format( 'Y-m-d H:i:s' ),
+			$now->modify( '-1 hour' )->format( 'Y-m-d H:i:s' )
+		);
+
+		$result = $this->execute(
+			array(
+				'taxonomy' => 'term_timing_test',
+				'term_id'  => $term_id,
+			)
+		);
+
+		$this->assertNotWPError( $result );
+		$this->assertSame( array( $ongoing ), array_column( $result['upcoming'], 'event_id' ) );
+		$this->assertSame( array( $completed ), array_column( $result['past'], 'event_id' ) );
 	}
 }

--- a/tests/Unit/VenueMapAbilitiesTest.php
+++ b/tests/Unit/VenueMapAbilitiesTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Venue map ability timing tests.
+ *
+ * @package DataMachineEvents\Tests\Unit
+ */
+
+namespace DataMachineEvents\Tests\Unit;
+
+use DataMachineEvents\Abilities\VenueMapAbilities;
+use DataMachineEvents\Core\EventDatesTable;
+use DataMachineEvents\Core\Event_Post_Type;
+use DataMachineEvents\Core\Venue_Taxonomy;
+use WP_UnitTestCase;
+
+class VenueMapAbilitiesTest extends WP_UnitTestCase {
+	public function setUp(): void {
+		parent::setUp();
+
+		EventDatesTable::create_table();
+		if ( ! post_type_exists( Event_Post_Type::POST_TYPE ) ) {
+			Event_Post_Type::register();
+		}
+		if ( ! taxonomy_exists( 'venue' ) ) {
+			Venue_Taxonomy::register();
+		}
+		if ( ! taxonomy_exists( 'venue_map_timing_test' ) ) {
+			register_taxonomy( 'venue_map_timing_test', Event_Post_Type::POST_TYPE );
+		}
+	}
+
+	private function seed_event( string $title, int $venue_id, int $filter_id, string $start, string $end ): int {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'  => $title,
+				'post_type'   => Event_Post_Type::POST_TYPE,
+				'post_status' => 'publish',
+			)
+		);
+		EventDatesTable::upsert( $post_id, $start, $end, 'publish' );
+		wp_set_object_terms( $post_id, array( $venue_id ), 'venue' );
+		wp_set_object_terms( $post_id, array( $filter_id ), 'venue_map_timing_test' );
+
+		return $post_id;
+	}
+
+	public function test_venue_map_counts_and_rows_use_canonical_upcoming_predicate(): void {
+		$venue  = wp_insert_term( 'Map venue ' . uniqid(), 'venue' );
+		$filter = wp_insert_term( 'Map filter ' . uniqid(), 'venue_map_timing_test' );
+		$this->assertNotWPError( $venue );
+		$this->assertNotWPError( $filter );
+		$venue_id  = (int) $venue['term_id'];
+		$filter_id = (int) $filter['term_id'];
+		add_term_meta( $venue_id, '_venue_coordinates', '32.7765,-79.9311', true );
+
+		$now       = current_datetime();
+		$ongoing   = $this->seed_event(
+			'Ongoing map event',
+			$venue_id,
+			$filter_id,
+			$now->modify( '-1 day' )->format( 'Y-m-d H:i:s' ),
+			$now->modify( '+1 hour' )->format( 'Y-m-d H:i:s' )
+		);
+		$this->seed_event(
+			'Ended map event',
+			$venue_id,
+			$filter_id,
+			$now->setTime( 0, 0 )->format( 'Y-m-d H:i:s' ),
+			$now->modify( '-1 minute' )->format( 'Y-m-d H:i:s' )
+		);
+
+		$result = ( new VenueMapAbilities() )->executeListVenues(
+			array(
+				'taxonomy'       => 'venue_map_timing_test',
+				'term_id'        => $filter_id,
+				'include_events' => true,
+			)
+		);
+
+		$this->assertSame( 1, $result['total'] );
+		$this->assertSame( 1, $result['venues'][0]['event_count'] );
+		$this->assertSame( array( $ongoing ), array_column( $result['venues'][0]['upcoming_events_at_venue'], 'post_id' ) );
+	}
+}


### PR DESCRIPTION
## Summary
- make the REST-visible event query publish-only, bounded, and structured while preserving the privileged in-process query contract used by operational callers
- require complete, bounded geo coordinates and fail closed for empty, incomplete, nonnumeric, non-finite, and out-of-range inputs; only explicit `ignore_geo` drops the constraint
- make valid geo searches with no matching venues return no events by default
- reuse the canonical calendar upcoming/past predicates for term and venue-map queries, including ongoing events and site-timezone boundaries
- add regressions for anonymous draft/private access, malformed and empty geo behavior, ongoing and ended-today events, timezone bounds, venue-map parity, and internal caller compatibility

## Verification
- `php -l` passed for all changed PHP files
- `git diff --check` passed
- direct finite-coordinate validation smoke test passed for valid, nonnumeric, NaN-like, actual `NAN`, and out-of-range values
- Homeboy PR-profile audit passed with no warnings; one pre-existing informational `Venue_Taxonomy.php` line-count finding remains
- focused and full PHPUnit runs were re-attempted but the shared Codebox runner failed before test discovery because its PHPUnit harness was not initialized; an earlier run also omitted the required Data Machine dependency
- changed-file lint reported no findings, but the shared PHPCS/PHPStan installation still has the previously documented startup failures

Fixes #488