### PR TITLE
fix: make scraper qualification config-aware

### DIFF
--- a/inc/Abilities/EventScraperTest.php
+++ b/inc/Abilities/EventScraperTest.php
@@ -26,12 +26,16 @@
  * for backwards compatibility with the chat tool and the CLI command, which only
  * read a single event's fields.
  *
+ * Issue #511 adds config-aware source diagnostics only. Stable unique source
+ * counts collapse repeated packet identifiers, but do not represent production
+ * eligibility. Processed state, claims, reprocess policy, and max-items selection
+ * remain owned by Data Machine's production lifecycle.
+ *
  * @package DataMachineEvents\Abilities
  */
 
 namespace DataMachineEvents\Abilities;
 
-use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 use DataMachineEvents\Steps\EventImport\Handlers\WebScraper\UniversalWebScraper;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -52,38 +56,136 @@ class EventScraperTest {
 						'description'         => __( 'Test universal web scraper compatibility with a target URL', 'data-machine-events' ),
 						'category'            => 'datamachine-events-testing',
 						'input_schema'        => array(
-							'type'       => 'object',
-							'required'   => array( 'target_url' ),
-							'properties' => array(
+							'type'                 => 'object',
+							'required'             => array( 'target_url' ),
+							'additionalProperties' => false,
+							'properties'           => array(
 								'target_url' => array(
 									'type'        => 'string',
 									'format'      => 'uri',
-									'description' => 'Target URL to test scraper against',
+									'description' => 'Target URL to test. Overrides handler_config.source_url.',
 								),
 								'handler_config' => array(
-									'type'        => 'object',
-									'description' => 'Optional persisted universal web scraper config to apply during qualification.',
-								),
-								'flow_step_id'   => array(
-									'type'        => 'string',
-									'description' => 'Optional persisted flow step ID used for read-only processed-item diagnostics.',
+									'type'                 => 'object',
+									'description'          => 'Optional persisted universal web scraper config to apply during source extraction.',
+									'additionalProperties' => false,
+									'properties'           => array(
+										'source_url'       => array( 'type' => 'string', 'format' => 'uri' ),
+										'search'           => array( 'type' => 'string' ),
+										'exclude_keywords' => array( 'type' => 'string' ),
+										'venue'            => array( 'type' => array( 'integer', 'string' ) ),
+										'venue_name'       => array( 'type' => 'string' ),
+										'venue_address'    => array( 'type' => 'string' ),
+										'venue_city'       => array( 'type' => 'string' ),
+										'venue_state'      => array( 'type' => 'string' ),
+										'venue_zip'        => array( 'type' => 'string' ),
+										'venue_country'    => array( 'type' => 'string' ),
+										'venue_phone'      => array( 'type' => 'string' ),
+										'venue_website'    => array( 'type' => 'string' ),
+										'venue_capacity'   => array( 'type' => array( 'integer', 'string' ) ),
+										'max_items'        => array( 'type' => array( 'integer', 'string' ) ),
+									),
 								),
 							),
 						),
 						'output_schema'       => array(
-							'type'       => 'object',
-							'properties' => array(
+							'type'                 => 'object',
+							'additionalProperties' => false,
+							'required'             => array( 'success', 'status', 'target_url', 'event_data', 'extraction_info', 'coverage_issues', 'warnings', 'logs' ),
+							'properties'           => array(
 								'success'         => array( 'type' => 'boolean' ),
 								'status'          => array(
 									'type' => 'string',
 									'enum' => array( 'ok', 'warning', 'error' ),
 								),
-								'target_url'      => array( 'type' => 'string' ),
-								'event_data'      => array( 'type' => 'object' ),
-								'extraction_info' => array( 'type' => 'object' ),
-								'coverage_issues' => array( 'type' => 'object' ),
-								'warnings'        => array( 'type' => 'array' ),
-								'logs'            => array( 'type' => 'array' ),
+								'target_url'      => array( 'type' => 'string', 'format' => 'uri' ),
+								'event_data'      => array(
+									'type'                 => 'object',
+									'additionalProperties' => false,
+									'properties'           => array(
+										'title'        => array( 'type' => 'string' ),
+										'startDate'    => array( 'type' => 'string' ),
+										'startTime'    => array( 'type' => 'string' ),
+										'endDate'      => array( 'type' => 'string' ),
+										'endTime'      => array( 'type' => 'string' ),
+										'timezone'     => array( 'type' => 'string' ),
+										'ticketUrl'    => array( 'type' => 'string' ),
+										'venue'        => array( 'type' => 'string' ),
+										'venueAddress' => array( 'type' => 'string' ),
+										'venueCity'    => array( 'type' => 'string' ),
+										'venueState'   => array( 'type' => 'string' ),
+										'venueZip'     => array( 'type' => 'string' ),
+										'event_count'  => array( 'type' => 'integer', 'minimum' => 0 ),
+										'items'        => array(
+											'type'  => 'array',
+											'items' => array(
+												'type'                 => 'object',
+												'additionalProperties' => false,
+												'properties'           => array(
+													'title'     => array( 'type' => 'string' ),
+													'startDate' => array( 'type' => 'string' ),
+													'startTime' => array( 'type' => 'string' ),
+													'ticketUrl' => array( 'type' => 'string' ),
+												),
+											),
+										),
+										'raw_html'     => array( 'type' => 'string' ),
+										'image_url'    => array( 'type' => 'string' ),
+										'page_url'     => array( 'type' => 'string' ),
+									),
+								),
+								'extraction_info' => array(
+									'type'                 => 'object',
+									'additionalProperties' => false,
+									'required'             => array(
+										'packet_title',
+										'source_type',
+										'extraction_method',
+										'payload_type',
+										'event_count',
+										'extracted_packet_count',
+										'unique_source_event_count',
+										'duplicate_packet_count',
+										'context_supplied',
+									),
+									'properties'           => array(
+										'packet_title'              => array( 'type' => 'string' ),
+										'source_type'               => array( 'type' => 'string' ),
+										'extraction_method'         => array( 'type' => 'string' ),
+										'payload_type'              => array( 'type' => 'string', 'enum' => array( 'event', 'raw_html', 'vision_flyer' ) ),
+										'event_count'               => array( 'type' => 'integer', 'minimum' => 0 ),
+										'extracted_packet_count'    => array( 'type' => 'integer', 'minimum' => 0 ),
+										'unique_source_event_count' => array( 'type' => 'integer', 'minimum' => 0 ),
+										'duplicate_packet_count'    => array( 'type' => 'integer', 'minimum' => 0 ),
+										'context_supplied'          => array( 'type' => 'boolean' ),
+										'requires_ai_step'          => array( 'type' => 'boolean' ),
+										'image_file_stored'         => array( 'type' => 'boolean' ),
+									),
+								),
+								'coverage_issues' => array(
+									'type'                 => 'object',
+									'additionalProperties' => false,
+									'properties'           => array(
+										'missing_time'       => array( 'type' => 'boolean' ),
+										'missing_venue'      => array( 'type' => 'boolean' ),
+										'incomplete_address' => array( 'type' => 'boolean' ),
+										'time_data_warning'  => array( 'type' => 'boolean' ),
+										'raw_html_fallback'  => array( 'type' => 'boolean' ),
+										'vision_flyer'       => array( 'type' => 'boolean' ),
+									),
+								),
+								'warnings'        => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+								'logs'            => array(
+									'type'  => 'array',
+									'items' => array(
+										'type'       => 'object',
+										'properties' => array(
+											'level'   => array( 'type' => 'string' ),
+											'message' => array( 'type' => 'string' ),
+											'context' => array( 'type' => 'object' ),
+										),
+									),
+								),
 							),
 						),
 						'execute_callback'    => array( $this, 'executeAbility' ),
@@ -108,13 +210,14 @@ class EventScraperTest {
 			return new \WP_Error( 'missing_target_url', 'Missing required target_url parameter.', array( 'status' => 400 ) );
 		}
 
-		$handler_config = is_array( $input['handler_config'] ?? null ) ? $input['handler_config'] : array();
-		$flow_step_id   = sanitize_text_field( (string) ( $input['flow_step_id'] ?? '' ) );
+		$handler_config = array_key_exists( 'handler_config', $input ) && is_array( $input['handler_config'] )
+			? $input['handler_config']
+			: null;
 
-		return $this->test( $target_url, $handler_config, $flow_step_id );
+		return $this->test( $target_url, $handler_config );
 	}
 
-	public function test( string $target_url, array $handler_config = array(), string $flow_step_id = '' ): array|\WP_Error {
+	public function test( string $target_url, ?array $handler_config = null ): array|\WP_Error {
 		$logs = array();
 		add_action(
 			'datamachine_log',
@@ -130,7 +233,7 @@ class EventScraperTest {
 		);
 
 		$config = array_merge(
-			$handler_config,
+			$handler_config ?? array(),
 			array(
 				'source_url'   => $target_url,
 				'flow_step_id' => 'test_' . wp_generate_uuid4(),
@@ -168,10 +271,9 @@ class EventScraperTest {
 			}
 		}
 
-		$extracted_packet_count = count( $packet_entries );
-		$packet_entries         = $this->uniquePacketEntries( $packet_entries );
-		$source_event_count     = count( $packet_entries );
-		$processed_event_count  = $this->countProcessedPacketEntries( $packet_entries, $flow_step_id );
+		$extracted_packet_count    = count( $packet_entries );
+		$packet_entries            = $this->uniquePacketEntries( $packet_entries );
+		$unique_source_event_count = count( $packet_entries );
 
 		$packet_entry = $packet_entries[0] ?? array();
 		$packet_data  = $packet_entry['data'] ?? array();
@@ -191,15 +293,14 @@ class EventScraperTest {
 		$all_events = $this->summarizeEventsFromPackets( $packet_entries );
 
 		$extraction_info = array(
-			'packet_title'           => $packet_data['title'] ?? '',
-			'source_type'            => $packet_meta['source_type'] ?? '',
-			'extraction_method'      => $packet_meta['extraction_method'] ?? '',
-			'event_count'            => $source_event_count,
-			'extracted_packet_count' => $extracted_packet_count,
-			'source_event_count'     => $source_event_count,
-			'duplicate_packet_count' => $extracted_packet_count - $source_event_count,
-			'processed_event_count'  => $processed_event_count,
-			'eligible_event_count'   => $source_event_count - $processed_event_count,
+			'packet_title'              => $packet_data['title'] ?? '',
+			'source_type'               => $packet_meta['source_type'] ?? '',
+			'extraction_method'         => $packet_meta['extraction_method'] ?? '',
+			'event_count'               => $unique_source_event_count,
+			'extracted_packet_count'    => $extracted_packet_count,
+			'unique_source_event_count' => $unique_source_event_count,
+			'duplicate_packet_count'    => $extracted_packet_count - $unique_source_event_count,
+			'context_supplied'          => null !== $handler_config,
 		);
 
 		if ( is_array( $payload ) && isset( $payload['raw_html'] ) && is_string( $payload['raw_html'] ) ) {
@@ -414,7 +515,9 @@ class EventScraperTest {
 	}
 
 	/**
-	 * Mirror production's claim-time duplicate collapse without creating claims.
+	 * Collapse repeated packets into stable unique source identities.
+	 *
+	 * This is an extraction diagnostic, not a production eligibility result.
 	 *
 	 * @param array $packet_entries Packet entries from DataPacket::addTo().
 	 * @return array Unique packet entries.
@@ -437,31 +540,4 @@ class EventScraperTest {
 		return $unique;
 	}
 
-	/**
-	 * Count unique source events already completed by a persisted flow step.
-	 *
-	 * This deliberately reads only final processed rows. It neither creates
-	 * claims nor clears processed history, so operators can use it as a dry-run
-	 * explanation for a production fetch that correctly emits no new packets.
-	 *
-	 * @param array  $packet_entries Unique packet entries.
-	 * @param string $flow_step_id   Persisted flow step ID.
-	 */
-	private function countProcessedPacketEntries( array $packet_entries, string $flow_step_id ): int {
-		if ( '' === $flow_step_id ) {
-			return 0;
-		}
-
-		$processed_items = new ProcessedItems();
-		$count           = 0;
-		foreach ( $packet_entries as $entry ) {
-			$identifier  = (string) ( $entry['metadata']['item_identifier'] ?? '' );
-			$source_type = (string) ( $entry['metadata']['source_type'] ?? 'universal_web_scraper' );
-			if ( '' !== $identifier && $processed_items->has_item_been_processed( $flow_step_id, $source_type, $identifier ) ) {
-				++$count;
-			}
-		}
-
-		return $count;
-	}
 }

--- a/inc/Abilities/EventScraperTest.php
+++ b/inc/Abilities/EventScraperTest.php
@@ -19,12 +19,9 @@
  * events the extractor actually found. That undercount caused every Bandzoogle /
  * multi-event JSON-LD venue to be flagged `extraction_gap` on its first qualify run.
  *
- * Fix shape (Shape A from the issue): walk all packets, build an `event_data.events[]`
- * summary array (compatible with `QualifyFingerprinter::count_events()`'s existing
- * `items[]` check), and surface `event_count` in both `event_data` and
- * `extraction_info`. The first event's full record stays at `event_data` top-level
- * for backwards compatibility with the chat tool and the CLI command, which only
- * read a single event's fields.
+ * Fix shape: walk all packets and surface the exact `event_count` in both
+ * `event_data` and `extraction_info`. A bounded `event_data.items[]` sample and
+ * the first event's full record remain available to diagnostic consumers.
  *
  * Issue #511 adds config-aware source diagnostics only. Stable unique source
  * counts collapse repeated packet identifiers, but do not represent production
@@ -43,6 +40,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class EventScraperTest {
+
+	private const EVENT_SUMMARY_LIMIT = 100;
 
 	private static bool $registered = false;
 
@@ -117,8 +116,9 @@ class EventScraperTest {
 										'venueZip'     => array( 'type' => 'string' ),
 										'event_count'  => array( 'type' => 'integer', 'minimum' => 0 ),
 										'items'        => array(
-											'type'  => 'array',
-											'items' => array(
+											'type'     => 'array',
+											'maxItems' => self::EVENT_SUMMARY_LIMIT,
+											'items'    => array(
 												'type'                 => 'object',
 												'additionalProperties' => false,
 												'properties'           => array(
@@ -146,6 +146,9 @@ class EventScraperTest {
 										'extracted_packet_count',
 										'unique_source_event_count',
 										'duplicate_packet_count',
+										'production_max_items',
+										'summary_event_count',
+										'summary_truncated',
 										'context_supplied',
 									),
 									'properties'           => array(
@@ -157,6 +160,9 @@ class EventScraperTest {
 										'extracted_packet_count'    => array( 'type' => 'integer', 'minimum' => 0 ),
 										'unique_source_event_count' => array( 'type' => 'integer', 'minimum' => 0 ),
 										'duplicate_packet_count'    => array( 'type' => 'integer', 'minimum' => 0 ),
+										'production_max_items'      => array( 'type' => array( 'integer', 'null' ), 'minimum' => 0 ),
+										'summary_event_count'       => array( 'type' => 'integer', 'minimum' => 0 ),
+										'summary_truncated'         => array( 'type' => 'boolean' ),
 										'context_supplied'          => array( 'type' => 'boolean' ),
 										'requires_ai_step'          => array( 'type' => 'boolean' ),
 										'image_file_stored'         => array( 'type' => 'boolean' ),
@@ -240,6 +246,11 @@ class EventScraperTest {
 				'flow_id'      => 'direct',
 			)
 		);
+		$production_max_items = null;
+		if ( array_key_exists( 'max_items', $config ) ) {
+			$production_max_items = max( 0, (int) $config['max_items'] );
+			unset( $config['max_items'] );
+		}
 
 		$handler = new UniversalWebScraper();
 		$results = $handler->get_fetch_data( 'direct', $config, null );
@@ -271,9 +282,9 @@ class EventScraperTest {
 			}
 		}
 
-		$extracted_packet_count    = count( $packet_entries );
-		$packet_entries            = $this->uniquePacketEntries( $packet_entries );
-		$unique_source_event_count = count( $packet_entries );
+		$inventory       = $this->analyzePacketEntries( $packet_entries, null !== $handler_config, $production_max_items );
+		$packet_entries  = $inventory['packet_entries'];
+		$extraction_info = $inventory['extraction_info'];
 
 		$packet_entry = $packet_entries[0] ?? array();
 		$packet_data  = $packet_entry['data'] ?? array();
@@ -287,21 +298,12 @@ class EventScraperTest {
 		$payload = json_decode( (string) $body, true );
 		$event   = is_array( $payload ) ? ( $payload['event'] ?? null ) : null;
 
-		// Build a summary list of every event across all packets. Compatible
-		// with QualifyFingerprinter::count_events() which already handles
-		// $event_data['items'] / $event_data['events'] as the multi-event signal.
-		$all_events = $this->summarizeEventsFromPackets( $packet_entries );
+		// Build a bounded representative summary while retaining exact counts.
+		$all_events = array_slice( $this->summarizeEventsFromPackets( $packet_entries ), 0, self::EVENT_SUMMARY_LIMIT );
 
-		$extraction_info = array(
-			'packet_title'              => $packet_data['title'] ?? '',
-			'source_type'               => $packet_meta['source_type'] ?? '',
-			'extraction_method'         => $packet_meta['extraction_method'] ?? '',
-			'event_count'               => $unique_source_event_count,
-			'extracted_packet_count'    => $extracted_packet_count,
-			'unique_source_event_count' => $unique_source_event_count,
-			'duplicate_packet_count'    => $extracted_packet_count - $unique_source_event_count,
-			'context_supplied'          => null !== $handler_config,
-		);
+		$extraction_info['packet_title']      = $packet_data['title'] ?? '';
+		$extraction_info['source_type']       = $packet_meta['source_type'] ?? '';
+		$extraction_info['extraction_method'] = $packet_meta['extraction_method'] ?? '';
 
 		if ( is_array( $payload ) && isset( $payload['raw_html'] ) && is_string( $payload['raw_html'] ) ) {
 			return array(
@@ -396,15 +398,11 @@ class EventScraperTest {
 		$event_data['venueState']   = $venue_state;
 		$event_data['venueZip']     = $venue_zip;
 
-		// Surface the full event list and total count so qualify-path consumers
-		// downstream consumers see the true
-		// extraction count instead of just the first event (#265).
-		//
-		// `items` is the field QualifyFingerprinter::count_events() already
-		// inspects (`isset($event_data['items'])`) — populating it lets the fix
-		// land without requiring a matching consumer change.
+		// Keep the exact inventory count separate from the bounded event summaries.
+		// Consumers that need the full count must use event_count; items is only a
+		// representative diagnostic sample.
 		$event_data['items']       = $all_events;
-		$event_data['event_count'] = count( $all_events );
+		$event_data['event_count'] = $extraction_info['event_count'];
 
 		$extraction_info['payload_type'] = 'event';
 
@@ -538,6 +536,39 @@ class EventScraperTest {
 		}
 
 		return $unique;
+	}
+
+	/**
+	 * Build source-inventory counts without applying production selection state.
+	 *
+	 * @param array    $packet_entries       Extracted packet entries.
+	 * @param bool     $context_supplied     Whether handler configuration was supplied.
+	 * @param int|null $production_max_items Persisted production cap, if configured.
+	 * @return array{packet_entries:array,extraction_info:array}
+	 */
+	private function analyzePacketEntries( array $packet_entries, bool $context_supplied, ?int $production_max_items ): array {
+		$extracted_packet_count    = count( $packet_entries );
+		$packet_entries            = $this->uniquePacketEntries( $packet_entries );
+		$unique_source_event_count = count( $packet_entries );
+		$source_event_summaries    = count( $this->summarizeEventsFromPackets( $packet_entries ) );
+		$summary_event_count       = min( $source_event_summaries, self::EVENT_SUMMARY_LIMIT );
+
+		return array(
+			'packet_entries'  => $packet_entries,
+			'extraction_info' => array(
+				'packet_title'              => '',
+				'source_type'               => '',
+				'extraction_method'         => '',
+				'event_count'               => $unique_source_event_count,
+				'extracted_packet_count'    => $extracted_packet_count,
+				'unique_source_event_count' => $unique_source_event_count,
+				'duplicate_packet_count'    => $extracted_packet_count - $unique_source_event_count,
+				'production_max_items'      => $production_max_items,
+				'summary_event_count'       => $summary_event_count,
+				'summary_truncated'         => $summary_event_count < $source_event_summaries,
+				'context_supplied'          => $context_supplied,
+			),
+		);
 	}
 
 }

--- a/inc/Abilities/EventScraperTest.php
+++ b/inc/Abilities/EventScraperTest.php
@@ -31,6 +31,7 @@
 
 namespace DataMachineEvents\Abilities;
 
+use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 use DataMachineEvents\Steps\EventImport\Handlers\WebScraper\UniversalWebScraper;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -58,6 +59,14 @@ class EventScraperTest {
 									'type'        => 'string',
 									'format'      => 'uri',
 									'description' => 'Target URL to test scraper against',
+								),
+								'handler_config' => array(
+									'type'        => 'object',
+									'description' => 'Optional persisted universal web scraper config to apply during qualification.',
+								),
+								'flow_step_id'   => array(
+									'type'        => 'string',
+									'description' => 'Optional persisted flow step ID used for read-only processed-item diagnostics.',
 								),
 							),
 						),
@@ -99,10 +108,13 @@ class EventScraperTest {
 			return new \WP_Error( 'missing_target_url', 'Missing required target_url parameter.', array( 'status' => 400 ) );
 		}
 
-		return $this->test( $target_url );
+		$handler_config = is_array( $input['handler_config'] ?? null ) ? $input['handler_config'] : array();
+		$flow_step_id   = sanitize_text_field( (string) ( $input['flow_step_id'] ?? '' ) );
+
+		return $this->test( $target_url, $handler_config, $flow_step_id );
 	}
 
-	public function test( string $target_url ): array|\WP_Error {
+	public function test( string $target_url, array $handler_config = array(), string $flow_step_id = '' ): array|\WP_Error {
 		$logs = array();
 		add_action(
 			'datamachine_log',
@@ -117,11 +129,13 @@ class EventScraperTest {
 			3
 		);
 
-		$config = array(
-			'source_url'   => $target_url,
-			'flow_step_id' => 'test_' . wp_generate_uuid4(),
-			'flow_id'      => 'direct',
-			'search'       => '',
+		$config = array_merge(
+			$handler_config,
+			array(
+				'source_url'   => $target_url,
+				'flow_step_id' => 'test_' . wp_generate_uuid4(),
+				'flow_id'      => 'direct',
+			)
 		);
 
 		$handler = new UniversalWebScraper();
@@ -154,6 +168,11 @@ class EventScraperTest {
 			}
 		}
 
+		$extracted_packet_count = count( $packet_entries );
+		$packet_entries         = $this->uniquePacketEntries( $packet_entries );
+		$source_event_count     = count( $packet_entries );
+		$processed_event_count  = $this->countProcessedPacketEntries( $packet_entries, $flow_step_id );
+
 		$packet_entry = $packet_entries[0] ?? array();
 		$packet_data  = $packet_entry['data'] ?? array();
 		$packet_meta  = $packet_entry['metadata'] ?? array();
@@ -172,10 +191,15 @@ class EventScraperTest {
 		$all_events = $this->summarizeEventsFromPackets( $packet_entries );
 
 		$extraction_info = array(
-			'packet_title'      => $packet_data['title'] ?? '',
-			'source_type'       => $packet_meta['source_type'] ?? '',
-			'extraction_method' => $packet_meta['extraction_method'] ?? '',
-			'event_count'       => count( $packet_entries ),
+			'packet_title'           => $packet_data['title'] ?? '',
+			'source_type'            => $packet_meta['source_type'] ?? '',
+			'extraction_method'      => $packet_meta['extraction_method'] ?? '',
+			'event_count'            => $source_event_count,
+			'extracted_packet_count' => $extracted_packet_count,
+			'source_event_count'     => $source_event_count,
+			'duplicate_packet_count' => $extracted_packet_count - $source_event_count,
+			'processed_event_count'  => $processed_event_count,
+			'eligible_event_count'   => $source_event_count - $processed_event_count,
 		);
 
 		if ( is_array( $payload ) && isset( $payload['raw_html'] ) && is_string( $payload['raw_html'] ) ) {
@@ -387,5 +411,57 @@ class EventScraperTest {
 		}
 
 		return $summary;
+	}
+
+	/**
+	 * Mirror production's claim-time duplicate collapse without creating claims.
+	 *
+	 * @param array $packet_entries Packet entries from DataPacket::addTo().
+	 * @return array Unique packet entries.
+	 */
+	private function uniquePacketEntries( array $packet_entries ): array {
+		$unique = array();
+		$seen   = array();
+
+		foreach ( $packet_entries as $entry ) {
+			$identifier = (string) ( $entry['metadata']['item_identifier'] ?? '' );
+			if ( '' !== $identifier ) {
+				if ( isset( $seen[ $identifier ] ) ) {
+					continue;
+				}
+				$seen[ $identifier ] = true;
+			}
+			$unique[] = $entry;
+		}
+
+		return $unique;
+	}
+
+	/**
+	 * Count unique source events already completed by a persisted flow step.
+	 *
+	 * This deliberately reads only final processed rows. It neither creates
+	 * claims nor clears processed history, so operators can use it as a dry-run
+	 * explanation for a production fetch that correctly emits no new packets.
+	 *
+	 * @param array  $packet_entries Unique packet entries.
+	 * @param string $flow_step_id   Persisted flow step ID.
+	 */
+	private function countProcessedPacketEntries( array $packet_entries, string $flow_step_id ): int {
+		if ( '' === $flow_step_id ) {
+			return 0;
+		}
+
+		$processed_items = new ProcessedItems();
+		$count           = 0;
+		foreach ( $packet_entries as $entry ) {
+			$identifier  = (string) ( $entry['metadata']['item_identifier'] ?? '' );
+			$source_type = (string) ( $entry['metadata']['source_type'] ?? 'universal_web_scraper' );
+			if ( '' !== $identifier && $processed_items->has_item_been_processed( $flow_step_id, $source_type, $identifier ) ) {
+				++$count;
+			}
+		}
+
+		return $count;
 	}
 }

--- a/inc/Abilities/EventScraperTest.php
+++ b/inc/Abilities/EventScraperTest.php
@@ -20,13 +20,12 @@
  * multi-event JSON-LD venue to be flagged `extraction_gap` on its first qualify run.
  *
  * Fix shape: walk all packets and surface the exact `event_count` in both
- * `event_data` and `extraction_info`. A bounded `event_data.items[]` sample and
- * the first event's full record remain available to diagnostic consumers.
+ * `event_data` and `extraction_info`. The full `event_data.items[]` list remains
+ * available for existing qualification consumers.
  *
- * Issue #511 adds config-aware source diagnostics only. Stable unique source
- * counts collapse repeated packet identifiers, but do not represent production
- * eligibility. Processed state, claims, reprocess policy, and max-items selection
- * remain owned by Data Machine's production lifecycle.
+ * Issue #511 adds config-aware source diagnostics only. Stable structured-event
+ * counts collapse repeated packet identifiers, while raw sections and flyer
+ * candidates have separate counters. None represent production eligibility.
  *
  * @package DataMachineEvents\Abilities
  */
@@ -40,8 +39,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class EventScraperTest {
-
-	private const EVENT_SUMMARY_LIMIT = 100;
 
 	private static bool $registered = false;
 
@@ -116,9 +113,8 @@ class EventScraperTest {
 										'venueZip'     => array( 'type' => 'string' ),
 										'event_count'  => array( 'type' => 'integer', 'minimum' => 0 ),
 										'items'        => array(
-											'type'     => 'array',
-											'maxItems' => self::EVENT_SUMMARY_LIMIT,
-											'items'    => array(
+											'type'  => 'array',
+											'items' => array(
 												'type'                 => 'object',
 												'additionalProperties' => false,
 												'properties'           => array(
@@ -147,8 +143,9 @@ class EventScraperTest {
 										'unique_source_event_count',
 										'duplicate_packet_count',
 										'production_max_items',
-										'summary_event_count',
-										'summary_truncated',
+										'candidate_packet_count',
+										'raw_section_count',
+										'flyer_candidate_count',
 										'context_supplied',
 									),
 									'properties'           => array(
@@ -156,13 +153,14 @@ class EventScraperTest {
 										'source_type'               => array( 'type' => 'string' ),
 										'extraction_method'         => array( 'type' => 'string' ),
 										'payload_type'              => array( 'type' => 'string', 'enum' => array( 'event', 'raw_html', 'vision_flyer' ) ),
-										'event_count'               => array( 'type' => 'integer', 'minimum' => 0 ),
-										'extracted_packet_count'    => array( 'type' => 'integer', 'minimum' => 0 ),
-										'unique_source_event_count' => array( 'type' => 'integer', 'minimum' => 0 ),
-										'duplicate_packet_count'    => array( 'type' => 'integer', 'minimum' => 0 ),
-										'production_max_items'      => array( 'type' => array( 'integer', 'null' ), 'minimum' => 0 ),
-										'summary_event_count'       => array( 'type' => 'integer', 'minimum' => 0 ),
-										'summary_truncated'         => array( 'type' => 'boolean' ),
+										'event_count'               => array( 'type' => 'integer', 'minimum' => 0, 'description' => 'Unique structured events extracted from the source.' ),
+										'extracted_packet_count'    => array( 'type' => 'integer', 'minimum' => 0, 'description' => 'All packets returned by direct handler execution before stable-identifier deduplication.' ),
+										'unique_source_event_count' => array( 'type' => 'integer', 'minimum' => 0, 'description' => 'Unique structured events after stable-identifier deduplication.' ),
+										'duplicate_packet_count'    => array( 'type' => 'integer', 'minimum' => 0, 'description' => 'Packets removed because their stable identifier repeated.' ),
+										'production_max_items'      => array( 'type' => array( 'integer', 'null' ), 'minimum' => 0, 'description' => 'Configured production cap, reported but not applied to diagnostic extraction.' ),
+										'candidate_packet_count'    => array( 'type' => 'integer', 'minimum' => 0, 'description' => 'Non-structured raw-section and flyer candidate packets.' ),
+										'raw_section_count'         => array( 'type' => 'integer', 'minimum' => 0, 'description' => 'Raw HTML section candidates requiring downstream interpretation.' ),
+										'flyer_candidate_count'     => array( 'type' => 'integer', 'minimum' => 0, 'description' => 'Vision flyer candidates requiring downstream interpretation.' ),
 										'context_supplied'          => array( 'type' => 'boolean' ),
 										'requires_ai_step'          => array( 'type' => 'boolean' ),
 										'image_file_stored'         => array( 'type' => 'boolean' ),
@@ -298,8 +296,7 @@ class EventScraperTest {
 		$payload = json_decode( (string) $body, true );
 		$event   = is_array( $payload ) ? ( $payload['event'] ?? null ) : null;
 
-		// Build a bounded representative summary while retaining exact counts.
-		$all_events = array_slice( $this->summarizeEventsFromPackets( $packet_entries ), 0, self::EVENT_SUMMARY_LIMIT );
+		$all_events = $this->summarizeEventsFromPackets( $packet_entries );
 
 		$extraction_info['packet_title']      = $packet_data['title'] ?? '';
 		$extraction_info['source_type']       = $packet_meta['source_type'] ?? '';
@@ -398,9 +395,7 @@ class EventScraperTest {
 		$event_data['venueState']   = $venue_state;
 		$event_data['venueZip']     = $venue_zip;
 
-		// Keep the exact inventory count separate from the bounded event summaries.
-		// Consumers that need the full count must use event_count; items is only a
-		// representative diagnostic sample.
+		// Preserve the full list until every qualification consumer reads event_count.
 		$event_data['items']       = $all_events;
 		$event_data['event_count'] = $extraction_info['event_count'];
 
@@ -549,9 +544,24 @@ class EventScraperTest {
 	private function analyzePacketEntries( array $packet_entries, bool $context_supplied, ?int $production_max_items ): array {
 		$extracted_packet_count    = count( $packet_entries );
 		$packet_entries            = $this->uniquePacketEntries( $packet_entries );
-		$unique_source_event_count = count( $packet_entries );
-		$source_event_summaries    = count( $this->summarizeEventsFromPackets( $packet_entries ) );
-		$summary_event_count       = min( $source_event_summaries, self::EVENT_SUMMARY_LIMIT );
+		$structured_event_count    = 0;
+		$raw_section_count         = 0;
+		$flyer_candidate_count     = 0;
+		foreach ( $packet_entries as $entry ) {
+			$body    = (string) ( $entry['data']['body'] ?? '' );
+			$payload = json_decode( $body, true );
+			if ( ! is_array( $payload ) ) {
+				continue;
+			}
+			if ( is_array( $payload['event'] ?? null ) ) {
+				++$structured_event_count;
+			} elseif ( isset( $payload['raw_html'] ) && is_string( $payload['raw_html'] ) ) {
+				++$raw_section_count;
+			} elseif ( 'vision_flyer' === ( $payload['source_type'] ?? '' ) ) {
+				++$flyer_candidate_count;
+			}
+		}
+		$candidate_packet_count = $raw_section_count + $flyer_candidate_count;
 
 		return array(
 			'packet_entries'  => $packet_entries,
@@ -559,13 +569,14 @@ class EventScraperTest {
 				'packet_title'              => '',
 				'source_type'               => '',
 				'extraction_method'         => '',
-				'event_count'               => $unique_source_event_count,
+				'event_count'               => $structured_event_count,
 				'extracted_packet_count'    => $extracted_packet_count,
-				'unique_source_event_count' => $unique_source_event_count,
-				'duplicate_packet_count'    => $extracted_packet_count - $unique_source_event_count,
+				'unique_source_event_count' => $structured_event_count,
+				'duplicate_packet_count'    => $extracted_packet_count - count( $packet_entries ),
 				'production_max_items'      => $production_max_items,
-				'summary_event_count'       => $summary_event_count,
-				'summary_truncated'         => $summary_event_count < $source_event_summaries,
+				'candidate_packet_count'    => $candidate_packet_count,
+				'raw_section_count'         => $raw_section_count,
+				'flyer_candidate_count'     => $flyer_candidate_count,
 				'context_supplied'          => $context_supplied,
 			),
 		);

--- a/tests/Unit/EventScraperTestAbilityTest.php
+++ b/tests/Unit/EventScraperTestAbilityTest.php
@@ -29,7 +29,9 @@ namespace DataMachineEvents\Tests\Unit;
 
 use WP_UnitTestCase;
 use ReflectionClass;
+use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 use DataMachineEvents\Abilities\EventScraperTest;
+use DataMachineEvents\Utilities\EventIdentifierGenerator;
 use DataMachineEvents\Steps\EventImport\Handlers\WebScraper\Extractors\BandzoogleExtractor;
 use DataMachineEvents\Steps\EventImport\Handlers\WebScraper\Extractors\JsonLdExtractor;
 
@@ -104,6 +106,60 @@ class EventScraperTestAbilityTest extends WP_UnitTestCase {
 
 		$this->assertCount( 1, $summary, 'Only the one decodable event packet should be summarized.' );
 		$this->assertSame( 'Real Event', $summary[0]['title'] );
+	}
+
+	/**
+	 * Regression for #511: qualification must apply the production config,
+	 * collapse repeated source records by stable identifier, and explain when
+	 * all unique records are already processed without mutating lifecycle state.
+	 */
+	public function test_qualification_matches_production_config_and_processed_identity() {
+		$html = '<script type="application/ld+json">' . wp_json_encode(
+			array(
+				array(
+					'@context'  => 'https://schema.org',
+					'@type'     => 'MusicEvent',
+					'name'      => 'Repeated Concert',
+					'startDate' => '2030-08-01T20:00:00-04:00',
+				),
+				array(
+					'@context'  => 'https://schema.org',
+					'@type'     => 'MusicEvent',
+					'name'      => 'Repeated Concert',
+					'startDate' => '2030-08-01T20:00:00-04:00',
+				),
+				array(
+					'@context'  => 'https://schema.org',
+					'@type'     => 'MusicEvent',
+					'name'      => 'Trivia Club',
+					'startDate' => '2030-08-02T20:00:00-04:00',
+				),
+			)
+		) . '</script>';
+
+		$this->mockHttpResponse( $html );
+
+		$flow_step_id = 'qualify-production-' . wp_generate_uuid4();
+		$config       = array(
+			'exclude_keywords' => 'Trivia Club',
+			'venue_name'        => 'Test Venue',
+		);
+		$identifier   = EventIdentifierGenerator::generate( 'Repeated Concert', '2030-08-01', 'Test Venue' );
+
+		$processed_items = new ProcessedItems();
+		$processed_items->create_table();
+		$processed_items->add_processed_item( $flow_step_id, 'universal_web_scraper', $identifier, 123 );
+
+		$result = ( new EventScraperTest() )->test( 'https://example.com/events', $config, $flow_step_id );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 2, $result['extraction_info']['extracted_packet_count'] );
+		$this->assertSame( 1, $result['extraction_info']['source_event_count'] );
+		$this->assertSame( 1, $result['extraction_info']['duplicate_packet_count'] );
+		$this->assertSame( 1, $result['extraction_info']['processed_event_count'] );
+		$this->assertSame( 0, $result['extraction_info']['eligible_event_count'] );
+		$this->assertSame( 1, $result['event_data']['event_count'] );
+		$this->assertCount( 1, $result['event_data']['items'] );
 	}
 
 	// ────────────────────────────────────────────────────────────────────

--- a/tests/Unit/EventScraperTestAbilityTest.php
+++ b/tests/Unit/EventScraperTestAbilityTest.php
@@ -67,7 +67,10 @@ class EventScraperTestAbilityTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'context_supplied', $output['properties']['extraction_info']['properties'] );
 		$this->assertArrayHasKey( 'duplicate_packet_count', $output['properties']['extraction_info']['properties'] );
 		$this->assertArrayHasKey( 'production_max_items', $output['properties']['extraction_info']['properties'] );
-		$this->assertArrayHasKey( 'summary_truncated', $output['properties']['extraction_info']['properties'] );
+		$this->assertArrayHasKey( 'candidate_packet_count', $output['properties']['extraction_info']['properties'] );
+		$this->assertArrayHasKey( 'raw_section_count', $output['properties']['extraction_info']['properties'] );
+		$this->assertArrayHasKey( 'flyer_candidate_count', $output['properties']['extraction_info']['properties'] );
+		$this->assertArrayNotHasKey( 'summary_truncated', $output['properties']['extraction_info']['properties'] );
 		$this->assertArrayNotHasKey( 'processed_event_count', $output['properties']['extraction_info']['properties'] );
 		$this->assertArrayNotHasKey( 'eligible_event_count', $output['properties']['extraction_info']['properties'] );
 	}
@@ -216,7 +219,7 @@ class EventScraperTestAbilityTest extends WP_UnitTestCase {
 		$this->assertCount( 1, $result['event_data']['items'] );
 	}
 
-	public function test_max_items_does_not_cap_source_inventory_and_summaries_are_bounded(): void {
+	public function test_max_items_does_not_cap_source_inventory_or_full_items_list(): void {
 		$events = array();
 		foreach ( range( 1, 105 ) as $index ) {
 			$events[] = array(
@@ -249,10 +252,9 @@ class EventScraperTestAbilityTest extends WP_UnitTestCase {
 		$this->assertSame( 105, $result['extraction_info']['extracted_packet_count'] );
 		$this->assertSame( 105, $result['extraction_info']['unique_source_event_count'] );
 		$this->assertSame( 1, $result['extraction_info']['production_max_items'] );
-		$this->assertSame( 100, $result['extraction_info']['summary_event_count'] );
-		$this->assertTrue( $result['extraction_info']['summary_truncated'] );
+		$this->assertSame( 0, $result['extraction_info']['candidate_packet_count'] );
 		$this->assertSame( 105, $result['event_data']['event_count'] );
-		$this->assertCount( 100, $result['event_data']['items'] );
+		$this->assertCount( 105, $result['event_data']['items'] );
 	}
 
 	public function test_raw_and_vision_packets_report_truthful_source_counts(): void {
@@ -283,13 +285,17 @@ class EventScraperTestAbilityTest extends WP_UnitTestCase {
 
 		foreach ( array( $raw, $vision ) as $inventory ) {
 			$this->assertSame( 1, $inventory['extraction_info']['extracted_packet_count'] );
-			$this->assertSame( 1, $inventory['extraction_info']['unique_source_event_count'] );
+			$this->assertSame( 0, $inventory['extraction_info']['event_count'] );
+			$this->assertSame( 0, $inventory['extraction_info']['unique_source_event_count'] );
 			$this->assertSame( 0, $inventory['extraction_info']['duplicate_packet_count'] );
-			$this->assertSame( 0, $inventory['extraction_info']['summary_event_count'] );
-			$this->assertFalse( $inventory['extraction_info']['summary_truncated'] );
+			$this->assertSame( 1, $inventory['extraction_info']['candidate_packet_count'] );
 		}
+		$this->assertSame( 1, $raw['extraction_info']['raw_section_count'] );
+		$this->assertSame( 0, $raw['extraction_info']['flyer_candidate_count'] );
 		$this->assertNull( $raw['extraction_info']['production_max_items'] );
 		$this->assertFalse( $raw['extraction_info']['context_supplied'] );
+		$this->assertSame( 0, $vision['extraction_info']['raw_section_count'] );
+		$this->assertSame( 1, $vision['extraction_info']['flyer_candidate_count'] );
 		$this->assertSame( 5, $vision['extraction_info']['production_max_items'] );
 		$this->assertTrue( $vision['extraction_info']['context_supplied'] );
 	}

--- a/tests/Unit/EventScraperTestAbilityTest.php
+++ b/tests/Unit/EventScraperTestAbilityTest.php
@@ -66,6 +66,8 @@ class EventScraperTestAbilityTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'extraction_info', $output['properties'] );
 		$this->assertArrayHasKey( 'context_supplied', $output['properties']['extraction_info']['properties'] );
 		$this->assertArrayHasKey( 'duplicate_packet_count', $output['properties']['extraction_info']['properties'] );
+		$this->assertArrayHasKey( 'production_max_items', $output['properties']['extraction_info']['properties'] );
+		$this->assertArrayHasKey( 'summary_truncated', $output['properties']['extraction_info']['properties'] );
 		$this->assertArrayNotHasKey( 'processed_event_count', $output['properties']['extraction_info']['properties'] );
 		$this->assertArrayNotHasKey( 'eligible_event_count', $output['properties']['extraction_info']['properties'] );
 	}
@@ -212,6 +214,84 @@ class EventScraperTestAbilityTest extends WP_UnitTestCase {
 		$this->assertTrue( $result['extraction_info']['context_supplied'] );
 		$this->assertSame( 1, $result['event_data']['event_count'] );
 		$this->assertCount( 1, $result['event_data']['items'] );
+	}
+
+	public function test_max_items_does_not_cap_source_inventory_and_summaries_are_bounded(): void {
+		$events = array();
+		foreach ( range( 1, 105 ) as $index ) {
+			$events[] = array(
+				'@context'  => 'https://schema.org',
+				'@type'     => 'MusicEvent',
+				'name'      => 'Inventory Event ' . $index,
+				'startDate' => '2030-09-01T20:00:00-04:00',
+			);
+		}
+
+		$html = '<script type="application/ld+json">' . wp_json_encode( $events ) . '</script>';
+		$this->mockHttpResponse( $html );
+
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$ability = wp_get_ability( 'data-machine-events/test-event-scraper' );
+		$this->assertNotNull( $ability );
+		$result = $ability->execute(
+			array(
+				'target_url'     => 'https://example.com/large-calendar',
+				'handler_config' => array(
+					'max_items'  => 1,
+					'venue_name' => 'Inventory Venue',
+				),
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 105, $result['extraction_info']['extracted_packet_count'] );
+		$this->assertSame( 105, $result['extraction_info']['unique_source_event_count'] );
+		$this->assertSame( 1, $result['extraction_info']['production_max_items'] );
+		$this->assertSame( 100, $result['extraction_info']['summary_event_count'] );
+		$this->assertTrue( $result['extraction_info']['summary_truncated'] );
+		$this->assertSame( 105, $result['event_data']['event_count'] );
+		$this->assertCount( 100, $result['event_data']['items'] );
+	}
+
+	public function test_raw_and_vision_packets_report_truthful_source_counts(): void {
+		$ability = new EventScraperTest();
+		$method  = ( new ReflectionClass( $ability ) )->getMethod( 'analyzePacketEntries' );
+		$method->setAccessible( true );
+
+		$raw = $method->invoke(
+			$ability,
+			array( $this->buildNonEventPacketEntry( array( 'raw_html' => '<article>Event</article>' ), 'raw-section' ) ),
+			false,
+			null
+		);
+		$vision = $method->invoke(
+			$ability,
+			array(
+				$this->buildNonEventPacketEntry(
+					array(
+						'source_type' => 'vision_flyer',
+						'image_url'   => 'https://example.com/flyer.jpg',
+					),
+					'vision-flyer'
+				),
+			),
+			true,
+			5
+		);
+
+		foreach ( array( $raw, $vision ) as $inventory ) {
+			$this->assertSame( 1, $inventory['extraction_info']['extracted_packet_count'] );
+			$this->assertSame( 1, $inventory['extraction_info']['unique_source_event_count'] );
+			$this->assertSame( 0, $inventory['extraction_info']['duplicate_packet_count'] );
+			$this->assertSame( 0, $inventory['extraction_info']['summary_event_count'] );
+			$this->assertFalse( $inventory['extraction_info']['summary_truncated'] );
+		}
+		$this->assertNull( $raw['extraction_info']['production_max_items'] );
+		$this->assertFalse( $raw['extraction_info']['context_supplied'] );
+		$this->assertSame( 5, $vision['extraction_info']['production_max_items'] );
+		$this->assertTrue( $vision['extraction_info']['context_supplied'] );
 	}
 
 	// ────────────────────────────────────────────────────────────────────
@@ -388,6 +468,19 @@ class EventScraperTestAbilityTest extends WP_UnitTestCase {
 			),
 			'metadata'  => array(
 				'source_type' => 'universal_web_scraper',
+			),
+		);
+	}
+
+	private function buildNonEventPacketEntry( array $payload, string $identifier ): array {
+		return array(
+			'data'     => array(
+				'title' => 'Diagnostic Packet',
+				'body'  => wp_json_encode( $payload ),
+			),
+			'metadata' => array(
+				'item_identifier' => $identifier,
+				'source_type'     => 'universal_web_scraper',
 			),
 		);
 	}

--- a/tests/Unit/EventScraperTestAbilityTest.php
+++ b/tests/Unit/EventScraperTestAbilityTest.php
@@ -29,9 +29,7 @@ namespace DataMachineEvents\Tests\Unit;
 
 use WP_UnitTestCase;
 use ReflectionClass;
-use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 use DataMachineEvents\Abilities\EventScraperTest;
-use DataMachineEvents\Utilities\EventIdentifierGenerator;
 use DataMachineEvents\Steps\EventImport\Handlers\WebScraper\Extractors\BandzoogleExtractor;
 use DataMachineEvents\Steps\EventImport\Handlers\WebScraper\Extractors\JsonLdExtractor;
 
@@ -46,7 +44,58 @@ class EventScraperTestAbilityTest extends WP_UnitTestCase {
 
 	public function tearDown(): void {
 		remove_all_filters( 'pre_http_request' );
+		wp_set_current_user( 0 );
 		parent::tearDown();
+	}
+
+	public function test_ability_is_registered_with_complete_context_schema(): void {
+		$ability = wp_get_ability( 'data-machine-events/test-event-scraper' );
+
+		$this->assertNotNull( $ability );
+		$this->assertSame( 'data-machine-events/test-event-scraper', $ability->get_name() );
+
+		$input = $ability->get_input_schema();
+		$this->assertSame( array( 'target_url' ), $input['required'] );
+		$this->assertArrayHasKey( 'handler_config', $input['properties'] );
+		$this->assertArrayHasKey( 'exclude_keywords', $input['properties']['handler_config']['properties'] );
+		$this->assertArrayNotHasKey( 'flow_step_id', $input['properties'] );
+
+		$output = $ability->get_output_schema();
+		$this->assertArrayHasKey( 'event_data', $output['properties'] );
+		$this->assertArrayHasKey( 'items', $output['properties']['event_data']['properties'] );
+		$this->assertArrayHasKey( 'extraction_info', $output['properties'] );
+		$this->assertArrayHasKey( 'context_supplied', $output['properties']['extraction_info']['properties'] );
+		$this->assertArrayHasKey( 'duplicate_packet_count', $output['properties']['extraction_info']['properties'] );
+		$this->assertArrayNotHasKey( 'processed_event_count', $output['properties']['extraction_info']['properties'] );
+		$this->assertArrayNotHasKey( 'eligible_event_count', $output['properties']['extraction_info']['properties'] );
+	}
+
+	public function test_ability_permission_requires_manage_options(): void {
+		$ability = wp_get_ability( 'data-machine-events/test-event-scraper' );
+		$this->assertNotNull( $ability );
+
+		$subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $subscriber_id );
+		$this->assertFalse( $ability->check_permissions( array( 'target_url' => 'https://example.com/events' ) ) );
+		$denied = $ability->execute( array( 'target_url' => 'https://example.com/events' ) );
+		$this->assertInstanceOf( \WP_Error::class, $denied );
+		$this->assertSame( 'ability_invalid_permissions', $denied->get_error_code() );
+
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+		$this->assertTrue( $ability->check_permissions( array( 'target_url' => 'https://example.com/events' ) ) );
+	}
+
+	public function test_ability_rejects_missing_target_url_from_schema(): void {
+		$ability = wp_get_ability( 'data-machine-events/test-event-scraper' );
+		$this->assertNotNull( $ability );
+
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+		$result = $ability->execute( array() );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ability_invalid_input', $result->get_error_code() );
 	}
 
 	// ────────────────────────────────────────────────────────────────────
@@ -110,10 +159,10 @@ class EventScraperTestAbilityTest extends WP_UnitTestCase {
 
 	/**
 	 * Regression for #511: qualification must apply the production config,
-	 * collapse repeated source records by stable identifier, and explain when
-	 * all unique records are already processed without mutating lifecycle state.
+	 * collapse repeated source records by stable identifier, and explicitly
+	 * report that handler context was supplied.
 	 */
-	public function test_qualification_matches_production_config_and_processed_identity() {
+	public function test_qualification_matches_production_config_and_stable_identity() {
 		$html = '<script type="application/ld+json">' . wp_json_encode(
 			array(
 				array(
@@ -139,25 +188,28 @@ class EventScraperTestAbilityTest extends WP_UnitTestCase {
 
 		$this->mockHttpResponse( $html );
 
-		$flow_step_id = 'qualify-production-' . wp_generate_uuid4();
-		$config       = array(
+		$config = array(
 			'exclude_keywords' => 'Trivia Club',
 			'venue_name'        => 'Test Venue',
 		);
-		$identifier   = EventIdentifierGenerator::generate( 'Repeated Concert', '2030-08-01', 'Test Venue' );
 
-		$processed_items = new ProcessedItems();
-		$processed_items->create_table();
-		$processed_items->add_processed_item( $flow_step_id, 'universal_web_scraper', $identifier, 123 );
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
 
-		$result = ( new EventScraperTest() )->test( 'https://example.com/events', $config, $flow_step_id );
+		$ability = wp_get_ability( 'data-machine-events/test-event-scraper' );
+		$this->assertNotNull( $ability );
+		$result = $ability->execute(
+			array(
+				'target_url'     => 'https://example.com/events',
+				'handler_config' => $config,
+			)
+		);
 
 		$this->assertIsArray( $result );
 		$this->assertSame( 2, $result['extraction_info']['extracted_packet_count'] );
-		$this->assertSame( 1, $result['extraction_info']['source_event_count'] );
+		$this->assertSame( 1, $result['extraction_info']['unique_source_event_count'] );
 		$this->assertSame( 1, $result['extraction_info']['duplicate_packet_count'] );
-		$this->assertSame( 1, $result['extraction_info']['processed_event_count'] );
-		$this->assertSame( 0, $result['extraction_info']['eligible_event_count'] );
+		$this->assertTrue( $result['extraction_info']['context_supplied'] );
 		$this->assertSame( 1, $result['event_data']['event_count'] );
 		$this->assertCount( 1, $result['event_data']['items'] );
 	}
@@ -195,8 +247,12 @@ class EventScraperTestAbilityTest extends WP_UnitTestCase {
 
 		$this->mockHttpResponse( $html );
 
-		$ability = new EventScraperTest();
-		$result  = $ability->test( $target_url );
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$ability = wp_get_ability( 'data-machine-events/test-event-scraper' );
+		$this->assertNotNull( $ability );
+		$result = $ability->execute( array( 'target_url' => $target_url ) );
 
 		$this->assertIsArray( $result, 'Ability must succeed against the Bandzoogle fixture.' );
 		$this->assertTrue( $result['success'] ?? false, 'Ability must report success.' );
@@ -302,6 +358,7 @@ class EventScraperTestAbilityTest extends WP_UnitTestCase {
 			$result['event_data']['items'] ?? array(),
 			'Single-event JSON-LD page must produce items[] with exactly one entry.'
 		);
+		$this->assertFalse( $result['extraction_info']['context_supplied'] );
 	}
 
 	// ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- allow `data-machine-events/test-event-scraper` callers to supply persisted Universal Web Scraper handler configuration
- extract complete structured source inventory regardless of configured production `max_items`
- preserve the full `event_data.items` list required by the current `QualifyFingerprinter`
- report raw packet count, stable unique structured-event count, duplicate count, configured production cap, and explicit context metadata
- report raw HTML sections and vision flyers as candidate packets, never as structured events
- fully describe ability schemas and cover authorization, config filtering, caps, structured inventory, raw HTML, and vision counts

## Honest scope
This PR provides event-domain source diagnostics only. It does not classify production eligibility. Data Machine Events issue 511 remains pending after this PR.

No lifecycle approximation remains. Processed state, active claims, reprocess policy, and production selection ordering require the shared Data Machine primitive below.

`production_max_items` records the persisted cap separately; the cap is removed from direct diagnostic execution so it cannot truncate inventory. Structured `event_count`, `unique_source_event_count`, and `event_data.items` retain the same exact full count for existing consumers. Raw HTML and vision payloads report zero structured events and use `candidate_packet_count`, `raw_section_count`, and `flyer_candidate_count` instead.

## Remaining dependencies
- Extra-Chill/data-machine#2945: generic bulk, read-only, production-equivalent eligibility classification
- Extra-Chill/data-machine#2946: bounded lossless output from the generic `datamachine/test-handler` primitive
- Extra-Chill/extrachill-events#305: load and pass persisted flow context from the consumer audit

## Evidence
- `php -l inc/Abilities/EventScraperTest.php`: pass
- `php -l tests/Unit/EventScraperTestAbilityTest.php`: pass
- `git diff --check`: pass
- `homeboy review audit data-machine-events --changed-since origin/main --profile pr`: pass, zero introduced findings
- max-items regression models 105 unique structured events with `max_items=1`, full count 105, reported cap 1, and all 105 compatibility items
- raw HTML and vision packet tests assert structured counts 0 and their respective candidate count 1
- the targeted PHPUnit runner remains unavailable before project bootstrap because its Composer autoloader references missing class `Composer\\Autoload\\ComposerStaticInit63f0141519501a58f1a43910f2856084` (latest availability run `ab1f9e02-f9a8-4317-b41e-be04695b1605`)