### PR TITLE
fix: invalidate calendar caches under persistent object cache

### DIFF
--- a/inc/Abilities/CalendarAbilities.php
+++ b/inc/Abilities/CalendarAbilities.php
@@ -453,7 +453,7 @@ class CalendarAbilities {
 	 */
 	private static function compute_event_counts_via_ability(): array {
 		$cache_key = 'data-machine_cal_counts';
-		$cached    = get_transient( $cache_key );
+		$cached    = CalendarCache::get( $cache_key );
 		if ( false !== $cached ) {
 			return $cached;
 		}
@@ -474,7 +474,7 @@ class CalendarAbilities {
 			'future' => $future['total'],
 		);
 
-		set_transient( $cache_key, $result, 10 * MINUTE_IN_SECONDS );
+		CalendarCache::set( $cache_key, $result, 10 * MINUTE_IN_SECONDS );
 		return $result;
 	}
 

--- a/inc/Blocks/Calendar/Cache/CacheInvalidator.php
+++ b/inc/Blocks/Calendar/Cache/CacheInvalidator.php
@@ -210,51 +210,9 @@ class CacheInvalidator {
 
 	/**
 	 * Invalidate all calendar caches
-	 *
-	 * Uses database query to find and delete all calendar transients.
 	 */
 	public static function invalidate_all(): void {
-		global $wpdb;
-
-		// Find calendar-specific transient keys before deleting from DB.
-		$transient_keys = $wpdb->get_col(
-			$wpdb->prepare(
-				"SELECT REPLACE(option_name, '_transient_', '') FROM {$wpdb->options} WHERE option_name LIKE %s",
-				'_transient_' . CalendarCache::PREFIX . '%'
-			)
-		);
-
-		// Delete from DB (for non-persistent cache environments).
-		$wpdb->query(
-			$wpdb->prepare(
-				"DELETE FROM {$wpdb->options} WHERE option_name LIKE %s OR option_name LIKE %s",
-				'_transient_' . CalendarCache::PREFIX . '%',
-				'_transient_timeout_' . CalendarCache::PREFIX . '%'
-			)
-		);
-
-		// Delete specific keys from object cache instead of flushing the entire
-		// transient group. Flushing the group killed ALL transients site-wide on
-		// every event save, preventing any transient from surviving pipeline activity.
-		foreach ( $transient_keys as $key ) {
-			wp_cache_delete( $key, 'transient' );
-			wp_cache_delete( $key, 'site-transient' );
-		}
-
-		// Flush the dedicated full-response cache group. This is safe to
-		// flush wholesale because the group is private to the calendar —
-		// nothing else writes to `data-machine-calendar`.
-		if ( function_exists( 'wp_cache_flush_group' ) ) {
-			wp_cache_flush_group( CalendarCache::GROUP );
-		} else {
-			// On WP < 6.1 / object-cache drop-ins lacking flush_group support,
-			// the transient layer above still serves as the source of truth.
-			// The wp_cache entries will age out within TTL_FULL_PAST (24h).
-			// Acceptable downside for a fallback path that won't hit on
-			// extrachill.com (Redis Object Cache supports flush_group).
-			$noop = true;
-			unset( $noop );
-		}
+		CalendarCache::invalidate();
 	}
 }
 

--- a/inc/Blocks/Calendar/Cache/CalendarCache.php
+++ b/inc/Blocks/Calendar/Cache/CalendarCache.php
@@ -35,6 +35,7 @@ class CalendarCache {
 	const PREFIX            = 'data-machine_cal_';
 	const FULL_PREFIX       = 'data-machine_cal_full_';
 	const GROUP             = 'data-machine-calendar';
+	const GENERATION_OPTION = 'data_machine_events_calendar_cache_generation';
 	const TTL_DATES         = 30 * MINUTE_IN_SECONDS;
 	const TTL_COUNTS        = 30 * MINUTE_IN_SECONDS;
 	const TTL_FULL_UPCOMING = HOUR_IN_SECONDS;
@@ -47,7 +48,7 @@ class CalendarCache {
 	 * @return mixed Cached value or false if not found.
 	 */
 	public static function get( string $key ) {
-		return get_transient( $key );
+		return get_transient( self::storage_key( $key ) );
 	}
 
 	/**
@@ -59,7 +60,7 @@ class CalendarCache {
 	 * @return bool True on success.
 	 */
 	public static function set( string $key, $value, int $ttl ): bool {
-		return set_transient( $key, $value, $ttl );
+		return set_transient( self::storage_key( $key ), $value, $ttl );
 	}
 
 	/**
@@ -167,6 +168,7 @@ class CalendarCache {
 	 * @return mixed Cached envelope array or false on miss.
 	 */
 	public static function get_full_response( string $key ) {
+		$key    = self::storage_key( $key );
 		$found  = false;
 		$cached = wp_cache_get( $key, self::GROUP, false, $found );
 		if ( $found && false !== $cached ) {
@@ -201,8 +203,39 @@ class CalendarCache {
 	 * @return bool True on success.
 	 */
 	public static function set_full_response( string $key, $value, int $ttl ): bool {
+		$key = self::storage_key( $key );
 		wp_cache_set( $key, $value, self::GROUP, $ttl );
 		return set_transient( $key, $value, $ttl );
+	}
+
+	/**
+	 * Rotate the owner-scoped generation used by every calendar cache layer.
+	 */
+	public static function invalidate(): void {
+		self::get_generation();
+		update_option( self::GENERATION_OPTION, wp_generate_uuid4(), false );
+	}
+
+	/**
+	 * Get the current owner-scoped cache generation.
+	 */
+	public static function get_generation(): string {
+		$generation = get_option( self::GENERATION_OPTION );
+		if ( false === $generation ) {
+			$generation = wp_generate_uuid4();
+			if ( ! add_option( self::GENERATION_OPTION, $generation, '', false ) ) {
+				$generation = get_option( self::GENERATION_OPTION );
+			}
+		}
+
+		return (string) $generation;
+	}
+
+	/**
+	 * Resolve a logical calendar key to its current generation.
+	 */
+	private static function storage_key( string $key ): string {
+		return $key . '_' . self::get_generation();
 	}
 
 	/**

--- a/tests/Unit/CalendarCacheTest.php
+++ b/tests/Unit/CalendarCacheTest.php
@@ -365,6 +365,43 @@ class CalendarCacheTest extends WP_UnitTestCase {
 		$this->assertSame( 1, $invalidations );
 	}
 
+	/**
+	 * @dataProvider object_cache_modes
+	 */
+	public function test_real_venue_mutation_makes_calendar_caches_unreadable_without_flushing_other_transients( bool $persistent ): void {
+		$original_mode = wp_using_ext_object_cache();
+		wp_using_ext_object_cache( $persistent );
+
+		$post_id       = self::factory()->post->create( array( 'post_type' => Event_Post_Type::POST_TYPE ) );
+		$venue         = wp_insert_term( 'Cache Outcome Venue ' . uniqid(), 'venue' );
+		$bucket_key    = CalendarCache::generate_key( array(), 'dates' );
+		$response_key  = CalendarCache::generate_full_response_key( array() );
+		$unrelated_key = 'unrelated_calendar_invalidation_' . uniqid();
+		$this->assertNotWPError( $venue );
+
+		CalendarCache::set( $bucket_key, 'stale bucket', HOUR_IN_SECONDS );
+		CalendarCache::set_full_response( $response_key, 'stale response', HOUR_IN_SECONDS );
+		set_transient( $unrelated_key, 'preserved', HOUR_IN_SECONDS );
+
+		try {
+			wp_set_object_terms( $post_id, array( $venue['term_id'] ), 'venue' );
+
+			$this->assertFalse( CalendarCache::get( $bucket_key ) );
+			$this->assertFalse( CalendarCache::get_full_response( $response_key ) );
+			$this->assertSame( 'preserved', get_transient( $unrelated_key ) );
+		} finally {
+			delete_transient( $unrelated_key );
+			wp_using_ext_object_cache( $original_mode );
+		}
+	}
+
+	public function object_cache_modes(): array {
+		return array(
+			'nonpersistent object cache' => array( false ),
+			'persistent object cache'    => array( true ),
+		);
+	}
+
 	public function test_identical_venue_append_does_not_invalidate_calendar_cache(): void {
 		$post_id = self::factory()->post->create( array( 'post_type' => Event_Post_Type::POST_TYPE ) );
 		$venue   = wp_insert_term( 'Cache Identical Append Venue ' . uniqid(), 'venue' );
@@ -459,11 +496,9 @@ class CalendarCacheTest extends WP_UnitTestCase {
 		$nested       = false;
 		$invalidations = 0;
 		$snapshots     = array();
-		$query_filter  = static function ( string $query ) use ( &$invalidations ): string {
-			if ( str_starts_with( ltrim( $query ), 'DELETE FROM' ) && str_contains( $query, '_transient_' . CalendarCache::PREFIX ) ) {
-				++$invalidations;
-			}
-			return $query;
+		CalendarCache::get_generation();
+		$generation_listener = static function () use ( &$invalidations ): void {
+			++$invalidations;
 		};
 		$nested_removal = static function ( $object_id, $tt_ids, $taxonomy ) use ( $post_id, $first, &$nested ): void {
 			if ( ! $nested && $post_id === (int) $object_id && 'venue' === $taxonomy ) {
@@ -481,13 +516,13 @@ class CalendarCacheTest extends WP_UnitTestCase {
 			}
 		};
 
-		add_filter( 'query', $query_filter );
+		add_action( 'update_option_' . CalendarCache::GENERATION_OPTION, $generation_listener );
 		add_action( 'delete_term_relationships', $nested_removal, 20, 3 );
 		add_action( 'deleted_term_relationships', $observe_removal, 20, 3 );
 		try {
 			wp_remove_object_terms( $post_id, array( $first['term_id'], $second['term_id'] ), 'venue' );
 		} finally {
-			remove_filter( 'query', $query_filter );
+			remove_action( 'update_option_' . CalendarCache::GENERATION_OPTION, $generation_listener );
 			remove_action( 'delete_term_relationships', $nested_removal, 20 );
 			remove_action( 'deleted_term_relationships', $observe_removal, 20 );
 		}
@@ -561,17 +596,15 @@ class CalendarCacheTest extends WP_UnitTestCase {
 	}
 
 	private function count_calendar_invalidations( callable $operation ): int {
-		$count  = 0;
-		$filter = static function ( string $query ) use ( &$count ): string {
-			if ( str_starts_with( ltrim( $query ), 'DELETE FROM' ) && str_contains( $query, '_transient_' . CalendarCache::PREFIX ) ) {
-				++$count;
-			}
-			return $query;
+		$count = 0;
+		CalendarCache::get_generation();
+		$listener = static function () use ( &$count ): void {
+			++$count;
 		};
 
-		add_filter( 'query', $filter );
+		add_action( 'update_option_' . CalendarCache::GENERATION_OPTION, $listener );
 		$operation();
-		remove_filter( 'query', $filter );
+		remove_action( 'update_option_' . CalendarCache::GENERATION_OPTION, $listener );
 
 		return $count;
 	}

--- a/tests/Unit/EventUpsertTest.php
+++ b/tests/Unit/EventUpsertTest.php
@@ -335,7 +335,7 @@ class EventUpsertTest extends WP_UnitTestCase {
 		$this->assertNull( $identity['venue_term_id'] );
 
 		$cache_key = CalendarCache::PREFIX . 'no_change_repair_' . uniqid();
-		set_transient( $cache_key, 'stale', HOUR_IN_SECONDS );
+		CalendarCache::set( $cache_key, 'stale', HOUR_IN_SECONDS );
 		$content_before     = get_post_field( 'post_content', $post_id );
 		$attachments_before = (int) wp_count_posts( 'attachment' )->inherit;
 		$image_attempts     = 0;
@@ -346,18 +346,16 @@ class EventUpsertTest extends WP_UnitTestCase {
 		};
 		add_action( 'datamachine_log', $log_listener, 10, 2 );
 		$cache_invalidations = 0;
-		$query_listener      = static function ( string $query ) use ( &$cache_invalidations ): string {
-			if ( str_starts_with( ltrim( $query ), 'DELETE FROM' ) && str_contains( $query, '_transient_' . CalendarCache::PREFIX ) ) {
-				++$cache_invalidations;
-			}
-			return $query;
+		CalendarCache::get_generation();
+		$generation_listener = static function () use ( &$cache_invalidations ): void {
+			++$cache_invalidations;
 		};
-		add_filter( 'query', $query_listener );
+		add_action( 'update_option_' . CalendarCache::GENERATION_OPTION, $generation_listener );
 
 		$repaired = $execute->invoke( $this->handler, $parameters, $config );
 
 		remove_action( 'datamachine_log', $log_listener, 10 );
-		remove_filter( 'query', $query_listener );
+		remove_action( 'update_option_' . CalendarCache::GENERATION_OPTION, $generation_listener );
 		$this->assertTrue( $repaired['success'] ?? false );
 		$this->assertSame( 'no_change', $repaired['data']['action'] ?? '' );
 		$this->assertSame( $content_before, get_post_field( 'post_content', $post_id ) );
@@ -366,7 +364,7 @@ class EventUpsertTest extends WP_UnitTestCase {
 		$this->assertSame( array( $venue->term_id ), wp_get_object_terms( $post_id, 'venue', array( 'fields' => 'ids' ) ) );
 		$this->assertSame( (string) $venue->term_id, (string) ( new PostIdentityIndex() )->get( $post_id )['venue_term_id'] );
 		$this->assertSame( 1, $cache_invalidations, 'A no_change taxonomy repair must invalidate canonical caches exactly once.' );
-		$this->assertFalse( get_transient( $cache_key ), 'Taxonomy-only repair must invalidate calendar caches.' );
+		$this->assertFalse( CalendarCache::get( $cache_key ), 'Taxonomy-only repair must invalidate calendar caches.' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- replace options-table transient discovery with an owner-scoped Calendar cache generation
- route bucket, counts, and full-response cache reads/writes through the current generation so real mutations invalidate both persistent and nonpersistent cache paths
- add outcome-based coverage for both object-cache modes while proving unrelated transients survive, and retain taxonomy repair regression coverage

## Validation
- `homeboy review lint --changed-only --summary`: PHPCS and PHPStan level 7 passed
- `homeboy review audit --changed-since origin/main`: no introduced findings
- hosted MySQL 8 canonical venue-mutation smoke passed
- hosted WordPress suite executed 644 tests; changed Calendar cache tests produced no failures
- full suite remains baseline-red with 21 unrelated errors and 54 unrelated failures; recent `main` Homeboy runs are also failing
- PHP syntax checks and `git diff --check` passed

Closes #574