### PR TITLE
test: align calendar public contracts

### DIFF
--- a/tests/Unit/BlockRegistrationTest.php
+++ b/tests/Unit/BlockRegistrationTest.php
@@ -11,7 +11,6 @@
 namespace DataMachineEvents\Tests\Unit;
 
 use WP_UnitTestCase;
-use function WP_Block_Type_Registry\get_instance;
 
 class BlockRegistrationTest extends WP_UnitTestCase {
 
@@ -25,7 +24,7 @@ class BlockRegistrationTest extends WP_UnitTestCase {
 		foreach ( $GLOBALS['wp_filter'][ 'init' ]->callbacks as $priority => $callbacks ) {
 			foreach ( $callbacks as $callback ) {
 				if ( is_array( $callback['function'] ) ) {
-					if ( $callback['function'][0] === $plugin && 'register_blocks'=== $callback['function'][1] ) {
+					if ( $callback['function'][0] === $plugin && 'register_blocks' === $callback['function'][1] ) {
 						$has_init_hook = true;
 						break 2;
 					}
@@ -37,14 +36,22 @@ class BlockRegistrationTest extends WP_UnitTestCase {
 	}
 
 	public function test_blocks_registered_after_user_initialization() {
-		$this->assertTrue( current_user_can( 'read' ), 'Current user should be initialized' );
+		$original_user_id = get_current_user_id();
+		$user_id          = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $user_id );
 
-		$block_registry      = \WP_Block_Type_Registry::get_instance();
-		$calendar_block      = $block_registry->get_registered( 'data-machine-events/calendar' );
-		$event_details_block = $block_registry->get_registered( 'data-machine-events/event-details' );
+		try {
+			$this->assertTrue( current_user_can( 'read' ), 'Current user should be initialized' );
 
-		$this->assertNotNull( $calendar_block, 'Calendar block should be registered' );
-		$this->assertNotNull( $event_details_block, 'Event Details block should be registered' );
+			$block_registry      = \WP_Block_Type_Registry::get_instance();
+			$calendar_block      = $block_registry->get_registered( 'data-machine-events/calendar' );
+			$event_details_block = $block_registry->get_registered( 'data-machine-events/event-details' );
+
+			$this->assertNotNull( $calendar_block, 'Calendar block should be registered' );
+			$this->assertNotNull( $event_details_block, 'Event Details block should be registered' );
+		} finally {
+			wp_set_current_user( $original_user_id );
+		}
 	}
 
 	public function test_calendar_block_has_required_metadata() {
@@ -52,7 +59,7 @@ class BlockRegistrationTest extends WP_UnitTestCase {
 		$block          = $block_registry->get_registered( 'data-machine-events/calendar' );
 
 		$this->assertNotNull( $block, 'Calendar block should be registered' );
-		$this->assertEquals( 'widgets', $block->category, 'Block should be in widgets category' );
+		$this->assertSame( 'widgets', $block->category, 'Block should be in widgets category' );
 	}
 
 	public function test_event_details_block_has_required_metadata() {
@@ -60,6 +67,6 @@ class BlockRegistrationTest extends WP_UnitTestCase {
 		$block          = $block_registry->get_registered( 'data-machine-events/event-details' );
 
 		$this->assertNotNull( $block, 'Event Details block should be registered' );
-		$this->assertEquals( 'widgets', $block->category, 'Block should be in widgets category' );
+		$this->assertSame( 'data-machine-events', $block->category, 'Block should use the plugin category' );
 	}
 }

--- a/tests/Unit/CalendarAbilitiesTest.php
+++ b/tests/Unit/CalendarAbilitiesTest.php
@@ -7,7 +7,6 @@
 
 namespace DataMachineEvents\Tests\Unit;
 
-use DateTimeImmutable;
 use WP_UnitTestCase;
 use DataMachineEvents\Abilities\CalendarAbilities;
 use DataMachineEvents\Core\Event_Post_Type;
@@ -81,7 +80,7 @@ class CalendarAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function test_past_mode_returns_only_completed_events_with_chronological_boundaries(): void {
-		$now         = new DateTimeImmutable( current_time( 'mysql' ) );
+		$now         = current_datetime();
 		$older_past  = $now->modify( '-4 days' );
 		$recent_past = $now->modify( '-1 day' );
 		$future      = $now->modify( '+4 days' );
@@ -107,7 +106,7 @@ class CalendarAbilitiesTest extends WP_UnitTestCase {
 		$term = wp_insert_term( 'Past calendar venue ' . uniqid(), 'venue' );
 		$this->assertNotWPError( $term );
 		$venue_id = (int) $term['term_id'];
-		$now      = new DateTimeImmutable( current_time( 'mysql' ) );
+		$now      = current_datetime();
 		$past     = $now->modify( '-2 days' );
 		$future   = $now->modify( '+2 days' );
 
@@ -129,7 +128,7 @@ class CalendarAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function test_upcoming_boundaries_exclude_past_dates_from_ongoing_multi_day_events(): void {
-		$today = new DateTimeImmutable( current_time( 'Y-m-d' ) . ' 12:00:00' );
+		$today = current_datetime()->setTime( 12, 0 );
 		$start = $today->modify( '-3 days' );
 		$end   = $today->modify( '+2 days' );
 
@@ -146,14 +145,19 @@ class CalendarAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( $today->format( 'Y-m-d' ), $result['date_boundaries']['start_date'] );
 		$this->assertSame( $end->format( 'Y-m-d' ), $result['date_boundaries']['end_date'] );
 		$this->assertSame( $today->format( 'Y-m-d' ), $result['paged_date_groups'][0]['date'] );
-		$this->assertSame( array( $event_id ), $this->result_post_ids( $result ) );
+		$this->assertSame( 1, $result['event_count'], 'The page count reports unique event posts.' );
+		$this->assertSame(
+			array_fill( 0, 3, $event_id ),
+			$this->result_post_ids( $result ),
+			'A multi-day event has one occurrence in each visible date group.'
+		);
 	}
 
 	public function test_taxonomy_filtered_upcoming_boundaries_include_ongoing_multi_day_events(): void {
 		$term = wp_insert_term( 'Ongoing calendar venue ' . uniqid(), 'venue' );
 		$this->assertNotWPError( $term );
 		$venue_id = (int) $term['term_id'];
-		$today    = new DateTimeImmutable( current_time( 'Y-m-d' ) . ' 12:00:00' );
+		$today    = current_datetime()->setTime( 12, 0 );
 		$start    = $today->modify( '-3 days' );
 		$end      = $today->modify( '+2 days' );
 
@@ -172,11 +176,11 @@ class CalendarAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( $today->format( 'Y-m-d' ), $result['date_boundaries']['start_date'] );
 		$this->assertSame( $end->format( 'Y-m-d' ), $result['date_boundaries']['end_date'] );
 		$this->assertSame( $today->format( 'Y-m-d' ), $result['paged_date_groups'][0]['date'] );
-		$this->assertSame( array( $event_id ), $this->result_post_ids( $result ) );
+		$this->assertSame( array_fill( 0, 3, $event_id ), $this->result_post_ids( $result ) );
 	}
 
 	public function test_month_intersects_explicit_date_range(): void {
-		$month_start = new DateTimeImmutable( 'first day of +2 months 00:00:00' );
+		$month_start = current_datetime()->modify( 'first day of +2 months' )->setTime( 0, 0 );
 		$outside     = $month_start->modify( '+4 days' );
 		$inside      = $month_start->modify( '+9 days' );
 		$this->seed_event( 'Outside explicit range', $outside->format( 'Y-m-d 20:00:00' ), $outside->format( 'Y-m-d 22:00:00' ) );
@@ -198,7 +202,7 @@ class CalendarAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function test_month_intersects_resolved_scope_and_can_be_empty(): void {
-		$today         = new DateTimeImmutable( current_time( 'Y-m-d' ) . ' 12:00:00' );
+		$today         = current_datetime()->setTime( 12, 0 );
 		$tomorrow      = $today->modify( '+1 day' );
 		$today_id      = $this->seed_event( 'Today scoped event', $today->format( 'Y-m-d 12:00:00' ), $today->format( 'Y-m-d 14:00:00' ) );
 		$future_id     = $this->seed_event( 'Tomorrow unscoped event', $tomorrow->format( 'Y-m-d 12:00:00' ), $tomorrow->format( 'Y-m-d 14:00:00' ) );
@@ -232,7 +236,7 @@ class CalendarAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function test_search_constrains_totals_boundaries_and_repeated_date_rows(): void {
-		$date       = new DateTimeImmutable( '+7 days' );
+		$date       = current_datetime()->modify( '+7 days' );
 		$search     = 'needle-' . uniqid();
 		$first_id   = $this->seed_event( "{$search} first", $date->format( 'Y-m-d 18:00:00' ), $date->format( 'Y-m-d 20:00:00' ) );
 		$second_id  = $this->seed_event( "{$search} second", $date->format( 'Y-m-d 21:00:00' ), $date->format( 'Y-m-d 23:00:00' ) );
@@ -254,7 +258,7 @@ class CalendarAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function test_search_with_no_matches_returns_empty_boundaries(): void {
-		$date = new DateTimeImmutable( '+8 days' );
+		$date = current_datetime()->modify( '+8 days' );
 		$this->seed_event( 'Existing event', $date->format( 'Y-m-d 20:00:00' ), $date->format( 'Y-m-d 22:00:00' ) );
 
 		$result = $this->abilities->executeGetCalendarPage(
@@ -274,7 +278,7 @@ class CalendarAbilitiesTest extends WP_UnitTestCase {
 	public function test_geo_constrains_totals_boundaries_and_rows(): void {
 		$near_venue = $this->seed_venue( 'Nearby venue', '32.7765,-79.9311' );
 		$far_venue  = $this->seed_venue( 'Far venue', '40.7128,-74.0060' );
-		$near_date  = new DateTimeImmutable( '+9 days' );
+		$near_date  = current_datetime()->modify( '+9 days' );
 		$far_date   = $near_date->modify( '+1 day' );
 		$near_id    = $this->seed_event( 'Nearby event', $near_date->format( 'Y-m-d 20:00:00' ), $near_date->format( 'Y-m-d 22:00:00' ), $near_venue );
 		$this->seed_event( 'Far event', $far_date->format( 'Y-m-d 20:00:00' ), $far_date->format( 'Y-m-d 22:00:00' ), $far_venue );
@@ -307,7 +311,7 @@ class CalendarAbilitiesTest extends WP_UnitTestCase {
 		$this->assertNotWPError( $style );
 		$this->assertNotWPError( $other_style );
 
-		$date   = new DateTimeImmutable( '+10 days' );
+		$date   = current_datetime()->modify( '+10 days' );
 		$search = 'combined-' . uniqid();
 		$terms  = array(
 			'calendar_test_region' => (int) $region['term_id'],
@@ -345,7 +349,7 @@ class CalendarAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function test_search_pagination_boundaries_do_not_include_unmatched_dates(): void {
-		$global_start = new DateTimeImmutable( '+12 days' );
+		$global_start = current_datetime()->modify( '+12 days' );
 		$search_start = $global_start->modify( '+10 days' );
 		$search       = 'paged-' . uniqid();
 
@@ -386,7 +390,7 @@ class CalendarAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function test_scope_tokens_isolate_warm_boundary_caches_and_rows(): void {
-		$first_date = new DateTimeImmutable( '+30 days' );
+		$first_date = current_datetime()->modify( '+30 days' );
 		$second_date = $first_date->modify( '+1 day' );
 		$first_id = $this->seed_event( 'First scoped event', $first_date->format( 'Y-m-d 20:00:00' ), $first_date->format( 'Y-m-d 22:00:00' ) );
 		$second_id = $this->seed_event( 'Second scoped event', $second_date->format( 'Y-m-d 20:00:00' ), $second_date->format( 'Y-m-d 22:00:00' ) );
@@ -428,7 +432,7 @@ class CalendarAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function test_scope_token_keeps_pagination_counter_and_deferred_dates_aligned(): void {
-		$start       = new DateTimeImmutable( '+45 days' );
+		$start       = current_datetime()->modify( '+45 days' );
 		$allowed_ids = array();
 		for ( $day = 0; $day < 6; ++$day ) {
 			$date = $start->modify( "+{$day} days" );
@@ -472,7 +476,7 @@ class CalendarAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function test_scope_token_preserves_multi_day_boundary_expansion(): void {
-		$start = new DateTimeImmutable( '+60 days' );
+		$start = current_datetime()->modify( '+60 days' );
 		$end   = $start->modify( '+2 days' );
 		$allowed_id = $this->seed_event( 'Scoped multi-day event', $start->format( 'Y-m-d 20:00:00' ), $end->format( 'Y-m-d 22:00:00' ) );
 		$this->seed_event( 'Unscoped middle event', $start->modify( '+1 day' )->format( 'Y-m-d 20:00:00' ), $start->modify( '+1 day' )->format( 'Y-m-d 22:00:00' ) );
@@ -495,12 +499,13 @@ class CalendarAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( 1, $result['total_event_count'] );
 		$this->assertSame( $start->format( 'Y-m-d' ), $result['date_boundaries']['start_date'] );
 		$this->assertSame( $end->format( 'Y-m-d' ), $result['date_boundaries']['end_date'] );
-		$this->assertSame( array( $allowed_id ), $this->result_post_ids( $result ) );
+		$this->assertSame( 1, $result['event_count'] );
+		$this->assertSame( array_fill( 0, 3, $allowed_id ), $this->result_post_ids( $result ) );
 	}
 
 	public function test_search_geo_and_consumer_scope_constraints_stay_aligned(): void {
 		$venue  = $this->seed_venue( 'Scoped search venue', '32.7765,-79.9311' );
-		$date   = new DateTimeImmutable( '+70 days' );
+		$date   = current_datetime()->modify( '+70 days' );
 		$target = $this->seed_event( 'Scoped needle target', $date->format( 'Y-m-d 20:00:00' ), $date->format( 'Y-m-d 22:00:00' ), $venue );
 		$this->seed_event( 'Scoped needle excluded', $date->format( 'Y-m-d 21:00:00' ), $date->format( 'Y-m-d 23:00:00' ), $venue );
 

--- a/tests/Unit/CalendarBlockTest.php
+++ b/tests/Unit/CalendarBlockTest.php
@@ -11,7 +11,6 @@
 namespace DataMachineEvents\Tests\Unit;
 
 use WP_UnitTestCase;
-use DataMachineEvents\Blocks\Calendar\Calendar;
 use DataMachineEvents\Blocks\Calendar\Pagination\Renderer as Pagination;
 
 class CalendarBlockTest extends WP_UnitTestCase {
@@ -37,31 +36,33 @@ class CalendarBlockTest extends WP_UnitTestCase {
 		$this->assertNotNull( $block->render_callback, 'Block should have render callback' );
 	}
 
-	public function test_pagination_builds_args_correctly() {
-		$pagination = new Pagination();
-
-		$args = $pagination->build_pagination_args( 1, 3 );
-
-		$this->assertIsArray( $args );
-		$this->assertEquals( 1, $args['current'] );
-		$this->assertEquals( 3, $args['total'] );
-	}
-
-	public function test_pagination_sanitizes_query_params() {
-		$pagination = new Pagination();
-
-		$params = array(
-			'page'   => '2',
+	public function test_pagination_exposes_sanitized_public_arguments(): void {
+		$original_get = $_GET;
+		$_GET         = array(
+			'paged'  => '2',
 			'search' => '<script>alert("xss")</script>Test',
-			'nested' => array(
-				'value' => 'test<tag>',
-			),
+			'nested' => array( 'value' => 'test<tag>' ),
 		);
+		$observed_args = null;
+		$filter        = static function ( array $args ) use ( &$observed_args ): array {
+			$observed_args = $args;
+			return $args;
+		};
+		add_filter( 'data_machine_events_pagination_args', $filter );
 
-		$sanitized = $pagination->sanitize_query_params( $params );
+		try {
+			$html = Pagination::render_pagination( 1, 3 );
+		} finally {
+			remove_filter( 'data_machine_events_pagination_args', $filter );
+			$_GET = $original_get;
+		}
 
-		$this->assertIsArray( $sanitized );
-		$this->assertStringNotContainsString( '<script>', $sanitized['search'] ?? '' );
+		$this->assertSame( 1, $observed_args['current'] );
+		$this->assertSame( 3, $observed_args['total'] );
+		$this->assertArrayNotHasKey( 'paged', $observed_args['add_args'] );
+		$this->assertStringNotContainsString( '<script>', $observed_args['add_args']['search'] );
+		$this->assertSame( 'test', $observed_args['add_args']['nested']['value'] );
+		$this->assertStringContainsString( 'data-machine-events-pagination', $html );
 	}
 
 	public function test_calendar_query_args_filter_applied() {
@@ -214,12 +215,6 @@ class CalendarBlockTest extends WP_UnitTestCase {
 		$template_path = DATA_MACHINE_EVENTS_PATH . 'inc/Blocks/Calendar/templates/date-group.php';
 
 		$this->assertFileExists( $template_path, 'Date group template should exist' );
-	}
-
-	public function test_pagination_template_exists() {
-		$template_path = DATA_MACHINE_EVENTS_PATH . 'inc/Blocks/Calendar/templates/pagination.php';
-
-		$this->assertFileExists( $template_path, 'Pagination template should exist' );
 	}
 
 	public function test_no_events_template_exists() {

--- a/tests/Unit/EventDateQueryAbilitiesTest.php
+++ b/tests/Unit/EventDateQueryAbilitiesTest.php
@@ -218,8 +218,6 @@ class EventDateQueryAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function test_matching_ids_sql_preserves_consumer_constraints_without_querying(): void {
-		global $wpdb;
-
 		$filter = static function ( array $query_args, array $input ): array {
 			if ( 'sql-capture-scope' === ( $input['scope_token'] ?? '' ) ) {
 				$query_args['post__in'] = array( 123, 456 );
@@ -227,7 +225,12 @@ class EventDateQueryAbilitiesTest extends WP_UnitTestCase {
 			return $query_args;
 		};
 		add_filter( 'data_machine_events_calendar_query_args', $filter, 10, 2 );
-		$queries_before = $wpdb->num_queries;
+		$executed_queries = array();
+		$query_observer   = static function ( string $query ) use ( &$executed_queries ): string {
+			$executed_queries[] = $query;
+			return $query;
+		};
+		add_filter( 'query', $query_observer );
 		try {
 			$sql = ( new EventDateQueryAbilities() )->buildMatchingPostIdsSql(
 				array(
@@ -238,9 +241,10 @@ class EventDateQueryAbilitiesTest extends WP_UnitTestCase {
 			);
 		} finally {
 			remove_filter( 'data_machine_events_calendar_query_args', $filter, 10 );
+			remove_filter( 'query', $query_observer );
 		}
 
-		$this->assertSame( $queries_before, $wpdb->num_queries );
+		$this->assertSame( array(), $executed_queries );
 		$this->assertStringContainsString( 'SELECT DISTINCT', $sql );
 		$this->assertStringContainsString( '123,456', str_replace( ' ', '', $sql ) );
 		$this->assertStringContainsString( 'needle', $sql );
@@ -249,22 +253,26 @@ class EventDateQueryAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function test_matching_ids_sql_handles_large_consumer_sets_without_materializing_results(): void {
-		global $wpdb;
-
 		$large_set = range( 1, 17000 );
 		$filter    = static function ( array $query_args ) use ( $large_set ): array {
 			$query_args['post__in'] = $large_set;
 			return $query_args;
 		};
 		add_filter( 'data_machine_events_calendar_query_args', $filter );
-		$queries_before = $wpdb->num_queries;
+		$executed_queries = array();
+		$query_observer   = static function ( string $query ) use ( &$executed_queries ): string {
+			$executed_queries[] = $query;
+			return $query;
+		};
+		add_filter( 'query', $query_observer );
 		try {
 			$sql = ( new EventDateQueryAbilities() )->buildMatchingPostIdsSql( array( 'scope_token' => 'large-set' ) );
 		} finally {
 			remove_filter( 'data_machine_events_calendar_query_args', $filter );
+			remove_filter( 'query', $query_observer );
 		}
 
-		$this->assertSame( $queries_before, $wpdb->num_queries );
+		$this->assertSame( array(), $executed_queries );
 		$this->assertStringContainsString( '17000', $sql );
 		$this->assertStringNotContainsString( '%d', $sql );
 		$this->assertStringNotContainsString( ' LIMIT ', strtoupper( $sql ) );

--- a/tests/Unit/EventRestControllerTest.php
+++ b/tests/Unit/EventRestControllerTest.php
@@ -16,13 +16,22 @@ use WP_REST_Server;
 use DataMachineEvents\Core\Event_Post_Type;
 use DataMachineEvents\Core\EventDatesTable;
 use DataMachineEvents\Core\Venue_Taxonomy;
+use const DataMachineEvents\Api\API_NAMESPACE;
 
 class EventRestControllerTest extends WP_UnitTestCase {
 
 	protected $server;
+	private int $original_user_id;
 
 	public function setUp(): void {
+		// Create the table before WP_UnitTestCase rewrites CREATE TABLE as temporary.
+		if ( ! EventDatesTable::table_exists() ) {
+			EventDatesTable::create_table();
+		}
+
 		parent::setUp();
+		$this->original_user_id = get_current_user_id();
+		wp_set_current_user( 0 );
 
 		global $wp_rest_server;
 		$this->server = $wp_rest_server = new WP_REST_Server();
@@ -40,14 +49,21 @@ class EventRestControllerTest extends WP_UnitTestCase {
 	public function tearDown(): void {
 		global $wp_rest_server;
 		$wp_rest_server = null;
+		wp_set_current_user( $this->original_user_id );
 		parent::tearDown();
+	}
+
+	private function calendar_request(): WP_REST_Request {
+		$request = new WP_REST_Request( 'GET', '/' . API_NAMESPACE . '/events/calendar' );
+		$request->set_header( 'X-Requested-With', 'XMLHttpRequest' );
+		return $request;
 	}
 
 	public function test_calendar_endpoint_registered() {
 		$routes = $this->server->get_routes();
 
 		$this->assertArrayHasKey(
-			'/datamachine/v1/events/calendar',
+			'/' . API_NAMESPACE . '/events/calendar',
 			$routes,
 			'Calendar endpoint should be registered'
 		);
@@ -58,7 +74,7 @@ class EventRestControllerTest extends WP_UnitTestCase {
 
 		$has_venues_endpoint = false;
 		foreach ( array_keys( $routes ) as $route ) {
-			if ( strpos( $route, '/datamachine/v1/events/venues' ) !== false ) {
+			if ( strpos( $route, '/' . API_NAMESPACE . '/events/venues' ) !== false ) {
 				$has_venues_endpoint = true;
 				break;
 			}
@@ -71,7 +87,7 @@ class EventRestControllerTest extends WP_UnitTestCase {
 		$routes = $this->server->get_routes();
 
 		$this->assertArrayHasKey(
-			'/datamachine/v1/events/filters',
+			'/' . API_NAMESPACE . '/events/filters',
 			$routes,
 			'Filters endpoint should be registered'
 		);
@@ -88,16 +104,17 @@ class EventRestControllerTest extends WP_UnitTestCase {
 		);
 
 		// Set event datetime in the future (table is the query source of truth).
-		$future_datetime = date( 'Y-m-d H:i:s', strtotime( '+1 week' ) );
+		$future_datetime = current_datetime()->modify( '+1 week' )->format( 'Y-m-d H:i:s' );
 		EventDatesTable::upsert( $post_id, $future_datetime );
 
-		$request  = new WP_REST_Request( 'GET', '/datamachine/v1/events/calendar' );
+		$request  = $this->calendar_request();
+		$request->set_param( 'format', 'data' );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 200, $response->get_status() );
 
 		$data = $response->get_data();
-		$this->assertIsArray( $data );
+		$this->assertSame( array( $post_id ), array_column( $data['events'], 'id' ) );
 
 		// Cleanup
 		wp_delete_post( $post_id, true );
@@ -114,59 +131,61 @@ class EventRestControllerTest extends WP_UnitTestCase {
 			)
 		);
 
-		$future_datetime = date( 'Y-m-d H:i:s', strtotime( '+1 week' ) );
+		$future_datetime = current_datetime()->modify( '+1 week' )->format( 'Y-m-d H:i:s' );
 		EventDatesTable::upsert( $post_id, $future_datetime );
 
-		$request = new WP_REST_Request( 'GET', '/datamachine/v1/events/calendar' );
+		$request = $this->calendar_request();
 		$request->set_param( 'event_search', $unique_term );
+		$request->set_param( 'format', 'data' );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array( $post_id ), array_column( $response->get_data()['events'], 'id' ) );
 
 		// Cleanup
 		wp_delete_post( $post_id, true );
 	}
 
 	public function test_calendar_endpoint_accepts_date_range() {
-		$request = new WP_REST_Request( 'GET', '/datamachine/v1/events/calendar' );
-		$request->set_param( 'date_start', '2026-01-01' );
-		$request->set_param( 'date_end', '2026-12-31' );
+		$request = $this->calendar_request();
+		$date    = current_datetime()->modify( '+1 month' );
+		$request->set_param( 'date_start', $date->format( 'Y-m-01' ) );
+		$request->set_param( 'date_end', $date->format( 'Y-m-t' ) );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 200, $response->get_status() );
 	}
 
 	public function test_calendar_endpoint_accepts_pagination() {
-		$request = new WP_REST_Request( 'GET', '/datamachine/v1/events/calendar' );
+		$request = $this->calendar_request();
 		$request->set_param( 'paged', 1 );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 200, $response->get_status() );
 
 		$data = $response->get_data();
 		$this->assertIsArray( $data );
 	}
 
 	public function test_calendar_data_response_uses_canonical_empty_state(): void {
-		$request = new WP_REST_Request( 'GET', '/datamachine/v1/events/calendar' );
-		$request->set_header( 'X-Requested-With', 'XMLHttpRequest' );
+		$request = $this->calendar_request();
 		$request->set_param( 'format', 'data' );
 		$request->set_param( 'month', '2999-12' );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
 		$this->assertSame( 200, $response->get_status() );
-		$this->assertSame( 3, $data['schema']['version'] );
+		$this->assertSame( 4, $data['schema']['version'] );
 		$this->assertSame( array(), $data['grouping']['ordered_dates'] );
 		$this->assertStringContainsString( 'data-machine-events-no-events', $data['empty_html'] );
 		$this->assertStringContainsString( 'data-machine-events-no-events-today-link', $data['empty_html'] );
 	}
 
 	public function test_filters_endpoint_returns_taxonomies() {
-		$request  = new WP_REST_Request( 'GET', '/datamachine/v1/events/filters' );
+		$request  = new WP_REST_Request( 'GET', '/' . API_NAMESPACE . '/events/filters' );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 200, $response->get_status() );
 
 		$data = $response->get_data();
 		$this->assertIsArray( $data );
@@ -174,7 +193,7 @@ class EventRestControllerTest extends WP_UnitTestCase {
 
 	public function test_venues_check_duplicate_requires_auth() {
 		// Test that non-authenticated requests are rejected
-		$request = new WP_REST_Request( 'GET', '/datamachine/v1/events/venues/check-duplicate' );
+		$request = new WP_REST_Request( 'GET', '/' . API_NAMESPACE . '/events/venues/check-duplicate' );
 		$request->set_param( 'name', 'Test Venue' );
 		$response = $this->server->dispatch( $request );
 
@@ -191,17 +210,15 @@ class EventRestControllerTest extends WP_UnitTestCase {
 		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $admin_id );
 
-		$request = new WP_REST_Request( 'GET', '/datamachine/v1/events/venues/check-duplicate' );
+		$request = new WP_REST_Request( 'GET', '/' . API_NAMESPACE . '/events/venues/check-duplicate' );
 		$request->set_param( 'name', 'Non Existent Venue ' . uniqid() );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 200, $response->get_status() );
 
 		$data = $response->get_data();
 		$this->assertArrayHasKey( 'is_duplicate', $data );
 		$this->assertFalse( $data['is_duplicate'] );
 
-		// Cleanup
-		wp_set_current_user( 0 );
 	}
 }


### PR DESCRIPTION
## Summary
- replace stale pagination internals and removed-template assertions with public renderer behavior
- align calendar fixtures and assertions with site time, unique event counts, and repeated date occurrences
- update REST coverage for the shared namespace, schema v4, authenticated lifecycle, and structured responses
- observe SQL non-execution through the portable WordPress query filter

## Verification
- `homeboy --placement local review lint --path /var/lib/datamachine/workspace/data-machine-events@fix-543-calendar-test-contracts --changed-only --summary`
- `git diff --check`
- `php -l` on all five changed test files
- focused PHPUnit filter attempted twice, but Homeboy failed before PHPUnit while provisioning the managed MySQL 8.4 Docker service (`RuntimeServiceProvisionError: Managed runtime service failed: wordpress-database`)

Closes #543