### PR TITLE
fix: include explicit center in route bounds

### DIFF
--- a/inc/Blocks/EventsMap/src/frontend.tsx
+++ b/inc/Blocks/EventsMap/src/frontend.tsx
@@ -787,8 +787,8 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 				clusterGroup.addLayers( markersToAdd );
 			}
 
-			// Fit bounds to the full route and any supplied user location on
-			// the FIRST successful render. The user point anchors the viewport
+			// Fit bounds to the full route and any explicit map center on the
+			// FIRST successful render. The center anchors the viewport
 			// without becoming a stop in the chronological route polyline.
 			// Subsequent refetches (filter changes, bounds events) keep
 			// the current viewport so the user isn't yanked around.
@@ -798,8 +798,8 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 						? orderedLatLngs
 						: routeVenues.map( ( v ) => [ v.lat, v.lon ] as L.LatLngExpression ) ),
 				];
-				if ( hasUserLocation ) {
-					latlngs.push( [ userLat!, userLon! ] );
+				if ( hasCenter ) {
+					latlngs.push( [ centerLat!, centerLon! ] );
 				}
 				if ( latlngs.length > 0 ) {
 					const bounds = L.latLngBounds( latlngs );

--- a/inc/Blocks/EventsMap/src/frontend.tsx
+++ b/inc/Blocks/EventsMap/src/frontend.tsx
@@ -787,13 +787,20 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 				clusterGroup.addLayers( markersToAdd );
 			}
 
-			// Fit bounds to the full route on the FIRST successful render.
+			// Fit bounds to the full route and any supplied user location on
+			// the FIRST successful render. The user point anchors the viewport
+			// without becoming a stop in the chronological route polyline.
 			// Subsequent refetches (filter changes, bounds events) keep
 			// the current viewport so the user isn't yanked around.
 			if ( ! chronologicalRouteFitOnceRef.current ) {
-				const latlngs = orderedLatLngs.length > 0
-					? orderedLatLngs
-					: routeVenues.map( ( v ) => [ v.lat, v.lon ] as L.LatLngExpression );
+				const latlngs = [
+					...( orderedLatLngs.length > 0
+						? orderedLatLngs
+						: routeVenues.map( ( v ) => [ v.lat, v.lon ] as L.LatLngExpression ) ),
+				];
+				if ( hasUserLocation ) {
+					latlngs.push( [ userLat!, userLon! ] );
+				}
 				if ( latlngs.length > 0 ) {
 					const bounds = L.latLngBounds( latlngs );
 					map.fitBounds( bounds.pad( 0.15 ) );


### PR DESCRIPTION
## Summary

- include a supplied explicit map center when fitting chronological route bounds
- keep that center out of the route polyline and date ordering
- preserve existing route-only framing when no center is supplied

## Why

The generic map already accepts a consumer-provided center, but chronological route mode immediately reframed the viewport around route venues alone. Consumers such as My Shows therefore could not use an existing configured-market center as the map anchor.

## Verification

- `npm ci`
- `npm run build`
- `git diff --check`

The package's `wp-scripts lint-js` command currently fails before linting because its ESLint 9 flat config rejects the legacy `--eslintrc` option.

Closes #504