### PR TITLE
fix: clear root asset JavaScript lint

### DIFF
--- a/assets/js/pipeline-components.js
+++ b/assets/js/pipeline-components.js
@@ -279,7 +279,7 @@
 	addFilter(
 		'datamachine.handlerSettings.fieldComponent',
 		'data-machine-events/address-autocomplete',
-		function( component, fieldType, fieldKey, handlerSlug ) {
+		function( component, fieldType ) {
 			if ( fieldType === 'address-autocomplete' ) {
 				return AddressAutocompleteField;
 			}

--- a/assets/js/pipeline-hooks.js
+++ b/assets/js/pipeline-hooks.js
@@ -36,7 +36,9 @@
 
 	/**
 	 * Check if a value is a valid venue term ID (numeric string or number)
-	 * @param value
+	 *
+	 * @param {string|number} value Potential venue term ID.
+	 * @return {boolean} Whether the value is a venue term ID.
 	 */
 	function isValidVenueTermId( value ) {
 		if ( ! value ) {
@@ -47,7 +49,9 @@
 
 	/**
 	 * Fetch venue data from REST API and map to form fields
-	 * @param venueId
+	 *
+	 * @param {string|number} venueId Venue term ID.
+	 * @return {Promise<Object<string, string>|null>} Mapped venue fields.
 	 */
 	async function fetchVenueData( venueId ) {
 		const response = await apiFetch( {
@@ -86,7 +90,7 @@
 	addFilter(
 		'datamachine.handlerSettings.init',
 		'data-machine-events/venue-enrichment',
-		async function( settingsPromise, handlerSlug, fieldsSchema ) {
+		async function( settingsPromise ) {
 			const settings = await settingsPromise;
 
 			if ( ! isValidVenueTermId( settings.venue ) ) {
@@ -98,8 +102,8 @@
 				if ( venueData ) {
 					return { ...settings, ...venueData };
 				}
-			} catch ( error ) {
-				console.error( 'DM Events: Failed to load venue data:', error );
+			} catch {
+				// Venue enrichment is optional; retain the original settings on failure.
 			}
 
 			return settings;
@@ -116,7 +120,7 @@
 	addFilter(
 		'datamachine.handlerSettings.fieldChange',
 		'data-machine-events/venue-change',
-		async function( changesPromise, fieldKey, value, handlerSlug, currentData ) {
+		async function( changesPromise, fieldKey, value ) {
 			const changes = await changesPromise;
 
 			if ( fieldKey !== 'venue' ) {
@@ -129,8 +133,8 @@
 					if ( venueData ) {
 						return { ...changes, ...venueData };
 					}
-				} catch ( error ) {
-					console.error( 'DM Events: Failed to load venue data on change:', error );
+				} catch {
+					// Keep the selected value when its optional metadata cannot be loaded.
 				}
 			} else {
 				return { ...changes, ...getEmptyVenueFields() };

--- a/assets/js/venue-autocomplete.js
+++ b/assets/js/venue-autocomplete.js
@@ -11,6 +11,10 @@
 (function() {
     'use strict';
 
+    /** @typedef {Object<string, string>} NominatimAddress */
+
+    /** @typedef {{display_name: string, address: (NominatimAddress|undefined)}} NominatimPlace */
+
     // Nominatim API configuration
     const NOMINATIM_API = 'https://nominatim.openstreetmap.org/search';
     // User-Agent is localized from PHP off the deploying site host so a
@@ -53,7 +57,7 @@
 
     /**
      * Setup autocomplete for a single field
-     * @param field
+     * @param {HTMLInputElement} field Address input.
      */
     function setupAutocomplete(field) {
         // Wrap field in container
@@ -88,7 +92,7 @@
 
     /**
      * Handle input event with debouncing
-     * @param e
+     * @param {Event} e Input event.
      */
     function handleInput(e) {
         const field = e.target;
@@ -116,7 +120,7 @@
 
     /**
      * Handle keyboard navigation
-     * @param e
+     * @param {KeyboardEvent} e Keyboard event.
      */
     function handleKeydown(e) {
         const field = e.target;
@@ -157,7 +161,7 @@
 
     /**
      * Update visual selection in dropdown
-     * @param items
+     * @param {NodeList} items Dropdown items.
      */
     function updateSelection(items) {
         items.forEach((item, index) => {
@@ -172,8 +176,8 @@
 
     /**
      * Search address using Nominatim API
-     * @param field
-     * @param query
+     * @param {HTMLInputElement} field Address input.
+     * @param {string}           query Address query.
      */
     function searchAddress(field, query) {
         // Check cache first
@@ -223,16 +227,15 @@
             cacheResults(query, data);
             displayResults(field, data);
         })
-        .catch(error => {
-            console.error('Venue autocomplete error:', error);
+        .catch(() => {
             showError(field, 'Failed to load address suggestions. Please try again.');
         });
     }
 
     /**
      * Display search results in dropdown
-     * @param field
-     * @param results
+     * @param {HTMLInputElement} field   Address input.
+     * @param {NominatimPlace[]} results Search results.
      */
     function displayResults(field, results) {
         const dropdown = field.autocompleteDropdown;
@@ -244,7 +247,7 @@
             return;
         }
 
-        results.forEach((place, index) => {
+        results.forEach(place => {
             const item = document.createElement('div');
             item.className = 'venue-autocomplete-item';
             item.innerHTML = `
@@ -264,8 +267,8 @@
 
     /**
      * Select a place and populate dependent fields
-     * @param field
-     * @param place
+     * @param {HTMLInputElement} field Address input.
+     * @param {NominatimPlace}   place Selected place.
      */
     function selectPlace(field, place) {
         const address = place.address || {};
@@ -308,7 +311,7 @@
 
     /**
      * Build street address from Nominatim address components
-     * @param address
+     * @param {NominatimAddress} address Structured address.
      */
     function buildStreetAddress(address) {
         const components = [];
@@ -328,8 +331,8 @@
 
     /**
      * Set value of a dependent field
-     * @param fieldName
-     * @param value
+     * @param {string} fieldName Dependent field name.
+     * @param {string} value     Field value.
      */
     function setFieldValue(fieldName, value) {
         // Try multiple selector strategies to find the field
@@ -352,7 +355,7 @@
 
     /**
      * Show loading state
-     * @param field
+     * @param {HTMLInputElement} field Address input.
      */
     function showLoading(field) {
         const dropdown = field.autocompleteDropdown;
@@ -363,8 +366,8 @@
 
     /**
      * Show error message
-     * @param field
-     * @param message
+     * @param {HTMLInputElement} field   Address input.
+     * @param {string}           message Error message.
      */
     function showError(field, message) {
         const dropdown = field.autocompleteDropdown;
@@ -386,8 +389,8 @@
 
     /**
      * Cache results in sessionStorage
-     * @param query
-     * @param results
+     * @param {string}           query   Address query.
+     * @param {NominatimPlace[]} results Search results.
      */
     function cacheResults(query, results) {
         try {
@@ -397,15 +400,15 @@
                 timestamp: Date.now()
             };
             sessionStorage.setItem(CACHE_KEY, JSON.stringify(cache));
-        } catch (e) {
+        } catch {
             // SessionStorage might be full or unavailable
-            console.warn('Failed to cache autocomplete results:', e);
         }
     }
 
     /**
      * Get cached results if available and not expired
-     * @param query
+     * @param {string} query Address query.
+     * @return {NominatimPlace[]|null} Cached results, if fresh.
      */
     function getCachedResults(query) {
         try {
@@ -415,8 +418,8 @@
             if (cached && (Date.now() - cached.timestamp < CACHE_EXPIRY)) {
                 return cached.results;
             }
-        } catch (e) {
-            console.warn('Failed to retrieve cached results:', e);
+        } catch {
+            return null;
         }
 
         return null;
@@ -429,7 +432,7 @@
         try {
             const cacheStr = sessionStorage.getItem(CACHE_KEY);
             return cacheStr ? JSON.parse(cacheStr) : {};
-        } catch (e) {
+        } catch {
             return {};
         }
     }
@@ -465,7 +468,8 @@
 
     /**
      * Escape HTML to prevent XSS
-     * @param text
+     * @param {string} text Text to escape.
+     * @return {string} Escaped HTML.
      */
     function escapeHtml(text) {
         const div = document.createElement('div');

--- a/assets/js/venue-map.js
+++ b/assets/js/venue-map.js
@@ -23,8 +23,7 @@
         }
 
         // Check if Leaflet is loaded
-        if (typeof L === 'undefined') {
-            console.error('Leaflet library not loaded. Cannot initialize venue maps.');
+        if (!window.L) {
             return;
         }
 
@@ -35,7 +34,7 @@
 
     /**
      * Initialize a single venue map
-     * @param container
+     * @param {HTMLElement} container Map container.
      */
     function initSingleMap(container) {
         // Get map data from attributes
@@ -47,7 +46,6 @@
 
         // Validate coordinates
         if (isNaN(lat) || isNaN(lon)) {
-            console.warn('Invalid coordinates for venue map:', { lat, lon });
             container.innerHTML = '<p style="padding: 20px; text-align: center; color: #666;">Map unavailable (invalid coordinates)</p>';
             return;
         }
@@ -59,7 +57,7 @@
 
         try {
             // Create the map
-            const map = L.map(container.id).setView([lat, lon], 15);
+            const map = window.L.map(container.id).setView([lat, lon], 15);
 
             // Get tile layer configuration based on map type
             const tileConfigs = {
@@ -88,14 +86,14 @@
             const tileConfig = tileConfigs[mapType] || tileConfigs['osm-standard'];
 
             // Add tile layer with selected configuration
-            L.tileLayer(tileConfig.url, {
+            window.L.tileLayer(tileConfig.url, {
                 attribution: '', // Attribution handled in template
                 maxZoom: 19,
                 minZoom: 10
             }).addTo(map);
 
             // Create custom emoji marker icon
-            const emojiIcon = L.divIcon({
+            const emojiIcon = window.L.divIcon({
                 html: '<span style="font-size: 32px; line-height: 1; display: block;">📍</span>',
                 className: 'emoji-marker',
                 iconSize: [32, 32],
@@ -104,7 +102,7 @@
             });
 
             // Add marker with emoji icon
-            const marker = L.marker([lat, lon], { icon: emojiIcon }).addTo(map);
+            const marker = window.L.marker([lat, lon], { icon: emojiIcon }).addTo(map);
 
             // Create popup content
             let popupContent = `<div class="venue-popup"><strong>${escapeHtml(venueName)}</strong>`;
@@ -124,15 +122,15 @@
                 map.invalidateSize();
             }, 100);
 
-        } catch (error) {
-            console.error('Error initializing venue map:', error);
+        } catch {
             container.innerHTML = '<p style="padding: 20px; text-align: center; color: #666;">Map failed to load</p>';
         }
     }
 
     /**
      * Escape HTML to prevent XSS
-     * @param text
+     * @param {string} text Text to escape.
+     * @return {string} Escaped HTML.
      */
     function escapeHtml(text) {
         const div = document.createElement('div');

--- a/assets/js/venue-selector.js
+++ b/assets/js/venue-selector.js
@@ -49,7 +49,7 @@
 
     /**
      * Handle venue dropdown change event
-     * @param e
+     * @param {Event} e Change event.
      */
     function handleVenueChange(e) {
         const termId = e.target.value;
@@ -68,7 +68,7 @@
     /**
      * Toggle venue_name field visibility
      * Show when creating new venue, hide when editing existing
-     * @param show
+     * @param {boolean} show Whether to show the field.
      */
     function toggleVenueNameField(show) {
         const venueNameField = document.querySelector('[name="venue_name"]');
@@ -98,10 +98,11 @@
     /**
      * Load venue data via REST API and populate fields
      *
-     * @param {number} termId Venue term ID
+     * @param {string} termId Venue term ID
      */
     function loadVenueData(termId) {
-        if (!termId || typeof dmEventsVenue === 'undefined') {
+        const config = window.dmEventsVenue;
+        if (!termId || !config) {
             return;
         }
 
@@ -109,10 +110,10 @@
         const loadingIndicator = showLoadingState();
 
         // Make REST API request
-        fetch(dmEventsVenue.restUrl + '/events/venues/' + termId, {
+        fetch(config.restUrl + '/events/venues/' + termId, {
             method: 'GET',
             headers: {
-                'X-WP-Nonce': dmEventsVenue.nonce
+                'X-WP-Nonce': config.nonce
             }
         })
         .then(function(response) {
@@ -124,14 +125,12 @@
             if (data.success && data.data) {
                 populateVenueFields(data.data);
             } else {
-                console.error('DM Events: Failed to load venue data', data);
-                alert('Failed to load venue data. Please try again.');
+                showErrorState('Failed to load venue data. Please try again.');
             }
         })
-        .catch(function(error) {
+        .catch(function() {
             hideLoadingState(loadingIndicator);
-            console.error('DM Events: Error loading venue data', error);
-            alert('Error loading venue data. Please check your connection and try again.');
+            showErrorState('Error loading venue data. Please check your connection and try again.');
         });
     }
 
@@ -201,9 +200,31 @@
     }
 
     /**
+     * Show an inline venue loading error.
+     *
+     * @param {string} message Error message.
+     */
+    function showErrorState(message) {
+        const previousNotice = document.querySelector('.data-machine-events-venue-error');
+        if (previousNotice) {
+            previousNotice.remove();
+        }
+
+        const notice = document.createElement('div');
+        notice.className = 'notice notice-error inline data-machine-events-venue-error';
+        const text = document.createElement('p');
+        text.textContent = message;
+        notice.appendChild(text);
+
+        if (venueSelector && venueSelector.parentNode) {
+            venueSelector.parentNode.insertBefore(notice, venueSelector.nextSibling);
+        }
+    }
+
+    /**
      * Get changed fields by comparing current values with originals
      *
-     * @return {Object} Object containing only changed fields
+     * @return {Object<string, string>} Object containing only changed fields
      */
     function getChangedFields() {
         const changes = {};
@@ -228,10 +249,11 @@
      *
      * @param {string} venueName    Venue name
      * @param {string} venueAddress Venue address
-     * @return {Promise} Promise resolving to true if can proceed, false if duplicate
+     * @return {Promise<boolean>} Whether venue creation can proceed.
      */
     function checkDuplicateVenue(venueName, venueAddress) {
-        if (!venueName || typeof dmEventsVenue === 'undefined') {
+        const config = window.dmEventsVenue;
+        if (!venueName || !config) {
             return Promise.resolve(true);
         }
 
@@ -241,10 +263,10 @@
             address: venueAddress || ''
         });
 
-        return fetch(dmEventsVenue.restUrl + '/events/venues/check-duplicate?' + params.toString(), {
+        return fetch(config.restUrl + '/events/venues/check-duplicate?' + params.toString(), {
             method: 'GET',
             headers: {
-                'X-WP-Nonce': dmEventsVenue.nonce
+                'X-WP-Nonce': config.nonce
             }
         })
         .then(function(response) {
@@ -255,15 +277,69 @@
                 const message = data.data.message ||
                     'A venue with this name and address already exists. Create duplicate anyway?';
 
-                return confirm(message);
+                return confirmDuplicate(message);
             }
 
             return true;
         })
-        .catch(function(error) {
-            console.error('DM Events: Error checking duplicate venue', error);
+        .catch(function() {
             // On error, allow creation (fail open)
             return true;
+        });
+    }
+
+    /**
+     * Ask whether a duplicate venue should be created.
+     *
+     * @param {string} message Confirmation message.
+     * @return {Promise<boolean>} Whether duplicate creation was confirmed.
+     */
+    function confirmDuplicate(message) {
+        return new Promise(function(resolve) {
+            const dialog = document.createElement('dialog');
+            dialog.className = 'data-machine-events-confirm';
+
+            const text = document.createElement('p');
+            text.textContent = message;
+            dialog.appendChild(text);
+
+            const actions = document.createElement('div');
+            actions.className = 'data-machine-events-confirm-actions';
+
+            const cancelButton = document.createElement('button');
+            cancelButton.type = 'button';
+            cancelButton.className = 'button';
+            cancelButton.textContent = 'Cancel';
+
+            const confirmButton = document.createElement('button');
+            confirmButton.type = 'button';
+            confirmButton.className = 'button button-primary';
+            confirmButton.textContent = 'Create Duplicate';
+
+            actions.appendChild(cancelButton);
+            actions.appendChild(confirmButton);
+            dialog.appendChild(actions);
+            document.body.appendChild(dialog);
+
+            function finish(confirmed) {
+                dialog.close();
+                dialog.remove();
+                resolve(confirmed);
+            }
+
+            cancelButton.addEventListener('click', function() {
+                finish(false);
+            });
+            confirmButton.addEventListener('click', function() {
+                finish(true);
+            });
+            dialog.addEventListener('cancel', function(event) {
+                event.preventDefault();
+                finish(false);
+            });
+
+            dialog.showModal();
+            confirmButton.focus();
         });
     }
 


### PR DESCRIPTION
## Summary
- clear all Homeboy ESLint findings from the five maintained root JavaScript assets
- use precise browser, Leaflet, and localized plugin globals with concrete JSDoc types
- replace debug console and blocking alert flows with existing inline errors and accessible duplicate confirmation

## Verification
- `homeboy review lint --placement local --glob 'assets/js/*.js'` (5 files, zero findings)
- Calendar: `npm test` (29 tests passed) and `npm run build`
- EventDetails: `npm run build`
- EventDetails: `npm run test:unit` reports no tests found because the package currently contains no unit tests
- EventsMap: `npm run build` (no test script declared)

Closes #550