### PR TITLE
fix: serialize canonical event upserts

### DIFF
--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -52,6 +52,14 @@ jobs:
           app-id: ${{ secrets.HOMEBOY_APP_ID }}
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
+      - name: Verify MySQL advisory-lock contract
+        if: matrix.command == 'review test'
+        env:
+          DME_MYSQL_TEST_DSN: mysql:host=127.0.0.1;port=3306;dbname=homeboy_wptests
+          DME_MYSQL_TEST_USER: root
+          DME_MYSQL_TEST_PASSWORD: ''
+        run: php tests/Integration/mysql-lock-smoke.php
+
       - name: Run Homeboy ${{ matrix.command }}
         uses: Extra-Chill/homeboy-action@v2
         with:

--- a/inc/Abilities/EventUpsertAbilities.php
+++ b/inc/Abilities/EventUpsertAbilities.php
@@ -94,12 +94,16 @@ class EventUpsertAbilities {
 
 		$result = ( new EventUpsert() )->upsertCanonicalEvent( $event, $config );
 		if ( empty( $result['success'] ) ) {
+			$retryable  = ! empty( $result['retryable'] );
+			$error_code = (string) ( $result['error_code'] ?? $result['rule'] ?? 'event_upsert_failed' );
 			return new \WP_Error(
-				(string) ( $result['rule'] ?? 'event_upsert_failed' ),
+				$error_code,
 				(string) ( $result['error'] ?? 'Event upsert failed.' ),
 				array(
-					'status' => 400,
-					'rule'   => $result['rule'] ?? null,
+					'status'    => $retryable ? 503 : 400,
+					'rule'      => $result['rule'] ?? null,
+					'retryable' => $retryable,
+					'transient' => $retryable,
 				)
 			);
 		}

--- a/inc/Core/DuplicateDetection/EventDuplicateStrategy.php
+++ b/inc/Core/DuplicateDetection/EventDuplicateStrategy.php
@@ -291,60 +291,46 @@ class EventDuplicateStrategy {
 
 		$title_hash = self::computeTitleHash( $title );
 		$index      = new PostIdentityIndex();
-		$match      = $index->find_by_date_and_title_hash( $date_only, $title_hash );
+		$candidates = array_filter(
+			$index->find_by_date( $date_only, PHP_INT_MAX ),
+			static fn( array $candidate ): bool => ( $candidate['title_hash'] ?? '' ) === $title_hash
+		);
 
-		if ( ! $match ) {
-			return null;
-		}
+		foreach ( $candidates as $candidate ) {
+			$post_id = (int) $candidate['post_id'];
+			if ( ! self::isValidPost( $post_id ) ) {
+				continue;
+			}
 
-		$post_id = (int) $match['post_id'];
-		if ( ! self::isValidPost( $post_id ) ) {
-			return null;
-		}
-
-		// Exact title/date matches must honor the same time window as fuzzy
-		// matches. Import payloads commonly split startDate and startTime; once
-		// composed by EventUpsert, this prevents a legitimate early/late show
-		// pair from falling through the venue-name confirmation below.
-		if ( '' !== $startDate ) {
 			$candidate_dates   = \DataMachineEvents\Core\EventDatesTable::get( $post_id );
 			$existing_datetime = $candidate_dates ? $candidate_dates->start_datetime : '';
 			if ( ! self::isWithinTimeWindow( $startDate, $existing_datetime ) ) {
-				return null;
+				continue;
 			}
-		}
 
-		// Venue confirmation logic (same as old EventUpsert::findEventByExactTitle).
-		if ( empty( $venue ) && ! $venue_term ) {
-			if ( 'low' === $identity_confidence ) {
-				return null;
+			if ( empty( $venue ) && ! $venue_term ) {
+				if ( 'low' !== $identity_confidence ) {
+					return self::duplicateResult( $post_id, 'exact_title_no_venue' );
+				}
+				continue;
 			}
-			return self::duplicateResult( $post_id, 'exact_title_no_venue' );
-		}
 
-		// Term-id-aware short-circuit: when the incoming venue resolved to a
-		// term (via address or name), match directly on the candidate's
-		// venue term_ids. This catches dupes where the incoming venue string
-		// differs from the stored term name (e.g. "Monks Jazz" → term "Monks"),
-		// which the name-string compare below would miss.
-		if ( $venue_term ) {
-			$candidate_term_ids = wp_get_post_terms( $post_id, 'venue', array( 'fields' => 'ids' ) );
-			if ( ! is_wp_error( $candidate_term_ids ) && ! empty( $candidate_term_ids )
-				&& in_array( (int) $venue_term->term_id, array_map( 'intval', $candidate_term_ids ), true ) ) {
-
-				return self::duplicateResult( $post_id, 'exact_title_venue_term_id_match' );
+			if ( $venue_term ) {
+				$candidate_term_ids = wp_get_post_terms( $post_id, 'venue', array( 'fields' => 'ids' ) );
+				if ( ! is_wp_error( $candidate_term_ids ) && ! empty( $candidate_term_ids )
+					&& in_array( (int) $venue_term->term_id, array_map( 'intval', $candidate_term_ids ), true ) ) {
+					return self::duplicateResult( $post_id, 'exact_title_venue_term_id_match' );
+				}
 			}
-		}
 
-		$venue_terms = wp_get_post_terms( $post_id, 'venue', array( 'fields' => 'names' ) );
-		if ( empty( $venue_terms ) || is_wp_error( $venue_terms ) ) {
-			if ( 'low' === $identity_confidence ) {
-				return null;
+			$venue_terms = wp_get_post_terms( $post_id, 'venue', array( 'fields' => 'names' ) );
+			if ( empty( $venue_terms ) || is_wp_error( $venue_terms ) ) {
+				if ( 'low' !== $identity_confidence ) {
+					return self::duplicateResult( $post_id, 'exact_title_no_existing_venue' );
+				}
+				continue;
 			}
-			return self::duplicateResult( $post_id, 'exact_title_no_existing_venue' );
-		}
 
-		if ( '' !== $venue ) {
 			foreach ( $venue_terms as $existing_venue ) {
 				if ( $venue === $existing_venue || EventIdentifierGenerator::venuesMatch( $venue, $existing_venue ) ) {
 					return self::duplicateResult( $post_id, 'exact_title_venue_confirmed' );

--- a/inc/Core/DuplicateDetection/EventDuplicateStrategy.php
+++ b/inc/Core/DuplicateDetection/EventDuplicateStrategy.php
@@ -272,8 +272,8 @@ class EventDuplicateStrategy {
 	 *                                           term name.
 	 * @param string        $startDate           Full datetime (YYYY-MM-DDTHH:MM or
 	 *                                           similar) used to enforce a 2-hour
-	 *                                           window when the term_id bypass
-	 *                                           fires. Without this guard, two
+	 *                                           window before any exact-title
+	 *                                           match is accepted. Without it, two
 	 *                                           genuinely distinct shows that
 	 *                                           share a title hash and venue term
 	 *                                           on the same date but at very
@@ -302,6 +302,18 @@ class EventDuplicateStrategy {
 			return null;
 		}
 
+		// Exact title/date matches must honor the same time window as fuzzy
+		// matches. Import payloads commonly split startDate and startTime; once
+		// composed by EventUpsert, this prevents a legitimate early/late show
+		// pair from falling through the venue-name confirmation below.
+		if ( '' !== $startDate ) {
+			$candidate_dates   = \DataMachineEvents\Core\EventDatesTable::get( $post_id );
+			$existing_datetime = $candidate_dates ? $candidate_dates->start_datetime : '';
+			if ( ! self::isWithinTimeWindow( $startDate, $existing_datetime ) ) {
+				return null;
+			}
+		}
+
 		// Venue confirmation logic (same as old EventUpsert::findEventByExactTitle).
 		if ( empty( $venue ) && ! $venue_term ) {
 			if ( 'low' === $identity_confidence ) {
@@ -315,34 +327,12 @@ class EventDuplicateStrategy {
 		// venue term_ids. This catches dupes where the incoming venue string
 		// differs from the stored term name (e.g. "Monks Jazz" → term "Monks"),
 		// which the name-string compare below would miss.
-		//
-		// Time-window guard: Strategies 2 and 4 enforce a 2-hour window when
-		// matching by title fuzziness; Strategy 3 historically did not,
-		// because exact-title-hash + venue-name compare is highly specific.
-		// The term_id bypass widens that specificity in one direction (the
-		// incoming venue can now differ from the candidate's stored venue
-		// name), so we add the same 2-hour guard here to avoid falsely
-		// merging early/late shows at multi-room venues that share a title
-		// hash on the same date. When the guard fails, fall through to the
-		// existing venue-name compare path (legacy behavior).
 		if ( $venue_term ) {
 			$candidate_term_ids = wp_get_post_terms( $post_id, 'venue', array( 'fields' => 'ids' ) );
 			if ( ! is_wp_error( $candidate_term_ids ) && ! empty( $candidate_term_ids )
 				&& in_array( (int) $venue_term->term_id, array_map( 'intval', $candidate_term_ids ), true ) ) {
 
-				$within_window = true;
-				if ( '' !== $startDate ) {
-					$candidate_dates   = \DataMachineEvents\Core\EventDatesTable::get( $post_id );
-					$existing_datetime = $candidate_dates ? $candidate_dates->start_datetime : '';
-					$within_window     = self::isWithinTimeWindow( $startDate, $existing_datetime );
-				}
-
-				if ( $within_window ) {
-					return self::duplicateResult( $post_id, 'exact_title_venue_term_id_match' );
-				}
-				// Outside time window: skip the bypass and fall through to
-				// the existing venue-name compare. If that also fails to
-				// confirm, we return null (treat as distinct event).
+				return self::duplicateResult( $post_id, 'exact_title_venue_term_id_match' );
 			}
 		}
 

--- a/inc/Steps/Upsert/Events/EventUpsert.php
+++ b/inc/Steps/Upsert/Events/EventUpsert.php
@@ -597,35 +597,58 @@ class EventUpsert extends UpsertHandler {
 		$lock_keys = $this->buildUpsertLockKeys( $title, $venue, $startDate, $source_identity, $venue_context );
 		$acquired  = array();
 		$deadline  = microtime( true ) + 10;
+		$complete  = false;
 
-		foreach ( $lock_keys as $lock_key ) {
-			$timeout = max( 0, (int) ceil( $deadline - microtime( true ) ) );
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-			$result = $wpdb->get_var( $wpdb->prepare( 'SELECT GET_LOCK(%s, %d)', $lock_key, $timeout ) );
+		try {
+			foreach ( $lock_keys as $lock_key ) {
+				$timeout = max( 0, (int) ceil( $deadline - microtime( true ) ) );
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+				$result = $wpdb->get_var( $wpdb->prepare( 'SELECT GET_LOCK(%s, %d)', $lock_key, $timeout ) );
 
-			if ( '1' === (string) $result ) {
-				$acquired[] = $lock_key;
-				continue;
+				if ( '1' === (string) $result ) {
+					$acquired[] = $lock_key;
+					continue;
+				}
+
+				do_action(
+					'datamachine_log',
+					'warning',
+					'Event Upsert: Advisory lock unavailable; returning retryable failure',
+					array(
+						'lock_key'  => $lock_key,
+						'lock_keys' => $lock_keys,
+						'title'     => $title,
+						'startDate' => $startDate,
+						'result'    => null === $result ? 'error' : 'timeout',
+					)
+				);
+
+				return null;
 			}
 
-			$this->releaseUpsertLocks( $acquired );
+			$complete = true;
+
+			return $acquired;
+		} catch ( \Throwable $throwable ) {
 			do_action(
 				'datamachine_log',
 				'warning',
-				'Event Upsert: Advisory lock unavailable; returning retryable failure',
+				'Event Upsert: Advisory lock acquisition failed; returning retryable failure',
 				array(
-					'lock_key'  => $lock_key,
 					'lock_keys' => $lock_keys,
+					'acquired'  => $acquired,
 					'title'     => $title,
 					'startDate' => $startDate,
-					'result'    => null === $result ? 'error' : 'timeout',
+					'exception' => $throwable->getMessage(),
 				)
 			);
 
 			return null;
+		} finally {
+			if ( ! $complete ) {
+				$this->releaseUpsertLocks( $acquired );
+			}
 		}
-
-		return $acquired;
 	}
 
 	/**
@@ -633,8 +656,11 @@ class EventUpsert extends UpsertHandler {
 	 *
 	 * Known times acquire their own two-hour bucket and its predecessor. Any two
 	 * times within the duplicate strategy's two-hour window therefore overlap on
-	 * at least one key, including bucket boundaries. Distinct shows more than two
-	 * hours apart do not overlap. An unknown time acquires the finite set of 12
+	 * at least one key, including bucket boundaries. This deliberately serializes
+	 * unrelated titles at the same venue within that window: fuzzy equivalence has
+	 * no exact narrow key, so brief bounded contention is the correctness tradeoff.
+	 * Different venues and non-overlapping time buckets remain parallel. Distinct
+	 * shows more than two hours apart do not overlap. An unknown time acquires 12
 	 * venue/day buckets so it overlaps any time-aware equivalent. Unknown venues
 	 * include a stable title prefix fingerprint so venue-less events remain bounded.
 	 *
@@ -700,8 +726,20 @@ class EventUpsert extends UpsertHandler {
 		global $wpdb;
 
 		foreach ( array_reverse( $lock_keys ) as $lock_key ) {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-			$wpdb->query( $wpdb->prepare( 'SELECT RELEASE_LOCK(%s)', $lock_key ) );
+			try {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+				$wpdb->query( $wpdb->prepare( 'SELECT RELEASE_LOCK(%s)', $lock_key ) );
+			} catch ( \Throwable $throwable ) {
+				do_action(
+					'datamachine_log',
+					'warning',
+					'Event Upsert: Advisory lock release failed',
+					array(
+						'lock_key'  => $lock_key,
+						'exception' => $throwable->getMessage(),
+					)
+				);
+			}
 		}
 	}
 

--- a/inc/Steps/Upsert/Events/EventUpsert.php
+++ b/inc/Steps/Upsert/Events/EventUpsert.php
@@ -654,15 +654,14 @@ class EventUpsert extends UpsertHandler {
 	/**
 	 * Build globally ordered source and canonical collision-domain lock keys.
 	 *
-	 * Known times acquire their own two-hour bucket and its predecessor. Any two
-	 * times within the duplicate strategy's two-hour window therefore overlap on
-	 * at least one key, including bucket boundaries. This deliberately serializes
-	 * unrelated titles at the same venue within that window: fuzzy equivalence has
-	 * no exact narrow key, so brief bounded contention is the correctness tradeoff.
-	 * Different venues and non-overlapping time buckets remain parallel. Distinct
-	 * shows more than two hours apart do not overlap. An unknown time acquires 12
-	 * venue/day buckets so it overlaps any time-aware equivalent. Unknown venues
-	 * include a stable title prefix fingerprint so venue-less events remain bounded.
+	 * Known times acquire their own two-hour bucket and its predecessor. This is a
+	 * conservative adjacent-bucket collision domain, not an exact two-hour range:
+	 * starts beyond 120 minutes can briefly serialize when their bucket sets overlap.
+	 * Fuzzy equivalence has no exact narrow key, so that bounded false contention is
+	 * the correctness tradeoff. Different venue/geography scopes and distant bucket
+	 * sets remain parallel. An unknown time acquires 12 venue/day buckets so it
+	 * overlaps any time-aware equivalent. Unknown venues include a stable title
+	 * prefix fingerprint so venue-less events remain bounded.
 	 *
 	 * @param string $title           Event title.
 	 * @param string $venue           Event venue.
@@ -677,18 +676,24 @@ class EventUpsert extends UpsertHandler {
 		$identity  = \DataMachineEvents\Core\Venue_Taxonomy::resolve_venue_identity( $venue, $venue_context );
 
 		if ( ! empty( $identity['term_id'] ) ) {
-			$venue_scope = 'term:' . (int) $identity['term_id'];
+			$venue_scopes = array( 'term:' . (int) $identity['term_id'] );
 		} elseif ( '' !== trim( $venue ) ) {
-			$venue_scope = 'name:' . SimilarityEngine::normalizeBasic( $venue );
-		} elseif ( '' !== trim( (string) ( $venue_context['address'] ?? '' ) ) ) {
-			$venue_scope = 'geo:' . SimilarityEngine::normalizeBasic(
-				(string) $venue_context['address'] . '|' . (string) ( $venue_context['city'] ?? '' )
-			);
+			$venue_scopes = array( 'name:' . SimilarityEngine::normalizeBasic( $venue ) );
 		} else {
 			$normalized_title = SimilarityEngine::normalizeTitle( $title );
 			$title_tokens     = array_slice( array_filter( explode( ' ', $normalized_title ) ), 0, 3 );
-			$venue_scope      = 'unknown:' . implode( ' ', $title_tokens );
+			$venue_scopes     = array( 'unknown:' . implode( ' ', $title_tokens ) );
 		}
+
+		$normalized_address = \DataMachineEvents\Core\Venue_Taxonomy::normalize_address_for_matching(
+			(string) ( $venue_context['address'] ?? '' )
+		);
+		if ( '' !== $normalized_address ) {
+			// Address is intentionally independent of optional city/state/country.
+			// Partial source geography must still converge on the same physical key.
+			$venue_scopes[] = 'geo:address:' . $normalized_address;
+		}
+		$venue_scopes = array_values( array_unique( $venue_scopes ) );
 
 		$domains = array();
 		if ( '' !== $source_identity ) {
@@ -698,12 +703,16 @@ class EventUpsert extends UpsertHandler {
 		if ( preg_match( '/\b(\d{1,2}):(\d{2})/', $startDate, $matches ) ) {
 			$minutes = ( (int) $matches[1] * 60 ) + (int) $matches[2];
 			$bucket  = (int) floor( $minutes / 120 );
-			foreach ( array( $bucket - 1, $bucket ) as $time_bucket ) {
-				$domains[] = 'canonical|' . $blog_id . '|' . $date_only . '|' . $venue_scope . '|time:' . $time_bucket;
+			foreach ( $venue_scopes as $venue_scope ) {
+				foreach ( array( $bucket - 1, $bucket ) as $time_bucket ) {
+					$domains[] = 'canonical|' . $blog_id . '|' . $date_only . '|' . $venue_scope . '|time:' . $time_bucket;
+				}
 			}
 		} else {
-			foreach ( range( 0, 11 ) as $time_bucket ) {
-				$domains[] = 'canonical|' . $blog_id . '|' . $date_only . '|' . $venue_scope . '|time:' . $time_bucket;
+			foreach ( $venue_scopes as $venue_scope ) {
+				foreach ( range( 0, 11 ) as $time_bucket ) {
+					$domains[] = 'canonical|' . $blog_id . '|' . $date_only . '|' . $venue_scope . '|time:' . $time_bucket;
+				}
 			}
 		}
 

--- a/inc/Steps/Upsert/Events/EventUpsert.php
+++ b/inc/Steps/Upsert/Events/EventUpsert.php
@@ -164,10 +164,20 @@ class EventUpsert extends UpsertHandler {
 			)
 		);
 
-		// Source identities are owner-safe but source-specific. Canonical event
-		// identity must serialize different sources before the final duplicate check.
-		$lock_key = $this->acquireUpsertLock( $title, $startDate );
-		if ( null === $lock_key ) {
+		$identity_start = self::composeIdentityStart( $startDate, $start_time );
+		$lock_keys      = $this->acquireUpsertLocks(
+			$title,
+			$venue,
+			$identity_start,
+			(string) ( $parameters['source_identity'] ?? '' ),
+			array(
+				'address' => (string) ( $engine->get( 'venueAddress' ) ?? $parameters['venueAddress'] ?? '' ),
+				'city'    => (string) ( $engine->get( 'venueCity' ) ?? $parameters['venueCity'] ?? '' ),
+				'state'   => (string) ( $engine->get( 'venueState' ) ?? $parameters['venueState'] ?? '' ),
+				'country' => (string) ( $engine->get( 'venueCountry' ) ?? $parameters['venueCountry'] ?? '' ),
+			)
+		);
+		if ( null === $lock_keys ) {
 			return array(
 				'success'    => false,
 				'error'      => 'Event upsert lock unavailable; retry the event.',
@@ -177,12 +187,10 @@ class EventUpsert extends UpsertHandler {
 			);
 		}
 
-		$identity_start = self::composeIdentityStart( $startDate, $start_time );
-
 		try {
 			return $this->executeUpsertWithinLock( $title, $venue, $identity_start, $ticketUrl, $parameters, $handler_config, $engine );
 		} finally {
-			$this->releaseUpsertLock( $lock_key );
+			$this->releaseUpsertLocks( $lock_keys );
 		}
 	}
 
@@ -563,14 +571,12 @@ class EventUpsert extends UpsertHandler {
 	}
 
 	/**
-	 * Acquire a MySQL advisory lock for an event identity.
+	 * Acquire deterministic MySQL advisory locks for an event identity.
 	 *
-	 * Uses GET_LOCK() to serialize concurrent upserts for the same event.
-	 * The key deliberately uses canonical fields rather than source identity so
-	 * different feeds converging on one event queue instead of racing. The lock
-	 * is date/title scoped; the duplicate strategy receives the full start time
-	 * and venue context, so distinct early/late or multi-room shows serialize
-	 * briefly but are not collapsed.
+	 * A concrete source lock serializes updates even when source data changes its
+	 * title, date, or venue. Canonical venue/time locks serialize different feeds
+	 * whose fuzzy titles can resolve to the same event. Keys are globally sorted
+	 * before acquisition so overlapping key sets cannot deadlock each other.
 	 *
 	 * MySQL advisory locks are:
 	 * - Per-connection (each PHP-FPM worker has its own connection)
@@ -579,54 +585,124 @@ class EventUpsert extends UpsertHandler {
 	 *
 	 * @since 0.17.3
 	 * @param string $title           Event title.
-	 * @param string $startDate       Event start date.
-	 * @return string|null The acquired lock key, or null on timeout/error.
+	 * @param string $venue           Event venue.
+	 * @param string $startDate       Event start date or datetime.
+	 * @param string $source_identity Optional stable source identity.
+	 * @param array  $venue_context   Venue address geography.
+	 * @return array|null The acquired lock keys, or null on timeout/error.
 	 */
-	private function acquireUpsertLock( string $title, string $startDate ): ?string {
+	private function acquireUpsertLocks( string $title, string $venue, string $startDate, string $source_identity = '', array $venue_context = array() ): ?array {
 		global $wpdb;
 
-		$date_only  = self::extractDateForQuery( $startDate );
-		$normalized = SimilarityEngine::normalizeTitle( $title );
-		$blog_id    = get_current_blog_id();
-		$lock_key   = 'dme:' . $blog_id . ':' . md5( $date_only . '|' . $normalized );
+		$lock_keys = $this->buildUpsertLockKeys( $title, $venue, $startDate, $source_identity, $venue_context );
+		$acquired  = array();
+		$deadline  = microtime( true ) + 10;
 
-		// MySQL/MariaDB lock names are limited to 64 characters. The fixed prefix,
-		// numeric site id, separator, and 32-character digest remain below that
-		// limit for WordPress's maximum signed BIGINT blog id.
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$result = $wpdb->get_var( $wpdb->prepare( 'SELECT GET_LOCK(%s, %d)', $lock_key, 10 ) );
+		foreach ( $lock_keys as $lock_key ) {
+			$timeout = max( 0, (int) ceil( $deadline - microtime( true ) ) );
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$result = $wpdb->get_var( $wpdb->prepare( 'SELECT GET_LOCK(%s, %d)', $lock_key, $timeout ) );
 
-		if ( '1' !== (string) $result ) {
+			if ( '1' === (string) $result ) {
+				$acquired[] = $lock_key;
+				continue;
+			}
+
+			$this->releaseUpsertLocks( $acquired );
 			do_action(
 				'datamachine_log',
 				'warning',
 				'Event Upsert: Advisory lock unavailable; returning retryable failure',
 				array(
-					'lock_key'   => $lock_key,
-					'title'      => $title,
-					'startDate'  => $startDate,
-					'normalized' => $normalized,
-					'result'     => null === $result ? 'error' : 'timeout',
+					'lock_key'  => $lock_key,
+					'lock_keys' => $lock_keys,
+					'title'     => $title,
+					'startDate' => $startDate,
+					'result'    => null === $result ? 'error' : 'timeout',
 				)
 			);
 
 			return null;
 		}
 
-		return $lock_key;
+		return $acquired;
 	}
 
 	/**
-	 * Release a MySQL advisory lock.
+	 * Build globally ordered source and canonical collision-domain lock keys.
+	 *
+	 * Known times acquire their own two-hour bucket and its predecessor. Any two
+	 * times within the duplicate strategy's two-hour window therefore overlap on
+	 * at least one key, including bucket boundaries. Distinct shows more than two
+	 * hours apart do not overlap. An unknown time acquires the finite set of 12
+	 * venue/day buckets so it overlaps any time-aware equivalent. Unknown venues
+	 * include a stable title prefix fingerprint so venue-less events remain bounded.
+	 *
+	 * @param string $title           Event title.
+	 * @param string $venue           Event venue.
+	 * @param string $startDate       Event start date or datetime.
+	 * @param string $source_identity Optional stable source identity.
+	 * @param array  $venue_context   Venue address geography.
+	 * @return array Ordered advisory lock keys.
+	 */
+	private function buildUpsertLockKeys( string $title, string $venue, string $startDate, string $source_identity = '', array $venue_context = array() ): array {
+		$blog_id   = get_current_blog_id();
+		$date_only = self::extractDateForQuery( $startDate );
+		$identity  = \DataMachineEvents\Core\Venue_Taxonomy::resolve_venue_identity( $venue, $venue_context );
+
+		if ( ! empty( $identity['term_id'] ) ) {
+			$venue_scope = 'term:' . (int) $identity['term_id'];
+		} elseif ( '' !== trim( $venue ) ) {
+			$venue_scope = 'name:' . SimilarityEngine::normalizeBasic( $venue );
+		} elseif ( '' !== trim( (string) ( $venue_context['address'] ?? '' ) ) ) {
+			$venue_scope = 'geo:' . SimilarityEngine::normalizeBasic(
+				(string) $venue_context['address'] . '|' . (string) ( $venue_context['city'] ?? '' )
+			);
+		} else {
+			$normalized_title = SimilarityEngine::normalizeTitle( $title );
+			$title_tokens     = array_slice( array_filter( explode( ' ', $normalized_title ) ), 0, 3 );
+			$venue_scope      = 'unknown:' . implode( ' ', $title_tokens );
+		}
+
+		$domains = array();
+		if ( '' !== $source_identity ) {
+			$domains[] = 'source|' . $blog_id . '|' . $source_identity;
+		}
+
+		if ( preg_match( '/\b(\d{1,2}):(\d{2})/', $startDate, $matches ) ) {
+			$minutes = ( (int) $matches[1] * 60 ) + (int) $matches[2];
+			$bucket  = (int) floor( $minutes / 120 );
+			foreach ( array( $bucket - 1, $bucket ) as $time_bucket ) {
+				$domains[] = 'canonical|' . $blog_id . '|' . $date_only . '|' . $venue_scope . '|time:' . $time_bucket;
+			}
+		} else {
+			foreach ( range( 0, 11 ) as $time_bucket ) {
+				$domains[] = 'canonical|' . $blog_id . '|' . $date_only . '|' . $venue_scope . '|time:' . $time_bucket;
+			}
+		}
+
+		$lock_keys = array_map(
+			static fn( string $domain ): string => 'dme:' . md5( $domain ),
+			array_unique( $domains )
+		);
+		sort( $lock_keys, SORT_STRING );
+
+		return $lock_keys;
+	}
+
+	/**
+	 * Release acquired MySQL advisory locks.
 	 *
 	 * @since 0.17.3
-	 * @param string $lock_key The lock key to release.
+	 * @param array $lock_keys Lock keys to release.
 	 */
-	private function releaseUpsertLock( string $lock_key ): void {
+	private function releaseUpsertLocks( array $lock_keys ): void {
 		global $wpdb;
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$wpdb->query( $wpdb->prepare( 'SELECT RELEASE_LOCK(%s)', $lock_key ) );
+		foreach ( array_reverse( $lock_keys ) as $lock_key ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->query( $wpdb->prepare( 'SELECT RELEASE_LOCK(%s)', $lock_key ) );
+		}
 	}
 
 	/**

--- a/inc/Steps/Upsert/Events/EventUpsert.php
+++ b/inc/Steps/Upsert/Events/EventUpsert.php
@@ -164,12 +164,23 @@ class EventUpsert extends UpsertHandler {
 			)
 		);
 
-		// Acquire an advisory lock to prevent concurrent duplicate creation. Public
-		// callers lock on source identity; workflow imports retain title/date locking.
-		$lock_key = $this->acquireUpsertLock( $title, $startDate, (string) ( $parameters['source_identity'] ?? '' ) );
+		// Source identities are owner-safe but source-specific. Canonical event
+		// identity must serialize different sources before the final duplicate check.
+		$lock_key = $this->acquireUpsertLock( $title, $startDate );
+		if ( null === $lock_key ) {
+			return array(
+				'success'    => false,
+				'error'      => 'Event upsert lock unavailable; retry the event.',
+				'error_code' => 'event_upsert_lock_unavailable',
+				'retryable'  => true,
+				'tool_name'  => static::class,
+			);
+		}
+
+		$identity_start = self::composeIdentityStart( $startDate, $start_time );
 
 		try {
-			return $this->executeUpsertWithinLock( $title, $venue, $startDate, $ticketUrl, $parameters, $handler_config, $engine );
+			return $this->executeUpsertWithinLock( $title, $venue, $identity_start, $ticketUrl, $parameters, $handler_config, $engine );
 		} finally {
 			$this->releaseUpsertLock( $lock_key );
 		}
@@ -555,8 +566,11 @@ class EventUpsert extends UpsertHandler {
 	 * Acquire a MySQL advisory lock for an event identity.
 	 *
 	 * Uses GET_LOCK() to serialize concurrent upserts for the same event.
-	 * Public ability calls use their source identity; workflow calls use the
-	 * date and normalized title so equivalent events queue instead of racing.
+	 * The key deliberately uses canonical fields rather than source identity so
+	 * different feeds converging on one event queue instead of racing. The lock
+	 * is date/title scoped; the duplicate strategy receives the full start time
+	 * and venue context, so distinct early/late or multi-room shows serialize
+	 * briefly but are not collapsed.
 	 *
 	 * MySQL advisory locks are:
 	 * - Per-connection (each PHP-FPM worker has its own connection)
@@ -566,47 +580,37 @@ class EventUpsert extends UpsertHandler {
 	 * @since 0.17.3
 	 * @param string $title           Event title.
 	 * @param string $startDate       Event start date.
-	 * @param string $source_identity Optional caller-supplied source identity.
-	 * @return string The lock key (needed for release).
+	 * @return string|null The acquired lock key, or null on timeout/error.
 	 */
-	private function acquireUpsertLock( string $title, string $startDate, string $source_identity = '' ): string {
+	private function acquireUpsertLock( string $title, string $startDate ): ?string {
 		global $wpdb;
 
 		$date_only  = self::extractDateForQuery( $startDate );
 		$normalized = SimilarityEngine::normalizeTitle( $title );
-		$lock_value = '' !== $source_identity ? 'source|' . $source_identity : $date_only . '|' . $normalized;
-		$lock_key   = 'dme_' . md5( $lock_value );
+		$blog_id    = get_current_blog_id();
+		$lock_key   = 'dme:' . $blog_id . ':' . md5( $date_only . '|' . $normalized );
 
-		// MySQL lock names are limited to 64 characters; md5 = 36 + prefix = 40, safe.
-		// Try up to 3 times with increasing timeouts (5s, 10s, 15s).
-		// If all attempts fail, proceed without lock — better to risk a dupe
-		// than deadlock the pipeline entirely.
-		$timeouts = array( 5, 10, 15 );
-		$acquired = false;
+		// MySQL/MariaDB lock names are limited to 64 characters. The fixed prefix,
+		// numeric site id, separator, and 32-character digest remain below that
+		// limit for WordPress's maximum signed BIGINT blog id.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$result = $wpdb->get_var( $wpdb->prepare( 'SELECT GET_LOCK(%s, %d)', $lock_key, 10 ) );
 
-		foreach ( $timeouts as $attempt => $timeout ) {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-			$result = $wpdb->get_var( $wpdb->prepare( 'SELECT GET_LOCK(%s, %d)', $lock_key, $timeout ) );
-
-			if ( '1' === (string) $result ) {
-				$acquired = true;
-				break;
-			}
-		}
-
-		if ( ! $acquired ) {
+		if ( '1' !== (string) $result ) {
 			do_action(
 				'datamachine_log',
 				'warning',
-				'Event Upsert: Advisory lock failed after 3 attempts, proceeding without lock',
+				'Event Upsert: Advisory lock unavailable; returning retryable failure',
 				array(
-					'lock_key'        => $lock_key,
-					'title'           => $title,
-					'startDate'       => $startDate,
-					'normalized'      => $normalized,
-					'total_wait_secs' => array_sum( $timeouts ),
+					'lock_key'   => $lock_key,
+					'title'      => $title,
+					'startDate'  => $startDate,
+					'normalized' => $normalized,
+					'result'     => null === $result ? 'error' : 'timeout',
 				)
 			);
+
+			return null;
 		}
 
 		return $lock_key;
@@ -639,6 +643,21 @@ class EventUpsert extends UpsertHandler {
 			return $matches[1];
 		}
 		return $datetime;
+	}
+
+	/**
+	 * Compose the time-aware identity used by duplicate detection.
+	 *
+	 * @param string $start_date Event start date or datetime.
+	 * @param string $start_time Event start time when stored separately.
+	 * @return string Date or datetime suitable for duplicate comparison.
+	 */
+	private static function composeIdentityStart( string $start_date, string $start_time ): string {
+		if ( '' === $start_time || preg_match( '/\d{2}:\d{2}/', $start_date ) ) {
+			return $start_date;
+		}
+
+		return trim( $start_date ) . ' ' . trim( $start_time );
 	}
 
 	/**

--- a/tests/Integration/EventUpsertMySqlConcurrencyTest.php
+++ b/tests/Integration/EventUpsertMySqlConcurrencyTest.php
@@ -22,8 +22,14 @@ class EventUpsertMySqlConcurrencyTest extends WP_UnitTestCase {
 		parent::setUp();
 
 		global $wpdb;
-		if ( ! extension_loaded( 'mysqli' ) || ! function_exists( 'pcntl_fork' ) || ! $wpdb->dbh instanceof \mysqli ) {
-			$this->markTestSkipped( 'Real MySQL and pcntl are required for advisory-lock integration coverage.' );
+		if ( ! extension_loaded( 'mysqli' ) ) {
+			$this->markTestSkipped( 'MySQL lock integration skipped: the mysqli extension is unavailable.' );
+		}
+		if ( ! function_exists( 'pcntl_fork' ) ) {
+			$this->markTestSkipped( 'MySQL lock integration skipped: pcntl_fork() is unavailable.' );
+		}
+		if ( ! $wpdb->dbh instanceof \mysqli ) {
+			$this->markTestSkipped( 'MySQL lock integration skipped: the configured WordPress test database is not MySQL (' . get_debug_type( $wpdb->dbh ) . ').' );
 		}
 		if ( ! post_type_exists( Event_Post_Type::POST_TYPE ) ) {
 			Event_Post_Type::register();
@@ -107,6 +113,17 @@ class EventUpsertMySqlConcurrencyTest extends WP_UnitTestCase {
 		$this->assertTrue( $result['success'] ?? false, wp_json_encode( $result ) );
 		$this->assertSame( $winner_id, (int) ( $result['data']['post_id'] ?? 0 ) );
 		$this->assertContains( $result['data']['action'] ?? '', array( 'updated', 'no_change' ) );
+		clean_post_cache( $winner_id );
+		$matching_posts = get_posts(
+			array(
+				'post_type'      => Event_Post_Type::POST_TYPE,
+				'post_status'    => 'any',
+				'title'          => $title,
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+			)
+		);
+		$this->assertSame( array( $winner_id ), array_map( 'intval', $matching_posts ), 'Exactly one canonical event must remain after the blocked loser rechecks.' );
 		$this->assertSame( 1, $this->lock( $waiter, $held, 0 ), 'The same lock must be acquirable after release.' );
 		$this->assertSame( 1, $this->release( $waiter, $held ) );
 

--- a/tests/Integration/EventUpsertMySqlConcurrencyTest.php
+++ b/tests/Integration/EventUpsertMySqlConcurrencyTest.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Real MySQL advisory-lock concurrency coverage.
+ *
+ * @package DataMachineEvents\Tests\Integration
+ */
+
+namespace DataMachineEvents\Tests\Integration;
+
+use DataMachine\Core\Database\PostIdentityIndex\PostIdentityIndex;
+use DataMachine\Core\EngineData;
+use DataMachineEvents\Core\DuplicateDetection\EventIdentityWriter;
+use DataMachineEvents\Core\EventDatesTable;
+use DataMachineEvents\Core\Event_Post_Type;
+use DataMachineEvents\Core\Venue_Taxonomy;
+use DataMachineEvents\Steps\Upsert\Events\EventUpsert;
+use WP_UnitTestCase;
+
+class EventUpsertMySqlConcurrencyTest extends WP_UnitTestCase {
+
+	public function setUp(): void {
+		parent::setUp();
+
+		global $wpdb;
+		if ( ! extension_loaded( 'mysqli' ) || ! function_exists( 'pcntl_fork' ) || ! $wpdb->dbh instanceof \mysqli ) {
+			$this->markTestSkipped( 'Real MySQL and pcntl are required for advisory-lock integration coverage.' );
+		}
+		if ( ! post_type_exists( Event_Post_Type::POST_TYPE ) ) {
+			Event_Post_Type::register();
+		}
+		if ( ! taxonomy_exists( 'venue' ) ) {
+			Venue_Taxonomy::register();
+		}
+		if ( ! EventDatesTable::table_exists() ) {
+			EventDatesTable::create_table();
+		}
+		( new PostIdentityIndex() )->create_table();
+	}
+
+	public function test_held_lock_excludes_times_out_releases_and_loser_reuses_winner(): void {
+		$title      = 'MySQL Concurrent Winner ' . uniqid();
+		$venue_name = 'MySQL Lock Venue ' . uniqid();
+		$venue      = wp_insert_term( $venue_name, 'venue' );
+		$this->assertNotWPError( $venue );
+
+		$handler = new EventUpsert();
+		$keys    = $this->lockKeys( $handler, $title, $venue_name, '2026-12-01 20:00' );
+		$held    = $keys[0];
+		$owner   = $this->connection();
+		$waiter  = $this->connection();
+
+		$this->assertSame( 1, $this->lock( $owner, $held, 0 ) );
+		$started = microtime( true );
+		$this->assertSame( 0, $this->lock( $waiter, $held, 1 ), 'A second real connection must time out while the lock is held.' );
+		$this->assertGreaterThanOrEqual( 0.8, microtime( true ) - $started );
+
+		$result_file = tempnam( sys_get_temp_dir(), 'dme-lock-' );
+		$pid         = pcntl_fork();
+		$this->assertNotSame( -1, $pid );
+
+		if ( 0 === $pid ) {
+			global $wpdb, $table_prefix;
+			$wpdb = new \wpdb( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST );
+			$wpdb->set_prefix( $table_prefix );
+			$child_handler = new EventUpsert();
+			$parameters    = array(
+				'title'     => $title,
+				'venue'     => $venue_name,
+				'startDate' => '2026-12-01',
+				'startTime' => '20:00',
+				'engine'    => new EngineData(
+					array(
+						'title'     => $title,
+						'venue'     => $venue_name,
+						'startDate' => '2026-12-01',
+						'startTime' => '20:00',
+					),
+					0
+				),
+				'job_id'    => 0,
+			);
+			$method        = new \ReflectionMethod( $child_handler, 'executeUpsert' );
+			$method->setAccessible( true );
+			$result = $method->invoke( $child_handler, $parameters, array( 'post_status' => 'publish', 'post_author' => 1 ) );
+			file_put_contents( $result_file, wp_json_encode( $result ) );
+			exit( 0 );
+		}
+
+		usleep( 300000 );
+		$winner_id = wp_insert_post(
+			array(
+				'post_title'   => $title,
+				'post_type'    => Event_Post_Type::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:data-machine-events/event-details {"startDate":"2026-12-01","startTime":"20:00"} --><div></div><!-- /wp:data-machine-events/event-details -->',
+			)
+		);
+		wp_set_object_terms( $winner_id, array( $venue['term_id'] ), 'venue' );
+		EventIdentityWriter::syncIdentityRow( $winner_id, $title );
+
+		$this->assertSame( 1, $this->release( $owner, $held ) );
+		pcntl_waitpid( $pid, $status );
+		$this->assertTrue( pcntl_wifexited( $status ) );
+		$result = json_decode( (string) file_get_contents( $result_file ), true );
+		unlink( $result_file );
+
+		$this->assertTrue( $result['success'] ?? false, wp_json_encode( $result ) );
+		$this->assertSame( $winner_id, (int) ( $result['data']['post_id'] ?? 0 ) );
+		$this->assertContains( $result['data']['action'] ?? '', array( 'updated', 'no_change' ) );
+		$this->assertSame( 1, $this->lock( $waiter, $held, 0 ), 'The same lock must be acquirable after release.' );
+		$this->assertSame( 1, $this->release( $waiter, $held ) );
+
+		$owner->close();
+		$waiter->close();
+	}
+
+	private function lockKeys( EventUpsert $handler, string $title, string $venue, string $start ): array {
+		$method = new \ReflectionMethod( $handler, 'buildUpsertLockKeys' );
+		$method->setAccessible( true );
+
+		return $method->invoke( $handler, $title, $venue, $start );
+	}
+
+	private function connection(): \mysqli {
+		$connection = mysqli_init();
+		$connection->real_connect( DB_HOST, DB_USER, DB_PASSWORD, DB_NAME );
+
+		return $connection;
+	}
+
+	private function lock( \mysqli $connection, string $key, int $timeout ): int {
+		$statement = $connection->prepare( 'SELECT GET_LOCK(?, ?)' );
+		$statement->bind_param( 'si', $key, $timeout );
+		$statement->execute();
+
+		return (int) $statement->get_result()->fetch_row()[0];
+	}
+
+	private function release( \mysqli $connection, string $key ): int {
+		$statement = $connection->prepare( 'SELECT RELEASE_LOCK(?)' );
+		$statement->bind_param( 's', $key );
+		$statement->execute();
+
+		return (int) $statement->get_result()->fetch_row()[0];
+	}
+}

--- a/tests/Integration/mysql-lock-smoke.php
+++ b/tests/Integration/mysql-lock-smoke.php
@@ -1,0 +1,93 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Standalone two-session MySQL advisory-lock contract smoke test.
+ *
+ * Environment:
+ * - DME_MYSQL_TEST_DSN=mysql:host=127.0.0.1;dbname=events_test
+ * - DME_MYSQL_TEST_USER
+ * - DME_MYSQL_TEST_PASSWORD
+ *
+ * @package DataMachineEvents\Tests\Integration
+ */
+
+$dsn = trim( (string) getenv( 'DME_MYSQL_TEST_DSN' ) );
+if ( '' === $dsn ) {
+	fwrite( STDOUT, "SKIP: DME_MYSQL_TEST_DSN is unavailable; no MySQL test endpoint was contacted.\n" );
+	exit( 0 );
+}
+
+if ( ! extension_loaded( 'pdo_mysql' ) ) {
+	fwrite( STDERR, "FAIL: DME_MYSQL_TEST_DSN is configured but pdo_mysql is unavailable.\n" );
+	exit( 1 );
+}
+
+if ( ! preg_match( '/(?:^|;)dbname=([^;]+)/i', $dsn, $matches ) || ! str_contains( strtolower( $matches[1] ), 'test' ) ) {
+	fwrite( STDERR, "FAIL: DME_MYSQL_TEST_DSN must name an explicit database containing 'test'; refusing a possible production endpoint.\n" );
+	exit( 1 );
+}
+
+$user     = (string) getenv( 'DME_MYSQL_TEST_USER' );
+$password = (string) getenv( 'DME_MYSQL_TEST_PASSWORD' );
+$options  = array(
+	PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+	PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_NUM,
+	PDO::ATTR_EMULATE_PREPARES   => false,
+);
+$owner    = null;
+$waiter   = null;
+$lock_key = 'dme-smoke:' . bin2hex( random_bytes( 12 ) );
+$exit_code = 0;
+
+$query_lock = static function ( PDO $connection, string $key, int $timeout ): int {
+	$statement = $connection->prepare( 'SELECT GET_LOCK(?, ?)' );
+	$statement->execute( array( $key, $timeout ) );
+
+	return (int) $statement->fetchColumn();
+};
+
+$release_lock = static function ( PDO $connection, string $key ): int {
+	$statement = $connection->prepare( 'SELECT RELEASE_LOCK(?)' );
+	$statement->execute( array( $key ) );
+
+	return (int) $statement->fetchColumn();
+};
+
+try {
+	$owner  = new PDO( $dsn, $user, $password, $options );
+	$waiter = new PDO( $dsn, $user, $password, $options );
+
+	if ( 1 !== $query_lock( $owner, $lock_key, 0 ) ) {
+		throw new RuntimeException( 'Owner session did not acquire the free lock.' );
+	}
+	if ( 0 !== $query_lock( $waiter, $lock_key, 0 ) ) {
+		throw new RuntimeException( 'Waiter session was not excluded while the owner held the lock.' );
+	}
+	if ( 1 !== $release_lock( $owner, $lock_key ) ) {
+		throw new RuntimeException( 'Owner session did not release its lock.' );
+	}
+	if ( 1 !== $query_lock( $waiter, $lock_key, 0 ) ) {
+		throw new RuntimeException( 'Waiter session did not acquire the lock after release.' );
+	}
+	if ( 1 !== $release_lock( $waiter, $lock_key ) ) {
+		throw new RuntimeException( 'Waiter session did not release its lock.' );
+	}
+
+	fwrite( STDOUT, "PASS: two MySQL sessions verified GET_LOCK exclusion, release, and reacquisition.\n" );
+} catch ( Throwable $throwable ) {
+	fwrite( STDERR, 'FAIL: ' . $throwable->getMessage() . "\n" );
+	$exit_code = 1;
+} finally {
+	foreach ( array( $owner, $waiter ) as $connection ) {
+		if ( ! $connection instanceof PDO ) {
+			continue;
+		}
+		try {
+			$release_lock( $connection, $lock_key );
+		} catch ( Throwable ) {
+			// Closing the session also releases any remaining named lock.
+		}
+	}
+}
+
+exit( $exit_code );

--- a/tests/Unit/EventDuplicateStrategyTest.php
+++ b/tests/Unit/EventDuplicateStrategyTest.php
@@ -335,6 +335,53 @@ class EventDuplicateStrategyTest extends WP_UnitTestCase {
 		$this->cleanup( $term_id, $existing_post_id );
 	}
 
+	public function test_low_confidence_replay_scans_all_same_day_exact_title_candidates(): void {
+		$venue_name = 'Multiple Showcase Venue ' . uniqid();
+		[ $term_id, $early_post_id ] = $this->seedVenueWithEvent( 'Showcase', '2026-05-22 13:00:00', $venue_name );
+
+		$late_post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Showcase',
+				'post_type'   => Event_Post_Type::POST_TYPE,
+				'post_status' => 'publish',
+			)
+		);
+		$this->assertGreaterThan( 0, $late_post_id );
+		wp_set_object_terms( $late_post_id, array( $term_id ), 'venue' );
+		EventDatesTable::upsert( $late_post_id, '2026-05-22 21:00:00' );
+		( new \DataMachine\Core\Database\PostIdentityIndex\PostIdentityIndex() )->upsert(
+			$late_post_id,
+			array(
+				'post_type'     => Event_Post_Type::POST_TYPE,
+				'event_date'    => '2026-05-22',
+				'venue_term_id' => $term_id,
+				'title_hash'    => EventDuplicateStrategy::computeTitleHash( 'Showcase' ),
+			)
+		);
+
+		$result = EventDuplicateStrategy::check(
+			array(
+				'title'   => 'Showcase',
+				'context' => array(
+					'venue'     => $venue_name,
+					'startDate' => '2026-05-22 21:30:00',
+					'ticketUrl' => '',
+				),
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $late_post_id, $result['match']['post_id'], 'Replay must skip the arbitrary early candidate and reuse the in-window late show.' );
+
+		global $wpdb;
+		foreach ( array( $early_post_id, $late_post_id ) as $post_id ) {
+			$wpdb->delete( $wpdb->prefix . 'datamachine_post_identity', array( 'post_id' => $post_id ), array( '%d' ) );
+			$wpdb->delete( EventDatesTable::table_name(), array( 'post_id' => $post_id ), array( '%d' ) );
+			wp_delete_post( $post_id, true );
+		}
+		wp_delete_term( $term_id, 'venue' );
+	}
+
 	// ---------------------------------------------------------------------
 	// check() — date-aware end-to-end cascade tests (#423)
 	// ---------------------------------------------------------------------

--- a/tests/Unit/EventUpsertAbilitiesTest.php
+++ b/tests/Unit/EventUpsertAbilitiesTest.php
@@ -18,6 +18,7 @@ use WP_UnitTestCase;
 class EventUpsertAbilitiesTest extends WP_UnitTestCase {
 
 	private EventUpsertAbilities $ability;
+	private \Closure $lock_query_filter;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -34,8 +35,21 @@ class EventUpsertAbilitiesTest extends WP_UnitTestCase {
 		if ( class_exists( PostIdentityIndex::class ) ) {
 			( new PostIdentityIndex() )->create_table();
 		}
+		$this->lock_query_filter = static function ( string $query ): string {
+			if ( str_contains( $query, 'GET_LOCK' ) || str_contains( $query, 'RELEASE_LOCK' ) ) {
+				return 'SELECT 1';
+			}
+
+			return $query;
+		};
+		add_filter( 'query', $this->lock_query_filter );
 
 		$this->ability = new EventUpsertAbilities();
+	}
+
+	public function tearDown(): void {
+		remove_filter( 'query', $this->lock_query_filter );
+		parent::tearDown();
 	}
 
 	public function test_creates_canonical_event_and_returns_normalized_metadata(): void {
@@ -100,6 +114,22 @@ class EventUpsertAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( 'ambiguous_venue', $result->get_error_code() );
 		$this->assertSame( 409, $result->get_error_data()['status'] );
 		$this->assertSame( 0, $this->countEventsWithTitle( $input['event']['title'] ) );
+	}
+
+	public function test_lock_timeout_preserves_retryable_transient_contract(): void {
+		$force_timeout = static function ( string $query ): string {
+			return str_contains( $query, 'GET_LOCK' ) ? 'SELECT 0' : $query;
+		};
+		add_filter( 'query', $force_timeout, 9 );
+
+		$result = $this->ability->executeUpsertEvent( $this->validInput() );
+
+		remove_filter( 'query', $force_timeout, 9 );
+		$this->assertWPError( $result );
+		$this->assertSame( 'event_upsert_lock_unavailable', $result->get_error_code() );
+		$this->assertSame( 503, $result->get_error_data()['status'] ?? null );
+		$this->assertTrue( $result->get_error_data()['retryable'] ?? false );
+		$this->assertTrue( $result->get_error_data()['transient'] ?? false );
 	}
 
 	private function validInput(): array {

--- a/tests/Unit/EventUpsertTest.php
+++ b/tests/Unit/EventUpsertTest.php
@@ -381,7 +381,7 @@ class EventUpsertTest extends WP_UnitTestCase {
 		$winner_id = 0;
 		$inserting = false;
 		$interleave = static function ( string $query ) use ( &$winner_id, &$inserting, $title, $venue ): string {
-			if ( $inserting || ! str_contains( $query, 'GET_LOCK' ) ) {
+			if ( $winner_id > 0 || $inserting || ! str_contains( $query, 'GET_LOCK' ) ) {
 				return $query;
 			}
 
@@ -430,6 +430,38 @@ class EventUpsertTest extends WP_UnitTestCase {
 			)
 		);
 		$this->assertCount( 1, $posts, 'The loser must not insert a second canonical event.' );
+	}
+
+	public function test_lock_domains_cover_source_updates_and_fuzzy_canonical_matches(): void {
+		$method = new \ReflectionMethod( $this->handler, 'buildUpsertLockKeys' );
+		$method->setAccessible( true );
+
+		$source_before = $method->invoke( $this->handler, 'Original Billing', 'Shared Venue', '2026-11-14 20:00', 'stable-source' );
+		$source_after  = $method->invoke( $this->handler, 'Corrected Billing', 'Moved Venue', '2026-11-15 21:00', 'stable-source' );
+		$this->assertNotEmpty( array_intersect( $source_before, $source_after ), 'A concrete source identity must serialize updates when canonical fields change.' );
+
+		$fuzzy_a = $method->invoke( $this->handler, 'The Falling Spikes Live', 'Shared Venue', '2026-11-14 19:59' );
+		$fuzzy_b = $method->invoke( $this->handler, 'Falling Spikes', 'Shared Venue', '2026-11-14 21:58' );
+		$this->assertNotEmpty( array_intersect( $fuzzy_a, $fuzzy_b ), 'Likely equivalents within two hours must share a canonical collision lock despite title variation.' );
+		$this->assertSame( $fuzzy_a, array_values( $fuzzy_a ) );
+		$sorted = $fuzzy_a;
+		sort( $sorted, SORT_STRING );
+		$this->assertSame( $sorted, $fuzzy_a, 'Every request must acquire lock keys in the same deterministic order.' );
+	}
+
+	public function test_lock_domains_separate_different_time_and_unknown_venue_events(): void {
+		$method = new \ReflectionMethod( $this->handler, 'buildUpsertLockKeys' );
+		$method->setAccessible( true );
+
+		$early = $method->invoke( $this->handler, 'Same Day Residency', 'Two Stage Venue', '2026-11-16 13:00' );
+		$late  = $method->invoke( $this->handler, 'Same Day Residency', 'Two Stage Venue', '2026-11-16 21:00' );
+		$this->assertSame( array(), array_intersect( $early, $late ), 'Known shows outside the duplicate time window must not contend.' );
+		$unknown_time = $method->invoke( $this->handler, 'Same Day Residency', 'Two Stage Venue', '2026-11-16' );
+		$this->assertNotEmpty( array_intersect( $early, $unknown_time ), 'A date-only source must serialize with a time-aware equivalent at the same venue.' );
+
+		$unknown_a = $method->invoke( $this->handler, 'Acoustic Matinee Session', '', '2026-11-16 13:00' );
+		$unknown_b = $method->invoke( $this->handler, 'Electronic Night Session', '', '2026-11-16 13:00' );
+		$this->assertSame( array(), array_intersect( $unknown_a, $unknown_b ), 'Unknown venues must be bounded by a stable title fingerprint.' );
 	}
 
 	/**

--- a/tests/Unit/EventUpsertTest.php
+++ b/tests/Unit/EventUpsertTest.php
@@ -432,6 +432,71 @@ class EventUpsertTest extends WP_UnitTestCase {
 		$this->assertCount( 1, $posts, 'The loser must not insert a second canonical event.' );
 	}
 
+	public function test_first_time_venue_alias_race_converges_through_address_lock(): void {
+		$title         = 'Address Alias Race ' . uniqid();
+		$winner_id     = 0;
+		$inserting     = false;
+		$winner_venue  = 'Monks ' . uniqid();
+		$incoming_name = $winner_venue . ' Jazz';
+		$interleave    = static function ( string $query ) use ( &$winner_id, &$inserting, $title, $winner_venue ): string {
+			if ( $winner_id > 0 || $inserting || ! str_contains( $query, 'GET_LOCK' ) ) {
+				return $query;
+			}
+
+			$inserting = true;
+			$term      = wp_insert_term( $winner_venue, 'venue' );
+			if ( is_wp_error( $term ) ) {
+				throw new \RuntimeException( $term->get_error_message() );
+			}
+			update_term_meta( $term['term_id'], '_venue_address', '3010 Minnehaha St' );
+			update_term_meta( $term['term_id'], '_venue_city', 'Minneapolis' );
+			$winner_id = wp_insert_post(
+				array(
+					'post_title'   => $title,
+					'post_type'    => Event_Post_Type::POST_TYPE,
+					'post_status'  => 'publish',
+					'post_content' => '<!-- wp:data-machine-events/event-details {"startDate":"2026-11-14","startTime":"20:00"} --><div></div><!-- /wp:data-machine-events/event-details -->',
+				)
+			);
+			wp_set_object_terms( $winner_id, array( $term['term_id'] ), 'venue' );
+			\DataMachineEvents\Core\DuplicateDetection\EventIdentityWriter::syncIdentityRow( $winner_id, $title );
+			$inserting = false;
+
+			return $query;
+		};
+		add_filter( 'query', $interleave, 9 );
+
+		try {
+			$result = $this->invoke_upsert(
+				array(
+					'title'        => $title,
+					'venue'        => $incoming_name,
+					'venueAddress' => '3010 Minnehaha Street Suite 420',
+					'venueCity'    => 'Minneapolis',
+					'startDate'    => '2026-11-14',
+					'startTime'    => '20:00',
+				)
+			);
+		} finally {
+			remove_filter( 'query', $interleave, 9 );
+		}
+
+		$this->assertTrue( $result['success'] ?? false, wp_json_encode( $result ) );
+		$this->assertSame( $winner_id, (int) ( $result['data']['post_id'] ?? 0 ) );
+		$this->assertCount(
+			1,
+			get_posts(
+				array(
+					'post_type'      => Event_Post_Type::POST_TYPE,
+					'post_status'    => 'any',
+					'title'          => $title,
+					'posts_per_page' => -1,
+				)
+			),
+			'First-time aliases sharing a normalized address must produce one canonical event.'
+		);
+	}
+
 	public function test_lock_domains_cover_source_updates_and_fuzzy_canonical_matches(): void {
 		$method = new \ReflectionMethod( $this->handler, 'buildUpsertLockKeys' );
 		$method->setAccessible( true );
@@ -443,6 +508,10 @@ class EventUpsertTest extends WP_UnitTestCase {
 		$fuzzy_a = $method->invoke( $this->handler, 'The Falling Spikes Live', 'Shared Venue', '2026-11-14 19:59' );
 		$fuzzy_b = $method->invoke( $this->handler, 'Falling Spikes', 'Shared Venue', '2026-11-14 21:58' );
 		$this->assertNotEmpty( array_intersect( $fuzzy_a, $fuzzy_b ), 'Likely equivalents within two hours must share a canonical collision lock despite title variation.' );
+
+		$alias_a = $method->invoke( $this->handler, 'Alias Show', 'Monks', '2026-11-14 20:00', '', array( 'address' => '3010 Minnehaha Street', 'city' => 'Minneapolis' ) );
+		$alias_b = $method->invoke( $this->handler, 'Alias Show', 'Monks Jazz', '2026-11-14 20:00', '', array( 'address' => '3010 Minnehaha St' ) );
+		$this->assertNotEmpty( array_intersect( $alias_a, $alias_b ), 'Venue aliases must share an address-derived lock even when one source has only partial geography.' );
 		$this->assertSame( $fuzzy_a, array_values( $fuzzy_a ) );
 		$sorted = $fuzzy_a;
 		sort( $sorted, SORT_STRING );
@@ -456,6 +525,10 @@ class EventUpsertTest extends WP_UnitTestCase {
 		$early = $method->invoke( $this->handler, 'Same Day Residency', 'Two Stage Venue', '2026-11-16 13:00' );
 		$late  = $method->invoke( $this->handler, 'Same Day Residency', 'Two Stage Venue', '2026-11-16 21:00' );
 		$this->assertSame( array(), array_intersect( $early, $late ), 'Known shows outside the duplicate time window must not contend.' );
+		$conservative_overlap = $method->invoke( $this->handler, 'Different Billing', 'Two Stage Venue', '2026-11-16 15:01' );
+		$distant             = $method->invoke( $this->handler, 'Another Billing', 'Two Stage Venue', '2026-11-16 17:01' );
+		$this->assertNotEmpty( array_intersect( $early, $conservative_overlap ), 'Adjacent two-hour buckets deliberately allow conservative overlap at 121 minutes.' );
+		$this->assertSame( array(), array_intersect( $early, $distant ), 'Distant non-overlapping bucket sets must remain parallel.' );
 		$unknown_time = $method->invoke( $this->handler, 'Same Day Residency', 'Two Stage Venue', '2026-11-16' );
 		$this->assertNotEmpty( array_intersect( $early, $unknown_time ), 'A date-only source must serialize with a time-aware equivalent at the same venue.' );
 

--- a/tests/Unit/EventUpsertTest.php
+++ b/tests/Unit/EventUpsertTest.php
@@ -506,6 +506,60 @@ class EventUpsertTest extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_lock_exception_after_partial_acquisition_releases_owned_locks(): void {
+		$title         = 'Partial Lock Exception ' . uniqid();
+		$get_calls     = 0;
+		$release_calls = 0;
+		$inject        = static function ( string $query ) use ( &$get_calls ): string {
+			if ( str_contains( $query, 'GET_LOCK' ) && 2 === ++$get_calls ) {
+				throw new \RuntimeException( 'Injected second-lock failure.' );
+			}
+
+			return $query;
+		};
+		$observe       = static function ( string $query ) use ( &$release_calls ): string {
+			if ( str_contains( $query, 'RELEASE_LOCK' ) ) {
+				++$release_calls;
+			}
+
+			return $query;
+		};
+		add_filter( 'query', $observe, 8 );
+		add_filter( 'query', $inject, 9 );
+
+		try {
+			$result = $this->invoke_upsert(
+				array(
+					'title'     => $title,
+					'venue'     => 'Exception Lock Venue',
+					'startDate' => '2026-10-12',
+					'startTime' => '20:00',
+				)
+			);
+		} finally {
+			remove_filter( 'query', $inject, 9 );
+			remove_filter( 'query', $observe, 8 );
+		}
+
+		$this->assertFalse( $result['success'] ?? true );
+		$this->assertSame( 'event_upsert_lock_unavailable', $result['error_code'] ?? '' );
+		$this->assertTrue( $result['retryable'] ?? false );
+		$this->assertSame( 2, $get_calls, 'The exception must occur after one lock was acquired.' );
+		$this->assertSame( 1, $release_calls, 'The partial acquisition must release its one owned lock.' );
+		$this->assertSame(
+			array(),
+			get_posts(
+				array(
+					'post_type'      => Event_Post_Type::POST_TYPE,
+					'post_status'    => 'any',
+					'title'          => $title,
+					'posts_per_page' => -1,
+					'fields'         => 'ids',
+				)
+			)
+		);
+	}
+
 	/**
 	 * The duplicate strategy must receive time even when import payloads split it
 	 * from the date, preserving legitimate same-day early and late shows.

--- a/tests/Unit/EventUpsertTest.php
+++ b/tests/Unit/EventUpsertTest.php
@@ -24,6 +24,7 @@ use DataMachineEvents\Blocks\Calendar\Query\UpcomingFilter;
 class EventUpsertTest extends WP_UnitTestCase {
 
 	private EventUpsert $handler;
+	private \Closure $lock_query_filter;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -41,9 +42,117 @@ class EventUpsertTest extends WP_UnitTestCase {
 		if ( class_exists( PostIdentityIndex::class ) ) {
 			( new PostIdentityIndex() )->create_table();
 		}
+		$ability_registry = \WP_Abilities_Registry::get_instance();
+		if ( ! $ability_registry->is_registered( 'datamachine/upsert-post' ) ) {
+			$category_registry = \WP_Ability_Categories_Registry::get_instance();
+			$register_category = static function () use ( $category_registry ): void {
+				if ( ! $category_registry->is_registered( 'datamachine-content' ) ) {
+					wp_register_ability_category(
+						'datamachine-content',
+						array(
+							'label'       => 'Data Machine Content',
+							'description' => 'Test content abilities.',
+						)
+					);
+				}
+			};
+			add_action( 'wp_abilities_api_categories_init', $register_category );
+			do_action( 'wp_abilities_api_categories_init' );
+			remove_action( 'wp_abilities_api_categories_init', $register_category );
+
+			$register_upsert = static function () use ( $ability_registry ): void {
+				if ( $ability_registry->is_registered( 'datamachine/upsert-post' ) ) {
+					return;
+				}
+
+				wp_register_ability(
+					'datamachine/upsert-post',
+					array(
+						'label'               => 'Test Upsert Post',
+						'description'         => 'Test-only post upsert boundary.',
+						'category'            => 'datamachine-content',
+						'input_schema'        => array( 'type' => 'object' ),
+						'output_schema'       => array( 'type' => 'object' ),
+						'permission_callback' => '__return_true',
+						'execute_callback'    => static function ( array $input ): array {
+							$post_id = (int) ( $input['post_id'] ?? 0 );
+							$postarr  = array(
+								'post_title'   => $input['title'],
+								'post_content' => $input['content'],
+								'post_type'    => $input['post_type'],
+								'post_status'  => $input['post_status'] ?? 'publish',
+								'meta_input'   => $input['meta_input'] ?? array(),
+							);
+
+							if ( $post_id > 0 ) {
+								$postarr['ID'] = $post_id;
+								$result        = wp_update_post( $postarr, true );
+								$action        = 'updated';
+							} else {
+								$postarr['post_author'] = (int) ( $input['post_author'] ?? 0 );
+								$result                 = wp_insert_post( $postarr, true );
+								$action                 = 'created';
+							}
+
+							if ( is_wp_error( $result ) ) {
+								return array( 'success' => false, 'error' => $result->get_error_message() );
+							}
+
+							return array( 'success' => true, 'post_id' => (int) $result, 'action' => $action );
+						},
+					)
+				);
+			};
+			add_action( 'wp_abilities_api_init', $register_upsert );
+			do_action( 'wp_abilities_api_init' );
+			remove_action( 'wp_abilities_api_init', $register_upsert );
+		}
+		if ( ! $ability_registry->is_registered( 'datamachine/check-duplicate' ) ) {
+			$register_duplicate_check = static function () use ( $ability_registry ): void {
+				if ( $ability_registry->is_registered( 'datamachine/check-duplicate' ) ) {
+					return;
+				}
+
+				wp_register_ability(
+					'datamachine/check-duplicate',
+					array(
+						'label'               => 'Test Duplicate Check',
+						'description'         => 'Test-only event duplicate boundary.',
+						'category'            => 'datamachine-content',
+						'input_schema'        => array( 'type' => 'object' ),
+						'output_schema'       => array( 'type' => 'object' ),
+						'permission_callback' => '__return_true',
+						'execute_callback'    => static function ( array $input ): array {
+							return \DataMachineEvents\Core\DuplicateDetection\EventDuplicateStrategy::check( $input )
+								?? array( 'verdict' => 'clear' );
+						},
+					)
+				);
+			};
+			add_action( 'wp_abilities_api_init', $register_duplicate_check );
+			do_action( 'wp_abilities_api_init' );
+			remove_action( 'wp_abilities_api_init', $register_duplicate_check );
+		}
 		CacheInvalidator::init();
 
+		// WordPress Playground's SQLite runtime does not implement MySQL named
+		// locks. Unit tests emulate successful acquisition/release; contention
+		// coverage overrides GET_LOCK at an earlier filter priority.
+		$this->lock_query_filter = static function ( string $query ): string {
+			if ( str_contains( $query, 'GET_LOCK' ) || str_contains( $query, 'RELEASE_LOCK' ) ) {
+				return 'SELECT 1';
+			}
+
+			return $query;
+		};
+		add_filter( 'query', $this->lock_query_filter );
+
 		$this->handler = new EventUpsert();
+	}
+
+	public function tearDown(): void {
+		remove_filter( 'query', $this->lock_query_filter );
+		parent::tearDown();
 	}
 
 	public function test_handler_instantiation() {
@@ -255,6 +364,175 @@ class EventUpsertTest extends WP_UnitTestCase {
 		$this->assertSame( (string) $venue->term_id, (string) ( new PostIdentityIndex() )->get( $post_id )['venue_term_id'] );
 		$this->assertSame( 1, $cache_invalidations, 'A no_change taxonomy repair must invalidate canonical caches exactly once.' );
 		$this->assertFalse( get_transient( $cache_key ), 'Taxonomy-only repair must invalidate calendar caches.' );
+	}
+
+	/**
+	 * A competing writer can commit after this request starts but before its
+	 * lock-protected duplicate check. The protected recheck must reuse that row.
+	 *
+	 * @see https://github.com/Extra-Chill/data-machine-events/issues/123
+	 */
+	public function test_concurrent_winner_is_reused_after_lock_acquisition(): void {
+		$title      = 'Concurrent Canonical Winner ' . uniqid();
+		$venue_name = 'Concurrent Winner Venue ' . uniqid();
+		$venue      = wp_insert_term( $venue_name, 'venue' );
+		$this->assertNotWPError( $venue );
+
+		$winner_id = 0;
+		$inserting = false;
+		$interleave = static function ( string $query ) use ( &$winner_id, &$inserting, $title, $venue ): string {
+			if ( $inserting || ! str_contains( $query, 'GET_LOCK' ) ) {
+				return $query;
+			}
+
+			$inserting = true;
+			$winner_id = wp_insert_post(
+				array(
+					'post_title'   => $title,
+					'post_type'    => Event_Post_Type::POST_TYPE,
+					'post_status'  => 'publish',
+					'post_content' => '<!-- wp:data-machine-events/event-details {"startDate":"2026-11-14","startTime":"20:00"} --><div class="wp-block-data-machine-events-event-details"></div><!-- /wp:data-machine-events/event-details -->',
+				)
+			);
+			wp_set_object_terms( $winner_id, array( $venue['term_id'] ), 'venue' );
+			\DataMachineEvents\Core\DuplicateDetection\EventIdentityWriter::syncIdentityRow( $winner_id, $title );
+			$inserting = false;
+
+			return $query;
+		};
+		add_filter( 'query', $interleave, 9 );
+
+		$result = $this->invoke_upsert(
+			array(
+				'title'           => $title,
+				'venue'           => $venue_name,
+				'startDate'       => '2026-11-14',
+				'startTime'       => '20:00',
+				'description'     => 'The losing concurrent writer must update or reuse the winner.',
+				'source_identity' => 'venue-direct:event-123',
+			)
+		);
+
+		remove_filter( 'query', $interleave, 9 );
+
+		$this->assertGreaterThan( 0, $winner_id, 'The deterministic competing writer must insert first.' );
+		$this->assertTrue( $result['success'] ?? false, wp_json_encode( $result ) );
+		$this->assertSame( $winner_id, (int) ( $result['data']['post_id'] ?? 0 ) );
+		$this->assertContains( $result['data']['action'] ?? '', array( 'updated', 'no_change' ) );
+
+		$posts = get_posts(
+			array(
+				'post_type'      => Event_Post_Type::POST_TYPE,
+				'post_status'    => 'any',
+				'title'          => $title,
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+			)
+		);
+		$this->assertCount( 1, $posts, 'The loser must not insert a second canonical event.' );
+	}
+
+	/**
+	 * Lock contention must never reopen the race by continuing unlocked.
+	 *
+	 * @see https://github.com/Extra-Chill/data-machine-events/issues/123
+	 */
+	public function test_lock_timeout_returns_retryable_failure_without_writing(): void {
+		$title = 'Contended Event ' . uniqid();
+		$force_timeout = static function ( string $query ): string {
+			return str_contains( $query, 'GET_LOCK' ) ? 'SELECT 0' : $query;
+		};
+		add_filter( 'query', $force_timeout, 9 );
+
+		$result = $this->invoke_upsert(
+			array(
+				'title'           => $title,
+				'venue'           => 'Contended Venue',
+				'startDate'       => '2026-11-15',
+				'startTime'       => '21:00',
+				'source_identity' => 'ticketmaster:event-456',
+			)
+		);
+
+		remove_filter( 'query', $force_timeout, 9 );
+
+		$this->assertFalse( $result['success'] ?? true );
+		$this->assertTrue( $result['retryable'] ?? false );
+		$this->assertSame( 'event_upsert_lock_unavailable', $result['error_code'] ?? '' );
+		$this->assertSame(
+			array(),
+			get_posts(
+				array(
+					'post_type'      => Event_Post_Type::POST_TYPE,
+					'post_status'    => 'any',
+					'title'          => $title,
+					'posts_per_page' => -1,
+					'fields'         => 'ids',
+				)
+			),
+			'A timed-out request must not write without canonical serialization.'
+		);
+	}
+
+	/**
+	 * The duplicate strategy must receive time even when import payloads split it
+	 * from the date, preserving legitimate same-day early and late shows.
+	 *
+	 * @see https://github.com/Extra-Chill/data-machine-events/issues/219
+	 */
+	public function test_same_title_venue_and_date_outside_time_window_creates_distinct_event(): void {
+		$title      = 'Same Day Residency ' . uniqid();
+		$venue_name = 'Two Stage Venue ' . uniqid();
+		$config     = array(
+			'post_status' => 'publish',
+			'post_author' => self::factory()->user->create( array( 'role' => 'administrator' ) ),
+		);
+
+		$early = $this->invoke_upsert(
+			array(
+				'title'     => $title,
+				'venue'     => $venue_name,
+				'startDate' => '2026-11-16',
+				'startTime' => '13:00',
+			),
+			$config
+		);
+		$late = $this->invoke_upsert(
+			array(
+				'title'     => $title,
+				'venue'     => $venue_name,
+				'startDate' => '2026-11-16',
+				'startTime' => '21:00',
+			),
+			$config
+		);
+
+		$this->assertTrue( $early['success'] ?? false, wp_json_encode( $early ) );
+		$this->assertTrue( $late['success'] ?? false, wp_json_encode( $late ) );
+		$this->assertSame( 'created', $early['data']['action'] ?? '' );
+		$this->assertSame( 'created', $late['data']['action'] ?? '' );
+		$this->assertNotSame( $early['data']['post_id'] ?? 0, $late['data']['post_id'] ?? 0 );
+	}
+
+	/**
+	 * Invoke the protected upsert entry point with normal engine context.
+	 *
+	 * @param array $parameters Event parameters.
+	 * @param array $config     Handler configuration.
+	 * @return array Upsert result.
+	 */
+	private function invoke_upsert( array $parameters, array $config = array() ): array {
+		$method = new \ReflectionMethod( $this->handler, 'executeUpsert' );
+		$method->setAccessible( true );
+		$parameters['engine'] = new EngineData( $parameters, 0 );
+		$parameters['job_id'] = 0;
+
+		if ( empty( $config['post_author'] ) ) {
+			$config['post_author'] = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		}
+		$config['post_status'] = $config['post_status'] ?? 'publish';
+
+		return $method->invoke( $this->handler, $parameters, $config );
 	}
 
 	public function test_save_post_normalizes_implicit_overnight_end_time(): void {


### PR DESCRIPTION
## Summary
- serialize source updates and cross-source canonical convergence with globally ordered MySQL/MariaDB advisory-lock sets
- preserve retryable transient lock failures through the public upsert ability as HTTP 503
- scan every same-day exact-title candidate and compose split start date/time values before duplicate matching
- cover deterministic races, partial acquisition exceptions, and real two-session MySQL lock behavior

Closes #123.

## Identity granularity
Each request acquires a globally sorted set of 36-character `dme:{md5}` keys:
- source scope: site/blog ID plus concrete `source_identity`, when present, so source updates serialize even if canonical fields change
- primary venue scope: resolved venue term ID, normalized venue name, or bounded unknown-venue title fingerprint
- geography scope: whenever a usable normalized street address is supplied, its address-derived canonical keys are added alongside the primary venue keys; optional city/state/country do not perturb this key, so partial geography and first-time aliases such as `Monks` / `Monks Jazz` converge
- time scope: calendar date plus the event's two-hour bucket and its predecessor
- date-only events: the finite 12 venue/day buckets, allowing them to overlap time-aware equivalents

## Bounded correctness tradeoff
The time lock is a conservative adjacent-bucket collision domain, not an exact `<= 2 hours` range. Unrelated titles at the same site/date/venue or normalized address can serialize briefly, and starts beyond 120 minutes can still overlap when their adjacent bucket sets share a key (the regression suite documents a 121-minute case). This is deliberate: fuzzy canonical equivalence has no exact narrow lock key, and minute-level keys would create an unbounded lock explosion.

Different venue/geography scopes and distant non-overlapping bucket sets remain parallel. Locking only serializes the final decision; duplicate detection still decides whether records merge, so false serialization cannot collapse distinct events.

## Lock contract
- every source, venue, geography, and time key is generated before acquisition and sorted lexicographically
- one 10-second total deadline covers the complete key set
- duplicate/source checks are rerun only after every key is acquired
- the entire acquisition loop is wrapped in `try/catch/finally`
- timeout, database exception, or injected exception after partial acquisition releases every owned key
- release attempts are isolated so one release exception cannot prevent remaining releases
- successful upsert paths release every lock in their outer `finally`
- connection loss releases named locks automatically

## Timeout and deadlock behavior
A `GET_LOCK` timeout (`0`), database error (`NULL`), or thrown acquisition exception never proceeds unlocked. Internal and public results preserve:
- error code `event_upsert_lock_unavailable`
- `retryable: true`
- `transient: true` at the ability boundary
- HTTP status `503` at the ability boundary

Global key ordering prevents lock-order cycles. The one total deadline prevents indefinite queue blocking.

## Exact-title candidate handling
The prior composite lookup returned one arbitrary row. Exact-title resolution now inspects every indexed candidate on the event date, filters by title hash, and applies time/venue confirmation to each. A low-confidence replay can skip an out-of-window early show and reuse the correct late show.

## Query impact
A known-time event acquires two keys per active canonical scope: normally two primary venue keys, plus two address-derived keys when usable address data exists, plus one optional source key. Date-only identities acquire up to 12 keys per active canonical scope. All calls are immediate unless a request in the same bounded collision domain is active. Exact-title fallback reads all identity rows for one event date so confirmation is complete.

## Tests
- focused Playground correction suite: 7 tests, 29 assertions, 1 explicit non-MySQL skip
- first-time venue alias race: different names sharing normalized address converge on one canonical post
- geography key coverage: address+city and address-only inputs share a key deterministically
- bucket contract: 121-minute conservative overlap is documented; distant bucket sets remain parallel
- partial acquisition exception: second lock throws, first lock releases, no write occurs
- public ability: retryable/transient `event_upsert_lock_unavailable` with status 503 remains covered
- low-confidence replay: multiple same-day exact-title shows select the in-window candidate
- plugin MySQL integration retains exclusion/timeout/release and final exactly-one-post assertions; retried locally, but the available WordPress harness is SQLite and reports an explicit skip
- standalone two-session MySQL smoke runs against CI's isolated `homeboy_wptests` DSN and passes; it skips only when no DSN is configured and rejects database names not containing `test`
- PHPCS and PHPStan level 7: zero findings
- Homeboy PR audit: zero introduced findings
- PHP syntax and `git diff --check`: passed

## Infrastructure note
The repository's Homeboy PHPUnit CI still crashes before PHPUnit because the action ignores the declared `data-machine` validation dependency; tracked separately at Extra-Chill/homeboy#9754. The standalone MySQL lock contract step runs before that harness and passes against the isolated MySQL service.

## Rollout
This changes only future upsert serialization and duplicate selection. It adds no schema or parallel storage and does not mutate existing content. Historical duplicate cleanup remains a separate explicit operator action; this PR does not merge, trash, dedupe, release, or deploy production events.