### PR TITLE
fix: serialize native venue term edits

### DIFF
--- a/inc/Core/VenueProfileMutations.php
+++ b/inc/Core/VenueProfileMutations.php
@@ -112,14 +112,16 @@ class VenueProfileMutations {
 	}
 
 	/**
-	 * Acquire canonical serialization immediately before a native term write.
+	 * Acquire canonical serialization at WordPress's final pre-write filter.
 	 *
+	 * @param array  $data     Term data about to be written.
 	 * @param int    $term_id  Term ID.
 	 * @param string $taxonomy Taxonomy slug.
+	 * @return array
 	 */
-	public static function beginNativeTermEdit( int $term_id, string $taxonomy ): void {
+	public static function serializeNativeTermEdit( array $data, int $term_id, string $taxonomy ): array {
 		if ( self::$internal_term_update || self::TAXONOMY !== $taxonomy ) {
-			return;
+			return $data;
 		}
 
 		$lock_key = self::acquireLock( $term_id );
@@ -128,6 +130,7 @@ class VenueProfileMutations {
 		}
 		self::$native_term_locks[] = $lock_key;
 		self::registerShutdownCleanup();
+		return $data;
 	}
 
 	/**

--- a/inc/Core/Venue_Taxonomy.php
+++ b/inc/Core/Venue_Taxonomy.php
@@ -1388,7 +1388,7 @@ class Venue_Taxonomy {
 
 	private static function init_admin_hooks() {
 		add_filter( 'wp_update_term_parent', array( VenueProfileMutations::class, 'guardNativeTermEdit' ), 10, 3 );
-		add_action( 'edit_terms', array( VenueProfileMutations::class, 'beginNativeTermEdit' ), 10, 2 );
+		add_filter( 'wp_update_term_data', array( VenueProfileMutations::class, 'serializeNativeTermEdit' ), 10, 3 );
 		add_action( 'saved_venue', array( VenueProfileMutations::class, 'endNativeTermEdit' ), 99 );
 
 		add_action( 'venue_add_form_fields', array( __CLASS__, 'add_venue_form_fields' ) );

--- a/tests/Integration/VenueProfileMutationsTest.php
+++ b/tests/Integration/VenueProfileMutationsTest.php
@@ -29,9 +29,7 @@ class VenueProfileMutationsTest extends WP_UnitTestCase {
 		$wpdb->query( 'SET autocommit = 1' );
 		$this->had_settings    = false !== get_option( Settings_Page::OPTION_KEY, false );
 		$this->settings_before = get_option( Settings_Page::OPTION_KEY, null );
-		if ( ! taxonomy_exists( 'venue' ) ) {
-			Venue_Taxonomy::register();
-		}
+		Venue_Taxonomy::register();
 	}
 
 	public function tearDown(): void {
@@ -308,6 +306,7 @@ class VenueProfileMutationsTest extends WP_UnitTestCase {
 			$this->markTestSkipped( 'Native venue lock coverage requires mysqli.' );
 		}
 		$term_id  = $this->venue( 'Native Lock Failure' );
+		$original = get_term( $term_id, 'venue' )->name;
 		$lock_key = VenueProfileMutations::lockName( $term_id );
 		$owner    = mysqli_init();
 		$owner->real_connect( DB_HOST, DB_USER, DB_PASSWORD, DB_NAME );
@@ -325,7 +324,28 @@ class VenueProfileMutationsTest extends WP_UnitTestCase {
 		}
 
 		$this->assertTrue( $rejected );
-		$this->assertStringStartsWith( 'Native Lock Failure', get_term( $term_id, 'venue' )->name );
+		$this->assertSame( $original, get_term( $term_id, 'venue' )->name );
+	}
+
+	public function test_native_wordpress_edit_releases_serialization_after_saved_hooks(): void {
+		if ( ! extension_loaded( 'mysqli' ) ) {
+			$this->markTestSkipped( 'Native venue lock coverage requires mysqli.' );
+		}
+		$term_id  = $this->venue( 'Native Lock Success' );
+		$lock_key = VenueProfileMutations::lockName( $term_id );
+		$observer = mysqli_init();
+		$observer->real_connect( DB_HOST, DB_USER, DB_PASSWORD, DB_NAME );
+
+		try {
+			$result = wp_update_term( $term_id, 'venue', array( 'name' => 'Native Lock Persisted' ) );
+
+			$this->assertNotWPError( $result );
+			$this->assertSame( 'Native Lock Persisted', get_term( $term_id, 'venue' )->name );
+			$this->assertSame( 1, $this->namedLock( $observer, 'GET_LOCK', $lock_key ), 'saved_venue must release the native edit lock.' );
+		} finally {
+			$this->namedLock( $observer, 'RELEASE_LOCK', $lock_key );
+			$observer->close();
+		}
 	}
 
 	public function test_uncertain_commit_requires_a_fresh_read(): void {

--- a/tests/Integration/mysql-lock-smoke.php
+++ b/tests/Integration/mysql-lock-smoke.php
@@ -116,6 +116,7 @@ namespace {
 	function wp_term_is_shared(): bool { return false; }
 	function metadata_exists( string $type, int $term_id, string $key ): bool { return array() !== get_term_meta( $term_id, $key, false ); }
 	function add_filter( string $name, callable $callback ): void { $GLOBALS['dme_test_filters'][ $name ][] = $callback; }
+	function add_action( string $name, callable $callback ): void { add_filter( $name, $callback ); }
 	function remove_all_filters( string $name ): void { unset( $GLOBALS['dme_test_filters'][ $name ] ); }
 	function apply_filters( string $name, mixed $value, mixed ...$args ): mixed {
 		foreach ( $GLOBALS['dme_test_filters'][ $name ] ?? array() as $callback ) {
@@ -123,7 +124,12 @@ namespace {
 		}
 		return $value;
 	}
-	function do_action( string $name, mixed ...$args ): void { $GLOBALS['dme_test_actions'][ $name ][] = $args; }
+	function do_action( string $name, mixed ...$args ): void {
+		$GLOBALS['dme_test_actions'][ $name ][] = $args;
+		foreach ( $GLOBALS['dme_test_filters'][ $name ] ?? array() as $callback ) {
+			$callback( ...$args );
+		}
+	}
 	function wp_die( mixed $message = '' ): never { throw new \RuntimeException( (string) $message ); }
 
 	function dme_test_table(): string { return '`' . $GLOBALS['dme_test_table'] . '`'; }
@@ -173,8 +179,20 @@ namespace {
 		if ( ! $term ) {
 			return new WP_Error( 'invalid_term', 'Invalid term.' );
 		}
-		$statement = $wpdb->dbh->prepare( 'UPDATE ' . dme_test_table() . ' SET name = ?, description = ? WHERE term_id = ?' );
-		$statement->execute( array( $args['name'] ?? $term->name, $args['description'] ?? $term->description, $term_id ) );
+		$args['parent'] = apply_filters( 'wp_update_term_parent', $args['parent'] ?? 0, $term_id, $taxonomy );
+		$data           = apply_filters(
+			'wp_update_term_data',
+			array(
+				'name'        => $args['name'] ?? $term->name,
+				'description' => $args['description'] ?? $term->description,
+			),
+			$term_id,
+			$taxonomy,
+			$args
+		);
+		$statement      = $wpdb->dbh->prepare( 'UPDATE ' . dme_test_table() . ' SET name = ?, description = ? WHERE term_id = ?' );
+		$statement->execute( array( $data['name'], $data['description'], $term_id ) );
+		do_action( 'saved_' . $taxonomy, $term_id, $term_id, true, $args );
 		return array( 'term_id' => $term_id, 'term_taxonomy_id' => $term_id );
 	}
 }
@@ -199,6 +217,10 @@ namespace {
 	require_once dirname( __DIR__, 2 ) . '/inc/Core/VenueProfileMutations.php';
 
 	use DataMachineEvents\Core\VenueProfileMutations;
+
+	add_filter( 'wp_update_term_parent', array( VenueProfileMutations::class, 'guardNativeTermEdit' ) );
+	add_filter( 'wp_update_term_data', array( VenueProfileMutations::class, 'serializeNativeTermEdit' ) );
+	add_action( 'saved_venue', array( VenueProfileMutations::class, 'endNativeTermEdit' ) );
 
 	class DmeCommitUncertain extends VenueProfileMutations {
 		protected static function query( string $sql ): int|bool {
@@ -340,6 +362,27 @@ namespace {
 		remove_all_filters( 'update_term_metadata' );
 		dme_assert( ! is_wp_error( $result ) && is_wp_error( $nested ) && 'venue_mutation_reentrant' === $nested->get_error_code(), 'Same-venue reentrancy was not rejected.' );
 
+		dme_stage( 'native-term-serialization' );
+		$original_name = get_term( $term_id, 'venue' )->name;
+		dme_assert( 1 === dme_lock( $owner, 'GET_LOCK', $lock_key ), 'Owner could not acquire the native edit lock.' );
+		add_filter( 'data_machine_events_venue_lock_timeout', static fn() => 0 );
+		$rejected = false;
+		try {
+			wp_update_term( $term_id, 'venue', array( 'name' => 'Should Not Persist' ) );
+		} catch ( \RuntimeException ) {
+			$rejected = true;
+		}
+		remove_all_filters( 'data_machine_events_venue_lock_timeout' );
+		dme_assert( $rejected, 'Native venue edit did not fail closed when serialization was unavailable.' );
+		dme_assert( $original_name === get_term( $term_id, 'venue' )->name, 'Rejected native venue edit changed the term.' );
+		dme_assert( 1 === dme_lock( $owner, 'RELEASE_LOCK', $lock_key ), 'Owner could not release the native edit lock.' );
+
+		$result = wp_update_term( $term_id, 'venue', array( 'name' => 'Native Lock Persisted' ) );
+		dme_assert( ! is_wp_error( $result ), 'Serialized native venue edit failed.' );
+		dme_assert( 'Native Lock Persisted' === get_term( $term_id, 'venue' )->name, 'Serialized native venue edit did not persist.' );
+		dme_assert( 1 === dme_lock( $owner, 'GET_LOCK', $lock_key ), 'Successful native edit retained its advisory lock.' );
+		dme_assert( 1 === dme_lock( $owner, 'RELEASE_LOCK', $lock_key ), 'Observer could not release the post-save lock.' );
+
 		dme_stage( 'commit-uncertainty' );
 		$result = DmeCommitUncertain::updateSystem( $term_id, array( 'capacity' => '500' ) );
 		dme_assert( is_wp_error( $result ) && 'venue_commit_uncertain' === $result->get_error_code(), 'Uncertain commit was not surfaced.' );
@@ -371,7 +414,7 @@ namespace {
 		dme_lock( $owner, 'RELEASE_LOCK', $first_lock );
 
 		dme_stage( 'complete' );
-		fwrite( STDOUT, "PASS: actual venue mutation class passed race, duplicate, ordering, reentrancy, uncertainty, and multisite checks.\n" );
+		fwrite( STDOUT, "PASS: actual venue mutation class passed race, native serialization, ordering, reentrancy, uncertainty, and multisite checks.\n" );
 	} catch ( \Throwable $throwable ) {
 		fwrite( STDERR, 'FAIL: ' . $throwable->getMessage() . "\n" );
 		$exit_code = 1;


### PR DESCRIPTION
## Summary
- acquire the canonical venue advisory lock at WordPress's final `wp_update_term_data` pre-write filter
- fail closed before term-table persistence when another MySQL session owns the lock, while retaining early preflight and post-save cleanup
- cover unchanged-term rejection plus successful persistence and advisory-lock release with real two-session MySQL integration tests

## Verification
- changed-file PHPCS: passed
- changed-file PHPStan level 7: passed
- PHP syntax and `git diff --check`: passed
- local targeted MySQL harness attempted but Docker is unavailable on this host; PR MySQL 8 checks provide the disposable database run
- repository-wide Homeboy audit completed; only pre-existing baseline findings outside this change were reported

Closes #575