### PR TITLE
fix: normalize venue mutation hook IDs

### DIFF
--- a/inc/Abilities/EventUpdateAbilities.php
+++ b/inc/Abilities/EventUpdateAbilities.php
@@ -537,6 +537,15 @@ class EventUpdateAbilities {
 		$result             = null;
 
 		try {
+			/**
+			 * Filters whether a direct event venue mutation may proceed.
+			 *
+			 * @param bool|\WP_Error $preflight         Permission result.
+			 * @param int            $post_id           Event post ID.
+			 * @param int[]          $next_venue_ids    Venue term IDs to assign.
+			 * @param int[]          $previous_venue_ids Previously assigned venue term IDs.
+			 * @param string         $context           Mutation context.
+			 */
 			$preflight = apply_filters(
 				'datamachine_events_before_event_venue_mutation',
 				true,
@@ -568,9 +577,19 @@ class EventUpdateAbilities {
 					'error'   => $result,
 				);
 			}
+			$result = array_values( array_unique( array_filter( array_map( 'absint', $result ) ) ) );
 
 			return array( 'success' => true );
 		} finally {
+			/**
+			 * Fires after a direct event venue mutation attempt.
+			 *
+			 * @param int             $post_id           Event post ID.
+			 * @param int[]           $next_venue_ids     Requested venue term IDs.
+			 * @param int[]           $previous_venue_ids Previously assigned venue term IDs.
+			 * @param string          $context            Mutation context.
+			 * @param int[]|\WP_Error|null $result         Canonical assigned term-taxonomy IDs, an error, or null.
+			 */
 			do_action(
 				'datamachine_events_after_event_venue_mutation',
 				$post_id,

--- a/tests/Unit/EventUpdateAbilitiesTest.php
+++ b/tests/Unit/EventUpdateAbilitiesTest.php
@@ -37,12 +37,12 @@ class EventUpdateAbilitiesTest extends WP_UnitTestCase {
 	public function test_venue_mutation_success_assigns_term_and_returns_taxonomy_result(): void {
 		$event_id = $this->makeEvent();
 		$venue    = $this->makeVenue( 'Success Venue' );
-		$result   = null;
+		$payload  = null;
 
 		add_action(
 			'datamachine_events_after_event_venue_mutation',
-			static function ( int $post_id, array $next_ids, array $previous_ids, string $context, $mutation_result ) use ( &$result ): void {
-				$result = $mutation_result;
+			static function ( int $post_id, array $next_ids, array $previous_ids, string $context, $mutation_result ) use ( &$payload ): void {
+				$payload = array( $post_id, $next_ids, $previous_ids, $context, $mutation_result );
 			},
 			10,
 			5
@@ -57,7 +57,10 @@ class EventUpdateAbilitiesTest extends WP_UnitTestCase {
 
 		$this->assertSame( 'updated', $response['results'][0]['status'] );
 		$this->assertSame( array( $venue ), wp_get_object_terms( $event_id, 'venue', array( 'fields' => 'ids' ) ) );
-		$this->assertSame( array( (int) get_term( $venue, 'venue' )->term_taxonomy_id ), $result );
+		$this->assertSame(
+			array( $event_id, array( $venue ), array(), 'event_update_ability', array( (int) get_term( $venue, 'venue' )->term_taxonomy_id ) ),
+			$payload
+		);
 	}
 
 	public function test_venue_mutation_hooks_receive_exact_payload_in_order(): void {
@@ -94,6 +97,54 @@ class EventUpdateAbilitiesTest extends WP_UnitTestCase {
 			array(
 				array( 'before', $event_id, array( $next ), array( $previous ), 'event_update_ability' ),
 				array( 'after', $event_id, array( $next ), array( $previous ), 'event_update_ability', array( (int) get_term( $next, 'venue' )->term_taxonomy_id ) ),
+			),
+			$observed
+		);
+	}
+
+	public function test_venue_mutation_hooks_normalize_string_and_invalid_previous_ids(): void {
+		$event_id = $this->makeEvent();
+		$previous = $this->makeVenue( 'String Previous Venue' );
+		$next     = $this->makeVenue( 'Integer Next Venue' );
+		$observed = array();
+		wp_set_post_terms( $event_id, array( $previous ), 'venue' );
+
+		$stringify_ids = static function ( array $terms, array $object_ids, array $taxonomies, array $args ) use ( $previous ): array {
+			if ( array( 'venue' ) === $taxonomies && 'ids' === $args['fields'] ) {
+				return array( (string) $previous, '0', 'invalid', (string) $previous );
+			}
+
+			return $terms;
+		};
+		add_filter( 'get_object_terms', $stringify_ids, 10, 4 );
+		add_filter(
+			'datamachine_events_before_event_venue_mutation',
+			static function ( $allowed, int $post_id, array $next_ids, array $previous_ids ) use ( &$observed ) {
+				$observed[] = array( 'before', $post_id, $next_ids, $previous_ids );
+				return $allowed;
+			},
+			10,
+			4
+		);
+		add_action(
+			'datamachine_events_after_event_venue_mutation',
+			static function ( int $post_id, array $next_ids, array $previous_ids, string $context, $result ) use ( &$observed ): void {
+				$observed[] = array( 'after', $post_id, $next_ids, $previous_ids, $result );
+			},
+			10,
+			5
+		);
+
+		try {
+			$this->ability->executeUpdateEvent( array( 'event' => $event_id, 'venue' => $next ) );
+		} finally {
+			remove_filter( 'get_object_terms', $stringify_ids, 10 );
+		}
+
+		$this->assertSame(
+			array(
+				array( 'before', $event_id, array( $next ), array( $previous ) ),
+				array( 'after', $event_id, array( $next ), array( $previous ), array( (int) get_term( $next, 'venue' )->term_taxonomy_id ) ),
 			),
 			$observed
 		);
@@ -334,7 +385,7 @@ class EventUpdateAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	private function makeEvent(): int {
-		return self::factory()->post->create(
+		$event_id = self::factory()->post->create(
 			array(
 				'post_title'   => 'Venue Mutation Event ' . uniqid(),
 				'post_type'    => Event_Post_Type::POST_TYPE,
@@ -342,11 +393,23 @@ class EventUpdateAbilitiesTest extends WP_UnitTestCase {
 				'post_content' => '<!-- wp:data-machine-events/event-details {"startDate":"2027-01-01","startTime":"20:00"} --><div></div><!-- /wp:data-machine-events/event-details -->',
 			)
 		);
+		if ( is_wp_error( $event_id ) ) {
+			$this->fail( 'Event fixture creation failed: ' . $event_id->get_error_message() );
+		}
+		$this->assertIsInt( $event_id, 'Event fixture creation must return an integer post ID.' );
+		$this->assertGreaterThan( 0, $event_id, 'Event fixture creation must return a positive post ID.' );
+
+		return $event_id;
 	}
 
 	private function makeVenue( string $name ): int {
 		$term = wp_insert_term( $name . ' ' . uniqid(), 'venue' );
-		$this->assertNotWPError( $term );
+		if ( is_wp_error( $term ) ) {
+			$this->fail( 'Venue fixture creation failed: ' . $term->get_error_message() );
+		}
+		$this->assertArrayHasKey( 'term_id', $term, 'Venue fixture creation must return a term ID.' );
+		$this->assertGreaterThan( 0, (int) $term['term_id'], 'Venue fixture creation must return a positive term ID.' );
+
 		return (int) $term['term_id'];
 	}
 

--- a/tests/Unit/EventUpdateAbilitiesTest.php
+++ b/tests/Unit/EventUpdateAbilitiesTest.php
@@ -273,6 +273,7 @@ class EventUpdateAbilitiesTest extends WP_UnitTestCase {
 
 	public function test_update_lifecycle_completes_once_on_post_failure(): void {
 		$completions = array();
+		$event_id    = $this->makeEvent();
 		add_filter( 'wp_insert_post_empty_content', '__return_true' );
 		add_action(
 			'datamachine_events_after_event_update_persistence',
@@ -283,7 +284,7 @@ class EventUpdateAbilitiesTest extends WP_UnitTestCase {
 			2
 		);
 
-		$response = $this->ability->executeUpdateEvent( array( 'event' => $this->makeEvent(), 'startTime' => '22:00' ) );
+		$response = $this->ability->executeUpdateEvent( array( 'event' => $event_id, 'startTime' => '22:00' ) );
 
 		$this->assertSame( 'failed', $response['results'][0]['status'] );
 		$this->assertCount( 1, $completions );


### PR DESCRIPTION
## Summary
- normalize successful venue mutation taxonomy results to positive integer IDs across database implementations
- document canonical before/after hook argument types while preserving `WP_Error` identity and exactly-once completion
- add strict payload coverage for string, integer, invalid, duplicate, success, denial, and assignment-failure paths with isolated fixture failures

## Verification
- `homeboy review lint --placement local --changed-only --summary` (PHPCS and PHPStan level 7 passed)
- `homeboy review audit --placement local --changed-since origin/main --json-summary` (no introduced findings)
- GitHub Homeboy audit and lint passed
- GitHub ran all 639 PHPUnit update/upsert regressions; all `EventUpdateAbilitiesTest` cases passed after fixture isolation
- the complete suite remains red with 25 errors and 78 failures from the existing Playground/permission baseline tracked in #519
- local MySQL was blocked before PHPUnit because Docker is unavailable; local Playground SQLite was blocked in the wp-phpunit bootstrap by an uninitialized `$wpdb`

Closes #548