### PR TITLE
fix: preserve event URLs across cleanup

### DIFF
--- a/inc/Core/DuplicateDetection/EventDuplicateStrategy.php
+++ b/inc/Core/DuplicateDetection/EventDuplicateStrategy.php
@@ -483,7 +483,7 @@ class EventDuplicateStrategy {
 	 */
 	private static function isValidPost( int $post_id ): bool {
 		$status = get_post_status( $post_id );
-		return $status && in_array( $status, array( 'publish', 'draft', 'pending' ), true );
+		return $status && in_array( $status, array( 'publish', 'draft', 'pending', 'trash' ), true );
 	}
 
 	/**

--- a/inc/Core/DuplicateDetection/EventDuplicateStrategy.php
+++ b/inc/Core/DuplicateDetection/EventDuplicateStrategy.php
@@ -483,7 +483,7 @@ class EventDuplicateStrategy {
 	 */
 	private static function isValidPost( int $post_id ): bool {
 		$status = get_post_status( $post_id );
-		return $status && in_array( $status, array( 'publish', 'draft', 'pending', 'trash' ), true );
+		return $status && in_array( $status, array( 'publish', 'draft', 'pending' ), true );
 	}
 
 	/**

--- a/inc/Core/DuplicateDetection/EventDuplicateStrategy.php
+++ b/inc/Core/DuplicateDetection/EventDuplicateStrategy.php
@@ -227,7 +227,10 @@ class EventDuplicateStrategy {
 
 		foreach ( $candidates as $candidate ) {
 			$post_id = (int) $candidate['post_id'];
-			$post    = get_post( $post_id );
+			if ( ! self::isValidPost( $post_id ) ) {
+				continue;
+			}
+			$post = get_post( $post_id );
 			if ( ! $post ) {
 				continue;
 			}
@@ -367,7 +370,10 @@ class EventDuplicateStrategy {
 
 		foreach ( $candidates as $candidate ) {
 			$post_id = (int) $candidate['post_id'];
-			$post    = get_post( $post_id );
+			if ( ! self::isValidPost( $post_id ) ) {
+				continue;
+			}
+			$post = get_post( $post_id );
 			if ( ! $post ) {
 				continue;
 			}

--- a/inc/Core/DuplicateDetection/EventMergeHelper.php
+++ b/inc/Core/DuplicateDetection/EventMergeHelper.php
@@ -81,31 +81,49 @@ class EventMergeHelper {
 			$result['error'] = 'One or both posts do not exist.';
 			return $result;
 		}
+		if ( 'publish' !== $winner->post_status ) {
+			$result['error'] = 'Winner must be published before receiving redirect history.';
+			return $result;
+		}
 
-		$merge_ticket_url = $opts['merge_ticket_url'] ?? true;
+		$merge_ticket_url        = $opts['merge_ticket_url'] ?? true;
+		$winner_ticket_values    = get_post_meta( $winner_id, EVENT_TICKET_URL_META_KEY, false );
+		$transferred_slugs       = self::transferOldSlugs( $winner, $loser );
+		$ticket_url_was_modified = false;
+
+		if ( is_wp_error( $transferred_slugs ) ) {
+			$result['error'] = $transferred_slugs->get_error_message();
+			return $result;
+		}
 
 		if ( $merge_ticket_url ) {
-			$winner_ticket = get_post_meta( $winner_id, EVENT_TICKET_URL_META_KEY, true );
+			$winner_ticket = reset( $winner_ticket_values );
 			$loser_ticket  = get_post_meta( $loser_id, EVENT_TICKET_URL_META_KEY, true );
 
 			if ( ! empty( $loser_ticket ) && empty( $winner_ticket ) ) {
-				update_post_meta( $winner_id, EVENT_TICKET_URL_META_KEY, $loser_ticket );
-				$result['ticket_url_merged'] = true;
+				if ( false === update_post_meta( $winner_id, EVENT_TICKET_URL_META_KEY, $loser_ticket ) ) {
+					self::removeTransferredSlugs( $winner_id, $transferred_slugs );
+					self::restoreMetaValues( $winner_id, EVENT_TICKET_URL_META_KEY, $winner_ticket_values );
+					$result['error'] = 'Failed to transfer winner metadata.';
+					return $result;
+				}
+				$ticket_url_was_modified = true;
 			}
 		}
 
-		$transferred_slugs = self::transferOldSlugs( $winner, $loser );
-		$trashed           = wp_trash_post( $loser_id );
+		$trashed = wp_trash_post( $loser_id );
 		if ( ! $trashed ) {
-			foreach ( $transferred_slugs as $slug ) {
-				delete_post_meta( $winner_id, '_wp_old_slug', $slug );
+			self::removeTransferredSlugs( $winner_id, $transferred_slugs );
+			if ( $ticket_url_was_modified ) {
+				self::restoreMetaValues( $winner_id, EVENT_TICKET_URL_META_KEY, $winner_ticket_values );
 			}
 			$result['error'] = sprintf( 'Failed to trash post %d.', $loser_id );
 			return $result;
 		}
 
-		$result['trashed'] = true;
-		$result['success'] = true;
+		$result['ticket_url_merged'] = $ticket_url_was_modified;
+		$result['trashed']           = true;
+		$result['success']           = true;
 
 		return $result;
 	}
@@ -118,27 +136,45 @@ class EventMergeHelper {
 	 *
 	 * @param \WP_Post $winner Canonical event post.
 	 * @param \WP_Post $loser  Duplicate event post being removed.
-	 * @return string[] Slugs newly added to the winner.
+	 * @return string[]|\WP_Error Slugs newly added to the winner, or an error.
 	 */
-	private static function transferOldSlugs( \WP_Post $winner, \WP_Post $loser ): array {
-		$winner_slugs = array_merge(
+	private static function transferOldSlugs( \WP_Post $winner, \WP_Post $loser ): array|\WP_Error {
+		$original_values = get_post_meta( $winner->ID, '_wp_old_slug', false );
+		$winner_slugs    = array_merge(
 			array( $winner->post_name ),
-			get_post_meta( $winner->ID, '_wp_old_slug', false )
+			$original_values
 		);
-		$loser_slugs  = array_merge(
+		$loser_slugs     = array_merge(
 			array( $loser->post_name ),
 			get_post_meta( $loser->ID, '_wp_old_slug', false )
 		);
-		$slugs        = array_values( array_unique( array_filter( array_map( 'sanitize_title', $loser_slugs ) ) ) );
-		$existing     = array_values( array_unique( array_filter( array_map( 'sanitize_title', $winner_slugs ) ) ) );
-		$transferred  = array();
+		$slugs           = array_values( array_unique( array_filter( array_map( 'sanitize_title', $loser_slugs ) ) ) );
+		$existing        = array_values( array_unique( array_filter( array_map( 'sanitize_title', $winner_slugs ) ) ) );
+		$transferred     = array();
 
 		foreach ( array_diff( $slugs, $existing ) as $slug ) {
-			if ( add_post_meta( $winner->ID, '_wp_old_slug', $slug ) ) {
-				$transferred[] = $slug;
+			if ( ! add_post_meta( $winner->ID, '_wp_old_slug', $slug ) ) {
+				self::removeTransferredSlugs( $winner->ID, $transferred );
+				return new \WP_Error( 'event_slug_transfer_failed', 'Failed to transfer event URL history.' );
 			}
+			$transferred[] = $slug;
 		}
 
 		return $transferred;
+	}
+
+	/** Remove only old-slug values added by the current merge attempt. */
+	private static function removeTransferredSlugs( int $post_id, array $slugs ): void {
+		foreach ( $slugs as $slug ) {
+			delete_post_meta( $post_id, '_wp_old_slug', $slug );
+		}
+	}
+
+	/** Restore all values for metadata mutated before trashing the loser. */
+	private static function restoreMetaValues( int $post_id, string $meta_key, array $values ): void {
+		delete_post_meta( $post_id, $meta_key );
+		foreach ( $values as $value ) {
+			add_post_meta( $post_id, $meta_key, $value );
+		}
 	}
 }

--- a/inc/Core/DuplicateDetection/EventMergeHelper.php
+++ b/inc/Core/DuplicateDetection/EventMergeHelper.php
@@ -88,12 +88,23 @@ class EventMergeHelper {
 
 		$merge_ticket_url        = $opts['merge_ticket_url'] ?? true;
 		$winner_ticket_values    = get_post_meta( $winner_id, EVENT_TICKET_URL_META_KEY, false );
+		$loser_old_slug_values   = get_post_meta( $loser_id, '_wp_old_slug', false );
 		$transferred_slugs       = self::transferOldSlugs( $winner, $loser );
 		$ticket_url_was_modified = false;
 
 		if ( is_wp_error( $transferred_slugs ) ) {
 			$result['error'] = $transferred_slugs->get_error_message();
 			return $result;
+		}
+
+		if ( ! empty( $loser_old_slug_values ) ) {
+			delete_post_meta( $loser_id, '_wp_old_slug' );
+			if ( ! empty( get_post_meta( $loser_id, '_wp_old_slug', false ) ) ) {
+				self::removeTransferredSlugs( $winner_id, $transferred_slugs );
+				self::restoreMetaValues( $loser_id, '_wp_old_slug', $loser_old_slug_values );
+				$result['error'] = 'Failed to transfer event URL history ownership.';
+				return $result;
+			}
 		}
 
 		if ( $merge_ticket_url ) {
@@ -103,6 +114,7 @@ class EventMergeHelper {
 			if ( ! empty( $loser_ticket ) && empty( $winner_ticket ) ) {
 				if ( false === update_post_meta( $winner_id, EVENT_TICKET_URL_META_KEY, $loser_ticket ) ) {
 					self::removeTransferredSlugs( $winner_id, $transferred_slugs );
+					self::restoreMetaValues( $loser_id, '_wp_old_slug', $loser_old_slug_values );
 					self::restoreMetaValues( $winner_id, EVENT_TICKET_URL_META_KEY, $winner_ticket_values );
 					$result['error'] = 'Failed to transfer winner metadata.';
 					return $result;
@@ -114,6 +126,7 @@ class EventMergeHelper {
 		$trashed = wp_trash_post( $loser_id );
 		if ( ! $trashed ) {
 			self::removeTransferredSlugs( $winner_id, $transferred_slugs );
+			self::restoreMetaValues( $loser_id, '_wp_old_slug', $loser_old_slug_values );
 			if ( $ticket_url_was_modified ) {
 				self::restoreMetaValues( $winner_id, EVENT_TICKET_URL_META_KEY, $winner_ticket_values );
 			}

--- a/inc/Core/DuplicateDetection/EventMergeHelper.php
+++ b/inc/Core/DuplicateDetection/EventMergeHelper.php
@@ -29,9 +29,10 @@ class EventMergeHelper {
 	/**
 	 * Merge a duplicate event pair.
 	 *
-	 * Trashes the loser. Optionally forward-merges the ticket URL into the
-	 * winner when the winner has none and the loser has one. Returns a
-	 * structured result so callers can report on what happened.
+	 * Trashes the loser after transferring its URL history to the winner.
+	 * Optionally forward-merges the ticket URL into the winner when the winner
+	 * has none and the loser has one. Returns a structured result so callers
+	 * can report on what happened.
 	 *
 	 * Both IDs must refer to existing event posts. The caller is responsible
 	 * for picking which post wins (e.g. oldest, longest body, has ticket URL).
@@ -93,8 +94,12 @@ class EventMergeHelper {
 			}
 		}
 
-		$trashed = wp_trash_post( $loser_id );
+		$transferred_slugs = self::transferOldSlugs( $winner, $loser );
+		$trashed           = wp_trash_post( $loser_id );
 		if ( ! $trashed ) {
+			foreach ( $transferred_slugs as $slug ) {
+				delete_post_meta( $winner_id, '_wp_old_slug', $slug );
+			}
 			$result['error'] = sprintf( 'Failed to trash post %d.', $loser_id );
 			return $result;
 		}
@@ -103,5 +108,37 @@ class EventMergeHelper {
 		$result['success'] = true;
 
 		return $result;
+	}
+
+	/**
+	 * Transfer the loser's routable slug history to the canonical winner.
+	 *
+	 * WordPress core's wp_old_slug_redirect() resolves these values without a
+	 * plugin-owned redirect service.
+	 *
+	 * @param \WP_Post $winner Canonical event post.
+	 * @param \WP_Post $loser  Duplicate event post being removed.
+	 * @return string[] Slugs newly added to the winner.
+	 */
+	private static function transferOldSlugs( \WP_Post $winner, \WP_Post $loser ): array {
+		$winner_slugs = array_merge(
+			array( $winner->post_name ),
+			get_post_meta( $winner->ID, '_wp_old_slug', false )
+		);
+		$loser_slugs  = array_merge(
+			array( $loser->post_name ),
+			get_post_meta( $loser->ID, '_wp_old_slug', false )
+		);
+		$slugs        = array_values( array_unique( array_filter( array_map( 'sanitize_title', $loser_slugs ) ) ) );
+		$existing     = array_values( array_unique( array_filter( array_map( 'sanitize_title', $winner_slugs ) ) ) );
+		$transferred  = array();
+
+		foreach ( array_diff( $slugs, $existing ) as $slug ) {
+			if ( add_post_meta( $winner->ID, '_wp_old_slug', $slug ) ) {
+				$transferred[] = $slug;
+			}
+		}
+
+		return $transferred;
 	}
 }

--- a/inc/Steps/Upsert/Events/EventUpsert.php
+++ b/inc/Steps/Upsert/Events/EventUpsert.php
@@ -562,7 +562,7 @@ class EventUpsert extends UpsertHandler {
 		$query = new \WP_Query(
 			array(
 				'post_type'      => Event_Post_Type::POST_TYPE,
-				'post_status'    => 'any',
+				'post_status'    => array( 'publish', 'future', 'draft', 'pending', 'private', 'trash' ),
 				'posts_per_page' => 1,
 				'fields'         => 'ids',
 				'no_found_rows'  => true,

--- a/tests/Unit/EventDuplicateStrategyTest.php
+++ b/tests/Unit/EventDuplicateStrategyTest.php
@@ -76,22 +76,6 @@ class EventDuplicateStrategyTest extends WP_UnitTestCase {
 		wp_delete_term( $term['term_id'], 'venue' );
 	}
 
-	public function test_trashed_index_candidate_remains_valid_for_re_resolution(): void {
-		$post_id = wp_insert_post(
-			array(
-				'post_title'  => 'Trashed Duplicate Candidate',
-				'post_type'   => Event_Post_Type::POST_TYPE,
-				'post_status' => 'publish',
-			)
-		);
-		wp_trash_post( $post_id );
-
-		$method = new \ReflectionMethod( EventDuplicateStrategy::class, 'isValidPost' );
-		$method->setAccessible( true );
-
-		$this->assertTrue( $method->invoke( null, $post_id ) );
-	}
-
 	/**
 	 * Address-first resolution: when the incoming venue string does NOT
 	 * match the canonical term name but the address does match, the
@@ -485,6 +469,31 @@ class EventDuplicateStrategyTest extends WP_UnitTestCase {
 		);
 
 		$this->cleanup( $term_id, $existing_post_id );
+	}
+
+	public function test_trashed_event_is_not_recovered_by_broad_duplicate_matching(): void {
+		$venue_name = 'Cancelled Event Venue ' . uniqid();
+		[ $term_id, $post_id ] = $this->seedVenueWithEvent(
+			'Cancelled Event',
+			'2026-04-22 21:00:00',
+			$venue_name
+		);
+		wp_trash_post( $post_id );
+
+		$result = EventDuplicateStrategy::check(
+			array(
+				'title'   => 'Cancelled Event',
+				'context' => array(
+					'venue'     => $venue_name,
+					'startDate' => '2026-04-22T21:30:00',
+					'ticketUrl' => '',
+				),
+			)
+		);
+
+		$this->assertNull( $result );
+		$this->assertSame( 'trash', get_post_status( $post_id ) );
+		$this->cleanup( $term_id, $post_id );
 	}
 
 	/**

--- a/tests/Unit/EventDuplicateStrategyTest.php
+++ b/tests/Unit/EventDuplicateStrategyTest.php
@@ -479,6 +479,20 @@ class EventDuplicateStrategyTest extends WP_UnitTestCase {
 			$venue_name
 		);
 		wp_trash_post( $post_id );
+		EventDatesTable::upsert( $post_id, '2026-04-22 21:00:00' );
+		$index = new \DataMachine\Core\Database\PostIdentityIndex\PostIdentityIndex();
+		$index->upsert(
+			$post_id,
+			array(
+				'post_type'     => Event_Post_Type::POST_TYPE,
+				'event_date'    => '2026-04-22',
+				'venue_term_id' => $term_id,
+				'title_hash'    => EventDuplicateStrategy::computeTitleHash( 'Cancelled Event' ),
+			)
+		);
+
+		$this->assertNotNull( EventDatesTable::get( $post_id ), 'The stale date row must remain available to both fuzzy paths.' );
+		$this->assertSame( $post_id, (int) $index->get( $post_id )['post_id'], 'The stale identity candidate must be present after trash.' );
 
 		$result = EventDuplicateStrategy::check(
 			array(

--- a/tests/Unit/EventDuplicateStrategyTest.php
+++ b/tests/Unit/EventDuplicateStrategyTest.php
@@ -76,6 +76,22 @@ class EventDuplicateStrategyTest extends WP_UnitTestCase {
 		wp_delete_term( $term['term_id'], 'venue' );
 	}
 
+	public function test_trashed_index_candidate_remains_valid_for_re_resolution(): void {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Trashed Duplicate Candidate',
+				'post_type'   => Event_Post_Type::POST_TYPE,
+				'post_status' => 'publish',
+			)
+		);
+		wp_trash_post( $post_id );
+
+		$method = new \ReflectionMethod( EventDuplicateStrategy::class, 'isValidPost' );
+		$method->setAccessible( true );
+
+		$this->assertTrue( $method->invoke( null, $post_id ) );
+	}
+
 	/**
 	 * Address-first resolution: when the incoming venue string does NOT
 	 * match the canonical term name but the address does match, the

--- a/tests/Unit/EventMergeHelperTest.php
+++ b/tests/Unit/EventMergeHelperTest.php
@@ -27,12 +27,12 @@ class EventMergeHelperTest extends WP_UnitTestCase {
 		}
 	}
 
-	private function makeEventPost( string $title, string $ticket_url = '' ): int {
+	private function makeEventPost( string $title, string $ticket_url = '', string $status = 'publish' ): int {
 		$id = wp_insert_post(
 			array(
 				'post_type'   => Event_Post_Type::POST_TYPE,
 				'post_title'  => $title,
-				'post_status' => 'publish',
+				'post_status' => $status,
 			)
 		);
 
@@ -84,15 +84,18 @@ class EventMergeHelperTest extends WP_UnitTestCase {
 	public function test_merge_transfers_loser_url_history_to_winner(): void {
 		$winner = $this->makeEventPost( 'Canonical Winner' );
 		$loser  = $this->makeEventPost( 'Duplicate Loser' );
+		$loser_slug = get_post_field( 'post_name', $loser );
 		add_post_meta( $loser, '_wp_old_slug', 'original-loser-url' );
 
 		$result    = EventMergeHelper::merge( $winner, $loser );
 		$old_slugs = get_post_meta( $winner, '_wp_old_slug', false );
 
 		$this->assertTrue( $result['success'] );
-		$this->assertContains( 'duplicate-loser', $old_slugs );
+		$this->assertContains( $loser_slug, $old_slugs );
 		$this->assertContains( 'original-loser-url', $old_slugs );
 		$this->assertNotContains( 'canonical-winner', $old_slugs );
+		$this->assertSame( $loser_slug, get_post_meta( $loser, '_wp_desired_post_slug', true ) );
+		$this->assertSame( $loser_slug . '__trashed', get_post_field( 'post_name', $loser ) );
 	}
 
 	public function test_ordinary_trash_does_not_fabricate_redirect_history(): void {
@@ -102,6 +105,69 @@ class EventMergeHelperTest extends WP_UnitTestCase {
 
 		$this->assertSame( 'trash', get_post_status( $event ) );
 		$this->assertSame( array(), get_post_meta( $event, '_wp_old_slug', false ) );
+		$this->assertSame( 'cancelled-without-replacement', get_post_meta( $event, '_wp_desired_post_slug', true ) );
+		$this->assertSame( 'cancelled-without-replacement__trashed', get_post_field( 'post_name', $event ) );
+	}
+
+	public function test_merge_rejects_winner_that_is_not_live(): void {
+		$winner = $this->makeEventPost( 'Draft Winner', '', 'draft' );
+		$loser  = $this->makeEventPost( 'Published Loser', 'https://tickets.example.com/loser' );
+
+		$result = EventMergeHelper::merge( $winner, $loser );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'published', $result['error'] );
+		$this->assertSame( 'publish', get_post_status( $loser ) );
+		$this->assertSame( array(), get_post_meta( $winner, '_wp_old_slug', false ) );
+		$this->assertSame( '', get_post_meta( $winner, EVENT_TICKET_URL_META_KEY, true ) );
+	}
+
+	public function test_slug_transfer_failure_rolls_back_all_winner_metadata(): void {
+		$winner = $this->makeEventPost( 'Rollback Winner' );
+		$loser  = $this->makeEventPost( 'Rollback Loser', 'https://tickets.example.com/loser' );
+		add_post_meta( $winner, '_wp_old_slug', 'existing-winner-history' );
+		add_post_meta( $loser, '_wp_old_slug', 'blocked-loser-history' );
+		$fail_transfer = static function ( $check, $object_id, $meta_key, $meta_value ) use ( $winner ) {
+			if ( $winner === (int) $object_id && '_wp_old_slug' === $meta_key && 'blocked-loser-history' === $meta_value ) {
+				return false;
+			}
+			return $check;
+		};
+		add_filter( 'add_post_metadata', $fail_transfer, 10, 4 );
+
+		try {
+			$result = EventMergeHelper::merge( $winner, $loser );
+		} finally {
+			remove_filter( 'add_post_metadata', $fail_transfer, 10 );
+		}
+
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'URL history', $result['error'] );
+		$this->assertSame( 'publish', get_post_status( $loser ) );
+		$this->assertSame( array( 'existing-winner-history' ), get_post_meta( $winner, '_wp_old_slug', false ) );
+		$this->assertSame( '', get_post_meta( $winner, EVENT_TICKET_URL_META_KEY, true ) );
+	}
+
+	public function test_trash_failure_rolls_back_slug_and_ticket_transfers(): void {
+		$winner = $this->makeEventPost( 'Trash Rollback Winner' );
+		$loser  = $this->makeEventPost( 'Trash Rollback Loser', 'https://tickets.example.com/loser' );
+		add_post_meta( $winner, '_wp_old_slug', 'existing-winner-history' );
+		$prevent_trash = static function ( $trash, $post ) use ( $loser ) {
+			return $loser === $post->ID ? false : $trash;
+		};
+		add_filter( 'pre_trash_post', $prevent_trash, 10, 2 );
+
+		try {
+			$result = EventMergeHelper::merge( $winner, $loser );
+		} finally {
+			remove_filter( 'pre_trash_post', $prevent_trash, 10 );
+		}
+
+		$this->assertFalse( $result['success'] );
+		$this->assertFalse( $result['ticket_url_merged'] );
+		$this->assertSame( 'publish', get_post_status( $loser ) );
+		$this->assertSame( array( 'existing-winner-history' ), get_post_meta( $winner, '_wp_old_slug', false ) );
+		$this->assertSame( '', get_post_meta( $winner, EVENT_TICKET_URL_META_KEY, true ) );
 	}
 
 	public function test_ticket_url_forward_merge_when_winner_lacks_one(): void {

--- a/tests/Unit/EventMergeHelperTest.php
+++ b/tests/Unit/EventMergeHelperTest.php
@@ -81,6 +81,29 @@ class EventMergeHelperTest extends WP_UnitTestCase {
 		$this->assertSame( 'trash', get_post_status( $loser ) );
 	}
 
+	public function test_merge_transfers_loser_url_history_to_winner(): void {
+		$winner = $this->makeEventPost( 'Canonical Winner' );
+		$loser  = $this->makeEventPost( 'Duplicate Loser' );
+		add_post_meta( $loser, '_wp_old_slug', 'original-loser-url' );
+
+		$result    = EventMergeHelper::merge( $winner, $loser );
+		$old_slugs = get_post_meta( $winner, '_wp_old_slug', false );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertContains( 'duplicate-loser', $old_slugs );
+		$this->assertContains( 'original-loser-url', $old_slugs );
+		$this->assertNotContains( 'canonical-winner', $old_slugs );
+	}
+
+	public function test_ordinary_trash_does_not_fabricate_redirect_history(): void {
+		$event = $this->makeEventPost( 'Cancelled Without Replacement' );
+
+		wp_trash_post( $event );
+
+		$this->assertSame( 'trash', get_post_status( $event ) );
+		$this->assertSame( array(), get_post_meta( $event, '_wp_old_slug', false ) );
+	}
+
 	public function test_ticket_url_forward_merge_when_winner_lacks_one(): void {
 		$winner = $this->makeEventPost( 'Winner' );
 		$loser  = $this->makeEventPost( 'Loser', 'https://tickets.example.com/loser' );

--- a/tests/Unit/EventMergeHelperTest.php
+++ b/tests/Unit/EventMergeHelperTest.php
@@ -94,6 +94,7 @@ class EventMergeHelperTest extends WP_UnitTestCase {
 		$this->assertContains( $loser_slug, $old_slugs );
 		$this->assertContains( 'original-loser-url', $old_slugs );
 		$this->assertNotContains( 'canonical-winner', $old_slugs );
+		$this->assertSame( array(), get_post_meta( $loser, '_wp_old_slug', false ) );
 		set_query_var( 'name', $loser_slug );
 		$this->assertSame( $winner, _find_post_by_old_slug( Event_Post_Type::POST_TYPE ) );
 		set_query_var( 'name', 'original-loser-url' );
@@ -149,6 +150,7 @@ class EventMergeHelperTest extends WP_UnitTestCase {
 		$this->assertFalse( $result['success'] );
 		$this->assertStringContainsString( 'URL history', $result['error'] );
 		$this->assertSame( 'publish', get_post_status( $loser ) );
+		$this->assertSame( array( 'blocked-loser-history' ), get_post_meta( $loser, '_wp_old_slug', false ) );
 		$this->assertSame( array( 'existing-winner-history' ), get_post_meta( $winner, '_wp_old_slug', false ) );
 		$this->assertSame( '', get_post_meta( $winner, EVENT_TICKET_URL_META_KEY, true ) );
 	}
@@ -157,6 +159,7 @@ class EventMergeHelperTest extends WP_UnitTestCase {
 		$winner = $this->makeEventPost( 'Trash Rollback Winner' );
 		$loser  = $this->makeEventPost( 'Trash Rollback Loser', 'https://tickets.example.com/loser' );
 		add_post_meta( $winner, '_wp_old_slug', 'existing-winner-history' );
+		add_post_meta( $loser, '_wp_old_slug', 'existing-loser-history' );
 		$prevent_trash = static function ( $trash, $post ) use ( $loser ) {
 			return $loser === $post->ID ? false : $trash;
 		};
@@ -171,6 +174,7 @@ class EventMergeHelperTest extends WP_UnitTestCase {
 		$this->assertFalse( $result['success'] );
 		$this->assertFalse( $result['ticket_url_merged'] );
 		$this->assertSame( 'publish', get_post_status( $loser ) );
+		$this->assertSame( array( 'existing-loser-history' ), get_post_meta( $loser, '_wp_old_slug', false ) );
 		$this->assertSame( array( 'existing-winner-history' ), get_post_meta( $winner, '_wp_old_slug', false ) );
 		$this->assertSame( '', get_post_meta( $winner, EVENT_TICKET_URL_META_KEY, true ) );
 	}

--- a/tests/Unit/EventMergeHelperTest.php
+++ b/tests/Unit/EventMergeHelperTest.php
@@ -94,6 +94,11 @@ class EventMergeHelperTest extends WP_UnitTestCase {
 		$this->assertContains( $loser_slug, $old_slugs );
 		$this->assertContains( 'original-loser-url', $old_slugs );
 		$this->assertNotContains( 'canonical-winner', $old_slugs );
+		set_query_var( 'name', $loser_slug );
+		$this->assertSame( $winner, _find_post_by_old_slug( Event_Post_Type::POST_TYPE ) );
+		set_query_var( 'name', 'original-loser-url' );
+		$this->assertSame( $winner, _find_post_by_old_slug( Event_Post_Type::POST_TYPE ) );
+		set_query_var( 'name', '' );
 		$this->assertSame( $loser_slug, get_post_meta( $loser, '_wp_desired_post_slug', true ) );
 		$this->assertSame( $loser_slug . '__trashed', get_post_field( 'post_name', $loser ) );
 	}

--- a/tests/Unit/EventUpsertTest.php
+++ b/tests/Unit/EventUpsertTest.php
@@ -164,24 +164,31 @@ class EventUpsertTest extends WP_UnitTestCase {
 		$this->assertInstanceOf( EventUpsert::class, $this->handler );
 	}
 
-	public function test_source_identity_re_resolves_the_same_trashed_post(): void {
-		$source_identity = 'source:event-' . uniqid();
-		$post_id         = wp_insert_post(
-			array(
-				'post_title'  => 'Trashed Source Event',
-				'post_type'   => Event_Post_Type::POST_TYPE,
-				'post_status' => 'publish',
-				'post_name'   => 'stable-source-event-url',
-			)
+	public function test_unchanged_trash_reimport_reuses_exact_source_post_but_awaits_core_status_reconciliation(): void {
+		$parameters = array(
+			'title'           => 'Exact Source Trash Replay ' . uniqid(),
+			'venue'           => 'Exact Source Venue ' . uniqid(),
+			'startDate'       => '2026-11-20',
+			'startTime'       => '20:00',
+			'description'     => 'Stable content for an exact source replay.',
+			'source_identity' => 'source:event-' . uniqid(),
 		);
-		update_post_meta( $post_id, EventUpsert::SOURCE_IDENTITY_META_KEY, $source_identity );
+		$created = $this->invoke_upsert( $parameters );
+
+		$this->assertTrue( $created['success'] ?? false, wp_json_encode( $created ) );
+		$post_id       = (int) $created['data']['post_id'];
+		$original_slug = get_post_field( 'post_name', $post_id );
 		wp_trash_post( $post_id );
 
-		$method = new \ReflectionMethod( $this->handler, 'findExistingEventBySourceIdentity' );
-		$method->setAccessible( true );
+		$this->assertSame( $original_slug, get_post_meta( $post_id, '_wp_desired_post_slug', true ) );
+		$this->assertSame( $original_slug . '__trashed', get_post_field( 'post_name', $post_id ) );
 
-		$this->assertSame( $post_id, $method->invoke( $this->handler, $source_identity ) );
-		$this->assertSame( 'stable-source-event-url', get_post_field( 'post_name', $post_id ) );
+		$reimported = $this->invoke_upsert( $parameters );
+
+		$this->assertTrue( $reimported['success'] ?? false, wp_json_encode( $reimported ) );
+		$this->assertSame( $post_id, (int) $reimported['data']['post_id'] );
+		$this->assertSame( 'no_change', $reimported['data']['action'] );
+		$this->assertSame( 'trash', get_post_status( $post_id ), 'Data Machine #2993 owns unchanged-content status reconciliation.' );
 		$this->assertCount(
 			1,
 			get_posts(
@@ -189,7 +196,7 @@ class EventUpsertTest extends WP_UnitTestCase {
 					'post_type'      => Event_Post_Type::POST_TYPE,
 					'post_status'    => array( 'publish', 'future', 'draft', 'pending', 'private', 'trash' ),
 					'meta_key'       => EventUpsert::SOURCE_IDENTITY_META_KEY,
-					'meta_value'     => $source_identity,
+					'meta_value'     => $parameters['source_identity'],
 					'posts_per_page' => -1,
 				)
 			)

--- a/tests/Unit/EventUpsertTest.php
+++ b/tests/Unit/EventUpsertTest.php
@@ -164,7 +164,7 @@ class EventUpsertTest extends WP_UnitTestCase {
 		$this->assertInstanceOf( EventUpsert::class, $this->handler );
 	}
 
-	public function test_unchanged_trash_reimport_reuses_exact_source_post_but_awaits_core_status_reconciliation(): void {
+	public function test_unchanged_trash_reimport_republishes_the_exact_source_post(): void {
 		$parameters = array(
 			'title'           => 'Exact Source Trash Replay ' . uniqid(),
 			'venue'           => 'Exact Source Venue ' . uniqid(),
@@ -187,8 +187,12 @@ class EventUpsertTest extends WP_UnitTestCase {
 
 		$this->assertTrue( $reimported['success'] ?? false, wp_json_encode( $reimported ) );
 		$this->assertSame( $post_id, (int) $reimported['data']['post_id'] );
-		$this->assertSame( 'no_change', $reimported['data']['action'] );
-		$this->assertSame( 'trash', get_post_status( $post_id ), 'Data Machine #2993 owns unchanged-content status reconciliation.' );
+		$this->assertSame( 'updated', $reimported['data']['action'] );
+		$this->assertSame( 'publish', get_post_status( $post_id ) );
+		$this->assertSame( $original_slug, get_post_field( 'post_name', $post_id ) );
+		$this->assertSame( array(), get_post_meta( $post_id, '_wp_desired_post_slug', false ) );
+		$this->assertSame( array(), get_post_meta( $post_id, '_wp_trash_meta_status', false ) );
+		$this->assertSame( array(), get_post_meta( $post_id, '_wp_trash_meta_time', false ) );
 		$this->assertCount(
 			1,
 			get_posts(
@@ -200,6 +204,18 @@ class EventUpsertTest extends WP_UnitTestCase {
 					'posts_per_page' => -1,
 				)
 			)
+		);
+		$this->assertCount(
+			1,
+			get_posts(
+				array(
+					'post_type'      => Event_Post_Type::POST_TYPE,
+					'post_status'    => array( 'publish', 'future', 'draft', 'pending', 'private', 'trash' ),
+					'title'          => $parameters['title'],
+					'posts_per_page' => -1,
+				)
+			),
+			'Reimport must restore the original slug instead of creating a suffixed replacement.'
 		);
 	}
 

--- a/tests/Unit/EventUpsertTest.php
+++ b/tests/Unit/EventUpsertTest.php
@@ -164,6 +164,38 @@ class EventUpsertTest extends WP_UnitTestCase {
 		$this->assertInstanceOf( EventUpsert::class, $this->handler );
 	}
 
+	public function test_source_identity_re_resolves_the_same_trashed_post(): void {
+		$source_identity = 'source:event-' . uniqid();
+		$post_id         = wp_insert_post(
+			array(
+				'post_title'  => 'Trashed Source Event',
+				'post_type'   => Event_Post_Type::POST_TYPE,
+				'post_status' => 'publish',
+				'post_name'   => 'stable-source-event-url',
+			)
+		);
+		update_post_meta( $post_id, EventUpsert::SOURCE_IDENTITY_META_KEY, $source_identity );
+		wp_trash_post( $post_id );
+
+		$method = new \ReflectionMethod( $this->handler, 'findExistingEventBySourceIdentity' );
+		$method->setAccessible( true );
+
+		$this->assertSame( $post_id, $method->invoke( $this->handler, $source_identity ) );
+		$this->assertSame( 'stable-source-event-url', get_post_field( 'post_name', $post_id ) );
+		$this->assertCount(
+			1,
+			get_posts(
+				array(
+					'post_type'      => Event_Post_Type::POST_TYPE,
+					'post_status'    => array( 'publish', 'future', 'draft', 'pending', 'private', 'trash' ),
+					'meta_key'       => EventUpsert::SOURCE_IDENTITY_META_KEY,
+					'meta_value'     => $source_identity,
+					'posts_per_page' => -1,
+				)
+			)
+		);
+	}
+
 	public function test_consumer_can_provide_automated_import_author(): void {
 		$user_id = self::factory()->user->create();
 		$callback = static function ( int $author_id ) use ( $user_id ): int {


### PR DESCRIPTION
## Summary
- preserve duplicate loser URLs on a published canonical winner through WordPress core `_wp_old_slug`
- fail closed and roll back slug/ticket metadata when continuity transfer or trashing fails
- recover trashed events only through exact source identity; all broad/fuzzy duplicate paths reject trash
- restore unchanged exact-source reimports through Data Machine's merged core untrash lifecycle

## Root cause
Duplicate cleanup trashed loser events without transferring routable slug history. Exact source lookup also used `post_status => any`, which excludes trash, allowing reimports to create suffixed replacements.

WordPress already owns both primitives needed here: `_wp_old_slug`/`wp_old_slug_redirect()` for canonical replacement URLs and `wp_untrash_post()` for full restoration. This PR supplies domain identity and merge semantics without adding a redirect service.

## Safety boundaries
- only exact source identity lookup includes `trash`
- ticket, exact-title, venue/date fuzzy, and date-wide fuzzy matching reject trashed candidates
- merge requires a published winner
- failed continuity writes leave the loser live and remove partial mutations
- trash failure restores winner slug and ticket metadata
- ordinary cancellation/deletion creates no redirect

## Dependency
Data Machine PR #2994 is merged as `9200f612a5f602e7e1ebddbf03fb858d7040eff1` and released on current main. The integration test verifies unchanged trash replay restores the same ID to `publish`, restores the original slug, clears trash metadata, and creates no suffixed replacement.

## Verification
- independent PHPUnit source execution on the prior implementation head: 661 tests, 2,361 assertions, 2 skipped
- final changed-scope Homeboy lint against current Data Machine main: PHPCS and PHPStan passed with zero findings
- PHP syntax and `git diff --check` passed
- focused tests cover core old-slug resolution, exact-source restoration, stale fuzzy identity rows, published-winner enforcement, partial transfer rollback, and trash rollback
- GitHub Homeboy checks have intermittently failed after successful underlying tools because process supervision did not emit valid structured output; no source assertion failure was reported

Closes #587