### PR TITLE
style: satisfy release coding standards

### DIFF
--- a/inc/Abilities/EventDateQueryAbilities.php
+++ b/inc/Abilities/EventDateQueryAbilities.php
@@ -26,8 +26,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class EventDateQueryAbilities {
-	private const CAPTURE_IDS_QUERY_VAR = '_data_machine_events_capture_ids_sql';
-	private const MAX_PUBLIC_RESULTS = 100;
+	private const CAPTURE_IDS_QUERY_VAR  = '_data_machine_events_capture_ids_sql';
+	private const MAX_PUBLIC_RESULTS     = 100;
 	private const DEFAULT_PUBLIC_RESULTS = 50;
 
 	private static bool $registered = false;
@@ -161,11 +161,11 @@ class EventDateQueryAbilities {
 										array(
 											'type'       => 'object',
 											'properties' => array(
-												'event_id'       => array( 'type' => 'integer' ),
-												'title'          => array( 'type' => 'string' ),
-												'permalink'      => array( 'type' => 'string' ),
+												'event_id' => array( 'type' => 'integer' ),
+												'title'    => array( 'type' => 'string' ),
+												'permalink' => array( 'type' => 'string' ),
 												'start_datetime' => array( 'type' => 'string' ),
-												'end_datetime'   => array( 'type' => array( 'string', 'null' ) ),
+												'end_datetime' => array( 'type' => array( 'string', 'null' ) ),
 											),
 										),
 									),
@@ -239,7 +239,7 @@ class EventDateQueryAbilities {
 			return $result;
 		}
 
-		$result['posts'] = array_values(
+		$result['posts']      = array_values(
 			array_filter(
 				array_map( array( $this, 'serializePublicEvent' ), $result['posts'] )
 			)

--- a/inc/Abilities/EventScraperTest.php
+++ b/inc/Abilities/EventScraperTest.php
@@ -56,7 +56,7 @@ class EventScraperTest {
 							'required'             => array( 'target_url' ),
 							'additionalProperties' => false,
 							'properties'           => array(
-								'target_url' => array(
+								'target_url'     => array(
 									'type'        => 'string',
 									'format'      => 'uri',
 									'description' => 'Target URL to test. Overrides handler_config.source_url.',
@@ -66,7 +66,10 @@ class EventScraperTest {
 									'description'          => 'Optional persisted universal web scraper config to apply during source extraction.',
 									'additionalProperties' => false,
 									'properties'           => array(
-										'source_url'       => array( 'type' => 'string', 'format' => 'uri' ),
+										'source_url'       => array(
+											'type'   => 'string',
+											'format' => 'uri',
+										),
 										'search'           => array( 'type' => 'string' ),
 										'exclude_keywords' => array( 'type' => 'string' ),
 										'venue'            => array( 'type' => array( 'integer', 'string' ) ),
@@ -94,7 +97,10 @@ class EventScraperTest {
 									'type' => 'string',
 									'enum' => array( 'ok', 'warning', 'error' ),
 								),
-								'target_url'      => array( 'type' => 'string', 'format' => 'uri' ),
+								'target_url'      => array(
+									'type'   => 'string',
+									'format' => 'uri',
+								),
 								'event_data'      => array(
 									'type'                 => 'object',
 									'additionalProperties' => false,
@@ -111,13 +117,16 @@ class EventScraperTest {
 										'venueCity'    => array( 'type' => 'string' ),
 										'venueState'   => array( 'type' => 'string' ),
 										'venueZip'     => array( 'type' => 'string' ),
-										'event_count'  => array( 'type' => 'integer', 'minimum' => 0 ),
+										'event_count'  => array(
+											'type'    => 'integer',
+											'minimum' => 0,
+										),
 										'items'        => array(
 											'type'  => 'array',
 											'items' => array(
-												'type'                 => 'object',
+												'type' => 'object',
 												'additionalProperties' => false,
-												'properties'           => array(
+												'properties' => array(
 													'title'     => array( 'type' => 'string' ),
 													'startDate' => array( 'type' => 'string' ),
 													'startTime' => array( 'type' => 'string' ),
@@ -149,36 +158,74 @@ class EventScraperTest {
 										'context_supplied',
 									),
 									'properties'           => array(
-										'packet_title'              => array( 'type' => 'string' ),
-										'source_type'               => array( 'type' => 'string' ),
-										'extraction_method'         => array( 'type' => 'string' ),
-										'payload_type'              => array( 'type' => 'string', 'enum' => array( 'event', 'raw_html', 'vision_flyer' ) ),
-										'event_count'               => array( 'type' => 'integer', 'minimum' => 0, 'description' => 'Unique structured events extracted from the source.' ),
-										'extracted_packet_count'    => array( 'type' => 'integer', 'minimum' => 0, 'description' => 'All packets returned by direct handler execution before stable-identifier deduplication.' ),
-										'unique_source_event_count' => array( 'type' => 'integer', 'minimum' => 0, 'description' => 'Unique structured events after stable-identifier deduplication.' ),
-										'duplicate_packet_count'    => array( 'type' => 'integer', 'minimum' => 0, 'description' => 'Packets removed because their stable identifier repeated.' ),
-										'production_max_items'      => array( 'type' => array( 'integer', 'null' ), 'minimum' => 0, 'description' => 'Configured production cap, reported but not applied to diagnostic extraction.' ),
-										'candidate_packet_count'    => array( 'type' => 'integer', 'minimum' => 0, 'description' => 'Non-structured raw-section and flyer candidate packets.' ),
-										'raw_section_count'         => array( 'type' => 'integer', 'minimum' => 0, 'description' => 'Raw HTML section candidates requiring downstream interpretation.' ),
-										'flyer_candidate_count'     => array( 'type' => 'integer', 'minimum' => 0, 'description' => 'Vision flyer candidates requiring downstream interpretation.' ),
-										'context_supplied'          => array( 'type' => 'boolean' ),
-										'requires_ai_step'          => array( 'type' => 'boolean' ),
-										'image_file_stored'         => array( 'type' => 'boolean' ),
+										'packet_title'     => array( 'type' => 'string' ),
+										'source_type'      => array( 'type' => 'string' ),
+										'extraction_method' => array( 'type' => 'string' ),
+										'payload_type'     => array(
+											'type' => 'string',
+											'enum' => array( 'event', 'raw_html', 'vision_flyer' ),
+										),
+										'event_count'      => array(
+											'type'        => 'integer',
+											'minimum'     => 0,
+											'description' => 'Unique structured events extracted from the source.',
+										),
+										'extracted_packet_count' => array(
+											'type'        => 'integer',
+											'minimum'     => 0,
+											'description' => 'All packets returned by direct handler execution before stable-identifier deduplication.',
+										),
+										'unique_source_event_count' => array(
+											'type'        => 'integer',
+											'minimum'     => 0,
+											'description' => 'Unique structured events after stable-identifier deduplication.',
+										),
+										'duplicate_packet_count' => array(
+											'type'        => 'integer',
+											'minimum'     => 0,
+											'description' => 'Packets removed because their stable identifier repeated.',
+										),
+										'production_max_items' => array(
+											'type'        => array( 'integer', 'null' ),
+											'minimum'     => 0,
+											'description' => 'Configured production cap, reported but not applied to diagnostic extraction.',
+										),
+										'candidate_packet_count' => array(
+											'type'        => 'integer',
+											'minimum'     => 0,
+											'description' => 'Non-structured raw-section and flyer candidate packets.',
+										),
+										'raw_section_count' => array(
+											'type'        => 'integer',
+											'minimum'     => 0,
+											'description' => 'Raw HTML section candidates requiring downstream interpretation.',
+										),
+										'flyer_candidate_count' => array(
+											'type'        => 'integer',
+											'minimum'     => 0,
+											'description' => 'Vision flyer candidates requiring downstream interpretation.',
+										),
+										'context_supplied' => array( 'type' => 'boolean' ),
+										'requires_ai_step' => array( 'type' => 'boolean' ),
+										'image_file_stored' => array( 'type' => 'boolean' ),
 									),
 								),
 								'coverage_issues' => array(
 									'type'                 => 'object',
 									'additionalProperties' => false,
 									'properties'           => array(
-										'missing_time'       => array( 'type' => 'boolean' ),
-										'missing_venue'      => array( 'type' => 'boolean' ),
+										'missing_time'  => array( 'type' => 'boolean' ),
+										'missing_venue' => array( 'type' => 'boolean' ),
 										'incomplete_address' => array( 'type' => 'boolean' ),
-										'time_data_warning'  => array( 'type' => 'boolean' ),
-										'raw_html_fallback'  => array( 'type' => 'boolean' ),
-										'vision_flyer'       => array( 'type' => 'boolean' ),
+										'time_data_warning' => array( 'type' => 'boolean' ),
+										'raw_html_fallback' => array( 'type' => 'boolean' ),
+										'vision_flyer'  => array( 'type' => 'boolean' ),
 									),
 								),
-								'warnings'        => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+								'warnings'        => array(
+									'type'  => 'array',
+									'items' => array( 'type' => 'string' ),
+								),
 								'logs'            => array(
 									'type'  => 'array',
 									'items' => array(
@@ -236,7 +283,7 @@ class EventScraperTest {
 			3
 		);
 
-		$config = array_merge(
+		$config               = array_merge(
 			$handler_config ?? array(),
 			array(
 				'source_url'   => $target_url,
@@ -542,11 +589,11 @@ class EventScraperTest {
 	 * @return array{packet_entries:array,extraction_info:array}
 	 */
 	private function analyzePacketEntries( array $packet_entries, bool $context_supplied, ?int $production_max_items ): array {
-		$extracted_packet_count    = count( $packet_entries );
-		$packet_entries            = $this->uniquePacketEntries( $packet_entries );
-		$structured_event_count    = 0;
-		$raw_section_count         = 0;
-		$flyer_candidate_count     = 0;
+		$extracted_packet_count = count( $packet_entries );
+		$packet_entries         = $this->uniquePacketEntries( $packet_entries );
+		$structured_event_count = 0;
+		$raw_section_count      = 0;
+		$flyer_candidate_count  = 0;
 		foreach ( $packet_entries as $entry ) {
 			$body    = (string) ( $entry['data']['body'] ?? '' );
 			$payload = json_decode( $body, true );
@@ -581,5 +628,4 @@ class EventScraperTest {
 			),
 		);
 	}
-
 }

--- a/inc/Abilities/EventUpsertAbilities.php
+++ b/inc/Abilities/EventUpsertAbilities.php
@@ -111,11 +111,11 @@ class EventUpsertAbilities {
 		$dates       = \DataMachineEvents\Core\EventDatesTable::get( $post_id );
 
 		return array(
-			'success'   => true,
-			'event_id'  => $post_id,
-			'event_url' => (string) ( $result['data']['post_url'] ?? get_permalink( $post_id ) ),
-			'action'    => (string) $result['data']['action'],
-			'source'    => array(
+			'success'    => true,
+			'event_id'   => $post_id,
+			'event_url'  => (string) ( $result['data']['post_url'] ?? get_permalink( $post_id ) ),
+			'action'     => (string) $result['data']['action'],
+			'source'     => array(
 				'name'     => $source,
 				'id'       => $source_id,
 				'identity' => $event['source_identity'],
@@ -168,10 +168,25 @@ class EventUpsertAbilities {
 			'type'       => 'object',
 			'required'   => array( 'source', 'source_id', 'event' ),
 			'properties' => array(
-				'source'      => array( 'type' => 'string', 'minLength' => 1, 'description' => 'Stable caller/source namespace.' ),
-				'source_id'   => array( 'type' => 'string', 'minLength' => 1, 'description' => 'Stable item ID within the source namespace.' ),
-				'post_status' => array( 'type' => 'string', 'enum' => array( 'draft', 'publish', 'pending', 'private' ), 'default' => 'publish' ),
-				'post_author' => array( 'type' => 'integer', 'minimum' => 1 ),
+				'source'      => array(
+					'type'        => 'string',
+					'minLength'   => 1,
+					'description' => 'Stable caller/source namespace.',
+				),
+				'source_id'   => array(
+					'type'        => 'string',
+					'minLength'   => 1,
+					'description' => 'Stable item ID within the source namespace.',
+				),
+				'post_status' => array(
+					'type'    => 'string',
+					'enum'    => array( 'draft', 'publish', 'pending', 'private' ),
+					'default' => 'publish',
+				),
+				'post_author' => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+				),
 				'event'       => array(
 					'type'       => 'object',
 					'required'   => array( 'title', 'startDate' ),
@@ -182,7 +197,10 @@ class EventUpsertAbilities {
 						'startTime'         => $string,
 						'endDate'           => $string,
 						'endTime'           => $string,
-						'occurrenceDates'   => array( 'type' => 'array', 'items' => $string ),
+						'occurrenceDates'   => array(
+							'type'  => 'array',
+							'items' => $string,
+						),
 						'venue'             => $string,
 						'venueAddress'      => $string,
 						'venueCity'         => $string,
@@ -196,13 +214,19 @@ class EventUpsertAbilities {
 						'venueTimezone'     => $string,
 						'price'             => $string,
 						'priceCurrency'     => $string,
-						'ticketUrl'         => array( 'type' => 'string', 'format' => 'uri' ),
+						'ticketUrl'         => array(
+							'type'   => 'string',
+							'format' => 'uri',
+						),
 						'offerAvailability' => $string,
 						'performer'         => $string,
 						'performerType'     => $string,
 						'organizer'         => $string,
 						'organizerType'     => $string,
-						'organizerUrl'      => array( 'type' => 'string', 'format' => 'uri' ),
+						'organizerUrl'      => array(
+							'type'   => 'string',
+							'format' => 'uri',
+						),
 						'eventStatus'       => $string,
 						'previousStartDate' => $string,
 						'eventType'         => $string,
@@ -220,7 +244,10 @@ class EventUpsertAbilities {
 				'success'    => array( 'type' => 'boolean' ),
 				'event_id'   => array( 'type' => 'integer' ),
 				'event_url'  => array( 'type' => 'string' ),
-				'action'     => array( 'type' => 'string', 'enum' => array( 'created', 'updated', 'no_change' ) ),
+				'action'     => array(
+					'type' => 'string',
+					'enum' => array( 'created', 'updated', 'no_change' ),
+				),
 				'source'     => array(
 					'type'       => 'object',
 					'required'   => array( 'name', 'id', 'identity' ),

--- a/inc/Blocks/Calendar/Cache/CacheInvalidator.php
+++ b/inc/Blocks/Calendar/Cache/CacheInvalidator.php
@@ -130,7 +130,7 @@ class CacheInvalidator {
 			return;
 		}
 
-		$key = self::relationship_key( (int) $post_id, (string) $taxonomy );
+		$key                         = self::relationship_key( (int) $post_id, (string) $taxonomy );
 		self::$added_terms[ $key ]   = self::$added_terms[ $key ] ?? array();
 		self::$added_terms[ $key ][] = (int) $tt_id;
 		self::$added_terms[ $key ]   = self::normalize_term_ids( self::$added_terms[ $key ] );

--- a/inc/Core/Venue_Taxonomy.php
+++ b/inc/Core/Venue_Taxonomy.php
@@ -416,7 +416,7 @@ class Venue_Taxonomy {
 				$venues,
 				static fn( $venue ) => $normalized_name === self::normalize_venue_name_for_matching( $venue->name )
 			);
-		$tiers = array(
+		$tiers                 = array(
 			array_filter(
 				$venues,
 				static fn( $venue ) => 0 === strcasecmp( trim( $venue->name ), trim( $venue_name ) )
@@ -427,7 +427,7 @@ class Venue_Taxonomy {
 			),
 			$normalized_candidates,
 		);
-		$had_candidates = false;
+		$had_candidates        = false;
 
 		foreach ( $tiers as $candidates ) {
 			if ( empty( $candidates ) ) {

--- a/inc/Core/event-dates-sync.php
+++ b/inc/Core/event-dates-sync.php
@@ -198,10 +198,10 @@ function data_machine_events_sync_datetime_meta( $post_id, $post, $update ) {
 	foreach ( $blocks as $block ) {
 		if ( 'data-machine-events/event-details' === $block['blockName'] ) {
 			$event_details_found = true;
-			$start_date         = $block['attrs']['startDate'] ?? '';
-			$start_time         = $block['attrs']['startTime'] ?? '';
-			$end_date           = $block['attrs']['endDate'] ?? '';
-			$end_time           = $block['attrs']['endTime'] ?? '';
+			$start_date          = $block['attrs']['startDate'] ?? '';
+			$start_time          = $block['attrs']['startTime'] ?? '';
+			$end_date            = $block['attrs']['endDate'] ?? '';
+			$end_time            = $block['attrs']['endTime'] ?? '';
 
 			$start_time_parts = $start_time ? explode( ':', $start_time ) : array();
 			if ( $start_time && count( $start_time_parts ) === 2 ) {

--- a/inc/Steps/EventImport/Handlers/Ticketmaster/Ticketmaster.php
+++ b/inc/Steps/EventImport/Handlers/Ticketmaster/Ticketmaster.php
@@ -285,8 +285,8 @@ class Ticketmaster extends EventImportHandler {
 					)
 				);
 
-				$venue_metadata = $this->extractVenueMetadata( $standardized_event );
-				$engine_data    = $this->buildEventEngineData( $standardized_event, $venue_metadata );
+				$venue_metadata                 = $this->extractVenueMetadata( $standardized_event );
+				$engine_data                    = $this->buildEventEngineData( $standardized_event, $venue_metadata );
 				$engine_data['item_identifier'] = $item_identifier;
 				$engine_data['source_type']     = 'ticketmaster';
 				$engine_data[ TicketmasterSourceIdentity::ENGINE_KEY ] = array(
@@ -359,17 +359,17 @@ class Ticketmaster extends EventImportHandler {
 			'info',
 			'Ticketmaster: Import fan-out summary',
 			array(
-				'fetched'                 => $fetched_count,
-				'pre_fanout_deduped'      => $pre_fanout_deduped,
-				'unchanged_revisions'     => $unchanged_count,
-				'repeated_source_ids'     => $repeated_source_count,
-				'contended_claims'        => $contended_count,
-				'eligible_before_bound'   => $eligible_count,
-				'overflow'                => $overflow_count,
-				'fanout_limit'            => $fanout_limit,
-				'source_claimed'          => count( $eligible_items ),
-				'packets_ready'           => count( $eligible_items ),
-				'pages_searched'          => $current_page,
+				'fetched'               => $fetched_count,
+				'pre_fanout_deduped'    => $pre_fanout_deduped,
+				'unchanged_revisions'   => $unchanged_count,
+				'repeated_source_ids'   => $repeated_source_count,
+				'contended_claims'      => $contended_count,
+				'eligible_before_bound' => $eligible_count,
+				'overflow'              => $overflow_count,
+				'fanout_limit'          => $fanout_limit,
+				'source_claimed'        => count( $eligible_items ),
+				'packets_ready'         => count( $eligible_items ),
+				'pages_searched'        => $current_page,
 			)
 		);
 

--- a/inc/Steps/Upsert/Events/EventUpsert.php
+++ b/inc/Steps/Upsert/Events/EventUpsert.php
@@ -254,7 +254,7 @@ class EventUpsert extends UpsertHandler {
 		$venueCity        = (string) ( $engine->get( 'venueCity' ) ?? $parameters['venueCity'] ?? '' );
 		$venueState       = (string) ( $engine->get( 'venueState' ) ?? $parameters['venueState'] ?? '' );
 		$venueCountry     = (string) ( $engine->get( 'venueCountry' ) ?? $parameters['venueCountry'] ?? '' );
-		$source_identity   = (string) ( $parameters['source_identity'] ?? '' );
+		$source_identity  = (string) ( $parameters['source_identity'] ?? '' );
 		$existing_post_id = $this->findExistingEventBySourceIdentity( $source_identity );
 		if ( $existing_post_id <= 0 ) {
 			$existing_post_id = (int) $this->findExistingEventViaAbility(
@@ -755,7 +755,7 @@ class EventUpsert extends UpsertHandler {
 	 * @return array Meta key/value pairs.
 	 */
 	private function buildEventMetaInput( array $event_data, array $parameters, EngineData $engine ): array {
-		$meta_input = array();
+		$meta_input      = array();
 		$source_identity = (string) ( $parameters['source_identity'] ?? '' );
 
 		if ( '' !== $source_identity ) {


### PR DESCRIPTION
## Summary

- apply the PHPCBF fixes required by the release lint gate
- keep the cleanup mechanical across eight existing source files
- unblock the event ingestion correctness release without changing behavior

## Verification

- PHPCBF fixed all 84 reported findings
- PHPCS passes with zero findings
- PHPStan passes
- `git diff --check` passes
- Homeboy Audit reports only the repository's existing informational baseline
- Homeboy Test was prevented from starting by the shared WordPress archive cache lock timeout

Tracks #332.