### PR TITLE
feat: publish canonical calendar occurrence contract

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,9 @@
         "php": ">=8.2",
         "johngrogg/ics-parser": "^3.5"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^9.6"
+    },
     "autoload": {
         "psr-4": {
             "DataMachineEvents\\": "inc/"

--- a/contracts/calendar-occurrence-v1.json
+++ b/contracts/calendar-occurrence-v1.json
@@ -1,0 +1,88 @@
+{
+    "event": {
+        "id": 507001,
+        "title": "Seeded Calendar Contract Event",
+        "date": {
+            "start_date": "2099-07-21",
+            "start_time": "19:30:00",
+            "end_date": "2099-07-22",
+            "end_time": "00:30:00",
+            "venue_timezone": "America/New_York"
+        },
+        "venue": {
+            "term_id": 507101,
+            "name": "Seeded Hall",
+            "slug": "seeded-hall",
+            "address": "100 Fixture Way",
+            "formatted_address": "100 Fixture Way, Seed City, SC, 29000",
+            "city": "Seed City",
+            "state": "SC",
+            "zip": "29000",
+            "country": "US",
+            "coordinates": "32.000000,-80.000000",
+            "timezone": "America/New_York",
+            "website": "https://venue.invalid"
+        },
+        "organizer": {
+            "name": "Seeded Productions",
+            "url": "https://producer.invalid",
+            "type": "Organization"
+        },
+        "ticket": {
+            "url": "https://tickets.invalid/seeded-show"
+        },
+        "performer": {
+            "name": "The Seeded Performers",
+            "type": "PerformingGroup"
+        },
+        "status": "EventRescheduled",
+        "taxonomies": {
+            "artist": [
+                {
+                    "term_id": 507102,
+                    "name": "The Seeded Performers",
+                    "slug": "the-seeded-performers"
+                }
+            ],
+            "location": [
+                {
+                    "term_id": 507103,
+                    "name": "Seed City",
+                    "slug": "seed-city"
+                }
+            ],
+            "promoter": [
+                {
+                    "term_id": 507104,
+                    "name": "Seeded Productions",
+                    "slug": "seeded-productions"
+                }
+            ]
+        }
+    },
+    "occurrence": {
+        "post_id": 507001,
+        "display_context": {
+            "is_multi_day": true,
+            "is_start_day": true,
+            "is_end_day": false,
+            "is_continuation": false,
+            "display_date": "2099-07-21",
+            "original_start_date": "2099-07-21",
+            "original_end_date": "2099-07-22",
+            "day_number": 1,
+            "total_days": 1
+        },
+        "display": {
+            "formatted_time_display": "7:30 PM",
+            "multi_day_label": "through Jul 22",
+            "iso_start_date": "2099-07-21T19:30:00-04:00",
+            "venue_name": "Seeded Hall",
+            "performer_name": "The Seeded Performers",
+            "show_performer": false,
+            "show_ticket_link": true,
+            "is_continuation": false,
+            "is_multi_day": true
+        }
+    }
+}

--- a/contracts/calendar-occurrence-v1.manifest.json
+++ b/contracts/calendar-occurrence-v1.manifest.json
@@ -1,0 +1,8 @@
+{
+  "name": "data-machine-events/calendar-occurrence",
+  "version": 1,
+  "producer": "DataMachineEvents\\Api\\Controllers\\Calendar::serialize_contract_occurrence",
+  "schema_version": 4,
+  "file": "calendar-occurrence-v1.json",
+  "sha256": "fd1cbb79a52c405f747eaacf30b161f444c210c75c5189d9e446623d2badc84f"
+}

--- a/docs/calendar-data-schema.md
+++ b/docs/calendar-data-schema.md
@@ -43,7 +43,7 @@ full-response cache key (`CalendarCache::generate_full_response_key()`).
   "success": true,
   "schema": {
     "name": "calendar-data",
-    "version": 3,
+    "version": 4,
     "phase": 1,
     "issue": 298
   },
@@ -83,7 +83,7 @@ full-response cache key (`CalendarCache::generate_full_response_key()`).
 ### `schema`
 
 Identifies the schema for forward compatibility. Clients should check
-`schema.name === 'calendar-data'` and `schema.version === 3` before
+`schema.name === 'calendar-data'` and `schema.version === 4` before
 reading the rest. Future phases bump `phase`; backward-incompatible
 shape changes bump `version`.
 
@@ -127,15 +127,23 @@ page — its multi-day expansion is represented in `grouping.by_date`.
     "term_id": 678,
     "name":    "The Royal American",
     "slug":    "the-royal-american",
-    "address": "970 Morrison Dr, Charleston, SC 29403"
+    "address": "970 Morrison Dr",
+    "formatted_address": "970 Morrison Dr, Charleston, SC 29403",
+    "city": "Charleston",
+    "state": "SC",
+    "zip": "29403",
+    "country": "US",
+    "coordinates": "32.8007,-79.9362",
+    "timezone": "America/New_York"
   },
   "organizer": {
     "name": "Local Promoter",
     "url":  "https://example.com",
-    "type": "promoter"
+    "type": "Organization"
   },
   "ticket":    { "url": "https://etix.com/..." },
-  "performer": { "name": "Headliner Name" },
+  "performer": { "name": "Headliner Name", "type": "MusicGroup" },
+  "status": "EventScheduled",
   "address":   "970 Morrison Dr, Charleston, SC 29403",
   "taxonomies": {
     "artist": [

--- a/inc/Api/Controllers/Calendar.php
+++ b/inc/Api/Controllers/Calendar.php
@@ -28,6 +28,8 @@
  * Both envelopes are cached independently via
  * `CalendarCache::generate_full_response_key()`, which includes
  * `format` in its key surface as of this phase.
+ *
+ * @package DataMachineEvents\Api\Controllers
  */
 
 namespace DataMachineEvents\Api\Controllers;
@@ -37,6 +39,7 @@ defined( 'ABSPATH' ) || exit;
 use WP_REST_Request;
 use DataMachineEvents\Abilities\CalendarAbilities;
 use DataMachineEvents\Api\BrowserNavigationGuard;
+use DataMachineEvents\Api\Serializers\CalendarOccurrence;
 use DataMachineEvents\Blocks\Calendar\Cache\CalendarCache;
 use DataMachineEvents\Blocks\Calendar\Display\DisplayVars;
 use DataMachineEvents\Blocks\Calendar\Display\EventRenderer;
@@ -59,13 +62,14 @@ class Calendar {
 	 *
 	 * v2 (#381): per-occurrence `display` block added to `grouping.by_date`.
 	 * v3 (#465): canonical server-rendered empty-state fragment added.
+	 * v4 (#507): complete performer, status, and venue context added.
 	 */
-	const DATA_SCHEMA_VERSION = 3;
+	const DATA_SCHEMA_VERSION = 4;
 
 	/**
 	 * Calendar endpoint implementation
 	 *
-	 * @param WP_REST_Request $request REST request object
+	 * @param WP_REST_Request $request REST request object.
 	 * @return \WP_REST_Response
 	 */
 	public function calendar( WP_REST_Request $request ) {
@@ -185,11 +189,11 @@ class Calendar {
 
 		// Flatten paged_date_groups (already serialized by
 		// CalendarAbilities::serializeDateGroups()) into:
-		//   - `events`: a deduplicated array of structured event objects.
-		//   - `grouping.by_date`: a `Y-m-d => [post_id, ...]` index that
-		//     preserves the day-bucket ordering AND multi-day expansion
-		//     produced by DateGrouper (a multi-day event appears under
-		//     every spanned date, in order).
+		// - `events`: a deduplicated array of structured event objects.
+		// - `grouping.by_date`: a `Y-m-d => [post_id, ...]` index that
+		// preserves the day-bucket ordering AND multi-day expansion
+		// produced by DateGrouper (a multi-day event appears under
+		// every spanned date, in order).
 		//
 		// Deduplication is keyed on post_id so a multi-day event ships
 		// once in `events` but reappears as needed in `grouping.by_date`.
@@ -221,25 +225,17 @@ class Calendar {
 			$grouping[ $date_key ] = array();
 
 			foreach ( $date_group['events'] as $event_entry ) {
-				$post_id = (int) ( $event_entry['post_id'] ?? 0 );
+				$serialized = $this->serialize_occurrence( $event_entry );
+				$post_id    = (int) ( $serialized['event']['id'] ?? 0 );
 				if ( $post_id <= 0 ) {
 					continue;
 				}
 
 				if ( ! isset( $events_by_id[ $post_id ] ) ) {
-					$events_by_id[ $post_id ] = $this->serialize_event( $post_id, $event_entry );
+					$events_by_id[ $post_id ] = $serialized['event'];
 				}
 
-				$display_context = $event_entry['display_context'] ?? array();
-
-				$grouping[ $date_key ][] = array(
-					'post_id'         => $post_id,
-					'display_context' => $display_context,
-					'display'         => $this->serialize_display(
-						$event_entry['event_data'] ?? array(),
-						$display_context
-					),
-				);
+				$grouping[ $date_key ][] = $serialized['occurrence'];
 			}
 		}
 
@@ -292,6 +288,47 @@ class Calendar {
 			),
 			'empty_html' => $empty_html,
 		);
+	}
+
+	/**
+	 * Serialize one canonical calendar event occurrence.
+	 *
+	 * This is the shared producer boundary for the REST data response and the
+	 * pinned calendar occurrence contract artifact. Consumers should adapt this
+	 * output rather than reconstructing event, taxonomy, venue, or occurrence
+	 * fields independently.
+	 *
+	 * @param array $event_entry Serialized CalendarAbilities event entry.
+	 * @return array{event: array<string,mixed>, occurrence: array<string,mixed>}
+	 */
+	public function serialize_occurrence( array $event_entry ): array {
+		$post_id         = (int) ( $event_entry['post_id'] ?? 0 );
+		$event_data      = $event_entry['event_data'] ?? array();
+		$display_context = $event_entry['display_context'] ?? array();
+
+		return array(
+			'event'      => $this->serialize_event( $post_id, $event_entry ),
+			'occurrence' => array(
+				'post_id'         => $post_id,
+				'display_context' => $display_context,
+				'display'         => $this->serialize_display( $event_data, $display_context ),
+			),
+		);
+	}
+
+	/**
+	 * Serialize the pinned, presentation-neutral occurrence contract.
+	 *
+	 * The REST producer carries additional HTML and URL presentation fields.
+	 * This artifact surface selects only canonical event, taxonomy, venue, and
+	 * occurrence data while still deriving every value through the same
+	 * serializer used by the REST response.
+	 *
+	 * @param array $event_entry Serialized CalendarAbilities event entry.
+	 * @return array{event: array<string,mixed>, occurrence: array<string,mixed>}
+	 */
+	public function serialize_contract_occurrence( array $event_entry ): array {
+		return CalendarOccurrence::serialize( $this->serialize_occurrence( $event_entry ) );
 	}
 
 	/**
@@ -348,8 +385,10 @@ class Calendar {
 				'url' => (string) ( $event_data['ticketUrl'] ?? '' ),
 			),
 			'performer'      => array(
-				'name' => (string) ( $event_data['performerName'] ?? '' ),
+				'name' => (string) ( $event_data['performer'] ?? '' ),
+				'type' => (string) ( $event_data['performerType'] ?? '' ),
 			),
+			'status'         => (string) ( $event_data['eventStatus'] ?? '' ),
 			'address'        => (string) ( $event_data['address'] ?? '' ),
 			'taxonomies'     => $this->serialize_taxonomies( $post_id ),
 			// Server-filtered badge HTML so client-rendered (Load More)
@@ -425,13 +464,22 @@ class Calendar {
 		if ( ! $venue_terms || is_wp_error( $venue_terms ) ) {
 			return null;
 		}
-		$term = $venue_terms[0];
+		$term       = $venue_terms[0];
+		$venue_data = \DataMachineEvents\Core\Venue_Taxonomy::get_venue_data( $term->term_id );
 
 		return array(
-			'term_id' => (int) $term->term_id,
-			'name'    => (string) ( $event_data['venue'] ?? $term->name ),
-			'slug'    => (string) $term->slug,
-			'address' => (string) ( $event_data['address'] ?? '' ),
+			'term_id'           => (int) $term->term_id,
+			'name'              => (string) ( $event_data['venue'] ?? $term->name ),
+			'slug'              => (string) $term->slug,
+			'address'           => (string) ( $venue_data['address'] ?? '' ),
+			'formatted_address' => (string) ( $event_data['address'] ?? '' ),
+			'city'              => (string) ( $venue_data['city'] ?? '' ),
+			'state'             => (string) ( $venue_data['state'] ?? '' ),
+			'zip'               => (string) ( $venue_data['zip'] ?? '' ),
+			'country'           => (string) ( $venue_data['country'] ?? '' ),
+			'coordinates'       => (string) ( $venue_data['coordinates'] ?? '' ),
+			'timezone'          => (string) ( $venue_data['timezone'] ?? $event_data['venueTimezone'] ?? '' ),
+			'website'           => (string) ( $venue_data['website'] ?? '' ),
 		);
 	}
 

--- a/inc/Api/Serializers/CalendarOccurrence.php
+++ b/inc/Api/Serializers/CalendarOccurrence.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Canonical calendar occurrence contract serializer.
+ *
+ * @package DataMachineEvents\Api\Serializers
+ */
+
+namespace DataMachineEvents\Api\Serializers;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Projects the calendar data producer onto its portable occurrence contract.
+ */
+final class CalendarOccurrence {
+
+	/**
+	 * Remove presentation-only fields while preserving canonical producer data.
+	 *
+	 * @param array $serialized Full serialized event and occurrence.
+	 * @return array{event: array<string,mixed>, occurrence: array<string,mixed>}
+	 */
+	public static function serialize( array $serialized ): array {
+		$event      = $serialized['event'];
+		$taxonomies = array();
+
+		foreach ( array( 'artist', 'location', 'promoter' ) as $taxonomy ) {
+			$taxonomies[ $taxonomy ] = array_map(
+				static function ( array $term ): array {
+					return array(
+						'term_id' => $term['term_id'],
+						'name'    => $term['name'],
+						'slug'    => $term['slug'],
+					);
+				},
+				$event['taxonomies'][ $taxonomy ] ?? array()
+			);
+		}
+
+		return array(
+			'event'      => array(
+				'id'         => $event['id'],
+				'title'      => $event['title'],
+				'date'       => $event['date'],
+				'venue'      => $event['venue'],
+				'organizer'  => $event['organizer'],
+				'ticket'     => $event['ticket'],
+				'performer'  => $event['performer'],
+				'status'     => $event['status'],
+				'taxonomies' => $taxonomies,
+			),
+			'occurrence' => $serialized['occurrence'],
+		);
+	}
+}

--- a/inc/Blocks/Calendar/src/modules/month-grid-response-renderer.test.ts
+++ b/inc/Blocks/Calendar/src/modules/month-grid-response-renderer.test.ts
@@ -17,6 +17,7 @@ jest.mock( './date-group-renderer', () => ( {
 } ) );
 
 import { renderMonthGridResponse } from './month-grid-response-renderer';
+import { renderDateGroup } from './date-group-renderer';
 
 import type { CalendarDataResponse } from '../types';
 
@@ -25,19 +26,88 @@ function response(): CalendarDataResponse {
 		success: true,
 		schema: {
 			name: 'calendar-data',
-			version: 3,
+			version: 4,
 			phase: 1,
 			issue: 298,
 		},
-		events: [],
+		events: [
+			{
+				id: 7,
+				title: 'Seeded event',
+				permalink: 'https://producer.invalid/events/7',
+				date: {
+					start_date: '2026-08-10',
+					start_time: '19:30:00',
+					end_date: '2026-08-10',
+					end_time: '22:00:00',
+					venue_timezone: 'America/New_York',
+				},
+				venue: {
+					term_id: 11,
+					name: 'Seeded Hall',
+					slug: 'seeded-hall',
+					address: '100 Fixture Way',
+					formatted_address: '100 Fixture Way, Seed City, SC 29000',
+					city: 'Seed City',
+					state: 'SC',
+					zip: '29000',
+					country: 'US',
+					coordinates: '32.000000,-80.000000',
+					timezone: 'America/New_York',
+					website: 'https://venue.invalid',
+				},
+				organizer: {
+					name: 'Seeded Productions',
+					url: 'https://producer.invalid',
+					type: 'Organization',
+				},
+				ticket: { url: 'https://tickets.invalid/seeded-show' },
+				performer: {
+					name: 'The Seeded Performers',
+					type: 'PerformingGroup',
+				},
+				status: 'EventRescheduled',
+				address: '100 Fixture Way, Seed City, SC 29000',
+				taxonomies: {
+					artist: [
+						{
+							term_id: 12,
+							name: 'The Seeded Performers',
+							slug: 'the-seeded-performers',
+							link: 'https://producer.invalid/artist',
+						},
+					],
+				},
+			},
+		],
 		grouping: {
 			ordered_dates: [ '2026-08-10' ],
 			by_date: {
 				'2026-08-10': [
 					{
 						post_id: 7,
-						display_context: {} as never,
-						display: {} as never,
+						display_context: {
+							is_multi_day: false,
+							is_start_day: true,
+							is_end_day: true,
+							is_continuation: false,
+							display_date: '2026-08-10',
+							original_start_date: '2026-08-10',
+							original_end_date: '2026-08-10',
+							day_number: 1,
+							total_days: 1,
+						},
+						display: {
+							formatted_time_display: '7:30 - 10:00 PM',
+							multi_day_label: '',
+							iso_start_date: '2026-08-10T19:30:00-04:00',
+							venue_name: 'Seeded Hall',
+							performer_name: 'The Seeded Performers',
+							show_performer: false,
+							show_ticket_link: true,
+							is_continuation: false,
+							is_multi_day: false,
+						},
 					},
 				],
 			},
@@ -108,6 +178,20 @@ describe( 'month-grid response rendering', () => {
 		expect(
 			calendar.querySelectorAll( '.data-machine-events-pagination a' )
 		).toHaveLength( 2 );
+		const eventsById = ( renderDateGroup as jest.Mock ).mock
+			.calls[ 0 ][ 2 ];
+		expect( eventsById.get( 7 ) ).toMatchObject( {
+			venue: {
+				city: 'Seed City',
+				coordinates: '32.000000,-80.000000',
+				timezone: 'America/New_York',
+			},
+			performer: {
+				name: 'The Seeded Performers',
+				type: 'PerformingGroup',
+			},
+			status: 'EventRescheduled',
+		} );
 		expect( updated ).toHaveBeenCalledTimes( 1 );
 	} );
 

--- a/inc/Blocks/Calendar/src/types.ts
+++ b/inc/Blocks/Calendar/src/types.ts
@@ -47,7 +47,7 @@ export interface ArchiveContext {
 /* ------------------------------------------------------------------ */
 
 /** Keyed by taxonomy slug, values are term IDs. */
-export type TaxFilters = Record<string, number[]>;
+export type TaxFilters = Record< string, number[] >;
 
 export interface TaxonomyTerm {
 	term_id: number;
@@ -141,7 +141,7 @@ export interface CalendarResponse {
 /** Identifies the schema version + phase the server returned. */
 export interface CalendarDataSchemaMeta {
 	name: 'calendar-data';
-	version: 3;
+	version: 4;
 	phase: 1;
 	issue: 298;
 }
@@ -161,6 +161,14 @@ export interface CalendarEventVenue {
 	name: string;
 	slug: string;
 	address: string;
+	formatted_address: string;
+	city: string;
+	state: string;
+	zip: string;
+	country: string;
+	coordinates: string;
+	timezone: string;
+	website: string;
 }
 
 /** Organizer (promoter) attached to an event, or null when none. */
@@ -187,9 +195,10 @@ export interface CalendarEventItem {
 	venue: CalendarEventVenue | null;
 	organizer: CalendarEventOrganizer | null;
 	ticket: { url: string };
-	performer: { name: string };
+	performer: { name: string; type: string };
+	status: string;
 	address: string;
-	taxonomies: Record<string, CalendarEventTaxonomyTerm[]>;
+	taxonomies: Record< string, CalendarEventTaxonomyTerm[] >;
 	/**
 	 * Server-rendered, filter-applied badge markup from
 	 * `Badges::render_taxonomy_badges()`. When present, the event renderer
@@ -265,9 +274,9 @@ export interface CalendarGrouping {
 	/** Ordered list of dates as rendered on this page. */
 	ordered_dates: string[];
 	/** `Y-m-d => occurrence[]` map matching `ordered_dates`. */
-	by_date: Record<string, CalendarEventOccurrence[]>;
+	by_date: Record< string, CalendarEventOccurrence[] >;
 	/** `Y-m-d => gap_days` map; gaps >= 2 days from `DateGrouper::detect_time_gaps`. */
-	gaps: Record<string, number>;
+	gaps: Record< string, number >;
 }
 
 /** Pagination metadata as JSON — no HTML. */
@@ -309,7 +318,7 @@ export interface CalendarDataResponse {
 
 export interface FilterResponse {
 	success: boolean;
-	taxonomies: Record<string, TaxonomyData>;
+	taxonomies: Record< string, TaxonomyData >;
 	archive_context?: ArchiveContext;
 	geo_context?: {
 		active: boolean;
@@ -363,5 +372,5 @@ export interface FlatpickrInstance {
 export interface CarouselObserverEntry {
 	observer: ResizeObserver;
 	wrapper: HTMLElement;
-	events: NodeListOf<HTMLElement>;
+	events: NodeListOf< HTMLElement >;
 }

--- a/inc/Contracts/CalendarOccurrenceArtifact.php
+++ b/inc/Contracts/CalendarOccurrenceArtifact.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Canonical calendar occurrence contract artifact.
+ *
+ * @package DataMachineEvents\Contracts
+ */
+
+namespace DataMachineEvents\Contracts;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Portable identity and integrity checks for the producer-owned fixture.
+ */
+final class CalendarOccurrenceArtifact {
+
+	public const NAME = 'data-machine-events/calendar-occurrence';
+
+	public const VERSION = 1;
+
+	public const MANIFEST_RELATIVE_PATH = 'contracts/calendar-occurrence-v1.manifest.json';
+
+	/**
+	 * Load the checked-in artifact manifest.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public static function manifest(): array {
+		$path = DATA_MACHINE_EVENTS_PATH . self::MANIFEST_RELATIVE_PATH;
+		if ( ! is_readable( $path ) ) {
+			return array();
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local checked-in artifact.
+		$manifest = json_decode( (string) file_get_contents( $path ), true );
+
+		return is_array( $manifest ) ? $manifest : array();
+	}
+
+	/**
+	 * Verify a downstream pin against the producer-owned artifact.
+	 *
+	 * @param string $name    Expected artifact name.
+	 * @param int    $version Expected artifact contract version.
+	 * @param string $hash    Expected SHA-256 fixture hash.
+	 * @return bool Whether identity, version, manifest hash, and bytes agree.
+	 */
+	public static function verify_pin( string $name, int $version, string $hash ): bool {
+		$manifest = self::manifest();
+		$file     = DATA_MACHINE_EVENTS_PATH . 'contracts/' . ( $manifest['file'] ?? '' );
+
+		if ( self::NAME !== $name || self::VERSION !== $version ) {
+			return false;
+		}
+
+		if ( self::NAME !== ( $manifest['name'] ?? '' ) || self::VERSION !== ( $manifest['version'] ?? 0 ) ) {
+			return false;
+		}
+
+		if ( ! is_readable( $file ) || ! hash_equals( (string) ( $manifest['sha256'] ?? '' ), hash_file( 'sha256', $file ) ) ) {
+			return false;
+		}
+
+		return hash_equals( (string) $manifest['sha256'], $hash );
+	}
+}

--- a/tests/Unit/CalendarOccurrenceContractTest.php
+++ b/tests/Unit/CalendarOccurrenceContractTest.php
@@ -52,6 +52,9 @@ final class CalendarOccurrenceContractTest extends TestCase {
 		$this->assertSame( 'Seeded Productions', $event['organizer']['name'] );
 		$this->assertSame( 'Organization', $event['organizer']['type'] );
 		$this->assertSame( 'EventRescheduled', $event['status'] );
+		$this->assertSame( 507101, $event['venue']['term_id'] );
+		$this->assertSame( 'Seeded Hall', $event['venue']['name'] );
+		$this->assertSame( 'seeded-hall', $event['venue']['slug'] );
 
 		foreach ( array( 'artist', 'location', 'promoter' ) as $taxonomy ) {
 			$this->assertNotEmpty( $event['taxonomies'][ $taxonomy ] );

--- a/tests/Unit/CalendarOccurrenceContractTest.php
+++ b/tests/Unit/CalendarOccurrenceContractTest.php
@@ -8,7 +8,7 @@
 namespace DataMachineEvents\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
-use DataMachineEvents\Api\Serializers\CalendarOccurrence;
+use DataMachineEvents\Api\Controllers\Calendar;
 use DataMachineEvents\Contracts\CalendarOccurrenceArtifact;
 
 /**
@@ -34,26 +34,41 @@ final class CalendarOccurrenceContractTest extends TestCase {
 	}
 
 	/**
-	 * Required canonical fields must remain on the producer boundary.
+	 * Required canonical fields must remain on the actual producer boundary.
 	 */
 	public function test_artifact_contains_required_canonical_fields(): void {
 		$artifact   = json_decode( $this->generate_artifact_bytes(), true, 512, JSON_THROW_ON_ERROR );
 		$event      = $artifact['event'];
 		$occurrence = $artifact['occurrence'];
 
+		$this->assertSame( 507001, $event['id'] );
+		$this->assertSame( 507001, $occurrence['post_id'] );
+		$this->assertSame( '2099-07-21', $event['date']['start_date'] );
+		$this->assertSame( '19:30:00', $event['date']['start_time'] );
+		$this->assertSame( '2099-07-22', $event['date']['end_date'] );
+		$this->assertSame( '00:30:00', $event['date']['end_time'] );
 		$this->assertSame( 'The Seeded Performers', $event['performer']['name'] );
 		$this->assertSame( 'PerformingGroup', $event['performer']['type'] );
 		$this->assertSame( 'Seeded Productions', $event['organizer']['name'] );
 		$this->assertSame( 'Organization', $event['organizer']['type'] );
 		$this->assertSame( 'EventRescheduled', $event['status'] );
+
 		foreach ( array( 'artist', 'location', 'promoter' ) as $taxonomy ) {
-			$this->assertArrayHasKey( $taxonomy, $event['taxonomies'] );
+			$this->assertNotEmpty( $event['taxonomies'][ $taxonomy ] );
+			foreach ( $event['taxonomies'][ $taxonomy ] as $term ) {
+				$this->assertSame( array( 'term_id', 'name', 'slug' ), array_keys( $term ) );
+				$this->assertNotSame( '', $term['name'] );
+				$this->assertNotSame( '', $term['slug'] );
+			}
 		}
-		foreach ( array( 'term_id', 'name', 'slug', 'address', 'formatted_address', 'city', 'state', 'zip', 'country', 'coordinates', 'timezone' ) as $field ) {
-			$this->assertArrayHasKey( $field, $event['venue'] );
+		foreach ( array( 'address', 'formatted_address', 'city', 'state', 'zip', 'country', 'coordinates', 'timezone' ) as $field ) {
+			$this->assertNotSame( '', $event['venue'][ $field ], $field );
 		}
 		foreach ( array( 'is_multi_day', 'is_start_day', 'is_end_day', 'is_continuation', 'display_date', 'original_start_date', 'original_end_date', 'day_number', 'total_days' ) as $field ) {
 			$this->assertArrayHasKey( $field, $occurrence['display_context'] );
+		}
+		foreach ( array( 'formatted_time_display', 'multi_day_label', 'iso_start_date', 'venue_name', 'performer_name', 'show_performer', 'show_ticket_link', 'is_continuation', 'is_multi_day' ) as $field ) {
+			$this->assertArrayHasKey( $field, $occurrence['display'] );
 		}
 	}
 
@@ -69,108 +84,48 @@ final class CalendarOccurrenceContractTest extends TestCase {
 	}
 
 	/**
-	 * Generate canonical bytes from deterministic generic producer data.
+	 * Generate canonical bytes from raw, deterministic producer input.
 	 */
 	private function generate_artifact_bytes(): string {
-		$artifact = CalendarOccurrence::serialize( $this->seeded_serializer_output() );
+		$artifact = ( new Calendar() )->serialize_contract_occurrence( $this->seeded_raw_occurrence() );
 
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- Portable test intentionally runs without WordPress.
 		return json_encode( $artifact, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR ) . "\n";
 	}
 
 	/**
-	 * Seed the complete generic output of the runtime calendar serializer.
+	 * Seed the raw occurrence shape emitted by CalendarAbilities.
 	 */
-	private function seeded_serializer_output(): array {
+	private function seeded_raw_occurrence(): array {
 		return array(
-			'event'      => array(
-				'id'             => 507001,
-				'title'          => 'Seeded Calendar Contract Event',
-				'date'           => array(
-					'start_date'     => '2099-07-21',
-					'start_time'     => '19:30:00',
-					'end_date'       => '2099-07-22',
-					'end_time'       => '00:30:00',
-					'venue_timezone' => 'America/New_York',
-				),
-				'venue'          => array(
-					'term_id'           => 507101,
-					'name'              => 'Seeded Hall',
-					'slug'              => 'seeded-hall',
-					'address'           => '100 Fixture Way',
-					'formatted_address' => '100 Fixture Way, Seed City, SC, 29000',
-					'city'              => 'Seed City',
-					'state'             => 'SC',
-					'zip'               => '29000',
-					'country'           => 'US',
-					'coordinates'       => '32.000000,-80.000000',
-					'timezone'          => 'America/New_York',
-					'website'           => 'https://venue.invalid',
-				),
-				'organizer'      => array(
-					'name' => 'Seeded Productions',
-					'url'  => 'https://producer.invalid',
-					'type' => 'Organization',
-				),
-				'ticket'         => array( 'url' => 'https://tickets.invalid/seeded-show' ),
-				'performer'      => array(
-					'name' => 'The Seeded Performers',
-					'type' => 'PerformingGroup',
-				),
-				'status'         => 'EventRescheduled',
-				'taxonomies'     => array(
-					'artist'   => array(
-						array(
-							'term_id' => 507102,
-							'name'    => 'The Seeded Performers',
-							'slug'    => 'the-seeded-performers',
-							'link'    => 'https://producer.invalid/artist',
-						),
-					),
-					'location' => array(
-						array(
-							'term_id' => 507103,
-							'name'    => 'Seed City',
-							'slug'    => 'seed-city',
-							'link'    => 'https://producer.invalid/location',
-						),
-					),
-					'promoter' => array(
-						array(
-							'term_id' => 507104,
-							'name'    => 'Seeded Productions',
-							'slug'    => 'seeded-productions',
-							'link'    => 'https://producer.invalid/promoter',
-						),
-					),
-				),
-				'badges_html'    => '<div>presentation-only</div>',
-				'button_classes' => 'presentation-only',
+			'post_id'         => 507001,
+			'title'           => 'Seeded Calendar Contract Event',
+			'event_data'      => array(
+				'startDate'     => '2099-07-21',
+				'startTime'     => '19:30:00',
+				'endDate'       => '2099-07-22',
+				'endTime'       => '00:30:00',
+				'venue'         => 'Seeded Hall',
+				'address'       => '100 Fixture Way, Seed City, SC, 29000',
+				'venueTimezone' => 'America/New_York',
+				'organizer'     => 'Seeded Productions',
+				'organizerUrl'  => 'https://producer.invalid',
+				'organizerType' => 'Organization',
+				'ticketUrl'     => 'https://tickets.invalid/seeded-show',
+				'performer'     => 'The Seeded Performers',
+				'performerType' => 'PerformingGroup',
+				'eventStatus'   => 'EventRescheduled',
 			),
-			'occurrence' => array(
-				'post_id'         => 507001,
-				'display_context' => array(
-					'is_multi_day'        => true,
-					'is_start_day'        => true,
-					'is_end_day'          => false,
-					'is_continuation'     => false,
-					'display_date'        => '2099-07-21',
-					'original_start_date' => '2099-07-21',
-					'original_end_date'   => '2099-07-22',
-					'day_number'          => 1,
-					'total_days'          => 1,
-				),
-				'display'         => array(
-					'formatted_time_display' => '7:30 PM',
-					'multi_day_label'        => 'through Jul 22',
-					'iso_start_date'         => '2099-07-21T19:30:00-04:00',
-					'venue_name'             => 'Seeded Hall',
-					'performer_name'         => 'The Seeded Performers',
-					'show_performer'         => false,
-					'show_ticket_link'       => true,
-					'is_continuation'        => false,
-					'is_multi_day'           => true,
-				),
+			'display_context' => array(
+				'is_multi_day'        => true,
+				'is_start_day'        => true,
+				'is_end_day'          => false,
+				'is_continuation'     => false,
+				'display_date'        => '2099-07-21',
+				'original_start_date' => '2099-07-21',
+				'original_end_date'   => '2099-07-22',
+				'day_number'          => 1,
+				'total_days'          => 1,
 			),
 		);
 	}

--- a/tests/Unit/CalendarOccurrenceContractTest.php
+++ b/tests/Unit/CalendarOccurrenceContractTest.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Canonical calendar occurrence artifact tests.
+ *
+ * @package DataMachineEvents\Tests\Unit
+ */
+
+namespace DataMachineEvents\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use DataMachineEvents\Api\Serializers\CalendarOccurrence;
+use DataMachineEvents\Contracts\CalendarOccurrenceArtifact;
+
+/**
+ * Verifies deterministic producer serialization and portable pinning.
+ */
+final class CalendarOccurrenceContractTest extends TestCase {
+
+	/**
+	 * Producer regeneration must equal the fixture byte for byte.
+	 */
+	public function test_checked_in_artifact_matches_byte_stable_producer_output(): void {
+		$first  = $this->generate_artifact_bytes();
+		$second = $this->generate_artifact_bytes();
+		$path   = dirname( __DIR__, 2 ) . '/contracts/calendar-occurrence-v1.json';
+		if ( '1' === getenv( 'DME_UPDATE_CONTRACT_FIXTURES' ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Explicit fixture regeneration mode.
+			file_put_contents( $path, $first );
+		}
+
+		$this->assertSame( $first, $second, 'Repeated producer serialization must be byte-stable.' );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local checked-in artifact.
+		$this->assertSame( (string) file_get_contents( $path ), $first );
+	}
+
+	/**
+	 * Required canonical fields must remain on the producer boundary.
+	 */
+	public function test_artifact_contains_required_canonical_fields(): void {
+		$artifact   = json_decode( $this->generate_artifact_bytes(), true, 512, JSON_THROW_ON_ERROR );
+		$event      = $artifact['event'];
+		$occurrence = $artifact['occurrence'];
+
+		$this->assertSame( 'The Seeded Performers', $event['performer']['name'] );
+		$this->assertSame( 'PerformingGroup', $event['performer']['type'] );
+		$this->assertSame( 'Seeded Productions', $event['organizer']['name'] );
+		$this->assertSame( 'Organization', $event['organizer']['type'] );
+		$this->assertSame( 'EventRescheduled', $event['status'] );
+		foreach ( array( 'artist', 'location', 'promoter' ) as $taxonomy ) {
+			$this->assertArrayHasKey( $taxonomy, $event['taxonomies'] );
+		}
+		foreach ( array( 'term_id', 'name', 'slug', 'address', 'formatted_address', 'city', 'state', 'zip', 'country', 'coordinates', 'timezone' ) as $field ) {
+			$this->assertArrayHasKey( $field, $event['venue'] );
+		}
+		foreach ( array( 'is_multi_day', 'is_start_day', 'is_end_day', 'is_continuation', 'display_date', 'original_start_date', 'original_end_date', 'day_number', 'total_days' ) as $field ) {
+			$this->assertArrayHasKey( $field, $occurrence['display_context'] );
+		}
+	}
+
+	/**
+	 * Portable pin checks must reject producer version and hash drift.
+	 */
+	public function test_portable_pin_verification_rejects_version_and_hash_drift(): void {
+		$manifest = CalendarOccurrenceArtifact::manifest();
+
+		$this->assertTrue( CalendarOccurrenceArtifact::verify_pin( $manifest['name'], $manifest['version'], $manifest['sha256'] ) );
+		$this->assertFalse( CalendarOccurrenceArtifact::verify_pin( $manifest['name'], $manifest['version'] + 1, $manifest['sha256'] ) );
+		$this->assertFalse( CalendarOccurrenceArtifact::verify_pin( $manifest['name'], $manifest['version'], str_repeat( '0', 64 ) ) );
+	}
+
+	/**
+	 * Generate canonical bytes from deterministic generic producer data.
+	 */
+	private function generate_artifact_bytes(): string {
+		$artifact = CalendarOccurrence::serialize( $this->seeded_serializer_output() );
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- Portable test intentionally runs without WordPress.
+		return json_encode( $artifact, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR ) . "\n";
+	}
+
+	/**
+	 * Seed the complete generic output of the runtime calendar serializer.
+	 */
+	private function seeded_serializer_output(): array {
+		return array(
+			'event'      => array(
+				'id'             => 507001,
+				'title'          => 'Seeded Calendar Contract Event',
+				'date'           => array(
+					'start_date'     => '2099-07-21',
+					'start_time'     => '19:30:00',
+					'end_date'       => '2099-07-22',
+					'end_time'       => '00:30:00',
+					'venue_timezone' => 'America/New_York',
+				),
+				'venue'          => array(
+					'term_id'           => 507101,
+					'name'              => 'Seeded Hall',
+					'slug'              => 'seeded-hall',
+					'address'           => '100 Fixture Way',
+					'formatted_address' => '100 Fixture Way, Seed City, SC, 29000',
+					'city'              => 'Seed City',
+					'state'             => 'SC',
+					'zip'               => '29000',
+					'country'           => 'US',
+					'coordinates'       => '32.000000,-80.000000',
+					'timezone'          => 'America/New_York',
+					'website'           => 'https://venue.invalid',
+				),
+				'organizer'      => array(
+					'name' => 'Seeded Productions',
+					'url'  => 'https://producer.invalid',
+					'type' => 'Organization',
+				),
+				'ticket'         => array( 'url' => 'https://tickets.invalid/seeded-show' ),
+				'performer'      => array(
+					'name' => 'The Seeded Performers',
+					'type' => 'PerformingGroup',
+				),
+				'status'         => 'EventRescheduled',
+				'taxonomies'     => array(
+					'artist'   => array(
+						array(
+							'term_id' => 507102,
+							'name'    => 'The Seeded Performers',
+							'slug'    => 'the-seeded-performers',
+							'link'    => 'https://producer.invalid/artist',
+						),
+					),
+					'location' => array(
+						array(
+							'term_id' => 507103,
+							'name'    => 'Seed City',
+							'slug'    => 'seed-city',
+							'link'    => 'https://producer.invalid/location',
+						),
+					),
+					'promoter' => array(
+						array(
+							'term_id' => 507104,
+							'name'    => 'Seeded Productions',
+							'slug'    => 'seeded-productions',
+							'link'    => 'https://producer.invalid/promoter',
+						),
+					),
+				),
+				'badges_html'    => '<div>presentation-only</div>',
+				'button_classes' => 'presentation-only',
+			),
+			'occurrence' => array(
+				'post_id'         => 507001,
+				'display_context' => array(
+					'is_multi_day'        => true,
+					'is_start_day'        => true,
+					'is_end_day'          => false,
+					'is_continuation'     => false,
+					'display_date'        => '2099-07-21',
+					'original_start_date' => '2099-07-21',
+					'original_end_date'   => '2099-07-22',
+					'day_number'          => 1,
+					'total_days'          => 1,
+				),
+				'display'         => array(
+					'formatted_time_display' => '7:30 PM',
+					'multi_day_label'        => 'through Jul 22',
+					'iso_start_date'         => '2099-07-21T19:30:00-04:00',
+					'venue_name'             => 'Seeded Hall',
+					'performer_name'         => 'The Seeded Performers',
+					'show_performer'         => false,
+					'show_ticket_link'       => true,
+					'is_continuation'        => false,
+					'is_multi_day'           => true,
+				),
+			),
+		);
+	}
+}

--- a/tests/contract-bootstrap.php
+++ b/tests/contract-bootstrap.php
@@ -1,11 +1,104 @@
 <?php
 /**
- * Bootstrap for portable calendar contract tests.
+ * Bootstrap and faithful WordPress doubles for calendar contract tests.
  *
  * @package DataMachineEvents\Tests
  */
 
-define( 'ABSPATH', dirname( __DIR__ ) . '/' );
-define( 'DATA_MACHINE_EVENTS_PATH', dirname( __DIR__ ) . '/' );
+// phpcs:disable -- Faithful test doubles intentionally define WordPress functions and classes across their owning namespaces.
 
-require dirname( __DIR__ ) . '/vendor/autoload.php';
+namespace {
+	define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+	define( 'DATA_MACHINE_EVENTS_PATH', dirname( __DIR__ ) . '/' );
+
+	final class DME_Contract_Term {
+		public function __construct(
+			public int $term_id,
+			public string $name,
+			public string $slug
+		) {}
+	}
+
+	function get_permalink( int $post_id ): string {
+		return 'https://producer.invalid/events/' . $post_id;
+	}
+
+	function get_the_terms( int $post_id, string $taxonomy ): array|false {
+		if ( 507001 === $post_id && 'venue' === $taxonomy ) {
+			return array( new DME_Contract_Term( 507101, 'Seeded Hall', 'seeded-hall' ) );
+		}
+
+		return false;
+	}
+
+	function is_wp_error(): bool {
+		return false;
+	}
+
+	function get_term_link( DME_Contract_Term $term, string $taxonomy ): string {
+		return 'https://producer.invalid/' . $taxonomy . '/' . $term->slug;
+	}
+
+	function apply_filters( string $hook, mixed $value ): mixed {
+		return $value;
+	}
+
+	require dirname( __DIR__ ) . '/vendor/autoload.php';
+}
+
+namespace DataMachineEvents\Core {
+	final class Venue_Taxonomy {
+		public static function get_venue_data( int $term_id ): array {
+			return array(
+				'term_id'     => $term_id,
+				'name'        => 'Seeded Hall',
+				'address'     => '100 Fixture Way',
+				'city'        => 'Seed City',
+				'state'       => 'SC',
+				'zip'         => '29000',
+				'country'     => 'US',
+				'coordinates' => '32.000000,-80.000000',
+				'timezone'    => 'America/New_York',
+				'website'     => 'https://venue.invalid',
+			);
+		}
+	}
+}
+
+namespace DataMachineEvents\Blocks\Calendar\Taxonomy {
+	final class Badges {
+		public static function get_event_taxonomies( int $post_id ): array {
+			if ( 507001 !== $post_id ) {
+				return array();
+			}
+
+			return array(
+				'artist'   => array( 'terms' => array( new \DME_Contract_Term( 507102, 'The Seeded Performers', 'the-seeded-performers' ) ) ),
+				'location' => array( 'terms' => array( new \DME_Contract_Term( 507103, 'Seed City', 'seed-city' ) ) ),
+				'promoter' => array( 'terms' => array( new \DME_Contract_Term( 507104, 'Seeded Productions', 'seeded-productions' ) ) ),
+			);
+		}
+
+		public static function render_taxonomy_badges( int $post_id ): string {
+			return 507001 === $post_id ? '<div>presentation-only</div>' : '';
+		}
+	}
+}
+
+namespace DataMachineEvents\Blocks\Calendar\Display {
+	final class DisplayVars {
+		public static function build( array $event_data, array $display_context ): array {
+			return array(
+				'formatted_time_display' => '7:30 PM',
+				'multi_day_label'        => 'through Jul 22',
+				'iso_start_date'         => '2099-07-21T19:30:00-04:00',
+				'venue_name'             => $event_data['venue'],
+				'performer_name'         => $event_data['performer'],
+				'show_performer'         => false,
+				'show_ticket_link'       => true,
+				'is_continuation'        => $display_context['is_continuation'],
+				'is_multi_day'           => $display_context['is_multi_day'],
+			);
+		}
+	}
+}

--- a/tests/contract-bootstrap.php
+++ b/tests/contract-bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Bootstrap for portable calendar contract tests.
+ *
+ * @package DataMachineEvents\Tests
+ */
+
+define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+define( 'DATA_MACHINE_EVENTS_PATH', dirname( __DIR__ ) . '/' );
+
+require dirname( __DIR__ ) . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- expose the canonical calendar occurrence serializer used by the REST data producer, including performer type, event status, taxonomy assignments, occurrence context, and complete venue geography
- publish a deterministic, generic producer-owned occurrence artifact with a versioned manifest and SHA-256 pin verifier
- regenerate the artifact through `Calendar::serialize_contract_occurrence()` from raw producer input, using faithful deterministic WordPress doubles for venue, taxonomy, permalink, filter, and display boundaries
- align the TypeScript calendar contract and runtime fixture with schema v4 and the current expanded producer shape

## Contract
- identity: `data-machine-events/calendar-occurrence`
- version: `1`
- SHA-256: `fd1cbb79a52c405f747eaacf30b161f444c210c75c5189d9e446623d2badc84f`
- producer: `DataMachineEvents\\Api\\Controllers\\Calendar::serialize_contract_occurrence`

## Verification
- `vendor/bin/phpunit --bootstrap tests/contract-bootstrap.php tests/Unit/CalendarOccurrenceContractTest.php` (3 tests, 57 assertions)
- Calendar JavaScript tests (6 suites, 29 tests)
- changed-file WordPress PHPCS passes under the repository's existing PSR-4 filename convention
- changed TypeScript files pass WordPress ESLint rules; the repository `wp-scripts lint-js` wrapper is currently incompatible with its ESLint 9 override and the untouched tree retains existing lint debt
- Calendar production build passes
- PHP syntax, deterministic regeneration, artifact hash integrity, and `git diff --check` pass
- the broader Homeboy WordPress suite remains blocked before test discovery by the existing WP PHPUnit/SQLite harness initialization failure (`db_version()` on null); the portable producer contract suite runs independently and passes

Fixes #507