### PR TITLE
fix: preserve Ticketmaster update and retry semantics

### DIFF
--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -19,8 +19,12 @@ permissions:
 
 jobs:
   homeboy:
-    name: Homeboy
+    name: Homeboy (${{ matrix.command }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        command: [review audit, review lint, review test]
     services:
       mysql:
         image: mysql:8.0
@@ -48,8 +52,10 @@ jobs:
           app-id: ${{ secrets.HOMEBOY_APP_ID }}
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
-      - uses: Extra-Chill/homeboy-action@v2
+      - name: Run Homeboy ${{ matrix.command }}
+        uses: Extra-Chill/homeboy-action@v2
         with:
-          commands: review audit
+          commands: ${{ matrix.command }}
+          expected-commands: review audit,review lint,review test
           app-token: ${{ steps.app-token.outputs.token || '' }}
           autofix: 'false'

--- a/docs/ticketmaster-handler.md
+++ b/docs/ticketmaster-handler.md
@@ -15,13 +15,13 @@ The Ticketmaster handler (`inc/Steps/EventImport/Handlers/Ticketmaster/Ticketmas
 
 ## Unique Capabilities
 
-Ticketmaster uses its stable upstream event ID for Data Machine processed-item tracking. Before creating packets, it removes repeated IDs from the current paginated response, skips processed or claimed IDs for the current flow, and checks the event identity index so neighboring city flows do not schedule child jobs for events that another city already imported. It sets `startDateTime` to one hour in the future, filters to events with `dates.status.code === "onsale"`, and supports include/exclude keyword filters.
+Ticketmaster uses its stable upstream event ID plus a revision hash of the mapped event fields. A shared atomic source claim prevents neighboring city flows from selecting the same ID concurrently. Successful child jobs persist the revision in Data Machine's tracked-item ledger; failed jobs release the claim without persisting it. Unchanged revisions are skipped before fan-out, while changed dates, times, venues, titles, prices, and ticket URLs continue to EventUpsert. The generic `datamachine_should_reprocess_item` policy can also make an unchanged revision eligible again.
 
 ## Pagination
 
 The handler paginates Ticketmaster API results up to `MAX_PAGE = 19`. Fan-out defaults to 100 child jobs per run; flows can set `max_items` explicitly when a lower rollout bound is appropriate. Items beyond the cap remain unclaimed so later runs can process them.
 
-Each run logs an `Import fan-out summary` with fetched, pre-fan-out deduped, eligible, fan-out limit, and schedule-candidate counts. When adding cities, start with `max_items` between 25 and 50, verify the deduped-to-scheduled ratio and parent completion time, then increase toward the default only if the worker queue remains healthy.
+Each run logs an `Import fan-out summary` with fetched, unchanged, contended, overflow, source-claimed, and packets-ready counts. `source_claimed` and `packets_ready` are measured after the handler's bound and atomic claims; Data Machine's pipeline-batch log remains authoritative for child jobs actually scheduled. When adding cities, start with `max_items` between 25 and 50, compare `pre_fanout_deduped` with `packets_ready`, and confirm parent completion time and worker queue health before increasing toward the 100-item default.
 
 ## Event Flow
 

--- a/homeboy.json
+++ b/homeboy.json
@@ -5,7 +5,10 @@
     "wordpress": {
       "php": "8.3",
       "node": "20",
-      "database_type": "mysql"
+      "database_type": "mysql",
+      "settings": {
+        "validation_dependencies": ["data-machine"]
+      }
     }
   },
   "id": "data-machine-events",

--- a/inc/Core/DuplicateDetection/PreAIEventDedupGate.php
+++ b/inc/Core/DuplicateDetection/PreAIEventDedupGate.php
@@ -50,6 +50,13 @@ class PreAIEventDedupGate {
 			return $result;
 		}
 
+		// Ticketmaster suppresses unchanged source revisions before fan-out.
+		// Changed revisions must reach upsert so mutable future event data is not
+		// frozen by the post identity index.
+		if ( 'ticketmaster' === $engine->get( 'source_type' ) ) {
+			return null;
+		}
+
 		// Only activate for event pipelines.
 		// Check if any adjacent step has upsert_event as a handler.
 		if ( ! self::isEventPipeline( $engine ) ) {

--- a/inc/Steps/EventImport/Handlers/Ticketmaster/Ticketmaster.php
+++ b/inc/Steps/EventImport/Handlers/Ticketmaster/Ticketmaster.php
@@ -8,7 +8,6 @@
 namespace DataMachineEvents\Steps\EventImport\Handlers\Ticketmaster;
 
 use DataMachine\Core\ExecutionContext;
-use DataMachineEvents\Core\DuplicateDetection\EventDuplicateStrategy;
 use DataMachineEvents\Steps\EventImport\Handlers\EventImportHandler;
 use DataMachineEvents\Steps\EventImport\JunkPayloadFilter;
 use DataMachine\Core\Steps\HandlerRegistrationTrait;
@@ -75,6 +74,7 @@ class Ticketmaster extends EventImportHandler {
 
 	public function __construct() {
 		parent::__construct( 'ticketmaster' );
+		TicketmasterSourceIdentity::register();
 
 		self::registerHandler(
 			'ticketmaster',
@@ -190,9 +190,9 @@ class Ticketmaster extends EventImportHandler {
 		$seen_source_ids       = array();
 		$fetched_count         = 0;
 		$pre_fanout_deduped    = 0;
-		$already_processed     = 0;
-		$existing_event_count  = 0;
+		$unchanged_count       = 0;
 		$repeated_source_count = 0;
+		$contended_count       = 0;
 
 		do {
 			$search_params['page'] = $current_page;
@@ -266,29 +266,11 @@ class Ticketmaster extends EventImportHandler {
 					$standardized_event['venue'] ?? ''
 				);
 				$item_identifier  = '' !== $source_id ? $source_id : $event_identifier;
+				$source_revision  = TicketmasterSourceIdentity::revision( $standardized_event );
 
-				if ( $context->isItemProcessed( $item_identifier ) || $context->isItemClaimed( $item_identifier ) ) {
+				if ( TicketmasterSourceIdentity::shouldSkip( $item_identifier, $source_revision, $context ) ) {
 					++$pre_fanout_deduped;
-					++$already_processed;
-					continue;
-				}
-
-				$existing_event = EventDuplicateStrategy::check(
-					array(
-						'title'   => $standardized_event['title'],
-						'context' => array(
-							'venue'     => $standardized_event['venue'] ?? '',
-							'startDate' => $standardized_event['startDate'] ?? '',
-							'ticketUrl' => $standardized_event['ticketUrl'] ?? '',
-							'address'   => $standardized_event['venueAddress'] ?? '',
-							'city'      => $standardized_event['venueCity'] ?? '',
-						),
-					)
-				);
-
-				if ( $existing_event ) {
-					++$pre_fanout_deduped;
-					++$existing_event_count;
+					++$unchanged_count;
 					continue;
 				}
 
@@ -305,6 +287,13 @@ class Ticketmaster extends EventImportHandler {
 
 				$venue_metadata = $this->extractVenueMetadata( $standardized_event );
 				$engine_data    = $this->buildEventEngineData( $standardized_event, $venue_metadata );
+				$engine_data['item_identifier'] = $item_identifier;
+				$engine_data['source_type']     = 'ticketmaster';
+				$engine_data[ TicketmasterSourceIdentity::ENGINE_KEY ] = array(
+					'item_id'    => $item_identifier,
+					'revision'   => $source_revision,
+					'source_ref' => $standardized_event['ticketUrl'] ?? '',
+				);
 				$this->stripVenueMetadataFromEvent( $standardized_event );
 
 				$eligible_items[] = array(
@@ -323,7 +312,8 @@ class Ticketmaster extends EventImportHandler {
 						'flow_id'          => $context->getFlowId(),
 						'original_title'   => $standardized_event['title'],
 						'event_identifier' => $event_identifier,
-						'item_identifier'  => $item_identifier,
+						'source_item_id'   => $item_identifier,
+						'source_revision'  => $source_revision,
 						'import_timestamp' => time(),
 						'_engine_data'     => $engine_data,
 					),
@@ -337,10 +327,33 @@ class Ticketmaster extends EventImportHandler {
 
 		} while ( $has_more_pages );
 
-		$fanout_limit        = (int) ( $config['max_items'] ?? $this->getDefaultMaxItems() );
-		$schedule_candidates = $fanout_limit > 0
-			? min( count( $eligible_items ), $fanout_limit )
-			: count( $eligible_items );
+		$fanout_limit   = (int) ( $config['max_items'] ?? $this->getDefaultMaxItems() );
+		$eligible_count = count( $eligible_items );
+		if ( $fanout_limit > 0 && $eligible_count > $fanout_limit ) {
+			$eligible_items = array_slice( $eligible_items, 0, $fanout_limit );
+		}
+		$overflow_count = $eligible_count - count( $eligible_items );
+		$claimed_items  = array();
+
+		foreach ( $eligible_items as $item ) {
+			$item_id  = (string) ( $item['metadata']['source_item_id'] ?? '' );
+			$revision = (string) ( $item['metadata']['source_revision'] ?? '' );
+			$claim    = TicketmasterSourceIdentity::claim( $item_id, $revision, $context );
+
+			if ( 'claimed' === $claim || 'direct' === $claim ) {
+				$claimed_items[] = $item;
+				continue;
+			}
+
+			++$pre_fanout_deduped;
+			if ( 'unchanged' === $claim ) {
+				++$unchanged_count;
+			} else {
+				++$contended_count;
+			}
+		}
+
+		$eligible_items = $claimed_items;
 
 		$context->log(
 			'info',
@@ -348,12 +361,14 @@ class Ticketmaster extends EventImportHandler {
 			array(
 				'fetched'                 => $fetched_count,
 				'pre_fanout_deduped'      => $pre_fanout_deduped,
-				'already_processed'       => $already_processed,
-				'existing_events'         => $existing_event_count,
+				'unchanged_revisions'     => $unchanged_count,
 				'repeated_source_ids'     => $repeated_source_count,
-				'eligible'                => count( $eligible_items ),
+				'contended_claims'        => $contended_count,
+				'eligible_before_bound'   => $eligible_count,
+				'overflow'                => $overflow_count,
 				'fanout_limit'            => $fanout_limit,
-				'schedule_candidates'     => $schedule_candidates,
+				'source_claimed'          => count( $eligible_items ),
+				'packets_ready'           => count( $eligible_items ),
 				'pages_searched'          => $current_page,
 			)
 		);

--- a/inc/Steps/EventImport/Handlers/Ticketmaster/TicketmasterSettings.php
+++ b/inc/Steps/EventImport/Handlers/Ticketmaster/TicketmasterSettings.php
@@ -90,6 +90,14 @@ class TicketmasterSettings {
 				'placeholder' => __( 'trivia, karaoke, brunch, bingo', 'data-machine-events' ),
 				'required'    => false,
 			),
+			'max_items'           => array(
+				'type'        => 'number',
+				'label'       => __( 'Max Items Per Run', 'data-machine-events' ),
+				'description' => __( 'Maximum Ticketmaster events selected for child-job fan-out per run. Items beyond the bound remain eligible for later runs.', 'data-machine-events' ),
+				'default'     => Ticketmaster::DEFAULT_MAX_ITEMS,
+				'min'         => 1,
+				'max'         => Ticketmaster::DEFAULT_MAX_ITEMS,
+			),
 		);
 	}
 
@@ -108,6 +116,7 @@ class TicketmasterSettings {
 			'venue_id'            => sanitize_text_field( $raw_settings['venue_id'] ?? '' ),
 			'search'              => sanitize_text_field( $raw_settings['search'] ?? '' ),
 			'exclude_keywords'    => sanitize_text_field( $raw_settings['exclude_keywords'] ?? '' ),
+			'max_items'           => max( 1, min( Ticketmaster::DEFAULT_MAX_ITEMS, absint( $raw_settings['max_items'] ?? Ticketmaster::DEFAULT_MAX_ITEMS ) ) ),
 		);
 	}
 
@@ -135,6 +144,7 @@ class TicketmasterSettings {
 			'venue_id'            => '',
 			'search'              => '',
 			'exclude_keywords'    => '',
+			'max_items'           => Ticketmaster::DEFAULT_MAX_ITEMS,
 		);
 	}
 }

--- a/inc/Steps/EventImport/Handlers/Ticketmaster/TicketmasterSourceIdentity.php
+++ b/inc/Steps/EventImport/Handlers/Ticketmaster/TicketmasterSourceIdentity.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * Cross-flow Ticketmaster source identity lifecycle.
+ *
+ * @package DataMachineEvents\Steps\EventImport\Handlers\Ticketmaster
+ */
+
+namespace DataMachineEvents\Steps\EventImport\Handlers\Ticketmaster;
+
+use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
+use DataMachine\Core\Database\TrackedItems\TrackedItems;
+use DataMachine\Core\ExecutionContext;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Coordinates stable source revisions and atomic claims across city flows.
+ */
+class TicketmasterSourceIdentity {
+
+	public const CLAIM_SCOPE     = 'event_import:ticketmaster';
+	public const TRACK_NAMESPACE = 'event_import:ticketmaster';
+	public const ENGINE_KEY      = 'ticketmaster_source_identity';
+	public const CLAIM_TTL       = 3 * DAY_IN_SECONDS;
+
+	/**
+	 * Static lifecycle service.
+	 */
+	private function __construct() {
+	}
+
+	/**
+	 * Register terminal lifecycle handlers for source claims and revisions.
+	 */
+	public static function register(): void {
+		add_action( 'datamachine_step_lifecycle_completed', array( static::class, 'handleCompleted' ), 20, 2 );
+		add_action( 'datamachine_step_lifecycle_failed', array( static::class, 'handleFailed' ), 20, 2 );
+	}
+
+	/**
+	 * Build a revision from the mapped fields that EventUpsert can persist.
+	 *
+	 * @param array $event Standardized event data.
+	 * @return string Source revision hash.
+	 */
+	public static function revision( array $event ): string {
+		return hash( 'sha256', (string) wp_json_encode( $event, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) );
+	}
+
+	/**
+	 * Check whether the current revision should remain suppressed.
+	 *
+	 * The generic reprocess filter remains authoritative, using one stable scope
+	 * shared by every Ticketmaster city flow.
+	 *
+	 * @return bool Whether the revision should be skipped.
+	 */
+	public static function shouldSkip( string $item_id, string $revision, ExecutionContext $context ): bool {
+		if ( $context->isDirect() || $context->isStandalone() ) {
+			return false;
+		}
+
+		$tracked = ( new TrackedItems() )->get( self::TRACK_NAMESPACE, $item_id );
+		$skip    = is_array( $tracked )
+			&& TrackedItems::STATE_GENERATED === ( $tracked['state'] ?? '' )
+			&& hash_equals( (string) ( $tracked['source_revision'] ?? '' ), $revision );
+
+		return (bool) apply_filters(
+			'datamachine_should_reprocess_item',
+			$skip,
+			array(
+				'flow_step_id'    => self::CLAIM_SCOPE,
+				'source_type'     => 'ticketmaster',
+				'item_identifier' => $item_id,
+				'job_id'          => (int) $context->getJobId(),
+				'source_revision' => $revision,
+			)
+		);
+	}
+
+	/**
+	 * Atomically select an item after the handler's fan-out cap is applied.
+	 *
+	 * @return string claimed, direct, unchanged, or contended.
+	 */
+	public static function claim( string $item_id, string $revision, ExecutionContext $context ): string {
+		if ( $context->isDirect() || $context->isStandalone() ) {
+			return 'direct';
+		}
+
+		$job_id = (int) $context->getJobId();
+		if ( $job_id < 1 ) {
+			return 'contended';
+		}
+
+		$processed_items = new ProcessedItems();
+		if ( ! $processed_items->claim_item( self::CLAIM_SCOPE, 'ticketmaster', $item_id, $job_id, self::CLAIM_TTL ) ) {
+			return 'contended';
+		}
+
+		// Recheck inside the lock because another city may have completed after
+		// the pre-cap revision check but before this claim was acquired.
+		if ( self::shouldSkip( $item_id, $revision, $context ) ) {
+			$processed_items->release_claim( self::CLAIM_SCOPE, 'ticketmaster', $item_id );
+			return 'unchanged';
+		}
+
+		return 'claimed';
+	}
+
+	/**
+	 * Persist the source revision only after the downstream pipeline succeeds.
+	 *
+	 * @param int        $job_id      Completed child job ID.
+	 * @param array|null $engine_data Child engine data.
+	 */
+	public static function handleCompleted( int $job_id, ?array $engine_data = null ): void {
+		$identity = self::identityFromEngine( $engine_data );
+		if ( null === $identity ) {
+			return;
+		}
+
+		( new TrackedItems() )->upsert(
+			array(
+				'namespace'       => self::TRACK_NAMESPACE,
+				'item_id'         => $identity['item_id'],
+				'item_type'       => 'event',
+				'state'           => TrackedItems::STATE_GENERATED,
+				'source_ref'      => $identity['source_ref'],
+				'source_revision' => $identity['revision'],
+				'last_job_id'     => $job_id,
+			)
+		);
+
+		self::release( $identity['item_id'] );
+	}
+
+	/**
+	 * Release the cross-flow claim after terminal failure without tracking the revision.
+	 *
+	 * @param int        $job_id      Failed child job ID.
+	 * @param array|null $engine_data Child engine data.
+	 */
+	public static function handleFailed( int $job_id, ?array $engine_data = null ): void {
+		$job_id;
+		$identity = self::identityFromEngine( $engine_data );
+		if ( null !== $identity ) {
+			self::release( $identity['item_id'] );
+		}
+	}
+
+	/**
+	 * Release a source claim explicitly.
+	 */
+	public static function release( string $item_id ): void {
+		( new ProcessedItems() )->release_claim( self::CLAIM_SCOPE, 'ticketmaster', $item_id );
+	}
+
+	/**
+	 * Read validated Ticketmaster identity data from a child engine snapshot.
+	 *
+	 * @param array|null $engine_data Engine data.
+	 * @return array{item_id:string,revision:string,source_ref:string}|null
+	 */
+	private static function identityFromEngine( ?array $engine_data ): ?array {
+		$identity = is_array( $engine_data[ self::ENGINE_KEY ] ?? null )
+			? $engine_data[ self::ENGINE_KEY ]
+			: array();
+
+		$item_id  = trim( (string) ( $identity['item_id'] ?? '' ) );
+		$revision = trim( (string) ( $identity['revision'] ?? '' ) );
+		if ( '' === $item_id || '' === $revision ) {
+			return null;
+		}
+
+		return array(
+			'item_id'    => $item_id,
+			'revision'   => $revision,
+			'source_ref' => (string) ( $identity['source_ref'] ?? '' ),
+		);
+	}
+}

--- a/tests/Unit/TicketmasterHandlerTest.php
+++ b/tests/Unit/TicketmasterHandlerTest.php
@@ -11,14 +11,18 @@
 namespace DataMachineEvents\Tests\Unit;
 
 use WP_UnitTestCase;
+use DataMachine\Core\Database\TrackedItems\TrackedItems;
+use DataMachine\Core\EngineData;
 use DataMachine\Core\ExecutionContext;
 use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
+use DataMachineEvents\Core\DuplicateDetection\PreAIEventDedupGate;
 use DataMachineEvents\Core\DuplicateDetection\EventIdentityWriter;
 use DataMachineEvents\Core\EventDatesTable;
 use DataMachineEvents\Core\Event_Post_Type;
 use DataMachineEvents\Core\Venue_Taxonomy;
 use DataMachineEvents\Steps\EventImport\Handlers\Ticketmaster\Ticketmaster;
 use DataMachineEvents\Steps\EventImport\Handlers\Ticketmaster\TicketmasterSettings;
+use DataMachineEvents\Steps\EventImport\Handlers\Ticketmaster\TicketmasterSourceIdentity;
 use ReflectionClass;
 
 class TicketmasterHandlerTest extends WP_UnitTestCase {
@@ -28,6 +32,8 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 	public function setUp(): void {
 		parent::setUp();
 		$this->ensureEventIdentityTables();
+		( new ProcessedItems() )->create_table();
+		( new TrackedItems() )->create_table();
 		$this->handler = new Ticketmaster();
 		set_transient( 'data_machine_events_ticketmaster_classifications', array( 'music' => 'Music' ) );
 	}
@@ -98,18 +104,21 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 		$this->assertEquals( '19:30', $result['startTime'] );
 	}
 
-	public function test_new_event_uses_stable_ticketmaster_id_for_processed_identity(): void {
+	public function test_new_event_uses_stable_ticketmaster_source_identity(): void {
 		$handler = new TicketmasterHandlerTestDouble(
 			array(
 				0 => $this->ticketmasterPage( array( $this->ticketmasterEvent( 'TM-new-event', 'New Event ' . uniqid() ) ) ),
 			)
 		);
 
-		$packets = $handler->get_fetch_data( 'direct', $this->handlerConfig( '32.7765,-79.9311' ) );
+		$packets = $handler->get_fetch_data( 1, $this->handlerConfig( '32.7765,-79.9311', 'charleston-fetch' ), '1001' );
 
 		$this->assertCount( 1, $packets );
 		$packet = $packets[0]->addTo( array() )[0];
-		$this->assertSame( 'TM-new-event', $packet['metadata']['item_identifier'] );
+		$this->assertSame( 'TM-new-event', $packet['metadata']['source_item_id'] );
+		$this->assertArrayNotHasKey( 'item_identifier', $packet['metadata'] );
+		$this->assertSame( 'TM-new-event', $packet['metadata']['_engine_data']['item_identifier'] );
+		$this->failPacket( $packet, 1001 );
 	}
 
 	public function test_repeated_ticketmaster_ids_across_pages_only_schedule_once(): void {
@@ -128,53 +137,18 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 			)
 		);
 
-		$packets = $handler->get_fetch_data( 'direct', $this->handlerConfig( '37.7749,-122.4194' ) );
+		$packets = $handler->get_fetch_data( 1, $this->handlerConfig( '37.7749,-122.4194', 'sf-pages' ), '1002' );
 
 		$this->assertCount( 2, $packets );
+		foreach ( $packets as $packet ) {
+			$this->failPacket( $packet->addTo( array() )[0], 1002 );
+		}
 	}
 
-	public function test_already_processed_ticketmaster_id_is_removed_before_packet_creation(): void {
-		$processed_items = new ProcessedItems();
-		$processed_items->create_table();
-		$flow_step_id    = 'ticketmaster-processed-' . wp_generate_uuid4();
-		$processed_items->add_processed_item( $flow_step_id, 'ticketmaster', 'TM-processed', 123 );
-
-		$handler = new TicketmasterHandlerTestDouble(
-			array(
-				0 => $this->ticketmasterPage(
-					array( $this->ticketmasterEvent( 'TM-processed', 'Processed Event ' . uniqid() ) )
-				),
-			)
-		);
-		$config  = array_merge(
-			$this->handlerConfig( '40.7128,-74.0060' ),
-			array(
-				'pipeline_id'  => 1,
-				'flow_id'      => 2,
-				'flow_step_id' => $flow_step_id,
-			)
-		);
-
-		$this->assertCount( 0, $handler->get_fetch_data( 1, $config, '123' ) );
-	}
-
-	public function test_overlapping_city_queries_skip_event_already_imported_by_neighboring_city(): void {
-		$title      = 'Neighboring City Event ' . uniqid();
-		$ticket_url = 'https://www.ticketmaster.com/event/TM-neighboring-city';
-		$raw_event  = $this->ticketmasterEvent( 'TM-neighboring-city', $title, $ticket_url );
-
-		$new_handler = new TicketmasterHandlerTestDouble(
-			array( 0 => $this->ticketmasterPage( array( $raw_event ) ) )
-		);
-		$this->assertCount(
-			1,
-			$new_handler->get_fetch_data( 'direct', $this->handlerConfig( '37.7749,-122.4194' ) ),
-			'A new Ticketmaster event must remain eligible.'
-		);
-
-		[ $post_id, $term_id ] = $this->seedImportedEvent( $title, $ticket_url );
-		$logs                  = array();
-		$logger                = static function ( string $level, string $message, array $context ) use ( &$logs ): void {
+	public function test_distinct_city_flows_racing_same_id_create_one_packet(): void {
+		$raw_event = $this->ticketmasterEvent( 'TM-race-' . uniqid(), 'Cross-flow Race' );
+		$logs      = array();
+		$logger    = static function ( string $level, string $message, array $context ) use ( &$logs ): void {
 			$level;
 			if ( 'Ticketmaster: Import fan-out summary' === $message ) {
 				$logs[] = $context;
@@ -189,31 +163,132 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 			array( 0 => $this->ticketmasterPage( array( $raw_event ) ) )
 		);
 
-		$this->assertCount( 0, $san_francisco->get_fetch_data( 'direct', $this->handlerConfig( '37.7749,-122.4194' ) ) );
-		$this->assertCount( 0, $oakland->get_fetch_data( 'direct', $this->handlerConfig( '37.8044,-122.2712' ) ) );
+		$first  = $san_francisco->get_fetch_data( 1, $this->handlerConfig( '37.7749,-122.4194', 'san-francisco-fetch' ), '1101' );
+		$second = $oakland->get_fetch_data( 1, $this->handlerConfig( '37.8044,-122.2712', 'oakland-fetch' ), '1102' );
 
 		remove_action( 'datamachine_log', $logger, 10 );
+		$this->assertCount( 1, $first );
+		$this->assertCount( 0, $second );
 		$this->assertCount( 2, $logs );
-		$this->assertSame( 1, $logs[0]['fetched'] );
-		$this->assertSame( 1, $logs[0]['pre_fanout_deduped'] );
-		$this->assertSame( 1, $logs[0]['existing_events'] );
-		$this->assertSame( 0, $logs[0]['schedule_candidates'] );
+		$this->assertSame( count( $first ), $logs[0]['source_claimed'] );
+		$this->assertSame( count( $first ), $logs[0]['packets_ready'] );
+		$this->assertSame( count( $second ), $logs[1]['source_claimed'] );
+		$this->assertSame( count( $second ), $logs[1]['packets_ready'] );
+		$this->assertSame( 1, $logs[1]['contended_claims'] );
+		$this->failPacket( $first[0]->addTo( array() )[0], 1101 );
+	}
+
+	public function test_mutable_future_event_revision_reaches_upsert(): void {
+		$item_id = 'TM-mutable-' . uniqid();
+		$initial = $this->ticketmasterEvent( $item_id, 'Initial Title' );
+		$first   = ( new TicketmasterHandlerTestDouble( array( 0 => $this->ticketmasterPage( array( $initial ) ) ) ) )
+			->get_fetch_data( 1, $this->handlerConfig( '37.7749,-122.4194', 'mutable-initial' ), '1201' );
+		$this->assertCount( 1, $first );
+		$this->completePacket( $first[0]->addTo( array() )[0], 1201 );
+
+		$changed                                      = $initial;
+		$changed['name']                              = 'Updated Title';
+		$changed['url']                               = 'https://www.ticketmaster.com/event/' . $item_id . '-updated';
+		$changed['dates']['start']['localDate']       = '2027-08-16';
+		$changed['dates']['start']['localTime']       = '21:30:00';
+		$changed['_embedded']['venues'][0]['name']    = 'Updated Arena';
+		$changed['priceRanges'][0]                    = array( 'min' => 45, 'max' => 60, 'currency' => 'USD' );
+		$second = ( new TicketmasterHandlerTestDouble( array( 0 => $this->ticketmasterPage( array( $changed ) ) ) ) )
+			->get_fetch_data( 1, $this->handlerConfig( '37.8044,-122.2712', 'mutable-update' ), '1202' );
+
+		$this->assertCount( 1, $second, 'A changed source revision must reach EventUpsert.' );
+		$body = json_decode( $second[0]->addTo( array() )[0]['data']['body'], true );
+		$this->assertSame( 'Updated Title', $body['event']['title'] );
+		$this->assertSame( '2027-08-16', $body['event']['startDate'] );
+		$this->assertSame( 'Updated Arena', $body['event']['venue'] );
+		$this->assertSame( '$45.00 - $60.00', $body['event']['price'] );
+		$this->failPacket( $second[0]->addTo( array() )[0], 1202 );
+	}
+
+	public function test_failure_after_identity_insertion_releases_claim_for_retry(): void {
+		$item_id    = 'TM-retry-' . uniqid();
+		$title      = 'Interrupted Import ' . uniqid();
+		$ticket_url = 'https://www.ticketmaster.com/event/' . $item_id;
+		$raw_event  = $this->ticketmasterEvent( $item_id, $title, $ticket_url );
+		[ $post_id, $term_id ] = $this->seedImportedEvent( $title, $ticket_url );
+
+		$first = ( new TicketmasterHandlerTestDouble( array( 0 => $this->ticketmasterPage( array( $raw_event ) ) ) ) )
+			->get_fetch_data( 1, $this->handlerConfig( '37.7749,-122.4194', 'retry-first' ), '1301' );
+		$this->assertCount( 1, $first, 'An identity-index row must not suppress source processing.' );
+		$this->failPacket( $first[0]->addTo( array() )[0], 1301 );
+
+		$retry = ( new TicketmasterHandlerTestDouble( array( 0 => $this->ticketmasterPage( array( $raw_event ) ) ) ) )
+			->get_fetch_data( 1, $this->handlerConfig( '37.8044,-122.2712', 'retry-second' ), '1302' );
+		$this->assertCount( 1, $retry, 'A failed child must not persist its source revision.' );
+		$this->failPacket( $retry[0]->addTo( array() )[0], 1302 );
 
 		wp_delete_post( $post_id, true );
 		wp_delete_term( $term_id, 'venue' );
 	}
 
-	public function test_default_fanout_is_bounded_to_one_hundred_packets(): void {
-		$events = array();
-		for ( $index = 0; $index < 101; ++$index ) {
-			$events[] = $this->ticketmasterEvent( 'TM-bound-' . $index, 'Bounded Event ' . $index . ' ' . uniqid() );
-		}
-
-		$handler = new TicketmasterHandlerTestDouble(
-			array( 0 => $this->ticketmasterPage( $events ) )
+	public function test_overflow_items_are_selected_on_later_runs(): void {
+		$prefix = uniqid();
+		$events = array(
+			$this->ticketmasterEvent( 'TM-overflow-a-' . $prefix, 'Overflow A' ),
+			$this->ticketmasterEvent( 'TM-overflow-b-' . $prefix, 'Overflow B' ),
 		);
 
-		$this->assertCount( 100, $handler->get_fetch_data( 'direct', $this->handlerConfig( '34.0522,-118.2437' ) ) );
+		$first = ( new TicketmasterHandlerTestDouble( array( 0 => $this->ticketmasterPage( $events ) ) ) )
+			->get_fetch_data( 1, $this->handlerConfig( '34.0522,-118.2437', 'overflow-first', 1 ), '1401' );
+		$this->assertCount( 1, $first );
+		$this->assertSame( 'TM-overflow-a-' . $prefix, $first[0]->addTo( array() )[0]['metadata']['source_item_id'] );
+		$this->completePacket( $first[0]->addTo( array() )[0], 1401 );
+
+		$second = ( new TicketmasterHandlerTestDouble( array( 0 => $this->ticketmasterPage( $events ) ) ) )
+			->get_fetch_data( 1, $this->handlerConfig( '34.0522,-118.2437', 'overflow-second', 1 ), '1402' );
+		$this->assertCount( 1, $second );
+		$this->assertSame( 'TM-overflow-b-' . $prefix, $second[0]->addTo( array() )[0]['metadata']['source_item_id'] );
+		$this->failPacket( $second[0]->addTo( array() )[0], 1402 );
+	}
+
+	public function test_reprocess_policy_can_select_unchanged_revision(): void {
+		$item_id   = 'TM-reprocess-' . uniqid();
+		$raw_event = $this->ticketmasterEvent( $item_id, 'Reprocess Event' );
+		$first     = ( new TicketmasterHandlerTestDouble( array( 0 => $this->ticketmasterPage( array( $raw_event ) ) ) ) )
+			->get_fetch_data( 1, $this->handlerConfig( '40.7128,-74.0060', 'reprocess-first' ), '1501' );
+		$this->completePacket( $first[0]->addTo( array() )[0], 1501 );
+
+		$unchanged = ( new TicketmasterHandlerTestDouble( array( 0 => $this->ticketmasterPage( array( $raw_event ) ) ) ) )
+			->get_fetch_data( 1, $this->handlerConfig( '40.7128,-74.0060', 'reprocess-default' ), '1502' );
+		$this->assertCount( 0, $unchanged );
+
+		$policy = static function ( bool $skip, array $context ): bool {
+			return TicketmasterSourceIdentity::CLAIM_SCOPE === $context['flow_step_id'] ? false : $skip;
+		};
+		add_filter( 'datamachine_should_reprocess_item', $policy, 10, 2 );
+		$reprocessed = ( new TicketmasterHandlerTestDouble( array( 0 => $this->ticketmasterPage( array( $raw_event ) ) ) ) )
+			->get_fetch_data( 1, $this->handlerConfig( '40.7128,-74.0060', 'reprocess-policy' ), '1503' );
+		remove_filter( 'datamachine_should_reprocess_item', $policy, 10 );
+
+		$this->assertCount( 1, $reprocessed );
+		$this->failPacket( $reprocessed[0]->addTo( array() )[0], 1503 );
+	}
+
+	public function test_ticketmaster_settings_expose_and_sanitize_fanout_bound(): void {
+		$fields = TicketmasterSettings::get_fields();
+		$this->assertSame( Ticketmaster::DEFAULT_MAX_ITEMS, $fields['max_items']['default'] );
+		$this->assertSame( 25, TicketmasterSettings::sanitize( array( 'max_items' => 25 ) )['max_items'] );
+		$this->assertSame( Ticketmaster::DEFAULT_MAX_ITEMS, TicketmasterSettings::sanitize( array( 'max_items' => 1000 ) )['max_items'] );
+		$this->assertSame( Ticketmaster::DEFAULT_MAX_ITEMS, TicketmasterSettings::get_defaults()['max_items'] );
+	}
+
+	public function test_pre_ai_gate_allows_ticketmaster_revision_updates(): void {
+		$engine = new EngineData(
+			array(
+				'source_type' => 'ticketmaster',
+				'flow_config' => array(
+					'upsert' => array( 'handler_slugs' => array( 'upsert_event' ) ),
+				),
+			),
+			null
+		);
+
+		$this->assertNull( PreAIEventDedupGate::check( null, $engine, array(), 1601 ) );
 	}
 
 	public function test_map_event_handles_missing_venue() {
@@ -506,13 +581,23 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 		);
 	}
 
-	private function handlerConfig( string $location ): array {
+	private function handlerConfig( string $location, string $flow_step_id, int $max_items = Ticketmaster::DEFAULT_MAX_ITEMS ): array {
 		return array(
-			'pipeline_id'        => 'direct',
-			'flow_id'            => 'direct',
+			'pipeline_id'        => 1,
+			'flow_id'            => abs( crc32( $flow_step_id ) ),
+			'flow_step_id'       => $flow_step_id,
 			'classification_type' => 'music',
 			'location'           => $location,
+			'max_items'          => $max_items,
 		);
+	}
+
+	private function completePacket( array $packet, int $job_id ): void {
+		TicketmasterSourceIdentity::handleCompleted( $job_id, $packet['metadata']['_engine_data'] );
+	}
+
+	private function failPacket( array $packet, int $job_id ): void {
+		TicketmasterSourceIdentity::handleFailed( $job_id, $packet['metadata']['_engine_data'] );
 	}
 
 	private function ticketmasterEvent( string $id, string $title, string $ticket_url = '' ): array {


### PR DESCRIPTION
## Summary
- replace permanent existing-event suppression with revision-aware Ticketmaster source identity
- atomically claim stable IDs across overlapping flows while releasing failed work for retry
- persist revisions only after terminal success and expose bounded scheduling through normal settings
- align fan-out metrics and add update, retry, cross-flow, overflow, and reprocess coverage

## Context
PR #498 merged before the corrected follow-up commit was pushed. This PR contains the reviewed fixes for the blockers found after that merge.

## Verification
- PHP syntax and diff checks pass
- targeted Ticketmaster coverage added for mutable updates, failure release, cross-flow claims, unchanged revisions, overflow, and reprocess behavior
- Homeboy workflow now declares audit, lint, and test jobs with the Data Machine validation dependency