### PR TITLE
fix: clear release-blocking PHPCS alignment warnings

### DIFF
--- a/inc/Cli/Check/CheckMissingVenueAddressesCommand.php
+++ b/inc/Cli/Check/CheckMissingVenueAddressesCommand.php
@@ -297,7 +297,7 @@ class CheckMissingVenueAddressesCommand {
 	 * @return array<int,string> Meta keys that were (or would be) filled.
 	 */
 	private function apply_smart_merge( int $term_id, array $components, bool $dry_run ): array {
-		$filled = array();
+		$filled  = array();
 		$pending = array();
 
 		foreach ( self::ADDRESS_META_KEYS as $field => $meta_key ) {

--- a/inc/Core/VenueProfileMutations.php
+++ b/inc/Core/VenueProfileMutations.php
@@ -311,8 +311,8 @@ class VenueProfileMutations {
 			if ( false === static::query( 'COMMIT' ) ) {
 				$transaction_open       = false;
 				$connection_quarantined = true;
-				$quarantine              = self::quarantineConnection( $term_id );
-				$quarantine_closed       = $quarantine['closed'];
+				$quarantine             = self::quarantineConnection( $term_id );
+				$quarantine_closed      = $quarantine['closed'];
 				return new \WP_Error(
 					'venue_commit_uncertain',
 					'The database did not confirm the venue commit; the connection was quarantined and callers must read again before retrying.',
@@ -348,8 +348,8 @@ class VenueProfileMutations {
 			if ( $transaction_open ) {
 				if ( false === static::query( 'ROLLBACK' ) ) {
 					$connection_quarantined = true;
-					$quarantine              = self::quarantineConnection( $term_id );
-					$quarantine_closed       = $quarantine['closed'];
+					$quarantine             = self::quarantineConnection( $term_id );
+					$quarantine_closed      = $quarantine['closed'];
 				}
 				self::clearCaches( $term_id );
 			}
@@ -397,8 +397,8 @@ class VenueProfileMutations {
 	 */
 	private static function inTransaction(): bool|\WP_Error {
 		global $wpdb;
-		$probe           = 'dme_venue_probe_' . substr( md5( uniqid( '', true ) ), 0, 12 );
-		$suppress_errors = $wpdb->suppress_errors();
+		$probe            = 'dme_venue_probe_' . substr( md5( uniqid( '', true ) ), 0, 12 );
+		$suppress_errors  = $wpdb->suppress_errors();
 		$wpdb->last_error = '';
 		$created          = static::query( 'SAVEPOINT ' . $probe );
 		$released         = false !== $created ? static::query( 'RELEASE SAVEPOINT ' . $probe ) : false;
@@ -563,8 +563,8 @@ class VenueProfileMutations {
 		if ( false === static::query( 'ROLLBACK' ) ) {
 			$transaction_open       = false;
 			$connection_quarantined = true;
-			$quarantine              = self::quarantineConnection( $term_id );
-			$quarantine_closed       = $quarantine['closed'];
+			$quarantine             = self::quarantineConnection( $term_id );
+			$quarantine_closed      = $quarantine['closed'];
 			return new \WP_Error(
 				'venue_rollback_uncertain',
 				'The database did not confirm the venue rollback; the connection was quarantined.',
@@ -600,7 +600,7 @@ class VenueProfileMutations {
 			);
 		}
 		self::$native_term_locks = array();
-		$recovered = true === $wpdb->check_connection( false );
+		$recovered               = true === $wpdb->check_connection( false );
 		if ( $recovered ) {
 			self::clearCaches( $term_id );
 		}


### PR DESCRIPTION
## Summary
- align assignments flagged by the 10 auto-fixable PHPCS findings
- preserve behavior and the explicit non-fixable reserved-keyword advisory
- leave changelog and version targets untouched

## Verification
- `homeboy --placement local review lint` (0 errors, 1 non-fixable warning, 0 auto-fixable findings; PHPStan passed)
- `php -l inc/Core/VenueProfileMutations.php`
- `php -l inc/Cli/Check/CheckMissingVenueAddressesCommand.php`
- `git diff --check`

Closes #537