### PR TITLE
fix: make event source identities time-aware

### DIFF
--- a/inc/Core/DuplicateDetection/EventDuplicateStrategy.php
+++ b/inc/Core/DuplicateDetection/EventDuplicateStrategy.php
@@ -272,16 +272,10 @@ class EventDuplicateStrategy {
 	 *                                           term name.
 	 * @param string        $startDate           Full datetime (YYYY-MM-DDTHH:MM or
 	 *                                           similar) used to enforce a 2-hour
-	 *                                           window when the term_id bypass
-	 *                                           fires. Without this guard, two
-	 *                                           genuinely distinct shows that
-	 *                                           share a title hash and venue term
-	 *                                           on the same date but at very
-	 *                                           different times (e.g. an early
-	 *                                           and a late show at a multi-room
-	 *                                           venue) could be falsely merged.
-	 *                                           When empty, the time window is
-	 *                                           skipped (matches legacy behavior).
+	 *                                           window for every exact-title
+	 *                                           confirmation. When either side
+	 *                                           lacks a time, matching retains the
+	 *                                           legacy date-only behavior.
 	 * @return array|null Duplicate result or null.
 	 */
 	private static function findByExactTitle( string $title, string $venue, string $date_only, string $identity_confidence, ?\WP_Term $venue_term = null, string $startDate = '' ): ?array {
@@ -302,6 +296,16 @@ class EventDuplicateStrategy {
 			return null;
 		}
 
+		// Exact title + date is not sufficient when both sources know the time:
+		// early and late performances can share the same title and venue. Apply
+		// one guard before every Strategy 3 confirmation branch so term IDs,
+		// exact venue names, and missing venue data cannot bypass the policy.
+		$candidate_dates   = \DataMachineEvents\Core\EventDatesTable::get( $post_id );
+		$existing_datetime = $candidate_dates ? $candidate_dates->start_datetime : '';
+		if ( ! self::isWithinTimeWindow( $startDate, $existing_datetime ) ) {
+			return null;
+		}
+
 		// Venue confirmation logic (same as old EventUpsert::findEventByExactTitle).
 		if ( empty( $venue ) && ! $venue_term ) {
 			if ( 'low' === $identity_confidence ) {
@@ -315,34 +319,11 @@ class EventDuplicateStrategy {
 		// venue term_ids. This catches dupes where the incoming venue string
 		// differs from the stored term name (e.g. "Monks Jazz" → term "Monks"),
 		// which the name-string compare below would miss.
-		//
-		// Time-window guard: Strategies 2 and 4 enforce a 2-hour window when
-		// matching by title fuzziness; Strategy 3 historically did not,
-		// because exact-title-hash + venue-name compare is highly specific.
-		// The term_id bypass widens that specificity in one direction (the
-		// incoming venue can now differ from the candidate's stored venue
-		// name), so we add the same 2-hour guard here to avoid falsely
-		// merging early/late shows at multi-room venues that share a title
-		// hash on the same date. When the guard fails, fall through to the
-		// existing venue-name compare path (legacy behavior).
 		if ( $venue_term ) {
 			$candidate_term_ids = wp_get_post_terms( $post_id, 'venue', array( 'fields' => 'ids' ) );
 			if ( ! is_wp_error( $candidate_term_ids ) && ! empty( $candidate_term_ids )
 				&& in_array( (int) $venue_term->term_id, array_map( 'intval', $candidate_term_ids ), true ) ) {
-
-				$within_window = true;
-				if ( '' !== $startDate ) {
-					$candidate_dates   = \DataMachineEvents\Core\EventDatesTable::get( $post_id );
-					$existing_datetime = $candidate_dates ? $candidate_dates->start_datetime : '';
-					$within_window     = self::isWithinTimeWindow( $startDate, $existing_datetime );
-				}
-
-				if ( $within_window ) {
-					return self::duplicateResult( $post_id, 'exact_title_venue_term_id_match' );
-				}
-				// Outside time window: skip the bypass and fall through to
-				// the existing venue-name compare. If that also fails to
-				// confirm, we return null (treat as distinct event).
+				return self::duplicateResult( $post_id, 'exact_title_venue_term_id_match' );
 			}
 		}
 

--- a/inc/Core/DuplicateDetection/PreAIEventDedupGate.php
+++ b/inc/Core/DuplicateDetection/PreAIEventDedupGate.php
@@ -6,7 +6,7 @@
  * conversation entirely when the event already exists in the database.
  *
  * The child job's engine_data already contains identity fields (title,
- * venue, startDate, ticketUrl) from the fetch handler. By checking the
+ * venue, startDate, startTime, ticketUrl) from the fetch handler. By checking the
  * PostIdentityIndex BEFORE burning AI tokens, we eliminate the most
  * expensive form of waste: running a full AI conversation just to have
  * upsert_event return "no_change".
@@ -18,6 +18,7 @@
 namespace DataMachineEvents\Core\DuplicateDetection;
 
 use DataMachine\Core\EngineData;
+use DataMachineEvents\Utilities\EventIdentifierGenerator;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -67,7 +68,11 @@ class PreAIEventDedupGate {
 		// These are set by the fetch handler (Ticketmaster, Dice, venue scrapers).
 		$title     = $engine->get( 'title' ) ?? $engine->get( 'label' ) ?? '';
 		$venue     = $engine->get( 'venue' ) ?? '';
-		$startDate = $engine->get( 'startDate' ) ?? '';
+		$startDate = EventIdentifierGenerator::normalizeStartDateTime(
+			(string) ( $engine->get( 'startDate' ) ?? '' ),
+			(string) ( $engine->get( 'startTime' ) ?? '' ),
+			(string) ( $engine->get( 'venueTimezone' ) ?? '' )
+		);
 		$ticketUrl = $engine->get( 'ticketUrl' ) ?? '';
 		$address   = $engine->get( 'venueAddress' ) ?? '';
 		$city      = $engine->get( 'venueCity' ) ?? '';

--- a/inc/Steps/EventImport/Handlers/DiceFm/DiceFm.php
+++ b/inc/Steps/EventImport/Handlers/DiceFm/DiceFm.php
@@ -131,11 +131,8 @@ class DiceFm extends EventImportHandler {
 				continue;
 			}
 
-			$event_identifier = \DataMachineEvents\Utilities\EventIdentifierGenerator::generate(
-				$standardized_event['title'],
-				$standardized_event['startDate'] ?? '',
-				$standardized_event['venue'] ?? ''
-			);
+			$source_identity  = \DataMachineEvents\Utilities\EventSourceIdentity::resolve( $standardized_event, $context );
+			$event_identifier = $source_identity['event_identifier'];
 
 			$context->log(
 				'info',
@@ -167,7 +164,7 @@ class DiceFm extends EventImportHandler {
 					'flow_id'          => $context->getFlowId(),
 					'original_title'   => $standardized_event['title'],
 					'event_identifier' => $event_identifier,
-					'item_identifier'  => $event_identifier,
+					'item_identifier'  => $source_identity['item_identifier'],
 					'import_timestamp' => time(),
 					'_engine_data'     => $engine_data,
 				),

--- a/inc/Steps/EventImport/Handlers/EventFlyer/EventFlyer.php
+++ b/inc/Steps/EventImport/Handlers/EventFlyer/EventFlyer.php
@@ -99,7 +99,9 @@ class EventFlyer extends EventImportHandler {
 		$event_identifier = EventIdentifierGenerator::generate(
 			$event_data['title'] ? $event_data['title'] : 'pending-extraction',
 			$event_data['startDate'] ? $event_data['startDate'] : '',
-			$event_data['venue'] ? $event_data['venue'] : ''
+			$event_data['venue'] ? $event_data['venue'] : '',
+			$event_data['startTime'] ? $event_data['startTime'] : '',
+			$event_data['venueTimezone'] ?? ''
 		);
 
 		$venue_metadata = $this->extractVenueMetadata( $event_data );

--- a/inc/Steps/EventImport/Handlers/SingleRecurring/SingleRecurring.php
+++ b/inc/Steps/EventImport/Handlers/SingleRecurring/SingleRecurring.php
@@ -13,7 +13,6 @@ namespace DataMachineEvents\Steps\EventImport\Handlers\SingleRecurring;
 
 use DataMachine\Core\ExecutionContext;
 use DataMachineEvents\Steps\EventImport\Handlers\EventImportHandler;
-use DataMachineEvents\Utilities\EventIdentifierGenerator;
 use DataMachine\Core\Steps\HandlerRegistrationTrait;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -102,10 +101,10 @@ class SingleRecurring extends EventImportHandler {
 		$next_occurrence = $this->calculateNextOccurrence( $day_of_week );
 		$next_date       = $next_occurrence->format( 'Y-m-d' );
 
-		$venue_name       = $config['venue_name'] ?? '';
-		$event_identifier = EventIdentifierGenerator::generate( $event_title, $next_date, $venue_name );
-
 		$standardized_event = $this->buildEventData( $config, $next_date );
+		$venue_name         = $config['venue_name'] ?? '';
+		$source_identity    = \DataMachineEvents\Utilities\EventSourceIdentity::resolve( $standardized_event, $context );
+		$event_identifier   = $source_identity['event_identifier'];
 
 		$context->log(
 			'info',
@@ -138,7 +137,7 @@ class SingleRecurring extends EventImportHandler {
 				'flow_id'          => $context->getFlowId(),
 				'original_title'   => $event_title,
 				'event_identifier' => $event_identifier,
-				'item_identifier'  => $event_identifier,
+				'item_identifier'  => $source_identity['item_identifier'],
 				'import_timestamp' => time(),
 				'_engine_data'     => $engine_data,
 			),

--- a/inc/Steps/EventImport/Handlers/Ticketmaster/Ticketmaster.php
+++ b/inc/Steps/EventImport/Handlers/Ticketmaster/Ticketmaster.php
@@ -263,7 +263,9 @@ class Ticketmaster extends EventImportHandler {
 				$event_identifier = \DataMachineEvents\Utilities\EventIdentifierGenerator::generate(
 					$standardized_event['title'],
 					$standardized_event['startDate'] ?? '',
-					$standardized_event['venue'] ?? ''
+					$standardized_event['venue'] ?? '',
+					$standardized_event['startTime'] ?? '',
+					$standardized_event['venueTimezone'] ?? ''
 				);
 				$item_identifier  = '' !== $source_id ? $source_id : $event_identifier;
 				$source_revision  = TicketmasterSourceIdentity::revision( $standardized_event );

--- a/inc/Steps/EventImport/Handlers/WebScraper/StructuredDataProcessor.php
+++ b/inc/Steps/EventImport/Handlers/WebScraper/StructuredDataProcessor.php
@@ -13,6 +13,7 @@ namespace DataMachineEvents\Steps\EventImport\Handlers\WebScraper;
 use DataMachine\Core\ExecutionContext;
 use DataMachineEvents\Steps\EventImport\EventEngineData;
 use DataMachineEvents\Steps\EventImport\Handlers\EventImportHandler;
+use DataMachineEvents\Utilities\EventSourceIdentity;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -70,11 +71,8 @@ class StructuredDataProcessor {
 
 			$this->applyVenueConfigOverride( $event, $config );
 
-			$event_identifier = \DataMachineEvents\Utilities\EventIdentifierGenerator::generate(
-				$event['title'],
-				$event['startDate'] ?? '',
-				$event['venue'] ?? ''
-			);
+			$source_identity  = EventSourceIdentity::resolve( $event, $context );
+			$event_identifier = $source_identity['event_identifier'];
 
 			$venue_from_config = ! empty( $config['venue'] ) || ! empty( $config['venue_name'] );
 			if ( ! $venue_from_config && empty( trim( (string) ( $event['venue'] ?? '' ) ) ) ) {
@@ -128,7 +126,7 @@ class StructuredDataProcessor {
 					'flow_id'           => $context->getFlowId(),
 					'original_title'    => $event['title'],
 					'event_identifier'  => $event_identifier,
-					'item_identifier'   => $event_identifier,
+					'item_identifier'   => $source_identity['item_identifier'],
 					'import_timestamp'  => time(),
 					'_engine_data'      => $engine_data,
 				),

--- a/inc/Utilities/EventIdentifierGenerator.php
+++ b/inc/Utilities/EventIdentifierGenerator.php
@@ -17,6 +17,9 @@
 namespace DataMachineEvents\Utilities;
 
 use DataMachine\Core\Similarity\SimilarityEngine;
+use DateTimeImmutable;
+use DateTimeZone;
+use Exception;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -30,22 +33,105 @@ class EventIdentifierGenerator {
 	/**
 	 * Generate event identifier from normalized event data
 	 *
-	 * Creates stable identifier based on title, start date, and venue.
+	 * Creates stable source identifier based on title, local start datetime, and venue.
 	 * Normalizes text to handle variations like:
 	 * - "The Blue Note" vs "Blue Note"
 	 * - "Foo Bar" vs "foo bar"
 	 * - Extra whitespace variations
 	 *
-	 * @param string $title     Event title
-	 * @param string $startDate Event start date (YYYY-MM-DD)
-	 * @param string $venue     Venue name
+	 * @param string $title     Event title.
+	 * @param string $startDate Event start date or datetime.
+	 * @param string $venue     Venue name.
+	 * @param string $startTime Optional local start time.
+	 * @param string $timezone  Optional venue timezone used to localize an absolute datetime.
 	 * @return string MD5 hash identifier
 	 */
-	public static function generate( string $title, string $startDate, string $venue ): string {
+	public static function generate( string $title, string $startDate, string $venue, string $startTime = '', string $timezone = '' ): string {
 		$normalized_title = SimilarityEngine::normalizeBasic( $title );
 		$normalized_venue = SimilarityEngine::normalizeBasic( $venue );
+		$normalized_start = self::normalizeStartDateTime( $startDate, $startTime, $timezone );
 
-		return md5( $normalized_title . $startDate . $normalized_venue );
+		return md5( $normalized_title . $normalized_start . $normalized_venue );
+	}
+
+	/**
+	 * Generate the date-only identifier used before time-aware source identity.
+	 *
+	 * Kept solely for bounded processed-history transition checks.
+	 *
+	 * @param string $title     Event title.
+	 * @param string $startDate Event start date.
+	 * @param string $venue     Venue name.
+	 * @return string Legacy MD5 hash identifier.
+	 */
+	public static function generateLegacy( string $title, string $startDate, string $venue ): string {
+		$normalized_title = SimilarityEngine::normalizeBasic( $title );
+		$normalized_venue = SimilarityEngine::normalizeBasic( $venue );
+		$date_only        = self::normalizeStartDateTime( $startDate );
+
+		return md5( $normalized_title . $date_only . $normalized_venue );
+	}
+
+	/**
+	 * Normalize a source start value to local wall-clock identity.
+	 *
+	 * Separate date/time values are interpreted as already local to the venue.
+	 * Datetimes with an embedded offset are converted to the supplied venue timezone.
+	 * The timezone name itself is not hashed: equivalent representations of the same
+	 * local event time must produce the same source identity. Genuine date-only values
+	 * retain a deterministic YYYY-MM-DD identity.
+	 *
+	 * @param string $startDate Event start date or datetime.
+	 * @param string $startTime Optional local start time.
+	 * @param string $timezone  Optional venue timezone.
+	 * @return string Normalized local datetime, date, or deterministic raw fallback.
+	 */
+	public static function normalizeStartDateTime( string $startDate, string $startTime = '', string $timezone = '' ): string {
+		$start_date = trim( $startDate );
+		$start_time = trim( $startTime );
+
+		if ( '' === $start_date ) {
+			return '';
+		}
+
+		$datetime_string = '' !== $start_time ? $start_date . ' ' . $start_time : $start_date;
+		if ( ! preg_match( '/^\d{4}-\d{2}-\d{2}/', $start_date ) ) {
+			return trim( preg_replace( '/\s+/', ' ', $datetime_string ) );
+		}
+
+		if ( '' === $start_time && preg_match( '/^\d{4}-\d{2}-\d{2}$/', $start_date ) ) {
+			return $start_date;
+		}
+
+		$timezone_object = null;
+		if ( '' !== $timezone ) {
+			try {
+				$timezone_object = new DateTimeZone( $timezone );
+			} catch ( Exception $e ) {
+				$timezone_object = null;
+			}
+		}
+
+		try {
+			$datetime = new DateTimeImmutable( $datetime_string, $timezone_object );
+			if ( null !== $timezone_object && self::hasEmbeddedTimezone( $datetime_string ) ) {
+				$datetime = $datetime->setTimezone( $timezone_object );
+			}
+
+			return $datetime->format( 'Y-m-d H:i' );
+		} catch ( Exception $e ) {
+			return trim( preg_replace( '/\s+/', ' ', $datetime_string ) );
+		}
+	}
+
+	/**
+	 * Determine whether a datetime carries an explicit timezone or offset.
+	 *
+	 * @param string $datetime Datetime value.
+	 * @return bool True when timezone information is embedded.
+	 */
+	private static function hasEmbeddedTimezone( string $datetime ): bool {
+		return (bool) preg_match( '/(?:Z|[+-]\d{2}:?\d{2}|\b[A-Za-z_]+\/[A-Za-z_]+)\s*$/', trim( $datetime ) );
 	}
 
 	/**

--- a/inc/Utilities/EventSourceIdentity.php
+++ b/inc/Utilities/EventSourceIdentity.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Event source identity transition utility.
+ *
+ * @package DataMachineEvents\Utilities
+ */
+
+namespace DataMachineEvents\Utilities;
+
+use DataMachine\Core\ExecutionContext;
+use DataMachineEvents\Core\DuplicateDetection\EventDuplicateStrategy;
+
+defined( 'ABSPATH' ) || exit;
+
+class EventSourceIdentity {
+
+	/**
+	 * Resolve current and persisted legacy source identities without mutating state.
+	 *
+	 * A processed legacy hash suppresses migration only when the canonical event
+	 * already exists. Otherwise the time-aware hash is allowed through so an event
+	 * lost under the old date-only identity is not stranded. Core owns claims and
+	 * marks the selected identity only after successful pipeline completion.
+	 *
+	 * @param array            $event   Standardized event packet.
+	 * @param ExecutionContext $context Fetch execution context.
+	 * @return array{event_identifier:string,item_identifier:string,legacy_identifier:string}
+	 */
+	public static function resolve( array $event, ExecutionContext $context ): array {
+		$title      = (string) ( $event['title'] ?? '' );
+		$start_date = (string) ( $event['startDate'] ?? '' );
+		$venue      = (string) ( $event['venue'] ?? '' );
+		$current    = EventIdentifierGenerator::generate(
+			$title,
+			$start_date,
+			$venue,
+			(string) ( $event['startTime'] ?? '' ),
+			(string) ( $event['venueTimezone'] ?? '' )
+		);
+		$legacy     = EventIdentifierGenerator::generateLegacy( $title, $start_date, $venue );
+
+		if ( $current === $legacy ) {
+			return self::result( $current, $current, $legacy );
+		}
+
+		$classification = $context->classifySourceItems( array( $current, $legacy ) );
+		$states         = array();
+		foreach ( $classification['classifications'] ?? array() as $state ) {
+			$states[ (string) ( $state['item_identifier'] ?? '' ) ] = $state;
+		}
+
+		$current_state = $states[ $current ] ?? array();
+		$legacy_state  = $states[ $legacy ] ?? array();
+
+		// Preserve explicit reprocessing and let core enforce current claims/history.
+		if ( ! empty( $current_state['processed'] ) || ! empty( $current_state['actively_claimed'] ) ) {
+			return self::result( $current, $current, $legacy );
+		}
+
+		if ( ! empty( $legacy_state['actively_claimed'] ) ) {
+			return self::result( $current, $legacy, $legacy );
+		}
+
+		if ( empty( $legacy_state['processed'] ) || ! empty( $legacy_state['selected'] ) ) {
+			return self::result( $current, $current, $legacy );
+		}
+
+		if ( self::canonicalEventExists( $event ) ) {
+			return self::result( $current, $legacy, $legacy );
+		}
+
+		$context->log(
+			'info',
+			'Event source identity: advancing processed legacy hash because no canonical event exists',
+			array(
+				'title'             => $title,
+				'start_datetime'    => EventIdentifierGenerator::normalizeStartDateTime(
+					$start_date,
+					(string) ( $event['startTime'] ?? '' ),
+					(string) ( $event['venueTimezone'] ?? '' )
+				),
+				'legacy_identifier' => $legacy,
+				'event_identifier'  => $current,
+			)
+		);
+
+		return self::result( $current, $current, $legacy );
+	}
+
+	/**
+	 * Check the existing event-domain identity index used by upsert.
+	 *
+	 * @param array $event Standardized event packet.
+	 * @return bool True when upsert would resolve an existing canonical event.
+	 */
+	private static function canonicalEventExists( array $event ): bool {
+		$result = EventDuplicateStrategy::check(
+			array(
+				'title'     => (string) ( $event['title'] ?? '' ),
+				'post_type' => 'data_machine_events',
+				'context'   => array(
+					'venue'     => (string) ( $event['venue'] ?? '' ),
+					'startDate' => EventIdentifierGenerator::normalizeStartDateTime(
+						(string) ( $event['startDate'] ?? '' ),
+						(string) ( $event['startTime'] ?? '' ),
+						(string) ( $event['venueTimezone'] ?? '' )
+					),
+					'ticketUrl' => (string) ( $event['ticketUrl'] ?? '' ),
+					'address'   => (string) ( $event['venueAddress'] ?? '' ),
+					'city'      => (string) ( $event['venueCity'] ?? '' ),
+					'state'     => (string) ( $event['venueState'] ?? '' ),
+					'country'   => (string) ( $event['venueCountry'] ?? '' ),
+				),
+			)
+		);
+
+		return is_array( $result ) && 'duplicate' === ( $result['verdict'] ?? '' );
+	}
+
+	/**
+	 * Build a typed identity result.
+	 *
+	 * @return array{event_identifier:string,item_identifier:string,legacy_identifier:string}
+	 */
+	private static function result( string $current, string $selected, string $legacy ): array {
+		return array(
+			'event_identifier'  => $current,
+			'item_identifier'   => $selected,
+			'legacy_identifier' => $legacy,
+		);
+	}
+}

--- a/inc/Utilities/EventSourceIdentity.php
+++ b/inc/Utilities/EventSourceIdentity.php
@@ -9,6 +9,7 @@ namespace DataMachineEvents\Utilities;
 
 use DataMachine\Core\ExecutionContext;
 use DataMachineEvents\Core\DuplicateDetection\EventDuplicateStrategy;
+use DataMachineEvents\Core\Event_Post_Type;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -97,7 +98,7 @@ class EventSourceIdentity {
 		$result = EventDuplicateStrategy::check(
 			array(
 				'title'     => (string) ( $event['title'] ?? '' ),
-				'post_type' => 'data_machine_events',
+				'post_type' => Event_Post_Type::POST_TYPE,
 				'context'   => array(
 					'venue'     => (string) ( $event['venue'] ?? '' ),
 					'startDate' => EventIdentifierGenerator::normalizeStartDateTime(

--- a/tests/Unit/EventDuplicateStrategyTest.php
+++ b/tests/Unit/EventDuplicateStrategyTest.php
@@ -300,6 +300,54 @@ class EventDuplicateStrategyTest extends WP_UnitTestCase {
 		$this->cleanup( $term_id, $existing_post_id );
 	}
 
+	public function test_exact_same_venue_name_matches_within_time_window(): void {
+		$venue_name = 'Exact Venue Within Window ' . uniqid();
+		[ $term_id, $existing_post_id ] = $this->seedVenueWithEvent(
+			'Showcase',
+			'2026-05-20 18:00:00',
+			$venue_name
+		);
+
+		$result = EventDuplicateStrategy::check(
+			array(
+				'title'   => 'Showcase',
+				'context' => array(
+					'venue'     => $venue_name,
+					'startDate' => '2026-05-20 19:30:00',
+					'ticketUrl' => '',
+				),
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'duplicate', $result['verdict'] );
+		$this->assertSame( $existing_post_id, $result['match']['post_id'] );
+		$this->cleanup( $term_id, $existing_post_id );
+	}
+
+	public function test_exact_same_venue_name_is_distinct_outside_time_window(): void {
+		$venue_name = 'Exact Venue Outside Window ' . uniqid();
+		[ $term_id, $existing_post_id ] = $this->seedVenueWithEvent(
+			'Showcase',
+			'2026-05-21 13:30:00',
+			$venue_name
+		);
+
+		$result = EventDuplicateStrategy::check(
+			array(
+				'title'   => 'Showcase',
+				'context' => array(
+					'venue'     => $venue_name,
+					'startDate' => '2026-05-21 21:30:00',
+					'ticketUrl' => '',
+				),
+			)
+		);
+
+		$this->assertNull( $result, 'Exact title and venue names must not merge known start times more than two hours apart.' );
+		$this->cleanup( $term_id, $existing_post_id );
+	}
+
 	/**
 	 * Belt-and-suspenders: when no $startDate is passed (legacy
 	 * call shape), the time-window guard is skipped and the term_id

--- a/tests/Unit/EventDuplicateStrategyTest.php
+++ b/tests/Unit/EventDuplicateStrategyTest.php
@@ -20,8 +20,10 @@
 
 namespace DataMachineEvents\Tests\Unit;
 
+use DataMachine\Core\EngineData;
 use WP_UnitTestCase;
 use DataMachineEvents\Core\DuplicateDetection\EventDuplicateStrategy;
+use DataMachineEvents\Core\DuplicateDetection\PreAIEventDedupGate;
 use DataMachineEvents\Core\Event_Post_Type;
 use DataMachineEvents\Core\EventDatesTable;
 use DataMachineEvents\Core\Venue_Taxonomy;
@@ -505,6 +507,73 @@ class EventDuplicateStrategyTest extends WP_UnitTestCase {
 		$this->cleanup( $term_id, $existing_post_id );
 	}
 
+	public function test_exact_ticket_identity_remains_authoritative_across_same_day_times(): void {
+		$venue_name = 'Authoritative Ticket Venue ' . uniqid();
+		$ticket_url = 'https://tickets.example.com/event/stable-' . uniqid();
+		[ $term_id, $existing_post_id ] = $this->seedVenueWithEvent(
+			'Authoritative Ticket Show',
+			'2026-04-24 13:30:00',
+			$venue_name,
+			$ticket_url
+		);
+
+		$result = EventDuplicateStrategy::check(
+			array(
+				'title'   => 'Different Source Title',
+				'context' => array(
+					'venue'     => $venue_name,
+					'startDate' => '2026-04-24 21:30:00',
+					'ticketUrl' => $ticket_url,
+				),
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'duplicate', $result['verdict'] );
+		$this->assertSame( $existing_post_id, $result['match']['post_id'] );
+		$this->assertStringContainsString( 'ticket_url_exact', $result['reason'], 'Stable ticket identity is intentionally authoritative over time-window heuristics.' );
+		$this->cleanup( $term_id, $existing_post_id );
+	}
+
+	public function test_pre_ai_gate_allows_exact_venue_late_show(): void {
+		$venue_name = 'Pre AI Exact Venue Late ' . uniqid();
+		[ $term_id, $existing_post_id ] = $this->seedVenueWithEvent(
+			'Pre AI Showcase',
+			'2026-05-22 13:30:00',
+			$venue_name
+		);
+
+		$result = PreAIEventDedupGate::check(
+			null,
+			$this->preAIEngine( 'Pre AI Showcase', $venue_name, '2026-05-22', '21:30' ),
+			array(),
+			219
+		);
+
+		$this->assertNull( $result, 'The pre-AI gate must compose split time fields and allow a distinct late show.' );
+		$this->cleanup( $term_id, $existing_post_id );
+	}
+
+	public function test_pre_ai_gate_skips_exact_venue_show_within_time_window(): void {
+		$venue_name = 'Pre AI Exact Venue Within ' . uniqid();
+		[ $term_id, $existing_post_id ] = $this->seedVenueWithEvent(
+			'Pre AI Showcase',
+			'2026-05-23 13:30:00',
+			$venue_name
+		);
+
+		$result = PreAIEventDedupGate::check(
+			null,
+			$this->preAIEngine( 'Pre AI Showcase', $venue_name, '2026-05-23', '15:00' ),
+			array(),
+			220
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['skip'] );
+		$this->cleanup( $term_id, $existing_post_id );
+	}
+
 	/**
 	 * Venue + date + fuzzy title match → IS a duplicate.
 	 *
@@ -540,6 +609,21 @@ class EventDuplicateStrategyTest extends WP_UnitTestCase {
 	// ---------------------------------------------------------------------
 	// Helpers
 	// ---------------------------------------------------------------------
+
+	private function preAIEngine( string $title, string $venue, string $start_date, string $start_time ): EngineData {
+		return new EngineData(
+			array(
+				'title'       => $title,
+				'venue'       => $venue,
+				'startDate'   => $start_date,
+				'startTime'   => $start_time,
+				'flow_config' => array(
+					'upsert' => array( 'handler_slugs' => array( 'upsert_event' ) ),
+				),
+			),
+			null
+		);
+	}
 
 	/**
 	 * Create a venue term (with address meta) + an event post tagged

--- a/tests/Unit/EventIdentifierGeneratorTest.php
+++ b/tests/Unit/EventIdentifierGeneratorTest.php
@@ -150,6 +150,39 @@ class EventIdentifierGeneratorTest extends WP_UnitTestCase {
 		$this->assertEquals( $hash1, $hash2, 'Article variations should produce same hash' );
 	}
 
+	public function test_generate_distinguishes_same_event_at_different_times(): void {
+		$early = EventIdentifierGenerator::generate( 'Two-Set Showcase', '2026-04-26', 'Charleston Pour House', '13:30' );
+		$late  = EventIdentifierGenerator::generate( 'Two-Set Showcase', '2026-04-26', 'Charleston Pour House', '21:30' );
+
+		$this->assertNotSame( $early, $late, 'Different local start times must have distinct source identities.' );
+	}
+
+	public function test_generate_normalizes_equivalent_datetime_formats_and_timezones(): void {
+		$local = EventIdentifierGenerator::generate(
+			'Motown Throwdown',
+			'2026-04-26',
+			'Charleston Pour House',
+			'1:30 PM',
+			'America/New_York'
+		);
+		$utc   = EventIdentifierGenerator::generate(
+			'Motown Throwdown',
+			'2026-04-26T17:30:00Z',
+			'Charleston Pour House',
+			'',
+			'America/New_York'
+		);
+
+		$this->assertSame( $local, $utc, 'Equivalent absolute and local source times must normalize to one local identity.' );
+	}
+
+	public function test_date_only_source_preserves_legacy_identifier(): void {
+		$current = EventIdentifierGenerator::generate( 'All Day Festival', '2026-04-26', 'Charleston Pour House' );
+		$legacy  = EventIdentifierGenerator::generateLegacy( 'All Day Festival', '2026-04-26', 'Charleston Pour House' );
+
+		$this->assertSame( $legacy, $current, 'Genuinely date-only sources must not churn persisted identities.' );
+	}
+
 	/**
 	 * Test earliest delimiter extraction
 	 *

--- a/tests/Unit/EventSourceIdentityTest.php
+++ b/tests/Unit/EventSourceIdentityTest.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Event source identity compatibility tests.
+ *
+ * @package DataMachineEvents\Tests\Unit
+ */
+
+namespace DataMachineEvents\Tests\Unit;
+
+use DataMachine\Core\Database\PostIdentityIndex\PostIdentityIndex;
+use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
+use DataMachine\Core\ExecutionContext;
+use DataMachineEvents\Core\DuplicateDetection\EventDuplicateStrategy;
+use DataMachineEvents\Core\EventDatesTable;
+use DataMachineEvents\Core\Event_Post_Type;
+use DataMachineEvents\Core\Venue_Taxonomy;
+use DataMachineEvents\Utilities\EventIdentifierGenerator;
+use DataMachineEvents\Utilities\EventSourceIdentity;
+use WP_UnitTestCase;
+
+class EventSourceIdentityTest extends WP_UnitTestCase {
+
+	private string $flow_step_id;
+	private string $source_type = 'universal_web_scraper';
+	private array $post_ids = array();
+	private array $term_ids = array();
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->flow_step_id = 'identity-transition-' . wp_generate_uuid4();
+		if ( ! post_type_exists( Event_Post_Type::POST_TYPE ) ) {
+			Event_Post_Type::register();
+		}
+		if ( ! taxonomy_exists( 'venue' ) ) {
+			Venue_Taxonomy::register();
+		}
+		if ( ! EventDatesTable::table_exists() ) {
+			EventDatesTable::create_table();
+		}
+		( new PostIdentityIndex() )->create_table();
+	}
+
+	public function tearDown(): void {
+		global $wpdb;
+
+		foreach ( $this->post_ids as $post_id ) {
+			$wpdb->delete( EventDatesTable::table_name(), array( 'post_id' => $post_id ), array( '%d' ) );
+			$wpdb->delete( $wpdb->prefix . 'datamachine_post_identity', array( 'post_id' => $post_id ), array( '%d' ) );
+			wp_delete_post( $post_id, true );
+		}
+		foreach ( $this->term_ids as $term_id ) {
+			wp_delete_term( $term_id, 'venue' );
+		}
+		$wpdb->delete( $wpdb->prefix . ProcessedItems::TABLE_NAME, array( 'flow_step_id' => $this->flow_step_id ), array( '%s' ) );
+
+		parent::tearDown();
+	}
+
+	public function test_processed_legacy_hash_advances_when_canonical_event_is_missing(): void {
+		$event      = $this->event();
+		$current    = $this->currentIdentifier( $event );
+		$legacy     = EventIdentifierGenerator::generateLegacy( $event['title'], $event['startDate'], $event['venue'] );
+		$context    = $this->context();
+		$repository = new ProcessedItems();
+
+		$repository->add_processed_item( $this->flow_step_id, $this->source_type, $legacy, 1001 );
+		$resolved = EventSourceIdentity::resolve( $event, $context );
+
+		$this->assertSame( $current, $resolved['item_identifier'], 'Missing canonical events must escape the old date-only processed hash.' );
+		$this->assertFalse( $repository->has_item_been_processed( $this->flow_step_id, $this->source_type, $current ), 'Identity resolution must never mark the new hash before successful ingestion.' );
+
+		$repository->add_processed_item( $this->flow_step_id, $this->source_type, $current, 1002 );
+		$state = $context->classifySourceItems( array( $current ) );
+		$this->assertFalse( $state['classifications'][0]['selected'], 'A successfully migrated current hash must not replay again.' );
+	}
+
+	public function test_processed_legacy_hash_does_not_replay_existing_canonical_event(): void {
+		$event      = $this->event();
+		$legacy     = EventIdentifierGenerator::generateLegacy( $event['title'], $event['startDate'], $event['venue'] );
+		$context    = $this->context();
+		$repository = new ProcessedItems();
+
+		$this->seedCanonicalEvent( $event );
+		$repository->add_processed_item( $this->flow_step_id, $this->source_type, $legacy, 2001 );
+		$resolved = EventSourceIdentity::resolve( $event, $context );
+
+		$this->assertSame( $legacy, $resolved['item_identifier'], 'Existing canonical events must retain the processed legacy identity during transition.' );
+		$state = $context->classifySourceItems( array( $resolved['item_identifier'] ) );
+		$this->assertFalse( $state['classifications'][0]['selected'], 'The retained legacy identity must be filtered instead of replaying an existing event.' );
+	}
+
+	private function event(): array {
+		return array(
+			'title'         => 'Motown Throwdown ' . $this->flow_step_id,
+			'startDate'     => '2026-04-26',
+			'startTime'     => '13:30',
+			'venue'         => 'Charleston Pour House ' . $this->flow_step_id,
+			'venueTimezone' => 'America/New_York',
+		);
+	}
+
+	private function context(): ExecutionContext {
+		return ExecutionContext::fromFlow( 219, 219, $this->flow_step_id, '219', $this->source_type );
+	}
+
+	private function currentIdentifier( array $event ): string {
+		return EventIdentifierGenerator::generate( $event['title'], $event['startDate'], $event['venue'], $event['startTime'], $event['venueTimezone'] );
+	}
+
+	private function seedCanonicalEvent( array $event ): void {
+		$term = wp_insert_term( $event['venue'], 'venue' );
+		$this->assertNotWPError( $term );
+		$term_id          = (int) $term['term_id'];
+		$this->term_ids[] = $term_id;
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => $event['title'],
+				'post_type'   => Event_Post_Type::POST_TYPE,
+				'post_status' => 'publish',
+			)
+		);
+		$this->assertGreaterThan( 0, $post_id );
+		$this->post_ids[] = $post_id;
+		wp_set_object_terms( $post_id, array( $term_id ), 'venue' );
+		EventDatesTable::upsert( $post_id, '2026-04-26 13:30:00' );
+
+		( new PostIdentityIndex() )->upsert(
+			$post_id,
+			array(
+				'post_type'     => Event_Post_Type::POST_TYPE,
+				'event_date'    => $event['startDate'],
+				'venue_term_id' => $term_id,
+				'title_hash'    => EventDuplicateStrategy::computeTitleHash( $event['title'] ),
+			)
+		);
+	}
+}

--- a/tests/Unit/EventSourceIdentityTest.php
+++ b/tests/Unit/EventSourceIdentityTest.php
@@ -38,6 +38,7 @@ class EventSourceIdentityTest extends WP_UnitTestCase {
 		if ( ! EventDatesTable::table_exists() ) {
 			EventDatesTable::create_table();
 		}
+		( new ProcessedItems() )->create_table();
 		( new PostIdentityIndex() )->create_table();
 	}
 
@@ -90,6 +91,23 @@ class EventSourceIdentityTest extends WP_UnitTestCase {
 		$this->assertFalse( $state['classifications'][0]['selected'], 'The retained legacy identity must be filtered instead of replaying an existing event.' );
 	}
 
+	public function test_late_show_advances_when_early_show_owns_legacy_hash(): void {
+		$early      = $this->event();
+		$late       = $early;
+		$late['startTime'] = '21:30';
+		$current    = $this->currentIdentifier( $late );
+		$legacy     = EventIdentifierGenerator::generateLegacy( $late['title'], $late['startDate'], $late['venue'] );
+		$context    = $this->context();
+		$repository = new ProcessedItems();
+
+		$this->seedCanonicalEvent( $early );
+		$repository->add_processed_item( $this->flow_step_id, $this->source_type, $legacy, 3001 );
+		$resolved = EventSourceIdentity::resolve( $late, $context );
+
+		$this->assertSame( $current, $resolved['item_identifier'], 'A canonical early show must not strand a distinct late show behind their shared legacy date-only hash.' );
+		$this->assertFalse( $repository->has_item_been_processed( $this->flow_step_id, $this->source_type, $current ) );
+	}
+
 	private function event(): array {
 		return array(
 			'title'         => 'Motown Throwdown ' . $this->flow_step_id,
@@ -101,7 +119,7 @@ class EventSourceIdentityTest extends WP_UnitTestCase {
 	}
 
 	private function context(): ExecutionContext {
-		return ExecutionContext::fromFlow( 219, 219, $this->flow_step_id, '219', $this->source_type );
+		return ExecutionContext::fromFlow( 219, 219, $this->flow_step_id, null, $this->source_type );
 	}
 
 	private function currentIdentifier( array $event ): string {
@@ -124,7 +142,7 @@ class EventSourceIdentityTest extends WP_UnitTestCase {
 		$this->assertGreaterThan( 0, $post_id );
 		$this->post_ids[] = $post_id;
 		wp_set_object_terms( $post_id, array( $term_id ), 'venue' );
-		EventDatesTable::upsert( $post_id, '2026-04-26 13:30:00' );
+		EventDatesTable::upsert( $post_id, $event['startDate'] . ' ' . $event['startTime'] . ':00' );
 
 		( new PostIdentityIndex() )->upsert(
 			$post_id,

--- a/tests/Unit/WordPressExtractorIdentityTest.php
+++ b/tests/Unit/WordPressExtractorIdentityTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * WordPress extractor source identity regression tests.
+ *
+ * @package DataMachineEvents\Tests\Unit
+ */
+
+namespace DataMachineEvents\Tests\Unit;
+
+use DataMachineEvents\Steps\EventImport\Handlers\WebScraper\Extractors\WordPressExtractor;
+use DataMachineEvents\Utilities\EventIdentifierGenerator;
+use WP_UnitTestCase;
+
+class WordPressExtractorIdentityTest extends WP_UnitTestCase {
+
+	public function test_charleston_pour_house_tribe_times_reach_source_identity(): void {
+		$extractor = new WordPressExtractor();
+		$payload   = wp_json_encode(
+			array(
+				'rest_url' => 'https://charlestonpourhouse.com/wp-json/tribe/events/v1/',
+				'events'   => array(
+					array(
+						'title'      => 'Motown Throwdown',
+						'start_date' => '2026-04-26 13:30:00',
+						'venue'      => array( 'venue' => 'Charleston Pour House' ),
+					),
+					array(
+						'title'      => 'Motown Throwdown',
+						'start_date' => '2026-04-26 21:30:00',
+						'venue'      => array( 'venue' => 'Charleston Pour House' ),
+					),
+				),
+			)
+		);
+
+		$events = $extractor->extract( $payload, 'https://charlestonpourhouse.com/events/' );
+
+		$this->assertCount( 2, $events );
+		$this->assertSame( '13:30', $events[0]['startTime'] );
+		$this->assertSame( '21:30', $events[1]['startTime'] );
+		$this->assertNotSame(
+			EventIdentifierGenerator::generate( $events[0]['title'], $events[0]['startDate'], $events[0]['venue'], $events[0]['startTime'] ),
+			EventIdentifierGenerator::generate( $events[1]['title'], $events[1]['startDate'], $events[1]['venue'], $events[1]['startTime'] )
+		);
+	}
+}

--- a/tests/event-identity-pre-ai-smoke.php
+++ b/tests/event-identity-pre-ai-smoke.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Deterministic event identity and pre-AI composition smoke test.
+ *
+ * Self-contained: no WordPress runtime, database, PHPUnit, or Codebox.
+ *
+ * Run directly:
+ *   php tests/event-identity-pre-ai-smoke.php
+ *
+ * @package DataMachineEvents\Tests
+ */
+
+namespace {
+	define( 'ABSPATH', __DIR__ . '/' );
+
+	function do_action(): void {}
+}
+
+namespace DataMachine\Core\Similarity {
+	class SimilarityEngine {
+		public static function normalizeBasic( string $value ): string {
+			$value = strtolower( trim( $value ) );
+			return (string) preg_replace( '/^(the|a|an)\s+/', '', $value );
+		}
+	}
+}
+
+namespace DataMachine\Core {
+	class EngineData {
+		public function __construct( private array $data ) {}
+
+		public function get( string $key ): mixed {
+			return $this->data[ $key ] ?? null;
+		}
+	}
+
+	class JobStatus {
+		public const COMPLETED_NO_ITEMS = 'completed_no_items';
+	}
+}
+
+namespace DataMachineEvents\Core\DuplicateDetection {
+	class EventDuplicateStrategy {
+		public static array $last_input = array();
+
+		public static function check( array $input ): ?array {
+			self::$last_input = $input;
+			return null;
+		}
+	}
+}
+
+namespace {
+	require_once dirname( __DIR__ ) . '/inc/Utilities/EventIdentifierGenerator.php';
+	require_once dirname( __DIR__ ) . '/inc/Core/DuplicateDetection/PreAIEventDedupGate.php';
+
+	use DataMachine\Core\EngineData;
+	use DataMachineEvents\Core\DuplicateDetection\EventDuplicateStrategy;
+	use DataMachineEvents\Core\DuplicateDetection\PreAIEventDedupGate;
+	use DataMachineEvents\Utilities\EventIdentifierGenerator;
+
+	$passed = 0;
+	$failed = 0;
+
+	function identity_check( string $label, bool $condition ): void {
+		global $passed, $failed;
+		if ( $condition ) {
+			++$passed;
+			return;
+		}
+
+		++$failed;
+		fwrite( STDERR, "FAIL: {$label}\n" );
+	}
+
+	$early = EventIdentifierGenerator::generate( 'Showcase', '2026-05-22', 'Exact Venue', '13:30', 'America/New_York' );
+	$late  = EventIdentifierGenerator::generate( 'Showcase', '2026-05-22', 'Exact Venue', '21:30', 'America/New_York' );
+	identity_check( 'different local times produce distinct source identities', $early !== $late );
+
+	$local = EventIdentifierGenerator::generate( 'Showcase', '2026-05-22', 'Exact Venue', '13:30', 'America/New_York' );
+	$utc   = EventIdentifierGenerator::generate( 'Showcase', '2026-05-22T17:30:00Z', 'Exact Venue', '', 'America/New_York' );
+	identity_check( 'equivalent timezone representations normalize identically', $local === $utc );
+
+	$engine = new EngineData(
+		array(
+			'title'         => 'Showcase',
+			'venue'         => 'Exact Venue',
+			'startDate'     => '2026-05-22',
+			'startTime'     => '21:30',
+			'venueTimezone' => 'America/New_York',
+			'flow_config'   => array(
+				'upsert' => array( 'handler_slugs' => array( 'upsert_event' ) ),
+			),
+		)
+	);
+	PreAIEventDedupGate::check( null, $engine, array(), 219 );
+	identity_check(
+		'pre-AI gate composes split local datetime',
+		'2026-05-22 21:30' === ( EventDuplicateStrategy::$last_input['context']['startDate'] ?? '' )
+	);
+
+	$date_only_engine = new EngineData(
+		array(
+			'title'       => 'All Day Showcase',
+			'venue'       => 'Exact Venue',
+			'startDate'   => '2026-05-23',
+			'flow_config' => array(
+				'upsert' => array( 'handler_slugs' => array( 'upsert_event' ) ),
+			),
+		)
+	);
+	PreAIEventDedupGate::check( null, $date_only_engine, array(), 220 );
+	identity_check(
+		'pre-AI gate preserves genuine date-only identity',
+		'2026-05-23' === ( EventDuplicateStrategy::$last_input['context']['startDate'] ?? '' )
+	);
+
+	printf( "%d passed, %d failed\n", $passed, $failed );
+	exit( $failed > 0 ? 1 : 0 );
+}


### PR DESCRIPTION
## Summary
- normalize event source identities to full local start datetime when a source provides time, while preserving date-only hashes for genuinely all-day/unknown-time sources
- dual-read persisted legacy hashes and suppress migration only when the canonical event identity index confirms the event already exists
- wire every generator caller consistently and cover the Charleston Pour House Tribe shape, timezone normalization, migration recovery, and replay suppression

Closes #219.

## Caller audit
- `StructuredDataProcessor`: date/time are split by extractors; now uses the compatibility resolver for both `event_identifier` and processed `item_identifier`
- `DiceFm`: UTC API values are already converted to venue-local `startDate`/`startTime`; now uses the same resolver
- `SingleRecurring`: configured local `start_time` now participates in source identity through the same resolver
- `Ticketmaster`: stable Ticketmaster IDs remain the primary processed identity; the generated fallback/event metadata hash now includes local time and venue timezone
- `EventFlyer`: uploaded file path remains the primary processed identity; generated event metadata now includes configured start time
- canonical duplicate audits/upsert do not use this source hash; they continue through `EventDuplicateStrategy` and the existing upsert advisory lock

## Compatibility state machine
1. Date-only source: current and legacy hashes are identical; behavior is unchanged.
2. Current hash already processed or claimed: retain it and let Data Machine enforce normal skip/reprocess/claim policy.
3. Legacy hash actively claimed: retain it so a concurrent migration cannot bypass ownership.
4. Legacy hash absent or explicitly reprocess-eligible: select the current time-aware hash.
5. Legacy hash processed and canonical event exists: retain the legacy hash, so the fetch filter suppresses an unnecessary replay.
6. Legacy hash processed but canonical event is missing: select the current hash, allowing previously stranded source data to ingest.
7. Identity resolution is observational only. The current hash is claimed after fetch selection and marked processed only after successful pipeline completion by Data Machine core.

## Migration / operator plan
- no table migration, processed-row deletion, or bulk reprocessing is required
- normal scheduled runs perform a bounded per-item transition using the two relevant hashes only
- existing canonical events stay on their legacy processed hash until source data changes; missing canonical events advance under the new hash
- date-only sources never transition
- existing EventUpsert locking from #123 remains authoritative for concurrent canonical creation; this PR adds no competing lock

## Tests
- standalone identifier assertions: passed
- PHPCS changed-file lint: passed
- PHPStan level 7 changed-file analysis: passed
- Homeboy PR audit: passed with no introduced findings
- PHP syntax and `git diff --check`: passed
- focused PHPUnit filter added for identifier, WordPress extractor, transition, duplicate strategy, and upsert coverage; execution was attempted twice but WP Codebox failed before PHPUnit startup because the shared WordPress 7.0.2 archive cache lock timed out

## Known production recovery scope
- this PR does not clear processed rows, mutate event content, or initiate production reprocessing
- missing timed events whose old hash is processed become eligible on their next ordinary source run only when canonical lookup finds no matching event
- the broader historical loss described in the issue may also include failures unrelated to date-only collisions; those remain outside this PR and require separate operator-controlled diagnosis/recovery
