### PR TITLE
fix: align audit convention contracts

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -1,4 +1,14 @@
 {
+  "audit_rules": {
+    "convention_exception_globs": [
+      "inc/Abilities/AbilityCategories.php",
+      "inc/Abilities/AbilityPermissions.php",
+      "inc/Cli/AgentsMdSection.php",
+      "inc/Cli/SettingsCommand.php",
+      "inc/Core/DuplicateDetection/EventMergeHelper.php",
+      "inc/Core/DuplicateDetection/VenueMergeHelper.php"
+    ]
+  },
   "auto_cleanup": false,
   "changelog_target": "docs/CHANGELOG.md",
   "extensions": {

--- a/inc/Steps/EventImport/Handlers/WebScraper/Extractors/BaseExtractor.php
+++ b/inc/Steps/EventImport/Handlers/WebScraper/Extractors/BaseExtractor.php
@@ -21,6 +21,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 abstract class BaseExtractor implements ExtractorInterface {
 
+	/** {@inheritdoc} */
+	abstract public function canExtract( string $html ): bool;
+
+	/** {@inheritdoc} */
+	abstract public function extract( string $html, string $source_url ): array;
+
+	/** {@inheritdoc} */
+	abstract public function getMethod(): string;
+
 	/**
 	 * Parse UTC timestamp and convert to local timezone.
 	 *

--- a/tests/Unit/BaseExtractorTest.php
+++ b/tests/Unit/BaseExtractorTest.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Base extractor contract tests.
+ *
+ * @package DataMachineEvents\Tests\Unit
+ */
+
+namespace DataMachineEvents\Tests\Unit;
+
+use DataMachineEvents\Steps\EventImport\Handlers\WebScraper\Extractors\BaseExtractor;
+use ReflectionClass;
+use WP_UnitTestCase;
+
+class BaseExtractorTest extends WP_UnitTestCase {
+
+	public function test_declares_extractor_interface_methods_as_abstract(): void {
+		$reflection = new ReflectionClass( BaseExtractor::class );
+
+		$this->assertTrue( $reflection->isAbstract() );
+
+		foreach ( array( 'canExtract', 'extract', 'getMethod' ) as $method_name ) {
+			$method = $reflection->getMethod( $method_name );
+
+			$this->assertSame( BaseExtractor::class, $method->getDeclaringClass()->getName() );
+			$this->assertTrue( $method->isPublic() );
+			$this->assertTrue( $method->isAbstract() );
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add exact convention exceptions for six intentional specializations that do not implement their directory's dominant runtime shape.
- Declare the existing extractor interface contract explicitly on `BaseExtractor` without changing behavior.
- Leave the four concrete extractor findings unsuppressed for the upstream fingerprint-cache fix in Extra-Chill/homeboy#9960.

Closes #225.

## Exact exceptions

- `inc/Abilities/AbilityCategories.php` is a static category-registration utility, not an ability handler.
- `inc/Abilities/AbilityPermissions.php` provides static permission callback factories, not an ability handler.
- `inc/Cli/AgentsMdSection.php` renders the repository's AGENTS.md section and is not a WP-CLI command.
- `inc/Cli/SettingsCommand.php` is a WP-CLI namespace exposing named `get`, `set`, and `list` subcommands, so it intentionally has no `__invoke()` leaf handler.
- `inc/Core/DuplicateDetection/EventMergeHelper.php` is a callable event merge primitive with no hooks to register.
- `inc/Core/DuplicateDetection/VenueMergeHelper.php` is a callable venue merge primitive with no hooks to register.

No directory-wide exclusions, audit baseline, detector suppression, fake methods, changelog edits, or version changes are included.

## Remaining upstream outliers

The active WordPress fingerprint provider sees `canExtract()`, `extract()`, and `getMethod()` in each file below, but full convention analysis still consumes stale fingerprints. These remain intentionally unsuppressed pending Extra-Chill/homeboy#9960:

- `AegAxsExtractor.php`
- `FreshtixExtractor.php`
- `DuskFmExtractor.php`
- `CraftpeakExtractor.php`

## Validation

- `jq empty homeboy.json`
- `homeboy component show --path .` confirms `audit_rules.convention_exception_globs` is loaded.
- `git diff --check`
- `php -l inc/Steps/EventImport/Handlers/WebScraper/Extractors/BaseExtractor.php`
- Direct WordPress fingerprint-provider runs confirm all three contract methods on `BaseExtractor` and each of the four concrete extractors.
- `homeboy --placement local review audit --profile full --ignore-baseline` completed; alignment improved from `0.9037` to `0.9111` and `BaseExtractor` stopped reporting as an outlier. The locally installed Homeboy `0.310.2` still emitted the six configured exceptions, so current repository CI must verify exception consumption on the supported Homeboy version.
- `composer test` could not start because `phpunit` is not installed in this worktree (`phpunit: not found`, exit 127).