### PR TITLE
fix: clear Calendar source lint findings

### DIFF
--- a/inc/Blocks/Calendar/src/frontend.test.ts
+++ b/inc/Blocks/Calendar/src/frontend.test.ts
@@ -49,6 +49,9 @@ jest.mock( './modules/month-grid-response-renderer', () => ( {
 	),
 } ) );
 
+/**
+ * Internal dependencies
+ */
 import { renderMonthGridResponse } from './modules/month-grid-response-renderer';
 import { initCalendarInstance } from './frontend';
 

--- a/inc/Blocks/Calendar/src/frontend.ts
+++ b/inc/Blocks/Calendar/src/frontend.ts
@@ -52,6 +52,7 @@ function isMonthGridMode( calendar: HTMLElement ): boolean {
  * emitted server-side in render.php and read here the same way
  * `isMonthGridMode` reads `data-display-mode`. Multi-day scopes
  * (this-week/this-weekend) keep the carousel. #428.
+ * @param calendar
  */
 function isSingleDayScope( calendar: HTMLElement ): boolean {
 	const scope = calendar.getAttribute( 'data-scope' );
@@ -287,6 +288,7 @@ function initSearchInput( calendar: HTMLElement ): void {
  * set server-side. In grid mode (#318) the month-grid controller
  * re-fetches the data envelope and swaps the grid in place so the
  * visible month doesn't reset.
+ * @param calendar
  */
 function handleFilterChange( calendar: HTMLElement ): void {
 	const filterState = getFilterState( calendar );
@@ -323,6 +325,7 @@ function handleMonthGridChange(
 
 /**
  * Navigate to URL with params (full page reload).
+ * @param params
  */
 function navigateToUrl( params: URLSearchParams ): void {
 	const queryString = params.toString();
@@ -347,6 +350,7 @@ window.addEventListener( 'beforeunload', function () {
 		.forEach( function ( calendar ) {
 			destroyDatePicker( calendar );
 			destroyCarousel( calendar );
+			destroyFilterModal( calendar );
 			destroyLazyRender( calendar );
 			destroyDayLoader( calendar );
 			destroyGeoSync( calendar );

--- a/inc/Blocks/Calendar/src/modules/api-client.ts
+++ b/inc/Blocks/Calendar/src/modules/api-client.ts
@@ -2,6 +2,9 @@
  * REST API communication and calendar DOM updates.
  */
 
+/**
+ * Internal dependencies
+ */
 import type {
 	ArchiveContext,
 	CalendarRequest,
@@ -71,6 +74,11 @@ const CALENDAR_PASSTHROUGH_KEYS: ( keyof CalendarRequest )[] = [
  * resets `paged` on geo change) can `params.delete( 'paged' )` on
  * the returned object — the helper intentionally does not encode
  * deletion semantics so the override semantics stay simple.
+ * @param opts
+ * @param opts.archiveContext
+ * @param opts.geoContext
+ * @param opts.overrides
+ * @param opts.source
  */
 export function buildCalendarRequest(
 	opts: {
@@ -200,7 +208,7 @@ export async function fetchCalendarEvents(
 
 		return data;
 	} catch ( error ) {
-		console.error( 'Error fetching filtered events:', error );
+		window.console.error( 'Error fetching filtered events:', error );
 		content.innerHTML =
 			'<div class="data-machine-events-error"><p>Error loading events. Please try again.</p></div>';
 		return {
@@ -218,6 +226,12 @@ export async function fetchCalendarEvents(
 /**
  * Fetch filter options from REST API with active filters, date context,
  * archive context, and geo context.
+ * @param activeFilters
+ * @param dateContext
+ * @param archiveContext
+ * @param geoContext
+ * @param requestContext
+ * @param signal
  */
 export async function fetchFilters(
 	activeFilters: TaxFilters = {},

--- a/inc/Blocks/Calendar/src/modules/carousel.test.ts
+++ b/inc/Blocks/Calendar/src/modules/carousel.test.ts
@@ -6,7 +6,13 @@ jest.mock(
 	{ virtual: true }
 );
 
+/**
+ * WordPress dependencies
+ */
 import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
 import { initCarousel } from './carousel';
 
 const mockTranslate = __ as jest.Mock;
@@ -89,7 +95,7 @@ describe( 'calendar carousel controls', () => {
 
 		next.focus();
 		next.click();
-		expect( document.activeElement ).toBe( next );
+		expect( calendar.ownerDocument.activeElement ).toBe( next );
 		expect( wrapper.scrollBy ).toHaveBeenCalledWith( {
 			left: 300,
 			behavior: 'smooth',

--- a/inc/Blocks/Calendar/src/modules/date-group-renderer.ts
+++ b/inc/Blocks/Calendar/src/modules/date-group-renderer.ts
@@ -32,6 +32,9 @@
  * way `DisplayVars::build` does for time strings.
  */
 
+/**
+ * Internal dependencies
+ */
 import { renderEventCard } from './event-renderer';
 
 import type {
@@ -42,11 +45,11 @@ import type {
 /**
  * Render a complete date group with its embedded event cards.
  *
- * @param date         The `Y-m-d` date this group represents.
- * @param occurrences  Per-occurrence list from `grouping.by_date[date]`.
- * @param eventsById   Lookup map from `event.id` → CalendarEventItem.
- *                     Built once at the call site so multi-day events
- *                     aren't deserialized repeatedly.
+ * @param date        The `Y-m-d` date this group represents.
+ * @param occurrences Per-occurrence list from `grouping.by_date[date]`.
+ * @param eventsById  Lookup map from `event.id` → CalendarEventItem.
+ *                    Built once at the call site so multi-day events
+ *                    aren't deserialized repeatedly.
  */
 export function renderDateGroup(
 	date: string,
@@ -117,6 +120,7 @@ export function renderDateGroup(
  * shift). `new Date( 'YYYY-MM-DD' )` parses as UTC midnight and can
  * roll over the weekday in negative offsets; explicit constructor
  * avoids that.
+ * @param date
  */
 function parseLocalDate( date: string ): Date | null {
 	const parts = date.split( '-' );
@@ -167,6 +171,7 @@ function weekdayName( date: Date ): string {
  * Server canonical format lives in
  * `EventRenderer::render_date_groups()` (`$date_obj->format( 'l, F jS' )`).
  * Mirror it locally because the data envelope only ships `Y-m-d`.
+ * @param date
  */
 function formatDateLabel( date: Date ): string {
 	const weekday = WEEKDAY_NAMES[ date.getDay() ] || '';

--- a/inc/Blocks/Calendar/src/modules/date-picker.ts
+++ b/inc/Blocks/Calendar/src/modules/date-picker.ts
@@ -7,6 +7,9 @@
  */
 import flatpickr from 'flatpickr';
 
+/**
+ * Internal dependencies
+ */
 import type { FlatpickrInstance } from '../types';
 
 interface DatePickerData {

--- a/inc/Blocks/Calendar/src/modules/day-loader.ts
+++ b/inc/Blocks/Calendar/src/modules/day-loader.ts
@@ -13,6 +13,9 @@
  * - If the user scrolls fast, at most they see a brief skeleton
  */
 
+/**
+ * Internal dependencies
+ */
 import type { ArchiveContext } from '../types';
 import { buildCalendarRequest } from './api-client';
 import { initLazyRender } from './lazy-render';
@@ -97,6 +100,10 @@ export function destroyDayLoader( calendar: HTMLElement ): void {
  * Prefetch all deferred days sequentially (in display order).
  * Each fetch starts as soon as the previous one completes,
  * so we don't slam the server with concurrent requests.
+ * @param wrappers
+ * @param calendar
+ * @param archiveContext
+ * @param geoContext
  */
 async function prefetchAllDays(
 	wrappers: NodeListOf< HTMLElement >,
@@ -143,6 +150,9 @@ async function prefetchAllDays(
 
 /**
  * Fetch a single day's events HTML from REST.
+ * @param date
+ * @param archiveContext
+ * @param geoContext
  */
 async function fetchDayHtml(
 	date: string,
@@ -200,6 +210,9 @@ async function fetchDayHtml(
 
 /**
  * Inject fetched HTML into a deferred wrapper.
+ * @param wrapper
+ * @param html
+ * @param calendar
  */
 function injectDayHtml(
 	wrapper: HTMLElement,
@@ -229,6 +242,10 @@ function injectDayHtml(
 
 /**
  * Show error UI in a failed wrapper with retry.
+ * @param wrapper
+ * @param calendar
+ * @param archiveContext
+ * @param geoContext
  */
 function showError(
 	wrapper: HTMLElement,

--- a/inc/Blocks/Calendar/src/modules/event-renderer.ts
+++ b/inc/Blocks/Calendar/src/modules/event-renderer.ts
@@ -20,6 +20,9 @@
  * exactly one place (PHP) that knows how to format an event. See #381.
  */
 
+/**
+ * Internal dependencies
+ */
 import type {
 	CalendarEventItem,
 	CalendarEventOccurrence,
@@ -219,6 +222,7 @@ function renderBadges( event: CalendarEventItem ): HTMLElement | null {
  * produced by `Taxonomy\Badges::render_taxonomy_badges()` — a single
  * `.data-machine-taxonomy-badges` wrapper element — so we lift that first
  * element child out of the parse container.
+ * @param badgesHtml
  */
 function renderServerBadges( badgesHtml?: string ): HTMLElement | null {
 	const html = ( badgesHtml || '' ).trim();

--- a/inc/Blocks/Calendar/src/modules/filter-modal.test.ts
+++ b/inc/Blocks/Calendar/src/modules/filter-modal.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import { destroyFilterModal, initFilterModal } from './filter-modal';
 import { destroyFilterState } from './filter-state';
 

--- a/inc/Blocks/Calendar/src/modules/filter-modal.ts
+++ b/inc/Blocks/Calendar/src/modules/filter-modal.ts
@@ -295,13 +295,14 @@ async function loadFilters(
 	const container = modal.querySelector< HTMLElement >(
 		'.data-machine-filter-taxonomies'
 	);
-	const loading = modal.querySelector< HTMLElement >(
-		'.data-machine-filter-loading'
-	);
 
 	if ( ! container ) {
 		return;
 	}
+
+	const loading = modal.querySelector< HTMLElement >(
+		'.data-machine-filter-loading'
+	);
 
 	modal._filterAbortController?.abort();
 	const controller = new AbortController();

--- a/inc/Blocks/Calendar/src/modules/filter-state.test.ts
+++ b/inc/Blocks/Calendar/src/modules/filter-state.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import { getFilterState, destroyFilterState } from './filter-state';
 
 const STORAGE_KEY = 'data_machine_events_calendar_state';

--- a/inc/Blocks/Calendar/src/modules/filter-state.ts
+++ b/inc/Blocks/Calendar/src/modules/filter-state.ts
@@ -8,6 +8,9 @@
  * Archive context is read from DOM data attributes (page-level, not user state).
  */
 
+/**
+ * Internal dependencies
+ */
 import type {
 	ArchiveContext,
 	DateContext,
@@ -177,6 +180,7 @@ class FilterStateManager {
 	/**
 	 * Build URLSearchParams from current UI state.
 	 * Reads from: search input, date picker, filter checkboxes, location input.
+	 * @param datePicker
 	 */
 	buildParams( datePicker: FlatpickrInstance | null = null ): URLSearchParams {
 		const params = new URLSearchParams();
@@ -283,6 +287,8 @@ class FilterStateManager {
 
 	/**
 	 * Apply shareable URL state back to controls after history navigation.
+	 * @param params
+	 * @param datePicker
 	 */
 	applyParams(
 		params: URLSearchParams,
@@ -331,10 +337,11 @@ class FilterStateManager {
 		if ( datePicker ) {
 			const start = params.get( 'date_start' );
 			const end = params.get( 'date_end' );
-			datePicker.setDate(
-				start ? ( end ? [ start, end ] : start ) : [],
-				false
-			);
+			let selectedDates: string | string[] = [];
+			if ( start ) {
+				selectedDates = end ? [ start, end ] : start;
+			}
+			datePicker.setDate( selectedDates, false );
 			this.calendar
 				.querySelector( '.data-machine-events-date-clear-btn' )
 				?.classList.toggle( 'visible', Boolean( start ) );
@@ -363,6 +370,7 @@ class FilterStateManager {
 
 	/**
 	 * Update URL via History API and save state to localStorage.
+	 * @param params
 	 */
 	updateUrl( params: URLSearchParams ): void {
 		const queryString = params.toString();
@@ -376,6 +384,7 @@ class FilterStateManager {
 
 	/**
 	 * Save taxonomy filters to localStorage (not dates or geo — geo has its own storage).
+	 * @param params
 	 */
 	saveToStorage( params: URLSearchParams ): void {
 		if ( ! this.isPersistenceEnabled() ) {
@@ -410,6 +419,7 @@ class FilterStateManager {
 
 	/**
 	 * Save geo state to localStorage.
+	 * @param geo
 	 */
 	saveGeoToStorage( geo: StoredGeo ): void {
 		try {
@@ -459,6 +469,7 @@ class FilterStateManager {
 	 * history in place would leave the URL and results contradictory. A replace
 	 * navigation gives the server one authoritative filtered request without
 	 * adding a duplicate history entry.
+	 * @param navigate
 	 */
 	restoreFromStorage(
 		navigate: ( url: string ) => void = ( url ) =>
@@ -560,6 +571,7 @@ class FilterStateManager {
 
 	/**
 	 * Format date as YYYY-MM-DD.
+	 * @param date
 	 */
 	private formatDate( date: Date ): string {
 		const year = date.getFullYear();
@@ -573,6 +585,7 @@ const instances = new WeakMap< HTMLElement, FilterStateManager >();
 
 /**
  * Get or create FilterStateManager instance for a calendar element.
+ * @param calendar
  */
 export function getFilterState( calendar: HTMLElement ): FilterStateManager {
 	if ( ! instances.has( calendar ) ) {
@@ -583,6 +596,7 @@ export function getFilterState( calendar: HTMLElement ): FilterStateManager {
 
 /**
  * Destroy FilterStateManager instance for a calendar element.
+ * @param calendar
  */
 export function destroyFilterState( calendar: HTMLElement ): void {
 	instances.delete( calendar );

--- a/inc/Blocks/Calendar/src/modules/geo-sync.ts
+++ b/inc/Blocks/Calendar/src/modules/geo-sync.ts
@@ -9,10 +9,13 @@
  * is derived from the viewport bounds (center-to-corner distance). No
  * separate radius control is needed — the map zoom level is the control.
  *
- * @package DataMachineEvents
+ * @package
  * @since 0.14.0
  */
 
+/**
+ * Internal dependencies
+ */
 import { buildCalendarRequest, fetchCalendarEvents } from './api-client';
 import { getFilterState } from './filter-state';
 
@@ -48,6 +51,8 @@ const instances = new WeakMap< HTMLElement, GeoSyncState >();
  *
  * Listens for map bounds-changed events and re-fetches the calendar
  * via REST, updating the DOM in-place.
+ * @param calendar
+ * @param onGridUpdate
  */
 export function initGeoSync(
 	calendar: HTMLElement,
@@ -78,6 +83,7 @@ export function initGeoSync(
 
 /**
  * Destroy geo sync listener for a calendar element.
+ * @param calendar
  */
 export function destroyGeoSync( calendar: HTMLElement ): void {
 	const state = instances.get( calendar );
@@ -98,6 +104,8 @@ export function destroyGeoSync( calendar: HTMLElement ): void {
  *
  * Used by external orchestrators (e.g. near-me page) to push geo
  * updates without waiting for a map bounds-changed event.
+ * @param calendar
+ * @param geo
  */
 export function updateCalendarGeo(
 	calendar: HTMLElement,
@@ -151,6 +159,8 @@ function createBoundsHandler(
 
 /**
  * Fetch calendar data via REST API and update the DOM.
+ * @param calendar
+ * @param geo
  */
 async function fetchAndUpdate(
 	calendar: HTMLElement,
@@ -216,6 +226,8 @@ async function fetchAndUpdate(
  * Calculates the haversine distance from the center to the NE corner
  * of the bounding box. This makes the calendar query match the map
  * viewport — the map zoom IS the radius.
+ * @param bounds
+ * @param center
  */
 function boundsToRadius(
 	bounds: BoundsChangedDetail[ 'bounds' ],

--- a/inc/Blocks/Calendar/src/modules/lazy-render.ts
+++ b/inc/Blocks/Calendar/src/modules/lazy-render.ts
@@ -5,6 +5,9 @@
  * approach the viewport during horizontal scroll.
  */
 
+/**
+ * Internal dependencies
+ */
 import type { EventDisplayVars, EventPlaceholderData } from '../types';
 
 interface LazyObserverEntry {
@@ -90,7 +93,7 @@ function hydratePlaceholder( placeholder: HTMLElement ): void {
 	try {
 		data = JSON.parse( jsonData ) as EventPlaceholderData;
 	} catch ( e ) {
-		console.error( 'Failed to parse event placeholder data:', e );
+		window.console.error( 'Failed to parse event placeholder data:', e );
 		return;
 	}
 

--- a/inc/Blocks/Calendar/src/modules/load-more.ts
+++ b/inc/Blocks/Calendar/src/modules/load-more.ts
@@ -43,6 +43,9 @@
  *      the content; a "you reached the end" chip is chrome.
  */
 
+/**
+ * Internal dependencies
+ */
 import type {
 	ArchiveContext,
 	CalendarDataResponse,
@@ -69,6 +72,7 @@ const instances = new WeakMap< HTMLElement, LoadMoreState >();
  * the click handler. No-op when there's no nav (max_pages <= 1).
  *
  * Idempotent: re-init on the same calendar is a no-op.
+ * @param calendar
  */
 export function initLoadMore( calendar: HTMLElement ): void {
 	if ( instances.has( calendar ) ) {
@@ -109,6 +113,8 @@ export function destroyLoadMore( calendar: HTMLElement ): void {
  * `buildCalendarRequest()` would pick it up anyway — this exposed
  * setter is a belt-and-suspenders path for code that doesn't go
  * through the URL.
+ * @param calendar
+ * @param geo
  */
 export function setLoadMoreGeo(
 	calendar: HTMLElement,
@@ -133,6 +139,7 @@ export function setLoadMoreGeo(
  * Page bounds are read from the server-rendered nav: the current page
  * is the `.page-numbers.current` span, and total_pages is the highest
  * numeric link / span inside the nav.
+ * @param calendar
  */
 function replacePaginationWithLoadMore(
 	calendar: HTMLElement
@@ -296,7 +303,7 @@ function createClickHandler(
 		} catch ( err ) {
 			// Surface the error inline; let the user retry. The
 			// existing `.data-machine-events-error` styles apply.
-			console.error( 'Load More failed:', err );
+			window.console.error( 'Load More failed:', err );
 			button.textContent = 'Retry';
 			// Leave the button clickable so retry works. Don't hide.
 		} finally {
@@ -377,6 +384,8 @@ async function fetchPage(
  * page matches the last date of the existing rendered content: in
  * that case, append the new occurrences to the existing date
  * group's `.data-machine-events-wrapper`, not a duplicate group.
+ * @param calendar
+ * @param data
  */
 function appendPage(
 	calendar: HTMLElement,
@@ -511,6 +520,7 @@ function isPastMode( calendar: HTMLElement ): boolean {
  * `[data-date="..."]` selector. `Y-m-d` strings only contain
  * digits + hyphens, which are safe — but we sanitize defensively in
  * case the server ever ships a date in a different shape.
+ * @param value
  */
 function cssEscape( value: string ): string {
 	if ( typeof window !== 'undefined' && typeof window.CSS !== 'undefined' && typeof window.CSS.escape === 'function' ) {

--- a/inc/Blocks/Calendar/src/modules/month-grid-nav.test.ts
+++ b/inc/Blocks/Calendar/src/modules/month-grid-nav.test.ts
@@ -13,6 +13,9 @@ jest.mock( './month-grid-response-renderer', () => ( {
 	),
 } ) );
 
+/**
+ * Internal dependencies
+ */
 import { renderMonthGridResponse } from './month-grid-response-renderer';
 import {
 	destroyMonthGridNav,

--- a/inc/Blocks/Calendar/src/modules/month-grid-nav.ts
+++ b/inc/Blocks/Calendar/src/modules/month-grid-nav.ts
@@ -12,6 +12,9 @@
  * legacy HTML-string envelope stays the contract for list mode.
  */
 
+/**
+ * Internal dependencies
+ */
 import { buildCalendarRequest } from './api-client';
 import { renderMonthGridResponse } from './month-grid-response-renderer';
 
@@ -109,6 +112,7 @@ class MonthGridController {
 	/**
 	 * Public entry point called by frontend.ts when a filter changes
 	 * in grid mode.
+	 * @param params
 	 */
 	async handleFilterChange( params: URLSearchParams ): Promise< boolean > {
 		return this.navigateToMonth(
@@ -122,6 +126,10 @@ class MonthGridController {
 	/**
 	 * Public entry point for callers that want to jump to a specific
 	 * month (kept narrow so future external callers can re-use it).
+	 * @param month
+	 * @param source
+	 * @param pushHistory
+	 * @param syncGeoState
 	 */
 	async navigateToMonth(
 		month: string,
@@ -228,7 +236,7 @@ class MonthGridController {
 			return true;
 		} catch ( error ) {
 			if ( requestId === this.requestSequence ) {
-				console.error( 'Month-grid fetch failed:', error );
+				window.console.error( 'Month-grid fetch failed:', error );
 			}
 			return false;
 		} finally {
@@ -298,6 +306,7 @@ class MonthGridController {
 	/**
 	 * Base URL used by the renderer for prev/next/today hrefs.
 	 * Preserves every URL param except `month`/`paged`/`past`.
+	 * @param params
 	 */
 	private buildBaseUrl( params: URLSearchParams ): string {
 		const url = new URL( window.location.href );

--- a/inc/Blocks/Calendar/src/modules/month-grid-renderer.ts
+++ b/inc/Blocks/Calendar/src/modules/month-grid-renderer.ts
@@ -11,6 +11,9 @@
  * the existing CSS rules apply uniformly.
  */
 
+/**
+ * Internal dependencies
+ */
 import type {
 	CalendarDataResponse,
 	CalendarEventItem,
@@ -72,6 +75,9 @@ interface RowPayload {
 
 /**
  * Build the DOM for a month grid from the data-only REST envelope.
+ * @param month
+ * @param data
+ * @param baseUrl
  */
 export function renderMonthGrid(
 	month: string,

--- a/inc/Blocks/Calendar/src/modules/month-grid-response-renderer.test.ts
+++ b/inc/Blocks/Calendar/src/modules/month-grid-response-renderer.test.ts
@@ -16,6 +16,9 @@ jest.mock( './date-group-renderer', () => ( {
 	} ),
 } ) );
 
+/**
+ * Internal dependencies
+ */
 import { renderMonthGridResponse } from './month-grid-response-renderer';
 import { renderDateGroup } from './date-group-renderer';
 

--- a/inc/Blocks/Calendar/src/modules/month-grid-response-renderer.ts
+++ b/inc/Blocks/Calendar/src/modules/month-grid-response-renderer.ts
@@ -2,6 +2,9 @@
  * Synchronize every month-grid presentation from one data response.
  */
 
+/**
+ * Internal dependencies
+ */
 import { renderDateGroup } from './date-group-renderer';
 import { renderGapSeparator } from './gap-renderer';
 import { renderMonthGrid } from './month-grid-renderer';

--- a/inc/Blocks/Calendar/src/modules/scope-presets.ts
+++ b/inc/Blocks/Calendar/src/modules/scope-presets.ts
@@ -19,10 +19,10 @@ const ACTIVE_CLASS = 'data-machine-events-scope-chip-active';
 /**
  * Wire scope-preset chip clicks to the shared filter-change flow.
  *
- * @param calendar        The calendar root element.
- * @param onFilterChange  The same callback the search/date controls fire;
- *                        it rebuilds params (including the now-active
- *                        scope) and re-fetches via the existing path.
+ * @param calendar       The calendar root element.
+ * @param onFilterChange The same callback the search/date controls fire;
+ *                       it rebuilds params (including the now-active
+ *                       scope) and re-fetches via the existing path.
  */
 export function initScopePresets(
 	calendar: HTMLElement,
@@ -57,6 +57,8 @@ export function initScopePresets(
 /**
  * Mark a single chip active and reset the rest, keeping `aria-pressed` in
  * sync for assistive tech.
+ * @param group
+ * @param activeChip
  */
 function setActiveChip(
 	group: HTMLElement,


### PR DESCRIPTION
## Summary
- clear the Homeboy WordPress ESLint baseline across maintained Calendar TypeScript source
- preserve error diagnostics while resolving import grouping, JSDoc, focus ownership, assignment timing, and nested ternary findings
- include filter-modal teardown in the existing frontend unload lifecycle

## Verification
- `homeboy --placement local review lint --glob '{inc/Blocks/Calendar/src/*.ts,inc/Blocks/Calendar/src/*.tsx,inc/Blocks/Calendar/src/modules/*.ts}'`
- `npm test -- --runInBand` (29 tests passed)
- `npm run build -- --output-path /mnt/extrachill-workspace/tmp/opencode/dme-553-calendar-build`
- `npm exec tsc -- --noEmit` (package baseline is not configured as a standalone type gate: missing Jest, React, and WordPress ambient types, plus an existing Flatpickr option mismatch)

No generated build bundles, changelog, or version files were modified.

Closes #553