### PR TITLE
Allow scoped event upsert authorization

### DIFF
--- a/inc/Abilities/EventUpsertAbilities.php
+++ b/inc/Abilities/EventUpsertAbilities.php
@@ -41,7 +41,7 @@ class EventUpsertAbilities {
 				'input_schema'        => $this->getInputSchema(),
 				'output_schema'       => $this->getOutputSchema(),
 				'execute_callback'    => array( $this, 'executeUpsertEvent' ),
-				'permission_callback' => AbilityPermissions::canWrite(),
+				'permission_callback' => array( $this, 'canUpsertEvent' ),
 				'meta'                => array(
 					'show_in_rest' => true,
 					'mcp'          => array( 'public' => true ),
@@ -53,6 +53,29 @@ class EventUpsertAbilities {
 				),
 			)
 		);
+	}
+
+	/**
+	 * Check access to the canonical event upsert boundary.
+	 *
+	 * The ability keeps the shared write gate as its default. Consumers may
+	 * narrowly grant or deny this one operation from the validated ability
+	 * input without changing permissions for unrelated event mutations.
+	 *
+	 * @param array $input Validated ability input.
+	 * @return bool
+	 */
+	public function canUpsertEvent( array $input = array() ): bool {
+		$can_write = AbilityPermissions::canWrite();
+		$allowed   = (bool) $can_write();
+
+		/**
+		 * Filter permission for the canonical event upsert ability only.
+		 *
+		 * @param bool  $allowed Shared DME write-gate decision.
+		 * @param array $input   Validated event-upsert input.
+		 */
+		return (bool) apply_filters( 'datamachine_events_upsert_event_permission', $allowed, $input );
 	}
 
 	/**

--- a/tests/Unit/EventUpsertAbilitiesTest.php
+++ b/tests/Unit/EventUpsertAbilitiesTest.php
@@ -8,6 +8,7 @@
 namespace DataMachineEvents\Tests\Unit;
 
 use DataMachine\Core\Database\PostIdentityIndex\PostIdentityIndex;
+use DataMachineEvents\Abilities\AbilityPermissions;
 use DataMachineEvents\Abilities\EventUpsertAbilities;
 use DataMachineEvents\Core\EventDatesTable;
 use DataMachineEvents\Core\Event_Post_Type;
@@ -49,7 +50,51 @@ class EventUpsertAbilitiesTest extends WP_UnitTestCase {
 
 	public function tearDown(): void {
 		remove_filter( 'query', $this->lock_query_filter );
+		remove_all_filters( 'datamachine_events_upsert_event_permission' );
+		wp_set_current_user( 0 );
 		parent::tearDown();
+	}
+
+	public function test_upsert_permission_uses_shared_write_gate_by_default(): void {
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id );
+
+		$this->assertTrue( $this->ability->canUpsertEvent( $this->validInput() ) );
+	}
+
+	public function test_upsert_permission_denies_callers_without_write_access(): void {
+		$subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $subscriber_id );
+
+		$this->assertFalse( $this->ability->canUpsertEvent( $this->validInput() ) );
+	}
+
+	public function test_upsert_permission_can_narrowly_grant_from_input(): void {
+		$subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $subscriber_id );
+		$input = $this->validInput();
+
+		add_filter(
+			'datamachine_events_upsert_event_permission',
+			static function ( bool $allowed, array $candidate ) use ( $input ): bool {
+				return $allowed || $input['event']['venue'] === ( $candidate['event']['venue'] ?? '' );
+			},
+			10,
+			2
+		);
+
+		$this->assertTrue( $this->ability->canUpsertEvent( $input ) );
+	}
+
+	public function test_upsert_permission_filter_does_not_widen_other_write_abilities(): void {
+		$subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $subscriber_id );
+		add_filter( 'datamachine_events_upsert_event_permission', '__return_true' );
+
+		$can_write = AbilityPermissions::canWrite();
+
+		$this->assertTrue( $this->ability->canUpsertEvent( $this->validInput() ) );
+		$this->assertFalse( $can_write() );
 	}
 
 	public function test_creates_canonical_event_and_returns_normalized_metadata(): void {

--- a/tests/event-upsert-permission-smoke.php
+++ b/tests/event-upsert-permission-smoke.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Standalone smoke test for event-upsert permission isolation.
+ *
+ * @package DataMachineEvents\Tests
+ */
+
+// phpcs:disable -- Standalone smoke doubles intentionally use global WordPress function names and state.
+
+define( 'ABSPATH', __DIR__ );
+
+$dme_test_capabilities = array();
+$dme_test_filters      = array();
+
+function add_action(): void {}
+
+function current_user_can( string $capability ): bool {
+	global $dme_test_capabilities;
+
+	return ! empty( $dme_test_capabilities[ $capability ] );
+}
+
+function add_filter( string $hook, callable $callback ): void {
+	global $dme_test_filters;
+
+	$dme_test_filters[ $hook ][] = $callback;
+}
+
+function remove_all_filters( string $hook ): void {
+	global $dme_test_filters;
+
+	unset( $dme_test_filters[ $hook ] );
+}
+
+function apply_filters( string $hook, mixed $value, mixed ...$args ): mixed {
+	global $dme_test_filters;
+
+	foreach ( $dme_test_filters[ $hook ] ?? array() as $callback ) {
+		$value = $callback( $value, ...$args );
+	}
+
+	return $value;
+}
+
+function dme_assert_permission( bool $expected, bool $actual, string $message ): void {
+	if ( $expected !== $actual ) {
+		fwrite( STDERR, "FAIL: {$message}\n" );
+		exit( 1 );
+	}
+}
+
+require_once dirname( __DIR__ ) . '/inc/Abilities/AbilityPermissions.php';
+require_once dirname( __DIR__ ) . '/inc/Abilities/EventUpsertAbilities.php';
+
+use DataMachineEvents\Abilities\AbilityPermissions;
+use DataMachineEvents\Abilities\EventUpsertAbilities;
+
+$ability = new EventUpsertAbilities();
+$input   = array(
+	'source'    => 'booking',
+	'source_id' => '42',
+	'event'     => array( 'venue' => 'Scoped Hall' ),
+);
+
+dme_assert_permission( false, $ability->canUpsertEvent( $input ), 'default gate denies an unprivileged caller' );
+
+$dme_test_capabilities['edit_others_posts'] = true;
+dme_assert_permission( true, $ability->canUpsertEvent( $input ), 'default gate allows an editor' );
+
+$dme_test_capabilities = array();
+add_filter(
+	'datamachine_events_upsert_event_permission',
+	static fn( bool $allowed, array $candidate ): bool => $allowed || 'Scoped Hall' === ( $candidate['event']['venue'] ?? '' )
+);
+dme_assert_permission( true, $ability->canUpsertEvent( $input ), 'narrow filter grants the matching upsert' );
+
+$other_write_gate = AbilityPermissions::canWrite();
+dme_assert_permission( false, $other_write_gate(), 'narrow filter does not widen another write ability' );
+
+remove_all_filters( 'datamachine_events_upsert_event_permission' );
+$dme_test_capabilities['edit_others_posts'] = true;
+add_filter( 'datamachine_events_upsert_event_permission', static fn(): bool => false );
+dme_assert_permission( false, $ability->canUpsertEvent( $input ), 'narrow filter may explicitly deny an editor' );
+
+fwrite( STDOUT, "Event upsert permission smoke passed (5 assertions).\n" );


### PR DESCRIPTION
## Summary
- preserve the existing shared DME write gate as the canonical event-upsert default
- add `datamachine_events_upsert_event_permission` for narrow input-aware authorization of this ability only
- prove the narrow grant does not widen venue, merge, geocoding, resync, or other DME write abilities

## Verification
- standalone permission contract smoke: 5 assertions passed
- changed-file Homeboy PHPCS/PHPStan passed before the unrelated local extension PHPStan binary became unavailable
- focused WordPress tests added for default grant, default denial, narrow grant, and isolation
- WP Codebox currently fails before test discovery while loading DME's Data Machine validation dependency; no focused test failures occurred

Closes #527

Related: Extra-Chill/extrachill-events#297