### PR TITLE
Fix nested ESLint dependency grouping

### DIFF
--- a/inc/Blocks/Calendar/eslint.config.mjs
+++ b/inc/Blocks/Calendar/eslint.config.mjs
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import wordpress from '@wordpress/eslint-plugin';
 
 export default [ ...wordpress.configs.recommended ];

--- a/inc/Blocks/EventDetails/eslint.config.mjs
+++ b/inc/Blocks/EventDetails/eslint.config.mjs
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import wordpress from '@wordpress/eslint-plugin';
 
 export default [ ...wordpress.configs.recommended ];

--- a/inc/Blocks/EventsMap/eslint.config.mjs
+++ b/inc/Blocks/EventsMap/eslint.config.mjs
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import wordpress from '@wordpress/eslint-plugin';
 
 export default [ ...wordpress.configs.recommended ];


### PR DESCRIPTION
## Summary
- classify the package-local WordPress ESLint plugin imports with the dependency-group marker required by the shared Homeboy rules
- preserve the existing WordPress recommended flat configs without disables, ignores, or weaker rules
- clear the reopened repository-wide lint regression across Calendar, EventDetails, and EventsMap

## Verification
- `homeboy --placement local review lint --summary` passes with zero findings across PHPCS, ESLint, and PHPStan; Homeboy's merged nested-build exclusion keeps generated bundles outside the maintained-source gate
- Calendar `npm run lint:js` runs ESLint 9.39.2 and reaches 71 existing package-local source findings
- EventDetails `npm run lint:js` runs ESLint 9.39.2 and reaches 188 existing package-local source findings
- EventsMap `npm run lint:js` runs ESLint 9.39.3 and reaches 2 existing package-local dependency findings
- package lockfiles remain unchanged after `npm ci`

Closes #551