### PR TITLE
fix: preserve DateTimeParser timezone semantics

### DIFF
--- a/inc/Core/DateTimeParser.php
+++ b/inc/Core/DateTimeParser.php
@@ -238,15 +238,19 @@ class DateTimeParser {
 		}
 
 		try {
-			$dt      = new DateTime( $datetime );
-			$tz      = $dt->getTimezone();
-			$tz_name = $tz ? $tz->getName() : '';
+			if ( self::hasTimezoneAbbreviation( $datetime ) ) {
+				return $result;
+			}
 
-			// Check if timezone was actually embedded or just defaulted
-			$has_embedded_tz = self::hasEmbeddedTimezone( $datetime );
+			$has_embedded_tz = self::hasEmbeddedTimezone( $datetime ) || preg_match( '/Z$/i', $datetime );
+			$constructor_tz  = ! $has_embedded_tz && self::isValidTimezone( $fallback_timezone )
+				? new DateTimeZone( $fallback_timezone )
+				: null;
+			$dt              = new DateTime( $datetime, $constructor_tz );
+			$tz              = $dt->getTimezone();
+			$tz_name         = $tz ? $tz->getName() : '';
 
-			if ( ! $has_embedded_tz && ! empty( $fallback_timezone ) && self::isValidTimezone( $fallback_timezone ) ) {
-				$dt->setTimezone( new DateTimeZone( $fallback_timezone ) );
+			if ( null !== $constructor_tz ) {
 				$tz_name = $fallback_timezone;
 			}
 
@@ -332,12 +336,7 @@ class DateTimeParser {
 			return false;
 		}
 
-		try {
-			new DateTimeZone( $timezone );
-			return true;
-		} catch ( Exception $e ) {
-			return false;
-		}
+		return in_array( $timezone, timezone_identifiers_list( DateTimeZone::ALL_WITH_BC ), true );
 	}
 
 	/**
@@ -347,8 +346,7 @@ class DateTimeParser {
 	 * @return bool True if timezone is embedded
 	 */
 	private static function hasEmbeddedTimezone( string $datetime ): bool {
-		// Z suffix means UTC, not an embedded timezone that should be preserved
-		// We want to convert UTC times to calendar timezone
+		// ICS parsing handles Z separately so it can convert to calendar timezone.
 		if ( preg_match( '/Z$/i', $datetime ) ) {
 			return false;
 		}
@@ -358,12 +356,25 @@ class DateTimeParser {
 			return true;
 		}
 
-		// Check for timezone abbreviation or name in string
-		if ( preg_match( '/\s[A-Z]{2,5}$/', $datetime ) ) {
-			return true;
+		if ( preg_match( '/\s([^\s]+)$/', $datetime, $matches ) ) {
+			return self::isValidTimezone( $matches[1] );
 		}
 
 		return false;
+	}
+
+	/**
+	 * Check for an ambiguous timezone abbreviation suffix.
+	 *
+	 * @param string $datetime Datetime string to check.
+	 * @return bool True when an abbreviation is present.
+	 */
+	private static function hasTimezoneAbbreviation( string $datetime ): bool {
+		if ( ! preg_match( '/\s([A-Z]{2,5})$/', $datetime, $matches ) ) {
+			return false;
+		}
+
+		return ! self::isValidTimezone( $matches[1] );
 	}
 
 	/**

--- a/tests/Unit/DateTimeParserTest.php
+++ b/tests/Unit/DateTimeParserTest.php
@@ -142,7 +142,67 @@ class DateTimeParserTest extends WP_UnitTestCase {
 	public function test_parse_uses_fallback_timezone() {
 		$result = DateTimeParser::parse( '2026-01-15 19:30', 'America/Chicago' );
 
+		$this->assertEquals( '2026-01-15', $result['date'] );
+		$this->assertEquals( '19:30', $result['time'] );
 		$this->assertEquals( 'America/Chicago', $result['timezone'] );
+	}
+
+	public function test_parse_date_only_uses_fallback_timezone_without_shifting_day() {
+		$result = DateTimeParser::parse( '2026-04-06', 'America/Chicago' );
+
+		$this->assertEquals( '2026-04-06', $result['date'] );
+		$this->assertEquals( '00:00', $result['time'] );
+		$this->assertEquals( 'America/Chicago', $result['timezone'] );
+	}
+
+	public function test_parse_preserves_wall_clock_time_across_dst_transition() {
+		$before = DateTimeParser::parse( '2026-03-07 00:30', 'America/New_York' );
+		$after  = DateTimeParser::parse( '2026-03-09 00:30', 'America/New_York' );
+
+		$this->assertEquals( '2026-03-07 00:30', $before['date'] . ' ' . $before['time'] );
+		$this->assertEquals( '2026-03-09 00:30', $after['date'] . ' ' . $after['time'] );
+		$this->assertEquals( 'America/New_York', $before['timezone'] );
+		$this->assertEquals( 'America/New_York', $after['timezone'] );
+	}
+
+	public function test_parse_preserves_explicit_utc() {
+		$result = DateTimeParser::parse( '2026-03-08T04:30:00Z', 'America/New_York' );
+
+		$this->assertEquals( '2026-03-08', $result['date'] );
+		$this->assertEquals( '04:30', $result['time'] );
+		$this->assertEquals( 'Z', $result['timezone'] );
+	}
+
+	public function test_parse_preserves_literal_utc_identifier() {
+		$result = DateTimeParser::parse( '2026-03-08 04:30 UTC', 'America/New_York' );
+
+		$this->assertEquals( '2026-03-08', $result['date'] );
+		$this->assertEquals( '04:30', $result['time'] );
+		$this->assertEquals( 'UTC', $result['timezone'] );
+	}
+
+	public function test_parse_preserves_explicit_offset() {
+		$result = DateTimeParser::parse( '2026-03-08T01:30:00-08:00', 'America/New_York' );
+
+		$this->assertEquals( '2026-03-08', $result['date'] );
+		$this->assertEquals( '01:30', $result['time'] );
+		$this->assertEquals( '-08:00', $result['timezone'] );
+	}
+
+	public function test_parse_preserves_embedded_iana_timezone() {
+		$result = DateTimeParser::parse( '2026-03-08 01:30 America/Los_Angeles', 'America/New_York' );
+
+		$this->assertEquals( '2026-03-08', $result['date'] );
+		$this->assertEquals( '01:30', $result['time'] );
+		$this->assertEquals( 'America/Los_Angeles', $result['timezone'] );
+	}
+
+	public function test_parse_rejects_timezone_abbreviation() {
+		$result = DateTimeParser::parse( '2026-03-08 01:30 CST', 'America/New_York' );
+
+		$this->assertEquals( '', $result['date'] );
+		$this->assertEquals( '', $result['time'] );
+		$this->assertEquals( '', $result['timezone'] );
 	}
 
 	public function test_is_valid_timezone_returns_true_for_valid() {


### PR DESCRIPTION
## Summary
- interpret naive dates and local datetimes directly in the supplied valid fallback timezone, preserving the submitted wall clock
- keep explicit `Z`, numeric offsets, and embedded IANA timezone identifiers authoritative
- restrict timezone validation to PHP's IANA identifier list and reject ambiguous abbreviations such as `CST`
- add focused date-only, DST-boundary, UTC, offset, named-zone, and abbreviation regression coverage

## Scope
This is limited to the documented `DateTimeParser` baseline defects in #198. It does not refactor Event Details, calendar rendering, extractors, or unrelated timezone handling.

Refs #198

## Verification
- `vendor/bin/phpunit --bootstrap <WordPress-compatible focused bootstrap> tests/Unit/DateTimeParserTest.php` (40 tests, 92 assertions)
- `homeboy review lint --placement local --changed-only` (PHPCS and PHPStan, zero findings)
- `git diff --check`

The full Homeboy WordPress test harness was attempted, but its managed MySQL service failed before tests because Docker is unavailable on this host (`docker: command not found`). PR CI remains the full WordPress/MySQL verification path.