### PR TITLE
fix: restore managed PHPUnit baseline

### DIFF
--- a/data-machine-events.php
+++ b/data-machine-events.php
@@ -196,6 +196,7 @@ class DATAMACHINE_Events {
 			}
 		}
 
+		$this->register_ability_hooks();
 		add_action( 'init', array( $this, 'init_data_machine_integration' ), 25 );
 
 		// Fire the public integration loaded action. Consumers gate filter
@@ -242,6 +243,50 @@ class DATAMACHINE_Events {
 		}
 
 		$this->load_data_machine_components();
+	}
+
+	/**
+	 * Attach lightweight ability registrations before the lazy registries fire.
+	 */
+	private function register_ability_hooks(): void {
+		require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Abilities/AbilityCategories.php';
+		require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Abilities/AbilityPermissions.php';
+		\DataMachineEvents\Abilities\AbilityCategories::ensure_registered();
+
+		$ability_classes = array(
+			\DataMachineEvents\Abilities\EventScraperTest::class,
+			\DataMachineEvents\Abilities\TimezoneAbilities::class,
+			\DataMachineEvents\Abilities\EventQueryAbilities::class,
+			\DataMachineEvents\Abilities\EventHealthAbilities::class,
+			\DataMachineEvents\Abilities\EventUpdateAbilities::class,
+			\DataMachineEvents\Abilities\EventUpsertAbilities::class,
+			\DataMachineEvents\Abilities\MoveEventAbilities::class,
+			\DataMachineEvents\Abilities\DeleteEventAbilities::class,
+			\DataMachineEvents\Abilities\BatchTimeFixAbilities::class,
+			\DataMachineEvents\Abilities\EncodingFixAbilities::class,
+			\DataMachineEvents\Abilities\VenueAbilities::class,
+			\DataMachineEvents\Abilities\VenueMapAbilities::class,
+			\DataMachineEvents\Abilities\CalendarAbilities::class,
+			\DataMachineEvents\Abilities\TicketUrlResyncAbilities::class,
+			\DataMachineEvents\Abilities\TicketmasterTest::class,
+			\DataMachineEvents\Abilities\DiceFmTest::class,
+			\DataMachineEvents\Abilities\GeocodingAbilities::class,
+			\DataMachineEvents\Abilities\VenueStatsAbilities::class,
+			\DataMachineEvents\Abilities\FilterAbilities::class,
+			\DataMachineEvents\Abilities\EventQualityAuditAbilities::class,
+			\DataMachineEvents\Abilities\SettingsAbilities::class,
+			\DataMachineEvents\Abilities\DuplicateDetectionAbilities::class,
+			\DataMachineEvents\Abilities\UpcomingCountAbilities::class,
+			\DataMachineEvents\Abilities\EventDateQueryAbilities::class,
+			\DataMachineEvents\Abilities\EventsByTermAbilities::class,
+			\DataMachineEvents\Abilities\MergedBillDetectAbilities::class,
+			\DataMachineEvents\Abilities\MergeEventPostsAbilities::class,
+			\DataMachineEvents\Abilities\MergedBillDecideAbilities::class,
+		);
+
+		foreach ( $ability_classes as $ability_class ) {
+			new $ability_class();
+		}
 	}
 
 	private function load_data_machine_components() {

--- a/inc/Core/DateTimeParser.php
+++ b/inc/Core/DateTimeParser.php
@@ -87,7 +87,7 @@ class DateTimeParser {
 				$tz = wp_timezone();
 				if ( $tz instanceof DateTimeZone ) {
 					$name = $tz->getName();
-					if ( ! empty( $name ) ) {
+					if ( self::isValidTimezone( $name ) ) {
 						return $name;
 					}
 				}

--- a/inc/Steps/Upsert/Events/EventUpsert.php
+++ b/inc/Steps/Upsert/Events/EventUpsert.php
@@ -687,6 +687,18 @@ class EventUpsert extends UpsertHandler {
 
 					return null;
 				}
+
+				$existing_identity_start = self::composeIdentityStart( $existing_startDate, (string) ( $existing_data['startTime'] ?? '' ) );
+				$existing_timestamp      = strtotime( $existing_identity_start );
+				$incoming_timestamp      = strtotime( $startDate );
+				if ( preg_match( '/\d{2}:\d{2}/', $existing_identity_start )
+					&& preg_match( '/\d{2}:\d{2}/', $startDate )
+					&& false !== $existing_timestamp
+					&& false !== $incoming_timestamp
+					&& abs( $existing_timestamp - $incoming_timestamp ) > 7200
+				) {
+					return null;
+				}
 			}
 		}
 

--- a/tests/Unit/BlockRegistrationTest.php
+++ b/tests/Unit/BlockRegistrationTest.php
@@ -17,7 +17,7 @@ class BlockRegistrationTest extends WP_UnitTestCase {
 	public function test_blocks_registered_on_init_hook() {
 		$this->assertTrue( class_exists( 'DATAMACHINE_Events' ), 'DATAMACHINE_Events class should exist' );
 
-		$plugin = DATAMACHINE_Events::get_instance();
+		$plugin = \DATAMACHINE_Events::get_instance();
 
 		$has_init_hook = false;
 

--- a/tests/Unit/CalendarBlockTest.php
+++ b/tests/Unit/CalendarBlockTest.php
@@ -13,6 +13,7 @@ namespace DataMachineEvents\Tests\Unit;
 use WP_UnitTestCase;
 use DataMachineEvents\Blocks\Calendar\Pagination\Renderer as Pagination;
 use DataMachineEvents\Blocks\Calendar\Cache\CalendarCache;
+use DataMachineEvents\Blocks\Calendar\Query\CalendarRequest;
 
 class CalendarBlockTest extends WP_UnitTestCase {
 
@@ -92,7 +93,7 @@ class CalendarBlockTest extends WP_UnitTestCase {
 
 		add_filter(
 			'data_machine_events_calendar_request_args',
-			function ( $args, $render_context ) use ( &$context ) {
+			function ( $args, $render_context ) use ( &$context, &$parsed_input ) {
 				$context                  = $render_context;
 				$args['lat']              = '32.7765<script>';
 				$args['lng']              = '-79.9311';
@@ -101,22 +102,13 @@ class CalendarBlockTest extends WP_UnitTestCase {
 				$args['tax_filter']       = array(
 					'Festival<script>' => array( '42', '-3', 'invalid' ),
 				);
+				$parsed_input             = CalendarRequest::fromQueryArgs( $args, $render_context['archive_term'] )->toAbilitiesArgs();
 
 				return $args;
 			},
 			10,
 			2
 		);
-		add_filter(
-			'data_machine_events_calendar_query_args',
-			function ( $args, $input ) use ( &$parsed_input ) {
-				$parsed_input = $input;
-				return $args;
-			},
-			10,
-			2
-		);
-
 		CalendarCache::invalidate();
 		$html = $this->render_calendar( array( 'displayMode' => 'date-groups', 'showSearch' => false ) );
 
@@ -145,24 +137,16 @@ class CalendarBlockTest extends WP_UnitTestCase {
 
 		add_filter(
 			'data_machine_events_calendar_request_args',
-			function ( $args ) {
+			function ( $args ) use ( &$parsed_input ) {
 				$args += array(
 					'lat'        => 'invalid-default',
 					'lng'        => 'invalid-default',
 					'tax_filter' => array( 'festival' => array( 42 ) ),
 					'month'     => 'not-a-month',
 				);
+				$parsed_input = CalendarRequest::fromQueryArgs( $args )->toAbilitiesArgs();
 				return $args;
 			}
-		);
-		add_filter(
-			'data_machine_events_calendar_query_args',
-			function ( $args, $input ) use ( &$parsed_input ) {
-				$parsed_input = $input;
-				return $args;
-			},
-			10,
-			2
 		);
 
 		CalendarCache::invalidate();

--- a/tests/Unit/CalendarBlockTest.php
+++ b/tests/Unit/CalendarBlockTest.php
@@ -12,6 +12,7 @@ namespace DataMachineEvents\Tests\Unit;
 
 use WP_UnitTestCase;
 use DataMachineEvents\Blocks\Calendar\Pagination\Renderer as Pagination;
+use DataMachineEvents\Blocks\Calendar\Cache\CalendarCache;
 
 class CalendarBlockTest extends WP_UnitTestCase {
 
@@ -116,6 +117,7 @@ class CalendarBlockTest extends WP_UnitTestCase {
 			2
 		);
 
+		CalendarCache::invalidate();
 		$html = $this->render_calendar( array( 'displayMode' => 'date-groups', 'showSearch' => false ) );
 
 		$this->assertSame( array(), $_GET, 'Consumers do not need to mutate request globals.' );
@@ -163,6 +165,7 @@ class CalendarBlockTest extends WP_UnitTestCase {
 			2
 		);
 
+		CalendarCache::invalidate();
 		$this->render_calendar();
 
 		$this->assertSame( '40.7128', $parsed_input['geo_lat'] );

--- a/tests/Unit/CheckOrphanPipelinesCommandTest.php
+++ b/tests/Unit/CheckOrphanPipelinesCommandTest.php
@@ -65,29 +65,38 @@ class CheckOrphanPipelinesCommandTest extends WP_UnitTestCase {
 	private function insert_pipeline( int $pipeline_id, string $name, ?string $config ): void {
 		global $wpdb;
 
-		$wpdb->insert(
+		$result = $wpdb->insert(
 			$wpdb->prefix . 'datamachine_pipelines',
 			array(
 				'pipeline_id'     => $pipeline_id,
+				'user_id'         => 0,
 				'pipeline_name'   => $name,
 				'pipeline_config' => $config,
+				'created_at'      => current_time( 'mysql', true ),
+				'updated_at'      => current_time( 'mysql', true ),
 			),
-			array( '%d', '%s', '%s' )
+			array( '%d', '%d', '%s', '%s', '%s', '%s' )
 		);
+
+		$this->assertSame( 1, $result, $wpdb->last_error );
 	}
 
 	private function insert_flow( int $pipeline_id, string $flow_config_json ): int {
 		global $wpdb;
 
-		$wpdb->insert(
+		$result = $wpdb->insert(
 			$wpdb->prefix . 'datamachine_flows',
 			array(
-				'pipeline_id' => $pipeline_id,
-				'flow_name'   => 'test flow',
-				'flow_config' => $flow_config_json,
+				'pipeline_id'       => $pipeline_id,
+				'user_id'           => 0,
+				'flow_name'         => 'test flow',
+				'flow_config'       => $flow_config_json,
+				'scheduling_config' => '{}',
 			),
-			array( '%d', '%s' )
+			array( '%d', '%d', '%s', '%s', '%s' )
 		);
+
+		$this->assertSame( 1, $result, $wpdb->last_error );
 
 		return (int) $wpdb->insert_id;
 	}

--- a/tests/Unit/EventDateQueryAbilitiesTest.php
+++ b/tests/Unit/EventDateQueryAbilitiesTest.php
@@ -218,6 +218,7 @@ class EventDateQueryAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function test_matching_ids_sql_preserves_consumer_constraints_without_querying(): void {
+		wp_load_alloptions();
 		$filter = static function ( array $query_args, array $input ): array {
 			if ( 'sql-capture-scope' === ( $input['scope_token'] ?? '' ) ) {
 				$query_args['post__in'] = array( 123, 456 );
@@ -253,6 +254,7 @@ class EventDateQueryAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function test_matching_ids_sql_handles_large_consumer_sets_without_materializing_results(): void {
+		wp_load_alloptions();
 		$large_set = range( 1, 17000 );
 		$filter    = static function ( array $query_args ) use ( $large_set ): array {
 			$query_args['post__in'] = $large_set;

--- a/tests/Unit/EventDateQueryAbilitiesTest.php
+++ b/tests/Unit/EventDateQueryAbilitiesTest.php
@@ -246,7 +246,7 @@ class EventDateQueryAbilitiesTest extends WP_UnitTestCase {
 		}
 
 		$this->assertSame( array(), $executed_queries );
-		$this->assertStringContainsString( 'SELECT DISTINCT', $sql );
+		$this->assertMatchesRegularExpression( '/SELECT\s+DISTINCT/', $sql );
 		$this->assertStringContainsString( '123,456', str_replace( ' ', '', $sql ) );
 		$this->assertStringContainsString( 'needle', $sql );
 		$this->assertStringNotContainsString( ' LIMIT ', strtoupper( $sql ) );

--- a/tests/Unit/EventIdentifierGeneratorTest.php
+++ b/tests/Unit/EventIdentifierGeneratorTest.php
@@ -214,19 +214,17 @@ class EventIdentifierGeneratorTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that em dash with/without surrounding content produces matching titles.
+	 * Test that punctuation variants do not override the current similarity threshold.
 	 *
-	 * The original bug: "Burgundy: Soul Nite — Bill Wilson & The Ingredients"
-	 * vs "Burgundy: Soul Nite Bill Wilson & The Ingredients" should match
-	 * because both normalize to the same core ("burgundy").
+	 * Data Machine #2988 stopped collapsing both titles to the colon prefix.
 	 */
 	public function test_burgundy_soul_nite_em_dash_variant_match(): void {
-		$this->assertTrue(
+		$this->assertFalse(
 			EventIdentifierGenerator::titlesMatch(
 				'Burgundy: Soul Nite — Bill Wilson & The Ingredients',
 				'Burgundy: Soul Nite Bill Wilson & The Ingredients'
 			),
-			'Em dash variant should match (both normalize to same core via colon split)'
+			'Punctuation alone must not force a match below the current similarity threshold.'
 		);
 	}
 

--- a/tests/Unit/EventQueryAbilitiesTest.php
+++ b/tests/Unit/EventQueryAbilitiesTest.php
@@ -161,7 +161,8 @@ class EventQueryAbilitiesTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertIsArray( $result );
-		$this->assertTrue( isset( $result['error'] ) || isset( $result['events'] ) );
+		$this->assertWPError( $result );
+		$this->assertSame( 'venue_not_found', $result->get_error_code() );
+		$this->assertSame( 404, $result->get_error_data()['status'] );
 	}
 }

--- a/tests/Unit/EventRestControllerTest.php
+++ b/tests/Unit/EventRestControllerTest.php
@@ -217,8 +217,9 @@ class EventRestControllerTest extends WP_UnitTestCase {
 		$this->assertSame( 200, $response->get_status() );
 
 		$data = $response->get_data();
-		$this->assertArrayHasKey( 'is_duplicate', $data );
-		$this->assertFalse( $data['is_duplicate'] );
+		$this->assertTrue( $data['success'] );
+		$this->assertArrayHasKey( 'is_duplicate', $data['data'] );
+		$this->assertFalse( $data['data']['is_duplicate'] );
 
 	}
 }

--- a/tests/Unit/EventScraperTestAbilityTest.php
+++ b/tests/Unit/EventScraperTestAbilityTest.php
@@ -319,6 +319,8 @@ class EventScraperTestAbilityTest extends WP_UnitTestCase {
 		}
 
 		$html         = (string) file_get_contents( $fixture_path );
+		$future_year  = (int) current_time( 'Y' ) + 1;
+		$html         = (string) preg_replace( '/(<span class="date">[^<]+)(<\/span>)/', '$1, ' . $future_year . '$2', $html );
 		$target_url   = 'https://elephantroom.com/calendar';
 		$direct       = ( new BandzoogleExtractor() )->extract( $html, $target_url );
 		$direct_count = count( $direct );

--- a/tests/Unit/EventScraperTestAbilityTest.php
+++ b/tests/Unit/EventScraperTestAbilityTest.php
@@ -374,6 +374,7 @@ class EventScraperTestAbilityTest extends WP_UnitTestCase {
 		}
 
 		$html         = (string) file_get_contents( $fixture_path );
+		$html         = str_replace( '2026-', ( (int) gmdate( 'Y' ) + 5 ) . '-', $html );
 		$target_url   = 'https://charlestonpourhouse.com';
 		$direct       = ( new JsonLdExtractor() )->extract( $html, $target_url );
 		$direct_count = count( $direct );

--- a/tests/Unit/EventScraperTestAbilityTest.php
+++ b/tests/Unit/EventScraperTestAbilityTest.php
@@ -320,7 +320,7 @@ class EventScraperTestAbilityTest extends WP_UnitTestCase {
 
 		$html         = (string) file_get_contents( $fixture_path );
 		$future_year  = (int) current_time( 'Y' ) + 1;
-		$html         = (string) preg_replace( '/(<span class="date">[^<]+)(<\/span>)/', '$1, ' . $future_year . '$2', $html );
+		$html         = str_replace( '2026', (string) $future_year, $html );
 		$target_url   = 'https://elephantroom.com/calendar';
 		$direct       = ( new BandzoogleExtractor() )->extract( $html, $target_url );
 		$direct_count = count( $direct );

--- a/tests/Unit/EventUpsertAbilitiesTest.php
+++ b/tests/Unit/EventUpsertAbilitiesTest.php
@@ -142,18 +142,8 @@ class EventUpsertAbilitiesTest extends WP_UnitTestCase {
 		$input = $this->validInput();
 		$name  = $input['event']['venue'];
 
-		Venue_Taxonomy::find_or_create_venue(
-			$name,
-			array(
-				'address' => '100 Main Street',
-				'city'    => 'Charleston',
-				'state'   => 'SC',
-				'country' => 'US',
-			)
-		);
-		$input['event']['venueAddress'] = '200 Main Street';
-		$input['event']['venueCity']    = 'Atlanta';
-		$input['event']['venueState']   = 'GA';
+		$this->assertNotWPError( wp_insert_term( $name . '!', 'venue' ) );
+		$this->assertNotWPError( wp_insert_term( $name . '?', 'venue' ) );
 
 		$result = $this->ability->executeUpsertEvent( $input );
 

--- a/tests/Unit/EventUpsertAbilitiesTest.php
+++ b/tests/Unit/EventUpsertAbilitiesTest.php
@@ -36,6 +36,7 @@ class EventUpsertAbilitiesTest extends WP_UnitTestCase {
 		if ( class_exists( PostIdentityIndex::class ) ) {
 			( new PostIdentityIndex() )->create_table();
 		}
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 		$this->lock_query_filter = static function ( string $query ): string {
 			if ( str_contains( $query, 'GET_LOCK' ) || str_contains( $query, 'RELEASE_LOCK' ) ) {
 				return 'SELECT 1';

--- a/tests/Unit/EventUpsertLifecycleTest.php
+++ b/tests/Unit/EventUpsertLifecycleTest.php
@@ -538,11 +538,12 @@ class EventUpsertLifecycleTest extends WP_UnitTestCase {
 		$post_id         = (int) $created['data']['post_id'];
 		$old_venue_id   = (int) reset( wp_get_object_terms( $post_id, 'venue', array( 'fields' => 'ids' ) ) );
 		$candidate      = 'Ambiguous Candidate ' . uniqid();
-		Venue_Taxonomy::find_or_create_venue( $candidate, array( 'address' => '100 Main Street', 'city' => 'Charleston', 'state' => 'SC', 'country' => 'US' ) );
+		$this->assertNotWPError( wp_insert_term( $candidate . '!', 'venue' ) );
+		$this->assertNotWPError( wp_insert_term( $candidate . '?', 'venue' ) );
 		$observed = 0;
 		add_filter( 'datamachine_events_before_event_upsert_persistence', static function ( $allowed, array $context ) use ( &$observed ) { $observed = $context['venue_term_id']; return $allowed; }, 10, 2 );
 
-		$result = $this->invoke_upsert( array( 'title' => 'Resolution Skip Event', 'venue' => $candidate, 'venueAddress' => '200 Main Street', 'venueCity' => 'Atlanta', 'venueState' => 'GA', 'venueCountry' => 'US', 'startDate' => '2027-03-06', 'startTime' => '21:00', 'source_identity' => $source_identity ) );
+		$result = $this->invoke_upsert( array( 'title' => 'Resolution Skip Event', 'venue' => $candidate, 'startDate' => '2027-03-06', 'startTime' => '21:00', 'source_identity' => $source_identity ) );
 
 		$this->assertTrue( $result['success'] ?? false, wp_json_encode( $result ) );
 		$this->assertSame( $old_venue_id, $observed );

--- a/tests/Unit/EventUpsertLifecycleTest.php
+++ b/tests/Unit/EventUpsertLifecycleTest.php
@@ -36,6 +36,7 @@ class EventUpsertLifecycleTest extends WP_UnitTestCase {
 		if ( class_exists( PostIdentityIndex::class ) ) {
 			( new PostIdentityIndex() )->create_table();
 		}
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 
 		$ability_registry = \WP_Abilities_Registry::get_instance();
 		if ( ! $ability_registry->is_registered( 'datamachine/upsert-post' ) ) {
@@ -147,6 +148,7 @@ class EventUpsertLifecycleTest extends WP_UnitTestCase {
 		remove_all_filters( 'datamachine_events_before_event_upsert_persistence' );
 		remove_all_actions( 'datamachine_events_after_event_upsert_persistence' );
 		remove_all_filters( 'wp_insert_post_empty_content' );
+		wp_set_current_user( 0 );
 		parent::tearDown();
 	}
 

--- a/tests/Unit/EventUpsertTest.php
+++ b/tests/Unit/EventUpsertTest.php
@@ -42,6 +42,7 @@ class EventUpsertTest extends WP_UnitTestCase {
 		if ( class_exists( PostIdentityIndex::class ) ) {
 			( new PostIdentityIndex() )->create_table();
 		}
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 		$ability_registry = \WP_Abilities_Registry::get_instance();
 		if ( ! $ability_registry->is_registered( 'datamachine/upsert-post' ) ) {
 			$category_registry = \WP_Ability_Categories_Registry::get_instance();
@@ -155,6 +156,7 @@ class EventUpsertTest extends WP_UnitTestCase {
 		remove_all_filters( 'datamachine_events_before_event_upsert_persistence' );
 		remove_all_actions( 'datamachine_events_after_event_upsert_persistence' );
 		remove_all_filters( 'wp_insert_post_empty_content' );
+		wp_set_current_user( 0 );
 		parent::tearDown();
 	}
 
@@ -178,12 +180,14 @@ class EventUpsertTest extends WP_UnitTestCase {
 	}
 
 	public function test_venue_taxonomy_handler_registered() {
-		$handlers = \DataMachine\Core\WordPress\TaxonomyHandler::getCustomHandlers();
+		$property = new \ReflectionProperty( \DataMachine\Core\WordPress\TaxonomyHandler::class, 'custom_handlers' );
+		$handlers = $property->getValue();
 		$this->assertArrayHasKey( 'venue', $handlers );
 	}
 
 	public function test_promoter_taxonomy_handler_registered() {
-		$handlers = \DataMachine\Core\WordPress\TaxonomyHandler::getCustomHandlers();
+		$property = new \ReflectionProperty( \DataMachine\Core\WordPress\TaxonomyHandler::class, 'custom_handlers' );
+		$handlers = $property->getValue();
 		$this->assertArrayHasKey( 'promoter', $handlers );
 	}
 


### PR DESCRIPTION
## Summary
- register lightweight DME ability hooks before WordPress lazily initializes its one-shot registries while preserving the established full integration lifecycle
- keep timezone fallback output inside the parser's documented IANA contract
- preserve time-aware duplicate detection when generic Data Machine strategies return a same-date title match
- align stale PHPUnit setup, fixtures, and assertions with current WordPress, Data Machine, REST, cache, database, venue-resolution, and scraper contracts

## Failure Groups
- **Ability lifecycle (production):** attach all lightweight ability constructors before registry initialization, fixing missing scraper and venue abilities and the duplicate-venue REST 500.
- **Timezone fallback (production):** reject offset-only `wp_timezone()` names at the IANA fallback boundary and use the stable UTC fallback.
- **Same-day event identity (production):** reject generic duplicate matches outside the two-hour identity window so distinct early and late shows are not merged.
- **Data Machine permissions (test contract):** execute real `datamachine/upsert-post` coverage as an administrator instead of weakening production permissions.
- **Current APIs and envelopes (test contract):** qualify the global plugin class, inspect current taxonomy-handler registration state without the removed getter, assert current `WP_Error` behavior, and read the venue duplicate REST success envelope.
- **Managed database/cache/query behavior (test contract):** seed current pipeline/flow schemas, invalidate calendar generations before filter assertions, inspect `CalendarRequest` directly, warm autoloaded options, and tolerate SQL formatter whitespace.
- **Current venue/extractor behavior (test contract):** create genuinely ambiguous normalized venue candidates, align the punctuation expectation with Data Machine #2988, and keep JSON-LD and Bandzoogle fixtures future-relative.

## Validation
- Local changed-file verification: PHP syntax, `git diff --check`, PHPCS, and PHPStan passed against Data Machine `main` at `c0cacac4`.
- Final managed MySQL 8 / WordPress multisite run: https://github.com/Extra-Chill/data-machine-events/actions/runs/30124949581
- PHPUnit: 653 tests, 2296 assertions, 0 failures, 0 errors, 2 skipped.
- Homeboy review audit: passed.
- Homeboy review lint: passed.
- Homeboy review test: passed.
- Local SQLite override was not used as acceptance evidence because its managed dependency bootstrap does not activate Data Machine's full fetch runtime.

Closes #519