### PR TITLE
fix: recognize specific two-token event titles

### DIFF
--- a/inc/Utilities/EventIdentifierGenerator.php
+++ b/inc/Utilities/EventIdentifierGenerator.php
@@ -208,7 +208,15 @@ class EventIdentifierGenerator {
 
 		$token_count = count( array_filter( explode( ' ', $normalized ) ) );
 
-		return $token_count >= 3 && ! self::isLowConfidenceTitle( $title );
+		if ( $token_count >= 3 ) {
+			return ! self::isLowConfidenceTitle( $title );
+		}
+
+		if ( 2 !== $token_count ) {
+			return false;
+		}
+
+		return self::hasStrongTokenSignal( $normalized, 2 ) && ! self::isLowConfidenceTitle( $title );
 	}
 
 	/**
@@ -218,14 +226,19 @@ class EventIdentifierGenerator {
 	 * hardcoded event/festival words here.
 	 *
 	 * @param string $normalized_title Normalized title.
-	 * @return bool True when any token appears specific enough.
+	 * @param int    $required_count   Minimum number of strong tokens required.
+	 * @return bool True when enough tokens appear specific.
 	 */
-	private static function hasStrongTokenSignal( string $normalized_title ): bool {
+	private static function hasStrongTokenSignal( string $normalized_title, int $required_count = 1 ): bool {
 		$tokens = array_filter( explode( ' ', $normalized_title ) );
+		$count  = 0;
 
 		foreach ( $tokens as $token ) {
 			if ( strlen( $token ) >= 5 ) {
-				return true;
+				++$count;
+				if ( $count >= $required_count ) {
+					return true;
+				}
 			}
 		}
 

--- a/tests/Unit/EventIdentifierGeneratorTest.php
+++ b/tests/Unit/EventIdentifierGeneratorTest.php
@@ -288,6 +288,39 @@ class EventIdentifierGeneratorTest extends WP_UnitTestCase {
 		$this->assertSame( 'medium', EventIdentifierGenerator::getIdentityConfidence( 'The California Honeydrops - Shine Delight Tour 2026', '2026-03-10', '' ) );
 	}
 
+	/**
+	 * @dataProvider get_specific_two_token_artist_titles
+	 */
+	public function test_specific_two_token_artist_title_with_date_is_medium_confidence( string $title ): void {
+		$this->assertSame( 'medium', EventIdentifierGenerator::getIdentityConfidence( $title, '2026-03-10', '' ) );
+	}
+
+	public function get_specific_two_token_artist_titles(): array {
+		return array(
+			'billy_strings' => array( 'Billy Strings' ),
+			'molly_tuttle'  => array( 'Molly Tuttle' ),
+		);
+	}
+
+	/**
+	 * @dataProvider get_generic_two_token_titles
+	 */
+	public function test_generic_two_token_title_with_date_remains_low_confidence( string $title ): void {
+		$this->assertSame( 'low', EventIdentifierGenerator::getIdentityConfidence( $title, '2026-03-10', '' ) );
+	}
+
+	public function get_generic_two_token_titles(): array {
+		return array(
+			'live_music' => array( 'Live Music' ),
+			'open_mic'   => array( 'Open Mic' ),
+			'jazz_night' => array( 'Jazz Night' ),
+		);
+	}
+
+	public function test_specific_two_token_artist_title_without_date_remains_low_confidence(): void {
+		$this->assertSame( 'low', EventIdentifierGenerator::getIdentityConfidence( 'Billy Strings', '', '' ) );
+	}
+
 	public function test_specific_title_with_venue_is_high_confidence(): void {
 		$this->assertSame( 'high', EventIdentifierGenerator::getIdentityConfidence( 'The California Honeydrops - Shine Delight Tour 2026', '2026-03-10', 'ACL Live' ) );
 	}


### PR DESCRIPTION
## Summary
- promote specific two-token artist titles with a date to medium event identity confidence
- require both short-title tokens to carry strong specificity, retaining low confidence for generic titles such as `Live Music`, `Open Mic`, and `Jazz Night`
- keep title normalization and colon-series matching wholly owned by Data Machine's `SimilarityEngine`; the upstream false-positive contract remains tracked in Extra-Chill/data-machine#2985

## Testing
- `homeboy review lint data-machine-events --path /var/lib/datamachine/workspace/data-machine-events@fix-547-event-identity-confidence --placement local --changed-only --errors-only --summary` (PHPCS and PHPStan passed)
- direct focused confidence assertions: 6 passed
- `php -l` on both changed PHP files and `git diff --check` passed
- focused `EventIdentifierGeneratorTest` PHPUnit run attempted, but Homeboy's local MySQL 8.4 Docker service failed provisioning before PHPUnit started; no Lab runner was connected for fallback

Closes #547