### PR TITLE
test: separate portable calendar contracts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,14 @@
             "DataMachineEvents\\": "inc/"
         }
     },
+    "scripts": {
+        "test": [
+            "@test:contracts",
+            "@test:wordpress"
+        ],
+        "test:contracts": "phpunit --configuration phpunit.contracts.xml",
+        "test:wordpress": "phpunit --configuration phpunit.xml"
+    },
     "authors": [
         {
             "name": "Chris Huber",

--- a/phpunit.contracts.xml
+++ b/phpunit.contracts.xml
@@ -1,4 +1,5 @@
 <phpunit
+	bootstrap="tests/contract-bootstrap.php"
 	backupGlobals="false"
 	colors="true"
 	convertErrorsToExceptions="true"
@@ -6,9 +7,8 @@
 	convertWarningsToExceptions="true"
 >
 	<testsuites>
-		<testsuite name="Data Machine Events">
-			<directory suffix="Test.php">tests/Unit</directory>
-			<directory suffix="Test.php">tests/Integration</directory>
+		<testsuite name="Portable CalendarOccurrence Contracts">
+			<directory suffix="Test.php">tests/Contracts</directory>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/tests/Contracts/CalendarOccurrenceContractTest.php
+++ b/tests/Contracts/CalendarOccurrenceContractTest.php
@@ -2,10 +2,10 @@
 /**
  * Canonical calendar occurrence artifact tests.
  *
- * @package DataMachineEvents\Tests\Unit
+ * @package DataMachineEvents\Tests\Contracts
  */
 
-namespace DataMachineEvents\Tests\Unit;
+namespace DataMachineEvents\Tests\Contracts;
 
 use PHPUnit\Framework\TestCase;
 use DataMachineEvents\Api\Controllers\Calendar;


### PR DESCRIPTION
## Summary
- isolate CalendarOccurrence contracts behind `phpunit.contracts.xml` and `tests/contract-bootstrap.php`
- restrict normal WordPress PHPUnit discovery to `tests/Unit` and `tests/Integration`, preventing duplicate contract collection
- expose focused Composer commands plus a full sequential test entrypoint while preserving opt-in fixture regeneration

## Verification
- `composer test:contracts` (3 tests, 57 assertions)
- `DME_UPDATE_CONTRACT_FIXTURES=1 composer test:contracts` (3 tests, 57 assertions; checked-in fixture SHA-256 and git diff unchanged)
- `vendor/bin/phpunit --configuration phpunit.contracts.xml --list-tests` (exactly three CalendarOccurrence contract methods)
- contract bootstrap PHP-only check confirmed neither `WP_UnitTestCase` nor `$wpdb` loaded
- normal WordPress discovery was invoked through Homeboy; the harness failed before PHPUnit when its managed MySQL 8.4 Docker service could not provision. The normal config structurally includes only `tests/Unit` and `tests/Integration`, so `tests/Contracts` cannot be collected there; CI remains the canonical full MySQL verification.

Closes #544