### PR TITLE
Fix canonical ticket identity reconciliation

### DIFF
--- a/inc/Abilities/MergedBillDetectAbilities.php
+++ b/inc/Abilities/MergedBillDetectAbilities.php
@@ -17,6 +17,7 @@
  *   - start_datetime >= NOW (upcoming only)
  *
  * Scoring signals (per issue #256):
+ *   - Matching canonical ticket identity +5
  *   - Mutual body-lineup mention      +5
  *   - Identical end_datetime          +2
  *   - Matching price                  +1
@@ -36,6 +37,8 @@ namespace DataMachineEvents\Abilities;
 use DataMachine\Engine\AI\Actions\PendingActionStore;
 use DataMachineEvents\Core\Event_Post_Type;
 use DataMachineEvents\Core\EventDatesTable;
+use function DataMachineEvents\Core\datamachine_extract_ticket_identity;
+use const DataMachineEvents\Core\EVENT_TICKET_URL_META_KEY;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -61,7 +64,7 @@ class MergedBillDetectAbilities {
 				'data-machine-events/merged-bill-detect',
 				array(
 					'label'               => __( 'Detect merged-bill duplicate events', 'data-machine-events' ),
-					'description'         => __( 'Scan upcoming events for same-venue + same-time + different-title pairs that look like the same bill scraped twice. Queues high-confidence pairs to the pending-actions queue for agent resolution.', 'data-machine-events' ),
+					'description'         => __( 'Scan upcoming events for same-venue + same-time + different-title pairs that share canonical ticket or lineup evidence. Queues high-confidence pairs to the pending-actions queue for agent resolution.', 'data-machine-events' ),
 					'category'            => 'datamachine-events-events',
 					'input_schema'        => array(
 						'type'       => 'object',
@@ -293,14 +296,21 @@ class MergedBillDetectAbilities {
 	 */
 	private function scorePair( array $a, array $b ): array {
 		$signals = array(
-			'mutual_lineup_mention' => false,
-			'identical_end'         => false,
-			'matching_price'        => false,
-			'matching_source_host'  => false,
+			'matching_ticket_identity' => false,
+			'mutual_lineup_mention'    => false,
+			'identical_end'            => false,
+			'matching_price'           => false,
+			'matching_source_host'     => false,
 		);
 
 		$detail_a = $this->loadEventDetail( (int) $a['post_id'] );
 		$detail_b = $this->loadEventDetail( (int) $b['post_id'] );
+
+		// Matching canonical ticket identity (+5). Stable provider IDs remain
+		// authoritative when affiliate wrappers or lineup-derived slugs drift.
+		if ( $this->ticketIdentitiesMatch( $detail_a['ticket_url'] ?? '', $detail_b['ticket_url'] ?? '' ) ) {
+			$signals['matching_ticket_identity'] = true;
+		}
 
 		// Mutual lineup mention (+5).
 		$mutual = $this->hasMutualLineupMention(
@@ -333,6 +343,9 @@ class MergedBillDetectAbilities {
 		}
 
 		$score = 0;
+		if ( $signals['matching_ticket_identity'] ) {
+			$score += 5;
+		}
 		if ( $signals['mutual_lineup_mention'] ) {
 			$score += 5;
 		}
@@ -350,6 +363,16 @@ class MergedBillDetectAbilities {
 			'score'   => $score,
 			'signals' => $signals,
 		);
+	}
+
+	/**
+	 * Compare stable provider ticket identities after unwrapping affiliates.
+	 */
+	public function ticketIdentitiesMatch( string $url_a, string $url_b ): bool {
+		$identity_a = datamachine_extract_ticket_identity( $url_a );
+		$identity_b = datamachine_extract_ticket_identity( $url_b );
+
+		return '' !== $identity_a && '' !== $identity_b && $identity_a === $identity_b;
 	}
 
 	/**
@@ -448,15 +471,16 @@ class MergedBillDetectAbilities {
 	 * Kept package-private (public for the chat tool to reuse) so the
 	 * decide step can use the same extraction logic without duplicating it.
 	 *
-	 * @return array{body_text: string, performer: string, price: string}
+	 * @return array{body_text: string, performer: string, price: string, ticket_url: string}
 	 */
 	public function loadEventDetail( int $post_id ): array {
 		$post = get_post( $post_id );
 		if ( ! $post ) {
 			return array(
-				'body_text' => '',
-				'performer' => '',
-				'price'     => '',
+				'body_text'  => '',
+				'performer'  => '',
+				'price'      => '',
+				'ticket_url' => '',
 			);
 		}
 
@@ -490,9 +514,10 @@ class MergedBillDetectAbilities {
 		}
 
 		return array(
-			'body_text' => $body_text,
-			'performer' => $performer,
-			'price'     => $price,
+			'body_text'  => $body_text,
+			'performer'  => $performer,
+			'price'      => $price,
+			'ticket_url' => (string) get_post_meta( $post_id, EVENT_TICKET_URL_META_KEY, true ),
 		);
 	}
 

--- a/inc/Cli/Check/CheckMergedBillsCommand.php
+++ b/inc/Cli/Check/CheckMergedBillsCommand.php
@@ -33,8 +33,8 @@ class CheckMergedBillsCommand {
 	 * ---
 	 *
 	 * [--threshold=<score>]
-	 * : Minimum score to queue a pair. Mutual lineup mention is +5; the
-	 *   default threshold of 5 makes that the minimum bar.
+	 * : Minimum score to queue a pair. Matching canonical ticket identity
+	 *   and mutual lineup mention are each +5; the default threshold is 5.
 	 * ---
 	 * default: 5
 	 * ---
@@ -93,6 +93,9 @@ class CheckMergedBillsCommand {
 		foreach ( $result['pairs'] as $pair ) {
 			$signals  = $pair['signals'] ?? array();
 			$tag_bits = array();
+			if ( ! empty( $signals['matching_ticket_identity'] ) ) {
+				$tag_bits[] = 'ticket';
+			}
 			if ( ! empty( $signals['mutual_lineup_mention'] ) ) {
 				$tag_bits[] = 'lineup';
 			}

--- a/inc/Core/event-dates-sync.php
+++ b/inc/Core/event-dates-sync.php
@@ -81,10 +81,12 @@ function datamachine_normalize_ticket_url( string $url ): string {
  * - ticketmaster.evyy.net/c/.../4272?u=<ticketmaster_url>  (affiliate)
  * - www.ticketmaster.com/event/...                          (direct)
  *
- * The result is normalized (scheme + host + path, no query params) for comparison.
+ * Provider URLs with stable event IDs return an opaque provider identity so
+ * source-generated title or lineup slugs do not fragment the same event. Other
+ * URLs fall back to normalized scheme + host + path comparison.
  *
  * @param string $url Ticket URL (may be affiliate-wrapped or direct)
- * @return string Canonical URL for dedup comparison
+ * @return string Canonical ticket identity for dedup comparison
  */
 function datamachine_extract_ticket_identity( string $url ): string {
 	if ( empty( $url ) ) {
@@ -98,6 +100,25 @@ function datamachine_extract_ticket_identity( string $url ): string {
 	$parsed = wp_parse_url( $canonical );
 	if ( ! $parsed || empty( $parsed['host'] ) ) {
 		return '';
+	}
+
+	$host = strtolower( preg_replace( '/^www\./', '', $parsed['host'] ) );
+	$path = $parsed['path'] ?? '';
+
+	// Ticketmaster embeds the stable event ID after /event/, while the
+	// preceding path is generated from the current source title.
+	if ( ( 'ticketmaster.com' === $host || str_ends_with( $host, '.ticketmaster.com' ) )
+		&& preg_match( '#/event/([^/]+)#i', $path, $matches )
+	) {
+		return 'ticketmaster:event:' . strtolower( rawurldecode( $matches[1] ) );
+	}
+
+	// Etix embeds its stable numeric event ID after /ticket/p/ and follows it
+	// with a source-generated lineup slug that can drift between feeds.
+	if ( ( 'etix.com' === $host || str_ends_with( $host, '.etix.com' ) )
+		&& preg_match( '#/ticket/p/([a-z0-9_-]+)#i', $path, $matches )
+	) {
+		return 'etix:event:' . strtolower( rawurldecode( $matches[1] ) );
 	}
 
 	$scheme     = $parsed['scheme'] ?? 'https';

--- a/tests/Unit/MergedBillDetectScoringTest.php
+++ b/tests/Unit/MergedBillDetectScoringTest.php
@@ -135,8 +135,66 @@ class MergedBillDetectScoringTest extends WP_UnitTestCase {
 	}
 
 	// ------------------------------------------------------------------
-	// scorePair via execute() — integration over fixtures requires the
-	// post records to exist. Skip; covered by direct lineup tests above.
+	// Canonical ticket identity
+	// ------------------------------------------------------------------
+
+	public function test_ticket_identity_matches_across_source_suffix_and_lineup_drift(): void {
+		$this->assertTrue(
+			$this->detector->ticketIdentitiesMatch(
+				'https://www.etix.com/ticket/p/80665941/campground-underground-music-showcase-wsinistarrj-bolivarmrfrickganocerval-denver-campground?partner_id=100',
+				'https://www.etix.com/ticket/p/80665941/campground-underground-music-showcase-wsinistarrj-bolivarmrfrickganolevi-double-u-denver-campground?partner_id=100'
+			),
+			'Source-generated lineup suffixes must not hide a shared stable provider event ID.'
+		);
+	}
+
+	public function test_ticket_identity_matches_across_affiliate_wrapped_title_variants(): void {
+		$this->assertTrue(
+			$this->detector->ticketIdentitiesMatch(
+				'https://ticketmaster.evyy.net/c/1191134/264167/4272?u=https%3A%2F%2Fwww.ticketmaster.com%2Freprise-recreating-10291994-at-spartanburg-memorial-charleston-south-carolina-07-30-2026%2Fevent%2F2D00649E9A9BF91F&utm_medium=affiliate',
+				'https://ticketmaster.evyy.net/c/1191134/264167/4272?u=https%3A%2F%2Fwww.ticketmaster.com%2Freprise-charleston-south-carolina-07-30-2026%2Fevent%2F2D00649E9A9BF91F&utm_medium=affiliate'
+			),
+			'Affiliate wrappers and source title variants must resolve to the shared Ticketmaster event ID.'
+		);
+	}
+
+	public function test_distinct_ticket_identities_do_not_match_at_same_venue_and_time(): void {
+		$this->assertFalse(
+			$this->detector->ticketIdentitiesMatch(
+				'https://www.etix.com/ticket/p/80665941/first-show',
+				'https://www.etix.com/ticket/p/80665942/second-show'
+			),
+			'Different provider event IDs must remain distinct even when venue and time collide.'
+		);
+	}
+
+	public function test_missing_ticket_identity_never_matches(): void {
+		$this->assertFalse( $this->detector->ticketIdentitiesMatch( '', '' ) );
+		$this->assertFalse( $this->detector->ticketIdentitiesMatch( 'https://tickets.example.com/show', '' ) );
+	}
+
+	public function test_matching_ticket_identity_reaches_review_threshold_without_lineup_overlap(): void {
+		$post_a = self::factory()->post->create( array( 'post_content' => 'Source A description.' ) );
+		$post_b = self::factory()->post->create( array( 'post_content' => 'Source B description.' ) );
+		update_post_meta( $post_a, \DataMachineEvents\Core\EVENT_TICKET_URL_META_KEY, 'https://www.etix.com/ticket/p/80665941/cerval' );
+		update_post_meta( $post_b, \DataMachineEvents\Core\EVENT_TICKET_URL_META_KEY, 'https://www.etix.com/ticket/p/80665941/levi-double-u' );
+
+		$score_pair = new \ReflectionMethod( MergedBillDetectAbilities::class, 'scorePair' );
+		$score_pair->setAccessible( true );
+		$result = $score_pair->invoke(
+			$this->detector,
+			array( 'post_id' => $post_a, 'title' => 'Campground with Cerval' ),
+			array( 'post_id' => $post_b, 'title' => 'Campground with Levi Double U' )
+		);
+
+		$this->assertSame( MergedBillDetectAbilities::DEFAULT_THRESHOLD, $result['score'] );
+		$this->assertTrue( $result['signals']['matching_ticket_identity'] );
+		$this->assertFalse( $result['signals']['mutual_lineup_mention'] );
+	}
+
+	// ------------------------------------------------------------------
+	// execute() candidate discovery remains covered by the managed database
+	// suite; scorePair() is exercised directly above with real post records.
 	// ------------------------------------------------------------------
 
 	public function test_buildPairKey_is_order_independent(): void {


### PR DESCRIPTION
## Summary

- extract stable Ticketmaster and Etix event IDs after affiliate unwrapping instead of treating source-generated title/lineup slugs as identity
- score canonical ticket identity as a high-confidence merged-bill signal while retaining same-venue, exact-minute, published-event preconditions and explicit review
- expose the ticket signal in the bounded dry-run report and cover lineup drift, affiliate variants, missing identity, and distinct provider IDs

Partial resolution of #594. This PR fixes the event-identity defect demonstrated by the Charleston Reprise and Denver Campground records. The independent legacy venue-alias normalization/remediation defect is tracked in #596.

## Root Cause

`datamachine_extract_ticket_identity()` unwrapped affiliate URLs but returned the complete provider path. Ticketmaster and Etix include source-generated title or lineup slugs in that path before or after a stable event ID, so two URLs for the same provider event remained unequal. Live import dedupe missed those variants, and the existing merged-bill detector ignored post ticket URLs entirely, leaving the Charleston pair at score 2 and below the default review threshold.

Production evidence confirms:

- Reprise posts `215253` and `237780` share Music Farm, `2026-07-30 20:00:00`, and Ticketmaster event ID `2D00649E9A9BF91F` despite different path slugs.
- Campground posts `269630` and `281781` share Larimer Lounge, `2026-07-26 16:00:00`, and Etix event ID `80665941` despite `Cerval` / `Levi Double U` lineup suffix drift.

## Confidence And Safety

Canonical provider identity is authoritative only for the two proven URL shapes:

- Ticketmaster: ID following `/event/`
- Etix: ID following `/ticket/p/`

Unknown providers retain the existing normalized-URL fallback. The merged-bill detector still requires the same canonical venue term, exact start minute, different title identity, published status, and upcoming date before scoring. A matching ticket identity adds 5 points, which queues inspection; it does not merge automatically. Different stable IDs, absent IDs, cross-venue pairs, and different-minute pairs remain protected.

## Source Precedence

Stable provider event ID outranks source-generated path slugs for identity only. It does not select a content winner. The existing decision contract remains authoritative: inspect both records, prefer the record with richer body/ticket/image evidence, use the older post on ties, and preserve the loser's source/lineup evidence in the trashed record and transferred URL history rather than silently overwriting the winner during detection.

## Remediation Contract

Existing records are report-only by default:

```bash
wp data-machine-events check merged-bills --dry-run --days-ahead=30 --threshold=5 --limit=100 --format=json
```

Removing `--dry-run` only queues candidates in `datamachine_pending_actions`; consolidation still requires an explicit `merged-bill-decide` verdict and winner. No production writes were performed for this PR.

## Verification

- `homeboy review lint --changed-only`: passed with PHPCS, ESLint, and PHPStan at zero findings
- `homeboy review audit --changed-since origin/main`: passed with zero introduced findings
- `php -l` on all four changed PHP files: passed
- `git diff --check`: passed
- standalone canonical-identity regression harness: 3 fixtures passed (Etix lineup drift, wrapped/direct Ticketmaster slug drift, distinct Etix IDs)
- production `merge-duplicate-venues --dry-run`: report only, no writes
- production `merged-bills --dry-run --threshold=0`: evaluated 441 candidate pairs, no writes; confirmed Reprise pair score was 2 before this fix
- managed frontend preparation: Calendar, Event Details, and Events Map builds passed
- managed PHPUnit gate: blocked before test execution because Homeboy could not provision its Docker MySQL 8.4 service (`wordpress-database`, zero tests run); the failure was runtime infrastructure, not an assertion failure

## Residual Risks

- Only the proven Ticketmaster and Etix path contracts receive provider-ID extraction; other providers continue using full normalized paths.
- Historical venue aliases can still split otherwise matching candidates across term IDs until #596 lands and its dry-run remediation is reviewed.
- Candidate inspection remains required because a provider could theoretically reuse an event ID incorrectly; this PR deliberately queues review instead of auto-merging.