### PR TITLE
test: refresh extractor contracts

### DIFF
--- a/tests/Unit/IcsExtractorTest.php
+++ b/tests/Unit/IcsExtractorTest.php
@@ -23,12 +23,14 @@ class IcsExtractorTest extends WP_UnitTestCase {
 	}
 
 	public function test_can_extract_detects_ics_content() {
-		$ics_content = "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nDTSTART:20260119T180000\nSUMMARY:Test Event\nEND:VEVENT\nEND:VCALENDAR";
+		$date        = gmdate( 'Ymd', strtotime( '+14 days' ) );
+		$ics_content = "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nDTSTART:{$date}T180000\nSUMMARY:Test Event\nEND:VEVENT\nEND:VCALENDAR";
 
 		$this->assertTrue( $this->extractor->canExtract( $ics_content ) );
 	}
 
 	public function test_floating_time_not_converted() {
+		$date        = gmdate( 'Ymd', strtotime( '+14 days' ) );
 		$ics_content = <<<ICS
 BEGIN:VCALENDAR
 VERSION:2.0
@@ -38,8 +40,8 @@ BEGIN:VTIMEZONE
 TZID:America/Chicago
 END:VTIMEZONE
 BEGIN:VEVENT
-DTSTART:20260119T180000
-DTEND:20260119T200000
+DTSTART:{$date}T180000
+DTEND:{$date}T200000
 SUMMARY:Floating Time Test
 LOCATION:Test Venue
 END:VEVENT
@@ -59,6 +61,7 @@ ICS;
 	}
 
 	public function test_explicit_utc_time_is_converted() {
+		$date        = gmdate( 'Ymd', strtotime( '+14 days' ) );
 		$ics_content = <<<ICS
 BEGIN:VCALENDAR
 VERSION:2.0
@@ -68,8 +71,8 @@ BEGIN:VTIMEZONE
 TZID:America/Chicago
 END:VTIMEZONE
 BEGIN:VEVENT
-DTSTART:20260119T180000Z
-DTEND:20260119T200000Z
+DTSTART:{$date}T180000Z
+DTEND:{$date}T200000Z
 SUMMARY:UTC Time Test
 LOCATION:Test Venue
 END:VEVENT
@@ -82,13 +85,17 @@ ICS;
 
 		$event = $events[0];
 
-		// Explicit UTC (Z suffix) SHOULD be converted to local timezone
-		// 18:00 UTC = 12:00 Central (CST is -6)
-		$this->assertEquals( '12:00', $event['startTime'], 'Explicit UTC time should be converted to local timezone' );
-		$this->assertEquals( '14:00', $event['endTime'], 'Explicit UTC end time should be converted to local timezone' );
+		$start = new \DateTime( $date . ' 18:00:00', new \DateTimeZone( 'UTC' ) );
+		$end   = new \DateTime( $date . ' 20:00:00', new \DateTimeZone( 'UTC' ) );
+		$start->setTimezone( new \DateTimeZone( 'America/Chicago' ) );
+		$end->setTimezone( new \DateTimeZone( 'America/Chicago' ) );
+
+		$this->assertEquals( $start->format( 'H:i' ), $event['startTime'], 'Explicit UTC time should be converted to local timezone' );
+		$this->assertEquals( $end->format( 'H:i' ), $event['endTime'], 'Explicit UTC end time should be converted to local timezone' );
 	}
 
 	public function test_explicit_tzid_time_preserved() {
+		$date        = gmdate( 'Ymd', strtotime( '+14 days' ) );
 		$ics_content = <<<ICS
 BEGIN:VCALENDAR
 VERSION:2.0
@@ -97,8 +104,8 @@ BEGIN:VTIMEZONE
 TZID:America/Chicago
 END:VTIMEZONE
 BEGIN:VEVENT
-DTSTART;TZID=America/Chicago:20260119T180000
-DTEND;TZID=America/Chicago:20260119T200000
+DTSTART;TZID=America/Chicago:{$date}T180000
+DTEND;TZID=America/Chicago:{$date}T200000
 SUMMARY:TZID Time Test
 LOCATION:Test Venue
 END:VEVENT

--- a/tests/Unit/JunkPayloadFilterTest.php
+++ b/tests/Unit/JunkPayloadFilterTest.php
@@ -10,14 +10,22 @@ namespace DataMachineEvents\Tests\Unit;
 
 use WP_UnitTestCase;
 use DataMachineEvents\Steps\EventImport\JunkPayloadFilter;
+use DataMachineEvents\Steps\EventImport\Handlers\Ticketmaster\Ticketmaster;
 
 class JunkPayloadFilterTest extends WP_UnitTestCase {
 
 	private JunkPayloadFilter $filter;
+	private Ticketmaster $ticketmaster;
 
 	public function setUp(): void {
 		parent::setUp();
-		$this->filter = new JunkPayloadFilter();
+		$this->ticketmaster = new Ticketmaster();
+		$this->filter       = new JunkPayloadFilter();
+	}
+
+	public function tearDown(): void {
+		remove_filter( 'data_machine_events_junk_payload_patterns', array( $this->ticketmaster, 'register_junk_patterns' ), 10 );
+		parent::tearDown();
 	}
 
 	public function test_explicit_test_flag_drops_payload() {

--- a/tests/Unit/SquarespaceExtractorTest.php
+++ b/tests/Unit/SquarespaceExtractorTest.php
@@ -486,16 +486,15 @@ class SquarespaceExtractorTest extends WP_UnitTestCase {
 	/**
 	 * Mock the WP HTTP layer with a URL → JSON-payload routing table.
 	 *
-	 * Matches on a substring of the requested URL so callers don't have to
-	 * worry about HttpClient adding extra query args. Unknown URLs return
-	 * a WP_Error so the extractor exercises its failure paths.
+	 * Matches the URL passed through HttpClient exactly. Unknown URLs return a
+	 * WP_Error so the extractor exercises its failure paths.
 	 */
 	private function mockHttpRoutes( array $routes ): void {
 		add_filter(
 			'pre_http_request',
 			static function ( $preempt, $args, $url ) use ( $routes ) {
-				foreach ( $routes as $needle => $payload ) {
-					if ( false !== strpos( $url, $needle ) ) {
+				foreach ( $routes as $route => $payload ) {
+					if ( $route === $url ) {
 						return array(
 							'headers'  => array(),
 							'body'     => is_string( $payload ) ? $payload : wp_json_encode( $payload ),

--- a/tests/Unit/TicketmasterHandlerTest.php
+++ b/tests/Unit/TicketmasterHandlerTest.php
@@ -39,12 +39,9 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 	}
 
 	public function tearDown(): void {
+		remove_filter( 'data_machine_events_junk_payload_patterns', array( $this->handler, 'register_junk_patterns' ), 10 );
 		delete_transient( 'data_machine_events_ticketmaster_classifications' );
 		parent::tearDown();
-	}
-
-	public function test_handler_type() {
-		$this->assertEquals( 'ticketmaster', $this->handler->getHandlerType() );
 	}
 
 	public function test_handler_extends_event_import_handler() {
@@ -67,7 +64,7 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 			'url'       => 'https://www.ticketmaster.com/event/123',
 			'dates'     => array(
 				'start'    => array(
-					'localDate' => '2026-03-15',
+					'localDate' => '2099-03-15',
 					'localTime' => '19:30:00',
 				),
 				'timezone' => 'America/Denver',
@@ -100,7 +97,7 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 		$this->assertIsArray( $result );
 		$this->assertEquals( 'Test Concert', $result['title'] );
 		$this->assertEquals( 'Test Arena', $result['venue'] );
-		$this->assertEquals( '2026-03-15', $result['startDate'] );
+		$this->assertEquals( '2099-03-15', $result['startDate'] );
 		$this->assertEquals( '19:30', $result['startTime'] );
 	}
 
@@ -189,7 +186,7 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 		$changed                                      = $initial;
 		$changed['name']                              = 'Updated Title';
 		$changed['url']                               = 'https://www.ticketmaster.com/event/' . $item_id . '-updated';
-		$changed['dates']['start']['localDate']       = '2027-08-16';
+		$changed['dates']['start']['localDate']       = '2099-08-16';
 		$changed['dates']['start']['localTime']       = '21:30:00';
 		$changed['_embedded']['venues'][0]['name']    = 'Updated Arena';
 		$changed['priceRanges'][0]                    = array( 'min' => 45, 'max' => 60, 'currency' => 'USD' );
@@ -199,7 +196,7 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 		$this->assertCount( 1, $second, 'A changed source revision must reach EventUpsert.' );
 		$body = json_decode( $second[0]->addTo( array() )[0]['data']['body'], true );
 		$this->assertSame( 'Updated Title', $body['event']['title'] );
-		$this->assertSame( '2027-08-16', $body['event']['startDate'] );
+		$this->assertSame( '2099-08-16', $body['event']['startDate'] );
 		$this->assertSame( 'Updated Arena', $body['event']['venue'] );
 		$this->assertSame( '$45.00 - $60.00', $body['event']['price'] );
 		$this->failPacket( $second[0]->addTo( array() )[0], 1202 );
@@ -299,7 +296,7 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 			'id'    => 'TM789',
 			'dates' => array(
 				'start' => array(
-					'localDate' => '2026-04-01',
+					'localDate' => '2099-04-01',
 				),
 			),
 		);
@@ -326,7 +323,7 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 			),
 			'dates'       => array(
 				'start' => array(
-					'localDate' => '2026-05-01',
+					'localDate' => '2099-05-01',
 				),
 			),
 		);
@@ -352,7 +349,7 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 			),
 			'dates'       => array(
 				'start' => array(
-					'localDate' => '2026-06-01',
+					'localDate' => '2099-06-01',
 				),
 			),
 		);
@@ -372,7 +369,7 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 			'id'    => 'TM999',
 			'dates' => array(
 				'start' => array(
-					'localDate' => '2026-07-01',
+					'localDate' => '2099-07-01',
 				),
 			),
 		);
@@ -608,7 +605,7 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 			'dates' => array(
 				'status' => array( 'code' => 'onsale' ),
 				'start'  => array(
-					'localDate' => '2027-08-15',
+					'localDate' => '2099-08-15',
 					'localTime' => '20:00:00',
 				),
 			),
@@ -666,7 +663,7 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 		$this->assertGreaterThan( 0, $post_id );
 		wp_set_object_terms( $post_id, array( $term_id ), 'venue' );
 		update_post_meta( $post_id, \DataMachineEvents\Core\EVENT_TICKET_URL_META_KEY, $ticket_url );
-		EventDatesTable::upsert( $post_id, '2027-08-15 20:00:00' );
+		EventDatesTable::upsert( $post_id, '2099-08-15 20:00:00' );
 		EventIdentityWriter::syncIdentityRow( $post_id, $title, $ticket_url );
 
 		return array( $post_id, $term_id );

--- a/tests/Unit/UniversalWebScraperTest.php
+++ b/tests/Unit/UniversalWebScraperTest.php
@@ -11,15 +11,15 @@
 namespace DataMachineEvents\Tests\Unit;
 
 use WP_UnitTestCase;
-use DataMachineEvents\Steps\EventImport\Handlers\WebScraper\StructuredDataProcessor;
+use DataMachineEvents\Steps\EventImport\Handlers\WebScraper\Extractors\JsonLdExtractor;
 
 class UniversalWebScraperTest extends WP_UnitTestCase {
 
-	private StructuredDataProcessor $processor;
+	private JsonLdExtractor $extractor;
 
 	public function setUp(): void {
 		parent::setUp();
-		$this->processor = new StructuredDataProcessor();
+		$this->extractor = new JsonLdExtractor();
 	}
 
 	public function test_json_ld_extraction_parses_single_event() {
@@ -32,7 +32,7 @@ class UniversalWebScraperTest extends WP_UnitTestCase {
     "@context": "https://schema.org",
     "@type": "MusicEvent",
     "name": "Test Concert",
-    "startDate": "2026-02-15T20:00:00-07:00",
+    "startDate": "2099-02-15T20:00:00-07:00",
     "location": {
         "@type": "Place",
         "name": "Red Rocks Amphitheatre",
@@ -50,7 +50,7 @@ class UniversalWebScraperTest extends WP_UnitTestCase {
 </html>
 HTML;
 
-		$events = $this->processor->extract( $html, 'https://example.com/events' );
+		$events = $this->extractor->extract( $html, 'https://example.com/events' );
 
 		$this->assertNotEmpty( $events, 'Should extract events from JSON-LD' );
 
@@ -70,13 +70,13 @@ HTML;
         "@context": "https://schema.org",
         "@type": "MusicEvent",
         "name": "Event One",
-        "startDate": "2026-02-15T20:00:00"
+        "startDate": "2099-02-15T20:00:00"
     },
     {
         "@context": "https://schema.org",
         "@type": "MusicEvent",
         "name": "Event Two",
-        "startDate": "2026-02-16T21:00:00"
+        "startDate": "2099-02-16T21:00:00"
     }
 ]
 </script>
@@ -85,7 +85,7 @@ HTML;
 </html>
 HTML;
 
-		$events = $this->processor->extract( $html, 'https://example.com/events' );
+		$events = $this->extractor->extract( $html, 'https://example.com/events' );
 
 		$this->assertCount( 2, $events, 'Should extract both events from array' );
 		$this->assertEquals( 'Event One', $events[0]['title'] );
@@ -101,9 +101,9 @@ HTML;
 </html>
 HTML;
 
-		$events = $this->processor->extract( $html, 'https://example.com' );
+		$events = $this->extractor->extract( $html, 'https://example.com' );
 
-		$this->assertIsArray( $events );
+		$this->assertSame( array(), $events );
 	}
 
 	public function test_extraction_handles_malformed_json_ld() {
@@ -119,9 +119,9 @@ HTML;
 </html>
 HTML;
 
-		$events = $this->processor->extract( $html, 'https://example.com' );
+		$events = $this->extractor->extract( $html, 'https://example.com' );
 
-		$this->assertIsArray( $events );
+		$this->assertSame( array(), $events );
 	}
 
 	public function test_extraction_includes_ticket_url() {
@@ -134,7 +134,7 @@ HTML;
     "@context": "https://schema.org",
     "@type": "MusicEvent",
     "name": "Ticketed Event",
-    "startDate": "2026-03-01T19:00:00",
+    "startDate": "2099-03-01T19:00:00",
     "offers": {
         "@type": "Offer",
         "url": "https://tickets.example.com/buy"
@@ -146,7 +146,7 @@ HTML;
 </html>
 HTML;
 
-		$events = $this->processor->extract( $html, 'https://example.com/events' );
+		$events = $this->extractor->extract( $html, 'https://example.com/events' );
 
 		$this->assertNotEmpty( $events );
 		$event = $events[0];
@@ -163,7 +163,7 @@ HTML;
     "@context": "https://schema.org",
     "@type": "MusicEvent",
     "name": "Band Concert",
-    "startDate": "2026-03-01T19:00:00",
+    "startDate": "2099-03-01T19:00:00",
     "performer": {
         "@type": "MusicGroup",
         "name": "The Test Band"
@@ -175,25 +175,14 @@ HTML;
 </html>
 HTML;
 
-		$events = $this->processor->extract( $html, 'https://example.com/events' );
+		$events = $this->extractor->extract( $html, 'https://example.com/events' );
 
 		$this->assertNotEmpty( $events );
 		$event = $events[0];
 		$this->assertEquals( 'The Test Band', $event['performer'] ?? '' );
 	}
 
-	public function test_get_extraction_method_returns_type() {
-		$html_with_json_ld = <<<HTML
-<html>
-<head>
-<script type="application/ld+json">{"@type": "Event", "name": "Test"}</script>
-</head>
-</html>
-HTML;
-
-		$method = $this->processor->getExtractionMethod( $html_with_json_ld, 'https://example.com' );
-
-		// Should return the extractor method or null if no match
-		$this->assertTrue( null=== $method || is_string( $method ) );
+	public function test_extraction_method_is_jsonld() {
+		$this->assertSame( 'jsonld', $this->extractor->getMethod() );
 	}
 }

--- a/tests/Unit/WeeblyExtractorTest.php
+++ b/tests/Unit/WeeblyExtractorTest.php
@@ -216,13 +216,15 @@ class WeeblyExtractorTest extends WP_UnitTestCase {
 				6:40 Brian Ashley Jones<br/>
 				7:30 Mount Pom<br/>
 				8:20 Anders Thomsen<br/>
-				9:10 Tanner Dane
+				9:10 Tanner Dane<br/>
+				Barn Jam May 20<br/>
+				5:50 Second Week Opener
 			</div>
 		' );
 
 		$events = $this->extractor->extract( $html, 'https://example.com/showcase' );
 
-		$this->assertCount( 1, $events );
+		$this->assertCount( 2, $events );
 		$event = $events[0];
 
 		// First artist at 5:00 PM = 17:00.


### PR DESCRIPTION
## Summary
- exercise JSON-LD through its owning extractor and remove assertions against retired handler accessors
- make ICS and Ticketmaster fixtures future-safe, register handler-owned junk patterns explicitly, and satisfy current Weebly extraction thresholds
- route Squarespace mocks through the WordPress HTTP boundary without ambiguous URL matches while preserving existing web-fetch header trust behavior

## Verification
- `homeboy review lint data-machine-events --changed-only --placement local --summary` passes
- focused PHP syntax checks pass for all affected extractor tests
- focused PHPUnit was attempted through Homeboy; local MySQL provisioning was unavailable, and the SQLite CI profile failed during bootstrap because the Data Machine dependency was not mounted (`FetchHandler` missing), before test discovery

Closes #549