### PR TITLE
feat: expose canonical event upsert ability

### DIFF
--- a/data-machine-events.php
+++ b/data-machine-events.php
@@ -334,6 +334,11 @@ class DATAMACHINE_Events {
 			new \DataMachineEvents\Abilities\EventUpdateAbilities();
 		}
 
+		if ( file_exists( DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Abilities/EventUpsertAbilities.php' ) ) {
+			require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Abilities/EventUpsertAbilities.php';
+			new \DataMachineEvents\Abilities\EventUpsertAbilities();
+		}
+
 		if ( file_exists( DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Abilities/MoveEventAbilities.php' ) ) {
 			require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Abilities/MoveEventAbilities.php';
 			new \DataMachineEvents\Abilities\MoveEventAbilities();

--- a/inc/Abilities/EventUpsertAbilities.php
+++ b/inc/Abilities/EventUpsertAbilities.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * Public canonical event upsert ability.
+ *
+ * @package DataMachineEvents\Abilities
+ */
+
+namespace DataMachineEvents\Abilities;
+
+use DataMachineEvents\Core\VenueParameterProvider;
+use DataMachineEvents\Core\Venue_Taxonomy;
+use DataMachineEvents\Steps\Upsert\Events\EventUpsert;
+
+defined( 'ABSPATH' ) || exit;
+
+class EventUpsertAbilities {
+
+	public const ABILITY_NAME = 'data-machine-events/upsert-event';
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( self::$registered ) {
+			return;
+		}
+
+		add_action( 'wp_abilities_api_init', array( $this, 'registerAbility' ) );
+		self::$registered = true;
+	}
+
+	/**
+	 * Register the public ability contract.
+	 */
+	public function registerAbility(): void {
+		wp_register_ability(
+			self::ABILITY_NAME,
+			array(
+				'label'               => __( 'Upsert Event', 'data-machine-events' ),
+				'description'         => __( 'Deterministically create or update a canonical event from a stable caller-supplied source identity.', 'data-machine-events' ),
+				'category'            => AbilityCategories::EVENTS,
+				'input_schema'        => $this->getInputSchema(),
+				'output_schema'       => $this->getOutputSchema(),
+				'execute_callback'    => array( $this, 'executeUpsertEvent' ),
+				'permission_callback' => AbilityPermissions::canWrite(),
+				'meta'                => array(
+					'show_in_rest' => true,
+					'mcp'          => array( 'public' => true ),
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Execute a canonical event upsert.
+	 *
+	 * @param array $input Ability input.
+	 * @return array|\WP_Error Normalized event result or validation failure.
+	 */
+	public function executeUpsertEvent( array $input ): array|\WP_Error {
+		$source    = trim( sanitize_text_field( (string) ( $input['source'] ?? '' ) ) );
+		$source_id = trim( sanitize_text_field( (string) ( $input['source_id'] ?? '' ) ) );
+		$event     = is_array( $input['event'] ?? null ) ? $input['event'] : array();
+
+		if ( '' === $source || '' === $source_id ) {
+			return new \WP_Error( 'missing_source_identity', 'Both source and source_id are required.', array( 'status' => 400 ) );
+		}
+
+		if ( empty( $event ) ) {
+			return new \WP_Error( 'missing_event', 'The event object is required.', array( 'status' => 400 ) );
+		}
+
+		$venue_error = $this->validateVenueIdentity( $event );
+		if ( $venue_error ) {
+			return $venue_error;
+		}
+
+		$event['source']          = $source;
+		$event['source_id']       = $source_id;
+		$event['source_identity'] = hash( 'sha256', $source . "\0" . $source_id );
+
+		$config = array(
+			'post_status'    => sanitize_key( (string) ( $input['post_status'] ?? 'publish' ) ),
+			'post_author'    => absint( $input['post_author'] ?? 0 ),
+			'include_images' => false,
+		);
+		if ( ! in_array( $config['post_status'], array( 'draft', 'publish', 'pending', 'private' ), true ) ) {
+			return new \WP_Error( 'invalid_post_status', 'post_status must be draft, publish, pending, or private.', array( 'status' => 400 ) );
+		}
+
+		$result = ( new EventUpsert() )->upsertCanonicalEvent( $event, $config );
+		if ( empty( $result['success'] ) ) {
+			return new \WP_Error(
+				(string) ( $result['rule'] ?? 'event_upsert_failed' ),
+				(string) ( $result['error'] ?? 'Event upsert failed.' ),
+				array(
+					'status' => 400,
+					'rule'   => $result['rule'] ?? null,
+				)
+			);
+		}
+
+		$post_id     = (int) $result['data']['post_id'];
+		$venue_terms = wp_get_object_terms( $post_id, 'venue' );
+		$venue_term  = ! is_wp_error( $venue_terms ) && ! empty( $venue_terms ) ? $venue_terms[0] : null;
+		$post        = get_post( $post_id );
+		$dates       = \DataMachineEvents\Core\EventDatesTable::get( $post_id );
+
+		return array(
+			'success'   => true,
+			'event_id'  => $post_id,
+			'event_url' => (string) ( $result['data']['post_url'] ?? get_permalink( $post_id ) ),
+			'action'    => (string) $result['data']['action'],
+			'source'    => array(
+				'name'     => $source,
+				'id'       => $source_id,
+				'identity' => $event['source_identity'],
+			),
+			'normalized' => array(
+				'title'          => $post instanceof \WP_Post ? $post->post_title : (string) ( $event['title'] ?? '' ),
+				'post_status'    => $post instanceof \WP_Post ? $post->post_status : $config['post_status'],
+				'start_datetime' => $dates ? (string) $dates->start_datetime : '',
+				'end_datetime'   => $dates ? (string) $dates->end_datetime : '',
+				'venue'          => $venue_term instanceof \WP_Term ? $venue_term->name : '',
+				'venue_id'       => $venue_term instanceof \WP_Term ? (int) $venue_term->term_id : 0,
+			),
+		);
+	}
+
+	/**
+	 * Reject geographically ambiguous existing venue identities before writes.
+	 *
+	 * @param array $event Canonical event fields.
+	 * @return \WP_Error|null Venue conflict error, or null when safe.
+	 */
+	private function validateVenueIdentity( array $event ): ?\WP_Error {
+		$venue_name = trim( (string) ( $event['venue'] ?? '' ) );
+		if ( '' === $venue_name ) {
+			return null;
+		}
+
+		$identity = Venue_Taxonomy::resolve_venue_identity(
+			$venue_name,
+			VenueParameterProvider::extractFromParameters( $event )
+		);
+		if ( 'ambiguous' !== $identity['match_status'] ) {
+			return null;
+		}
+
+		return new \WP_Error(
+			'ambiguous_venue',
+			'The venue name conflicts with existing geographic identity and cannot be resolved safely.',
+			array(
+				'status' => 409,
+				'venue'  => $venue_name,
+			)
+		);
+	}
+
+	private function getInputSchema(): array {
+		$string = array( 'type' => 'string' );
+
+		return array(
+			'type'       => 'object',
+			'required'   => array( 'source', 'source_id', 'event' ),
+			'properties' => array(
+				'source'      => array( 'type' => 'string', 'minLength' => 1, 'description' => 'Stable caller/source namespace.' ),
+				'source_id'   => array( 'type' => 'string', 'minLength' => 1, 'description' => 'Stable item ID within the source namespace.' ),
+				'post_status' => array( 'type' => 'string', 'enum' => array( 'draft', 'publish', 'pending', 'private' ), 'default' => 'publish' ),
+				'post_author' => array( 'type' => 'integer', 'minimum' => 1 ),
+				'event'       => array(
+					'type'       => 'object',
+					'required'   => array( 'title', 'startDate' ),
+					'properties' => array(
+						'title'             => $string,
+						'description'       => $string,
+						'startDate'         => $string,
+						'startTime'         => $string,
+						'endDate'           => $string,
+						'endTime'           => $string,
+						'occurrenceDates'   => array( 'type' => 'array', 'items' => $string ),
+						'venue'             => $string,
+						'venueAddress'      => $string,
+						'venueCity'         => $string,
+						'venueState'        => $string,
+						'venueZip'          => $string,
+						'venueCountry'      => $string,
+						'venuePhone'        => $string,
+						'venueWebsite'      => $string,
+						'venueCoordinates'  => $string,
+						'venueCapacity'     => $string,
+						'venueTimezone'     => $string,
+						'price'             => $string,
+						'priceCurrency'     => $string,
+						'ticketUrl'         => array( 'type' => 'string', 'format' => 'uri' ),
+						'offerAvailability' => $string,
+						'performer'         => $string,
+						'performerType'     => $string,
+						'organizer'         => $string,
+						'organizerType'     => $string,
+						'organizerUrl'      => array( 'type' => 'string', 'format' => 'uri' ),
+						'eventStatus'       => $string,
+						'previousStartDate' => $string,
+						'eventType'         => $string,
+					),
+				),
+			),
+		);
+	}
+
+	private function getOutputSchema(): array {
+		return array(
+			'type'       => 'object',
+			'required'   => array( 'success', 'event_id', 'event_url', 'action', 'source', 'normalized' ),
+			'properties' => array(
+				'success'    => array( 'type' => 'boolean' ),
+				'event_id'   => array( 'type' => 'integer' ),
+				'event_url'  => array( 'type' => 'string' ),
+				'action'     => array( 'type' => 'string', 'enum' => array( 'created', 'updated', 'no_change' ) ),
+				'source'     => array(
+					'type'       => 'object',
+					'required'   => array( 'name', 'id', 'identity' ),
+					'properties' => array(
+						'name'     => array( 'type' => 'string' ),
+						'id'       => array( 'type' => 'string' ),
+						'identity' => array( 'type' => 'string' ),
+					),
+				),
+				'normalized' => array(
+					'type'       => 'object',
+					'required'   => array( 'title', 'post_status', 'start_datetime', 'end_datetime', 'venue', 'venue_id' ),
+					'properties' => array(
+						'title'          => array( 'type' => 'string' ),
+						'post_status'    => array( 'type' => 'string' ),
+						'start_datetime' => array( 'type' => 'string' ),
+						'end_datetime'   => array( 'type' => 'string' ),
+						'venue'          => array( 'type' => 'string' ),
+						'venue_id'       => array( 'type' => 'integer' ),
+					),
+				),
+			),
+		);
+	}
+}

--- a/inc/Steps/Upsert/Events/EventUpsert.php
+++ b/inc/Steps/Upsert/Events/EventUpsert.php
@@ -42,6 +42,10 @@ defined( 'ABSPATH' ) || exit;
 
 class EventUpsert extends UpsertHandler {
 
+	public const SOURCE_IDENTITY_META_KEY = '_datamachine_event_source_identity';
+	public const SOURCE_NAME_META_KEY     = '_datamachine_event_source';
+	public const SOURCE_ID_META_KEY       = '_datamachine_event_source_id';
+
 	protected $taxonomy_handler;
 
 	/**
@@ -76,6 +80,23 @@ class EventUpsert extends UpsertHandler {
 		TaxonomyHandler::addCustomHandler( 'venue', array( $this->taxonomy_assigner, 'assignVenueTaxonomy' ) );
 		// Register custom handler for promoter taxonomy
 		TaxonomyHandler::addCustomHandler( 'promoter', array( $this->taxonomy_assigner, 'assignPromoterTaxonomy' ) );
+	}
+
+	/**
+	 * Run the canonical event upsert without workflow/job context.
+	 *
+	 * This is the supported entry point for the public event upsert ability.
+	 * Workflow handlers continue to use handle_tool_call() and executeUpsert().
+	 *
+	 * @param array $event          Canonical event fields.
+	 * @param array $handler_config Post and taxonomy settings.
+	 * @return array Canonical handler result.
+	 */
+	public function upsertCanonicalEvent( array $event, array $handler_config = array() ): array {
+		$event['engine'] = new EngineData( $event, 0 );
+		$event['job_id'] = 0;
+
+		return $this->executeUpsert( $event, $handler_config );
 	}
 
 	/**
@@ -143,11 +164,9 @@ class EventUpsert extends UpsertHandler {
 			)
 		);
 
-		// Acquire advisory lock to prevent race conditions between concurrent
-		// flows importing the same event. Lock key is derived from the date and
-		// normalized title so that two flows processing "Eggy" at Charleston Pour
-		// House on 2026-03-20 will serialize instead of both creating a new post.
-		$lock_key = $this->acquireUpsertLock( $title, $startDate );
+		// Acquire an advisory lock to prevent concurrent duplicate creation. Public
+		// callers lock on source identity; workflow imports retain title/date locking.
+		$lock_key = $this->acquireUpsertLock( $title, $startDate, (string) ( $parameters['source_identity'] ?? '' ) );
 
 		try {
 			return $this->executeUpsertWithinLock( $title, $venue, $startDate, $ticketUrl, $parameters, $handler_config, $engine );
@@ -235,16 +254,20 @@ class EventUpsert extends UpsertHandler {
 		$venueCity        = (string) ( $engine->get( 'venueCity' ) ?? $parameters['venueCity'] ?? '' );
 		$venueState       = (string) ( $engine->get( 'venueState' ) ?? $parameters['venueState'] ?? '' );
 		$venueCountry     = (string) ( $engine->get( 'venueCountry' ) ?? $parameters['venueCountry'] ?? '' );
-		$existing_post_id = (int) $this->findExistingEventViaAbility(
-			$title,
-			$venue,
-			$startDate,
-			$ticketUrl,
-			$venueAddress,
-			$venueCity,
-			$venueState,
-			$venueCountry
-		);
+		$source_identity   = (string) ( $parameters['source_identity'] ?? '' );
+		$existing_post_id = $this->findExistingEventBySourceIdentity( $source_identity );
+		if ( $existing_post_id <= 0 ) {
+			$existing_post_id = (int) $this->findExistingEventViaAbility(
+				$title,
+				$venue,
+				$startDate,
+				$ticketUrl,
+				$venueAddress,
+				$venueCity,
+				$venueState,
+				$venueCountry
+			);
+		}
 
 		// 2. Build event data.
 		$event_data = $this->buildEventData( $parameters, $handler_config, $engine, $existing_post_id );
@@ -270,6 +293,13 @@ class EventUpsert extends UpsertHandler {
 			'meta_input'   => $meta_input,
 		);
 
+		if ( '' !== $source_identity ) {
+			$upsert_input['identity_meta'] = array(
+				'key'   => self::SOURCE_IDENTITY_META_KEY,
+				'value' => $source_identity,
+			);
+		}
+
 		if ( $existing_post_id > 0 ) {
 			$upsert_input['post_id'] = $existing_post_id;
 		} else {
@@ -292,6 +322,11 @@ class EventUpsert extends UpsertHandler {
 
 		$post_id = (int) $result['post_id'];
 		$action  = $result['action'];
+		if ( '' !== $source_identity ) {
+			update_post_meta( $post_id, self::SOURCE_IDENTITY_META_KEY, $source_identity );
+			update_post_meta( $post_id, self::SOURCE_NAME_META_KEY, sanitize_text_field( (string) ( $parameters['source'] ?? '' ) ) );
+			update_post_meta( $post_id, self::SOURCE_ID_META_KEY, sanitize_text_field( (string) ( $parameters['source_id'] ?? '' ) ) );
+		}
 
 		// 7. Content idempotency does not imply taxonomy or identity integrity.
 		// Skip image work for unchanged content, but always reconcile indexed state.
@@ -369,6 +404,36 @@ class EventUpsert extends UpsertHandler {
 				'action'   => $action,
 			)
 		);
+	}
+
+	/**
+	 * Resolve a caller-supplied source identity before domain deduplication.
+	 *
+	 * @param string $source_identity Stable hashed source identity.
+	 * @return int Matching event ID, or 0 when no event is associated.
+	 */
+	private function findExistingEventBySourceIdentity( string $source_identity ): int {
+		if ( '' === $source_identity ) {
+			return 0;
+		}
+
+		$query = new \WP_Query(
+			array(
+				'post_type'      => Event_Post_Type::POST_TYPE,
+				'post_status'    => 'any',
+				'posts_per_page' => 1,
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+				'meta_query'     => array(
+					array(
+						'key'   => self::SOURCE_IDENTITY_META_KEY,
+						'value' => $source_identity,
+					),
+				),
+			)
+		);
+
+		return empty( $query->posts ) ? 0 : (int) $query->posts[0];
 	}
 
 	/**
@@ -490,8 +555,8 @@ class EventUpsert extends UpsertHandler {
 	 * Acquire a MySQL advisory lock for an event identity.
 	 *
 	 * Uses GET_LOCK() to serialize concurrent upserts for the same event.
-	 * The lock key is derived from the date and normalized title, so two
-	 * flows importing the same event will queue instead of racing.
+	 * Public ability calls use their source identity; workflow calls use the
+	 * date and normalized title so equivalent events queue instead of racing.
 	 *
 	 * MySQL advisory locks are:
 	 * - Per-connection (each PHP-FPM worker has its own connection)
@@ -499,16 +564,18 @@ class EventUpsert extends UpsertHandler {
 	 * - Non-blocking for unrelated events (different lock keys)
 	 *
 	 * @since 0.17.3
-	 * @param string $title     Event title.
-	 * @param string $startDate Event start date.
+	 * @param string $title           Event title.
+	 * @param string $startDate       Event start date.
+	 * @param string $source_identity Optional caller-supplied source identity.
 	 * @return string The lock key (needed for release).
 	 */
-	private function acquireUpsertLock( string $title, string $startDate ): string {
+	private function acquireUpsertLock( string $title, string $startDate, string $source_identity = '' ): string {
 		global $wpdb;
 
 		$date_only  = self::extractDateForQuery( $startDate );
 		$normalized = SimilarityEngine::normalizeTitle( $title );
-		$lock_key   = 'dme_' . md5( $date_only . '|' . $normalized );
+		$lock_value = '' !== $source_identity ? 'source|' . $source_identity : $date_only . '|' . $normalized;
+		$lock_key   = 'dme_' . md5( $lock_value );
 
 		// MySQL lock names are limited to 64 characters; md5 = 36 + prefix = 40, safe.
 		// Try up to 3 times with increasing timeouts (5s, 10s, 15s).
@@ -689,6 +756,13 @@ class EventUpsert extends UpsertHandler {
 	 */
 	private function buildEventMetaInput( array $event_data, array $parameters, EngineData $engine ): array {
 		$meta_input = array();
+		$source_identity = (string) ( $parameters['source_identity'] ?? '' );
+
+		if ( '' !== $source_identity ) {
+			$meta_input[ self::SOURCE_IDENTITY_META_KEY ] = $source_identity;
+			$meta_input[ self::SOURCE_NAME_META_KEY ]     = sanitize_text_field( (string) ( $parameters['source'] ?? '' ) );
+			$meta_input[ self::SOURCE_ID_META_KEY ]       = sanitize_text_field( (string) ( $parameters['source_id'] ?? '' ) );
+		}
 
 		$submission = $engine->get( 'submission' );
 		if ( is_array( $submission ) ) {

--- a/tests/Unit/EventUpsertAbilitiesTest.php
+++ b/tests/Unit/EventUpsertAbilitiesTest.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * EventUpsertAbilities tests.
+ *
+ * @package DataMachineEvents\Tests\Unit
+ */
+
+namespace DataMachineEvents\Tests\Unit;
+
+use DataMachine\Core\Database\PostIdentityIndex\PostIdentityIndex;
+use DataMachineEvents\Abilities\EventUpsertAbilities;
+use DataMachineEvents\Core\EventDatesTable;
+use DataMachineEvents\Core\Event_Post_Type;
+use DataMachineEvents\Core\Venue_Taxonomy;
+use DataMachineEvents\Steps\Upsert\Events\EventUpsert;
+use WP_UnitTestCase;
+
+class EventUpsertAbilitiesTest extends WP_UnitTestCase {
+
+	private EventUpsertAbilities $ability;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		if ( ! post_type_exists( Event_Post_Type::POST_TYPE ) ) {
+			Event_Post_Type::register();
+		}
+		if ( ! taxonomy_exists( 'venue' ) ) {
+			Venue_Taxonomy::register();
+		}
+		if ( ! EventDatesTable::table_exists() ) {
+			EventDatesTable::create_table();
+		}
+		if ( class_exists( PostIdentityIndex::class ) ) {
+			( new PostIdentityIndex() )->create_table();
+		}
+
+		$this->ability = new EventUpsertAbilities();
+	}
+
+	public function test_creates_canonical_event_and_returns_normalized_metadata(): void {
+		$result = $this->ability->executeUpsertEvent( $this->validInput() );
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'created', $result['action'] );
+		$this->assertGreaterThan( 0, $result['event_id'] );
+		$this->assertSame( 'publish', $result['normalized']['post_status'] );
+		$this->assertSame( '2027-02-20 20:00:00', $result['normalized']['start_datetime'] );
+		$this->assertGreaterThan( 0, $result['normalized']['venue_id'] );
+		$this->assertSame(
+			hash( 'sha256', $result['source']['name'] . "\0" . $result['source']['id'] ),
+			get_post_meta( $result['event_id'], EventUpsert::SOURCE_IDENTITY_META_KEY, true )
+		);
+		$this->assertStringContainsString( 'wp:data-machine-events/event-details', get_post_field( 'post_content', $result['event_id'] ) );
+	}
+
+	public function test_replay_of_source_identity_returns_same_event(): void {
+		$input  = $this->validInput();
+		$first  = $this->ability->executeUpsertEvent( $input );
+		$second = $this->ability->executeUpsertEvent( $input );
+
+		$this->assertIsArray( $first );
+		$this->assertIsArray( $second );
+		$this->assertSame( $first['event_id'], $second['event_id'] );
+		$this->assertSame( 'no_change', $second['action'] );
+	}
+
+	public function test_validation_failure_returns_machine_readable_error_without_write(): void {
+		$input = $this->validInput();
+		unset( $input['event']['startDate'] );
+
+		$result = $this->ability->executeUpsertEvent( $input );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_start_date', $result->get_error_code() );
+		$this->assertSame( 0, $this->countEventsWithTitle( $input['event']['title'] ) );
+	}
+
+	public function test_ambiguous_venue_resolution_fails_before_event_write(): void {
+		$input = $this->validInput();
+		$name  = $input['event']['venue'];
+
+		Venue_Taxonomy::find_or_create_venue(
+			$name,
+			array(
+				'address' => '100 Main Street',
+				'city'    => 'Charleston',
+				'state'   => 'SC',
+				'country' => 'US',
+			)
+		);
+		$input['event']['venueAddress'] = '200 Main Street';
+		$input['event']['venueCity']    = 'Atlanta';
+		$input['event']['venueState']   = 'GA';
+
+		$result = $this->ability->executeUpsertEvent( $input );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'ambiguous_venue', $result->get_error_code() );
+		$this->assertSame( 409, $result->get_error_data()['status'] );
+		$this->assertSame( 0, $this->countEventsWithTitle( $input['event']['title'] ) );
+	}
+
+	private function validInput(): array {
+		$suffix = uniqid();
+
+		return array(
+			'source'    => 'unit-test-source',
+			'source_id' => 'event-' . $suffix,
+			'event'     => array(
+				'title'        => 'Public Ability Event ' . $suffix,
+				'description'  => '<p>Canonical event body.</p>',
+				'startDate'    => '2027-02-20',
+				'startTime'    => '20:00',
+				'venue'        => 'Public Ability Venue ' . $suffix,
+				'venueAddress' => '300 King Street',
+				'venueCity'    => 'Charleston',
+				'venueState'   => 'SC',
+				'venueCountry' => 'US',
+				'performer'    => 'Ability Performer',
+				'ticketUrl'    => 'https://tickets.example/event-' . $suffix,
+				'eventStatus'  => 'EventScheduled',
+			),
+		);
+	}
+
+	private function countEventsWithTitle( string $title ): int {
+		$query = new \WP_Query(
+			array(
+				'post_type'      => Event_Post_Type::POST_TYPE,
+				'post_status'    => 'any',
+				'title'          => $title,
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+			)
+		);
+
+		return count( $query->posts );
+	}
+}


### PR DESCRIPTION
## Summary
- expose `data-machine-events/upsert-event` as the supported public write contract for canonical events
- route public writes through the existing `EventUpsert` orchestration and `datamachine/upsert-post` persistence path
- add stable source identity replay semantics, normalized result metadata, and pre-write ambiguous venue rejection

## Why
Consumers need to create canonical events without importing workflow-handler internals or recreating Data Machine Events validation, venue reconciliation, duplicate detection, block construction, taxonomy processing, date synchronization, and identity indexing. This ability provides that narrow supported boundary while keeping the event model and write path owned here.

## Existing implementation reused
The ability invokes `EventUpsert::upsertCanonicalEvent()`, which delegates directly to the existing `executeUpsert()` orchestrator. The existing validator, duplicate strategy, `EventBlockContentBuilder`, `EventTaxonomyAssigner`, `datamachine/upsert-post`, event date synchronization, and identity writer remain the implementation. Existing workflow handlers still call the same protected `executeUpsert(array $parameters, array $handler_config)` method through `handle_tool_call()`; its signature and response shape are unchanged.

## Contract
Ability: `data-machine-events/upsert-event`

Permission: the existing filterable `AbilityPermissions::canWrite()` gate. Exposed through the Abilities REST/MCP surfaces; no custom REST route was added.

Input:
- `source` (required string): stable caller/source namespace
- `source_id` (required string): stable item identity within that namespace
- `event` (required object): canonical event fields; schema requires `title` and `startDate` and accepts existing date/time, venue/geography, performer, organizer, ticket, pricing, status, occurrence, description, and type fields
- `post_status` (optional): `draft|publish|pending|private`, default `publish`
- `post_author` (optional integer): author used on creation

Success output:
- `success: true`
- `event_id`: canonical event post ID
- `event_url`: canonical permalink
- `action`: `created|updated|no_change`
- `source`: normalized `{name, id, identity}` where identity is SHA-256 over the source namespace and source ID
- `normalized`: canonical `{title, post_status, start_datetime, end_datetime, venue, venue_id}` read back from the stored post, date table, and venue taxonomy

## Idempotency and failures
`source + source_id` is hashed and stored as `_datamachine_event_source_identity`. Public calls lock on that identity, resolve it before domain-level duplicate detection, and stamp it even when an existing domain duplicate produces `no_change`. Replaying an identity therefore returns the same canonical event while changed payloads update that event through the same canonical path. Calls without source identity (existing workflows) retain title/date advisory locking and existing duplicate semantics.

Validation and canonical upsert failures return `WP_Error` with stable codes. Existing validator rule slugs (for example `invalid_start_date`) become error codes. A geographically conflicting venue returns `ambiguous_venue` with HTTP status 409 before an event post is written. Invalid/missing contract fields return HTTP 400 errors.

## Compatibility evidence
- workflow-handler entry point, protected method signature, and canonical result shape are unchanged
- source identity behavior is conditional and absent for workflow callers
- workflow advisory locking remains title/date based
- all event writes still delegate to `datamachine/upsert-post`
- focused tests cover create, replay/no-change, canonical validation failure, and ambiguous venue failure before write

## Verification
- `php -l inc/Abilities/EventUpsertAbilities.php`
- `php -l inc/Steps/Upsert/Events/EventUpsert.php`
- `php -l tests/Unit/EventUpsertAbilitiesTest.php`
- `php -l data-machine-events.php`
- `git diff --check`
- `homeboy review audit --changed-since origin/main` (passed, zero introduced findings)
- `homeboy review lint --changed-only --summary` (reported no findings; shared PHPCS/PHPStan installation also reported a corrupted autoloader)
- `vendor/bin/phpunit --filter EventUpsertAbilitiesTest` could not start because this checkout has no standalone WordPress test bootstrap (`WP_UnitTestCase` unavailable)
- `homeboy review test --changed-since origin/main` selected only `tests/Unit/EventUpsertAbilitiesTest.php` but failed before PHPUnit execution in shared WP Codebox Composer bootstrap: missing generated `ComposerStaticInit63f0141519501a58f1a43910f2856084`; retried after `composer dump-autoload` with the same infrastructure failure

## Layer purity
No Extra Chill, Lo-Fi, booking, settlement, Roadie, transport, or vendor-specific concepts were added. The contract is generic event source identity plus canonical event data, and no parallel model or REST route was introduced.

Closes #509