### PR TITLE
fix: reconcile qualified venue aliases

### DIFF
--- a/inc/Cli/Check/CheckMergeDuplicateVenuesCommand.php
+++ b/inc/Cli/Check/CheckMergeDuplicateVenuesCommand.php
@@ -7,9 +7,9 @@
  * (ampersand / HTML-entity / apostrophe + suite-suffix normalization)
  * shipped.
  *
- * Scans every venue term, groups them by normalized name AND normalized
- * address+city, and for each cluster picks the oldest term (lowest ID)
- * as the winner. Loser terms are smart-merged into the winner via
+ * Scans every venue term, groups them by normalized physical location,
+ * then requires venue-name similarity before selecting the oldest term
+ * (lowest ID) as the winner. Loser terms are smart-merged into the winner via
  * VenueMergeHelper: post-term relationships are reassigned, flow
  * handler_config references are rewritten, then the loser term is
  * deleted.
@@ -134,11 +134,11 @@ class CheckMergeDuplicateVenuesCommand {
 	}
 
 	/**
-	 * Walk every venue term and group by normalized name OR normalized
-	 * address+city. Returns only clusters with >=2 terms.
+	 * Walk every venue term and group by normalized physical location.
+	 * Returns only name-compatible clusters with >=2 terms.
 	 *
-	 * The address key intentionally includes the city to keep two
-	 * different "123 Main St" venues (different cities) apart.
+	 * The key includes city, state, and country. False negatives from missing
+	 * geography are safer than a destructive cross-location merge.
 	 *
 	 * @return array<int,array{key:string,term_ids:array<int,int>,terms:array}>
 	 */
@@ -155,102 +155,69 @@ class CheckMergeDuplicateVenuesCommand {
 			return array();
 		}
 
-		$by_name    = array();
 		$by_address = array();
 
 		foreach ( $terms as $term ) {
-			$name_key = Venue_Taxonomy::normalize_venue_name_for_matching( $term->name );
-			if ( strlen( $name_key ) >= 3 ) {
-				$by_name[ $name_key ][] = $term;
-			}
-
 			$address = (string) get_term_meta( $term->term_id, '_venue_address', true );
 			$city    = (string) get_term_meta( $term->term_id, '_venue_city', true );
+			$state   = (string) get_term_meta( $term->term_id, '_venue_state', true );
+			$country = (string) get_term_meta( $term->term_id, '_venue_country', true );
 
 			if ( '' === $address || '' === $city ) {
 				continue;
 			}
 
 			$addr_key = sprintf(
-				'%s|%s',
-				Venue_Taxonomy::normalize_address_for_matching( $address ),
-				strtolower( trim( $city ) )
+				'%s|%s|%s|%s',
+				VenueMergeHelper::normalize_address_for_alias_matching( $address, $city, $state ),
+				Venue_Taxonomy::normalize_geographic_value( $city, 'city' ),
+				Venue_Taxonomy::normalize_geographic_value( $state, 'state' ),
+				Venue_Taxonomy::normalize_geographic_value( $country, 'country' )
 			);
 
-			if ( '|' === $addr_key || str_starts_with( $addr_key, '|' ) ) {
+			if ( str_starts_with( $addr_key, '|' ) ) {
 				continue;
 			}
 
 			$by_address[ $addr_key ][] = $term;
 		}
 
-		$clusters      = array();
-		$seen_term_ids = array();
+		$clusters = array();
 
-		// Emit name-clusters first, then address-clusters. Each term is
-		// emitted in at most one cluster — once seen via name, the
-		// address loop ignores it.
-		//
-		// Name-clusters are accepted as-is: same normalized name = same
-		// venue (this IS Rule 1 of names_are_similar).
-		//
 		// Address-clusters are subdivided by name similarity to suppress
 		// false positives at multi-tenant addresses (issue #281). Two
 		// terms sharing an address+city are only kept together if their
 		// names pass VenueMergeHelper::names_are_similar().
-		foreach ( array(
-			'name' => $by_name,
-			'addr' => $by_address,
-		) as $kind => $groups ) {
-			foreach ( $groups as $key => $group_terms ) {
-				if ( count( $group_terms ) < 2 ) {
+		foreach ( $by_address as $key => $group_terms ) {
+			if ( count( $group_terms ) < 2 ) {
+				continue;
+			}
+
+			$subgroups = $this->split_by_name_similarity( $group_terms );
+
+			foreach ( $subgroups as $subgroup_index => $subgroup_terms ) {
+				if ( count( $subgroup_terms ) < 2 ) {
 					continue;
 				}
 
-				// Drop terms we've already clustered via the name pass.
-				$group_terms = array_values(
-					array_filter(
-						$group_terms,
-						static fn( $t ) => ! in_array( (int) $t->term_id, $seen_term_ids, true )
-					)
+				$ids = array();
+				foreach ( $subgroup_terms as $t ) {
+					$ids[] = (int) $t->term_id;
+				}
+
+				// When an address bucket is split, give each surviving
+				// sub-cluster a disambiguating suffix so the operator
+				// can tell them apart in the dry-run report.
+				$cluster_key = 'addr:' . $key;
+				if ( count( $subgroups ) > 1 ) {
+					$cluster_key .= '#' . ( $subgroup_index + 1 );
+				}
+
+				$clusters[] = array(
+					'key'      => $cluster_key,
+					'term_ids' => $ids,
+					'terms'    => array_values( $subgroup_terms ),
 				);
-
-				if ( count( $group_terms ) < 2 ) {
-					continue;
-				}
-
-				$subgroups = ( 'addr' === $kind )
-					? $this->split_by_name_similarity( $group_terms )
-					: array( $group_terms );
-
-				foreach ( $subgroups as $subgroup_index => $subgroup_terms ) {
-					if ( count( $subgroup_terms ) < 2 ) {
-						continue;
-					}
-
-					$ids = array();
-					foreach ( $subgroup_terms as $t ) {
-						$ids[] = (int) $t->term_id;
-					}
-
-					// When an address bucket is split, give each surviving
-					// sub-cluster a disambiguating suffix so the operator
-					// can tell them apart in the dry-run report.
-					$cluster_key = $kind . ':' . $key;
-					if ( 'addr' === $kind && count( $subgroups ) > 1 ) {
-						$cluster_key .= '#' . ( $subgroup_index + 1 );
-					}
-
-					$clusters[] = array(
-						'key'      => $cluster_key,
-						'term_ids' => $ids,
-						'terms'    => array_values( $subgroup_terms ),
-					);
-
-					foreach ( $ids as $tid ) {
-						$seen_term_ids[] = $tid;
-					}
-				}
 			}
 		}
 
@@ -281,7 +248,12 @@ class CheckMergeDuplicateVenuesCommand {
 				$similar_to_all = true;
 
 				foreach ( $sub_terms as $existing ) {
-					if ( ! VenueMergeHelper::names_are_similar( (string) $term->name, (string) $existing->name ) ) {
+					if ( ! VenueMergeHelper::names_are_similar(
+						(string) $term->name,
+						(string) $existing->name,
+						$this->term_geography( $term ),
+						$this->term_geography( $existing )
+					) ) {
 						$similar_to_all = false;
 						break;
 					}
@@ -300,6 +272,19 @@ class CheckMergeDuplicateVenuesCommand {
 		}
 
 		return $subgroups;
+	}
+
+	/**
+	 * Read the geography that qualifies venue-specific name suffix removal.
+	 *
+	 * @return array{city:string,state:string,country:string}
+	 */
+	private function term_geography( \WP_Term $term ): array {
+		return array(
+			'city'    => (string) get_term_meta( $term->term_id, '_venue_city', true ),
+			'state'   => (string) get_term_meta( $term->term_id, '_venue_state', true ),
+			'country' => (string) get_term_meta( $term->term_id, '_venue_country', true ),
+		);
 	}
 
 	/**

--- a/inc/Core/DuplicateDetection/VenueMergeHelper.php
+++ b/inc/Core/DuplicateDetection/VenueMergeHelper.php
@@ -39,13 +39,6 @@ class VenueMergeHelper {
 	public const NO_MERGE_META_KEY = '_venue_no_merge';
 
 	/**
-	 * Jaccard token-overlap threshold for Rule 3 of names_are_similar().
-	 * Stricter is safer for a destructive merge operation — do not lower
-	 * without revisiting the production false-positive set in issue #281.
-	 */
-	public const NAME_SIMILARITY_TOKEN_OVERLAP_THRESHOLD = 0.70;
-
-	/**
 	 * Decide whether two venue names are similar enough that two terms
 	 * sharing an address+city should be treated as the same venue.
 	 *
@@ -56,35 +49,42 @@ class VenueMergeHelper {
 	 * Hollywood — legitimately share a street address but are distinct
 	 * operators that must not be merged.
 	 *
-	 * Three rules — any single rule passing accepts the pair as "similar":
+	 * Two rules — either rule passing accepts the pair as "similar":
 	 *
 	 *   Rule 1: Exact equality after normalize_venue_name_for_matching().
 	 *           Handles "Hi-Fi Indianapolis" vs "HI-FI Indianapolis".
 	 *
-	 *   Rule 2: Substring containment after normalization, where the
-	 *           shorter normalized name is at least 4 characters.
-	 *           Handles "The Abbey" vs "The Abbey-Orlando".
+	 *   Rule 2: Exact token-set equality after stop-word removal. This allows
+	 *           harmless token reordering without treating a parent venue and
+	 *           an added room/annex/patio token as aliases.
 	 *
-	 *   Rule 3: Jaccard token overlap >= 70% after stop-word removal
-	 *           ("the", "a", "an", "and", "of", "at"). Handles
-	 *           "St Augustine Amphitheatre" vs "The St. Augustine
-	 *           Amphitheatre" (4/5 = 0.80). Correctly REJECTS
-	 *           "V Theater at Planet Hollywood" vs "Saxe Theater at
-	 *           Planet Hollywood" (3/5 = 0.60).
-	 *
-	 * If all three rules fail, the names are dissimilar and the pair
+	 * If both rules fail, the names are dissimilar and the pair
 	 * must NOT be clustered as duplicates even if they share an address.
 	 *
-	 * Empty / whitespace-only / sub-threshold inputs return false — when
+	 * Empty or whitespace-only inputs return false. When
 	 * in doubt the safer answer for a destructive merge is "not similar".
 	 *
 	 * @param string $a First venue name.
 	 * @param string $b Second venue name.
-	 * @return bool True if any of the three rules accepts the pair.
+	 * @param array  $geo_a Stored geography for the first venue.
+	 * @param array  $geo_b Stored geography for the second venue.
+	 * @return bool True if either rule accepts the pair.
 	 */
-	public static function names_are_similar( string $a, string $b ): bool {
-		$norm_a = Venue_Taxonomy::normalize_venue_name_for_matching( $a );
-		$norm_b = Venue_Taxonomy::normalize_venue_name_for_matching( $b );
+	public static function names_are_similar( string $a, string $b, array $geo_a = array(), array $geo_b = array() ): bool {
+		if ( ! self::geography_is_compatible( $geo_a, $geo_b ) ) {
+			return false;
+		}
+
+		$norm_a = self::normalize_name_for_alias_matching(
+			$a,
+			(string) ( $geo_a['city'] ?? '' ),
+			(string) ( $geo_a['state'] ?? '' )
+		);
+		$norm_b = self::normalize_name_for_alias_matching(
+			$b,
+			(string) ( $geo_b['city'] ?? '' ),
+			(string) ( $geo_b['state'] ?? '' )
+		);
 
 		if ( '' === $norm_a || '' === $norm_b ) {
 			return false;
@@ -95,16 +95,7 @@ class VenueMergeHelper {
 			return true;
 		}
 
-		// Rule 2: substring containment with a 4-char floor on the shorter
-		// name. The floor stops tiny tokens like "joe" matching every
-		// "Joe's <something>" but allows "joes" (4 chars) through.
-		$shorter = strlen( $norm_a ) <= strlen( $norm_b ) ? $norm_a : $norm_b;
-		$longer  = strlen( $norm_a ) <= strlen( $norm_b ) ? $norm_b : $norm_a;
-		if ( strlen( $shorter ) >= 4 && str_contains( $longer, $shorter ) ) {
-			return true;
-		}
-
-		// Rule 3: Jaccard token overlap on stop-word-stripped tokens.
+		// Rule 2: exact token-set equality after stop-word removal.
 		$stops = array( 'the', 'a', 'an', 'and', 'of', 'at' );
 
 		$tok_a = preg_split( '/\s+/', $norm_a, -1, PREG_SPLIT_NO_EMPTY );
@@ -120,14 +111,103 @@ class VenueMergeHelper {
 			return false;
 		}
 
-		$intersection = count( array_intersect( $tok_a, $tok_b ) );
-		$union        = count( array_unique( array_merge( $tok_a, $tok_b ) ) );
+		sort( $tok_a );
+		sort( $tok_b );
+		return array_values( array_unique( $tok_a ) ) === array_values( array_unique( $tok_b ) );
+	}
 
-		if ( 0 === $union ) {
-			return false;
+	/**
+	 * Normalize venue-only aliases without changing the generic taxonomy normalizer.
+	 *
+	 * Geography suffixes are removed only when they agree with the venue's stored
+	 * city or state. This keeps broad words such as "Denver" meaningful when the
+	 * term does not independently identify Denver as its location.
+	 */
+	public static function normalize_name_for_alias_matching( string $name, string $city = '', string $state = '' ): string {
+		$name = html_entity_decode( $name, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+
+		do {
+			$before = $name;
+			foreach ( self::geography_suffixes( $city, $state ) as $suffix ) {
+				$name = preg_replace( '/(?:\s|,|-)+' . preg_quote( $suffix, '/' ) . '\s*$/iu', '', $name );
+			}
+		} while ( $before !== $name );
+
+		$normalized = Venue_Taxonomy::normalize_venue_name_for_matching( $name );
+		return str_replace( array( 'amphitheatre', 'theatre' ), array( 'amphitheater', 'theater' ), $normalized );
+	}
+
+	/**
+	 * Normalize venue addresses for the legacy-alias remediation command.
+	 *
+	 * Stored geography qualifies removal of redundant trailing city/state fields,
+	 * while directional words are reduced to their common postal abbreviations.
+	 */
+	public static function normalize_address_for_alias_matching( string $address, string $city = '', string $state = '' ): string {
+		$address = html_entity_decode( $address, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+
+		$city = trim( $city );
+		if ( '' !== $city ) {
+			$state_suffixes = self::geography_suffixes( '', $state );
+			$state_pattern  = empty( $state_suffixes )
+				? ''
+				: '(?:\s*,?\s*(?:' . implode( '|', array_map( static fn( string $value ): string => preg_quote( $value, '/' ), $state_suffixes ) ) . '))?';
+			$address        = preg_replace(
+				'/\s*,?\s*' . preg_quote( $city, '/' ) . $state_pattern . '\s*$/iu',
+				'',
+				$address
+			);
 		}
 
-		return ( $intersection / $union ) >= self::NAME_SIMILARITY_TOKEN_OVERLAP_THRESHOLD;
+		$address = preg_replace_callback(
+			'/^(\s*\d+[a-z0-9-]*\s+)(north|south|east|west)\s+(?=(?:\d+(?:st|nd|rd|th)?\b|broadway\b))/i',
+			static function ( array $matches ): string {
+				$direction = array(
+					'north' => 'n',
+					'south' => 's',
+					'east'  => 'e',
+					'west'  => 'w',
+				);
+				return $matches[1] . $direction[ strtolower( $matches[2] ) ] . ' ';
+			},
+			$address
+		);
+
+		return Venue_Taxonomy::normalize_address_for_matching( $address );
+	}
+
+	/**
+	 * Return suffixes authorized by stored geography, longest first.
+	 *
+	 * @return array<int,string>
+	 */
+	private static function geography_suffixes( string $city, string $state ): array {
+		$suffixes = array_filter( array( trim( $city ) ) );
+		$suffixes = array_merge( $suffixes, Venue_Taxonomy::state_aliases_for_matching( $state ) );
+
+		$suffixes = array_values( array_unique( $suffixes ) );
+		usort( $suffixes, static fn( string $a, string $b ): int => strlen( $b ) <=> strlen( $a ) );
+		return $suffixes;
+	}
+
+	/**
+	 * Reject conflicting stored geography while allowing either side to omit it.
+	 */
+	private static function geography_is_compatible( array $geo_a, array $geo_b ): bool {
+		foreach ( array( 'city', 'state', 'country' ) as $field ) {
+			$value_a = self::normalize_geography_value( $field, (string) ( $geo_a[ $field ] ?? '' ) );
+			$value_b = self::normalize_geography_value( $field, (string) ( $geo_b[ $field ] ?? '' ) );
+
+			if ( '' !== $value_a && '' !== $value_b && $value_a !== $value_b ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	private static function normalize_geography_value( string $field, string $value ): string {
+		return Venue_Taxonomy::normalize_geographic_value( $value, $field );
 	}
 
 	/**

--- a/inc/Core/Venue_Taxonomy.php
+++ b/inc/Core/Venue_Taxonomy.php
@@ -503,7 +503,7 @@ class Venue_Taxonomy {
 	 * @param string $field Geographic field name.
 	 * @return string
 	 */
-	private static function normalize_geographic_value( string $value, string $field ): string {
+	public static function normalize_geographic_value( string $value, string $field ): string {
 		$value = html_entity_decode( $value, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
 		$value = strtolower( remove_accents( $value ) );
 		$value = preg_replace( '/[^a-z0-9]+/', ' ', $value );
@@ -524,6 +524,23 @@ class Venue_Taxonomy {
 		}
 
 		return $value;
+	}
+
+	/**
+	 * Return equivalent stored forms for a US state or territory.
+	 *
+	 * @return array<int,string>
+	 */
+	public static function state_aliases_for_matching( string $state ): array {
+		$normalized = self::normalize_geographic_value( $state, 'state' );
+		$abbrev     = strtoupper( $normalized );
+
+		if ( isset( self::$us_state_names[ $abbrev ] ) ) {
+			return array( $abbrev, self::$us_state_names[ $abbrev ] );
+		}
+
+		$state = trim( $state );
+		return '' === $state ? array() : array( $state );
 	}
 
 	/**

--- a/tests/Unit/VenueMergeHelperTest.php
+++ b/tests/Unit/VenueMergeHelperTest.php
@@ -152,8 +152,12 @@ class VenueMergeHelperTest extends WP_UnitTestCase {
 	// ---------------------------------------------------------------------
 
 	public function test_merge_command_dry_run_lists_clusters_without_writes(): void {
-		$winner = $this->make_venue( 'Hook and Ladder Theater' );
-		$loser  = $this->make_venue( 'Hook & Ladder Theater' );
+		$meta   = array(
+			'_venue_address' => '3010 Minnehaha Ave',
+			'_venue_city'    => 'Minneapolis',
+		);
+		$winner = $this->make_venue( 'Hook and Ladder Theater', $meta );
+		$loser  = $this->make_venue( 'Hook & Ladder Theater', $meta );
 
 		$winner_post = $this->make_event_with_venue( 'Show A', $winner );
 		$loser_post  = $this->make_event_with_venue( 'Show B', $loser );
@@ -179,7 +183,10 @@ class VenueMergeHelperTest extends WP_UnitTestCase {
 	public function test_merge_command_apply_reassigns_posts_and_deletes_loser(): void {
 		$winner = $this->make_venue(
 			'Hook and Ladder Theater',
-			array( '_venue_city' => 'Minneapolis' )
+			array(
+				'_venue_address' => '3010 Minnehaha Ave',
+				'_venue_city'    => 'Minneapolis',
+			)
 		);
 		$loser  = $this->make_venue(
 			'Hook & Ladder Theater',
@@ -222,8 +229,12 @@ class VenueMergeHelperTest extends WP_UnitTestCase {
 	}
 
 	public function test_merge_command_apply_reassigns_flow_handler_configs(): void {
-		$winner = $this->make_venue( 'Hook and Ladder Theater' );
-		$loser  = $this->make_venue( 'Hook & Ladder Theater' );
+		$meta   = array(
+			'_venue_address' => '3010 Minnehaha Ave',
+			'_venue_city'    => 'Minneapolis',
+		);
+		$winner = $this->make_venue( 'Hook and Ladder Theater', $meta );
+		$loser  = $this->make_venue( 'Hook & Ladder Theater', $meta );
 
 		// Two flow shapes from production: flat venue and nested
 		// universal_web_scraper.venue. Both must be rewritten.
@@ -275,9 +286,19 @@ class VenueMergeHelperTest extends WP_UnitTestCase {
 	public function test_merge_command_respects_no_merge_opt_out(): void {
 		$winner = $this->make_venue(
 			'Hook and Ladder Theater',
-			array( VenueMergeHelper::NO_MERGE_META_KEY => '1' )
+			array(
+				VenueMergeHelper::NO_MERGE_META_KEY => '1',
+				'_venue_address'                     => '3010 Minnehaha Ave',
+				'_venue_city'                        => 'Minneapolis',
+			)
 		);
-		$loser  = $this->make_venue( 'Hook & Ladder Theater' );
+		$loser  = $this->make_venue(
+			'Hook & Ladder Theater',
+			array(
+				'_venue_address' => '3010 Minnehaha Ave',
+				'_venue_city'    => 'Minneapolis',
+			)
+		);
 
 		$loser_post = $this->make_event_with_venue( 'Show B', $loser );
 
@@ -320,7 +341,7 @@ class VenueMergeHelperTest extends WP_UnitTestCase {
 	}
 
 	// ---------------------------------------------------------------------
-	// names_are_similar() — three-rule guard for address-cluster path
+	// names_are_similar() — conservative guard for address-cluster path
 	// (issue #281)
 	// ---------------------------------------------------------------------
 
@@ -331,31 +352,42 @@ class VenueMergeHelperTest extends WP_UnitTestCase {
 		);
 	}
 
-	public function test_names_are_similar_substring_containment(): void {
-		// "the abbey" is substring of "the abbeyorlando" after normalization
-		// strips the dash. Shorter is well above the 4-char floor → Rule 2.
+	public function test_names_are_similar_qualified_city_suffix(): void {
+		$orlando = array( 'city' => 'Orlando' );
 		$this->assertTrue(
-			VenueMergeHelper::names_are_similar( 'The Abbey', 'The Abbey-Orlando' )
+			VenueMergeHelper::names_are_similar( 'The Abbey', 'The Abbey-Orlando', $orlando, $orlando )
 		);
 	}
 
-	public function test_names_are_similar_token_overlap_above_threshold(): void {
-		// Token reordering keeps Rule 3 honest: same bag of tokens but
-		// not a substring of each other. 3/3 = 1.0, well over 0.70.
+	public function test_names_are_similar_accepts_token_reordering(): void {
+		// Token reordering keeps Rule 2 useful without accepting added tokens.
 		$this->assertTrue(
 			VenueMergeHelper::names_are_similar( 'Bowery Ballroom NYC', 'NYC Bowery Ballroom' )
 		);
 	}
 
-	public function test_names_are_similar_token_overlap_below_threshold(): void {
-		// {v, theater, planet, hollywood} vs {saxe, theater, planet, hollywood}
-		// intersection 3, union 5 → 0.60 → below the 0.70 cutoff.
+	public function test_names_are_similar_rejects_different_token_sets(): void {
+		// Distinct token sets must not match even with a shared location suffix.
 		$this->assertFalse(
 			VenueMergeHelper::names_are_similar(
 				'V Theater at Planet Hollywood',
 				'Saxe Theater at Planet Hollywood'
 			)
 		);
+		$this->assertFalse(
+			VenueMergeHelper::names_are_similar(
+				'V Theater at Planet Hollywood Inside the Miracle Mile Mall',
+				'Saxe Theater at Planet Hollywood Inside the Miracle Mile Mall'
+			)
+		);
+	}
+
+	public function test_names_are_similar_rejects_distinct_subvenues(): void {
+		$this->assertFalse( VenueMergeHelper::names_are_similar( 'Georgia Theatre', 'Georgia Theatre Rooftop' ) );
+		$this->assertFalse( VenueMergeHelper::names_are_similar( "Cat's Cradle", "Cat's Cradle Back Room" ) );
+		$this->assertFalse( VenueMergeHelper::names_are_similar( 'Bar Freda', 'Bar Freda - Basement' ) );
+		$this->assertFalse( VenueMergeHelper::names_are_similar( 'Cannery Hall', 'Mainstage at Cannery Hall' ) );
+		$this->assertFalse( VenueMergeHelper::names_are_similar( 'The Lounge at Venue A', 'The Lounge at Venue B' ) );
 	}
 
 	public function test_names_are_similar_completely_different(): void {
@@ -372,16 +404,8 @@ class VenueMergeHelperTest extends WP_UnitTestCase {
 		);
 	}
 
-	public function test_names_are_similar_short_substring_at_threshold(): void {
-		// Edge case: "joes" normalizes to exactly 4 chars, which meets the
-		// >=4 floor of Rule 2, and IS substring of "joes bar and grill"
-		// after normalization. This case PASSES — documenting the floor.
-		//
-		// Real-world impact is bounded: this only fires inside an
-		// address-bucket where both terms ALREADY share a normalized
-		// address+city, so spurious "Joe's" → "Joe's Bar and Grill" cross-
-		// city collisions are not possible.
-		$this->assertTrue(
+	public function test_names_are_similar_rejects_added_tokens(): void {
+		$this->assertFalse(
 			VenueMergeHelper::names_are_similar( 'Joes', "Joe's Bar and Grill" )
 		);
 	}
@@ -390,9 +414,62 @@ class VenueMergeHelperTest extends WP_UnitTestCase {
 		$this->assertFalse( VenueMergeHelper::names_are_similar( '', 'Anything' ) );
 		$this->assertFalse( VenueMergeHelper::names_are_similar( 'Anything', '' ) );
 		$this->assertFalse( VenueMergeHelper::names_are_similar( '   ', 'Anything' ) );
-		// Single-character "Z" normalizes to "z" (1 char) — fails Rule 1
-		// (not equal), Rule 2 (below 4-char floor), Rule 3 (no overlap).
+		// Single-character "Z" normalizes to "z" and has a different token set.
 		$this->assertFalse( VenueMergeHelper::names_are_similar( 'Z', 'Anything' ) );
+	}
+
+	public function test_names_are_similar_for_qualified_legacy_aliases(): void {
+		$denver = array(
+			'city'    => 'Denver',
+			'state'   => 'CO',
+			'country' => 'US',
+		);
+
+		$this->assertTrue( VenueMergeHelper::names_are_similar( 'Bluebird Theater', 'Bluebird Theatre', $denver, $denver ) );
+		$this->assertTrue( VenueMergeHelper::names_are_similar( 'Oriental Theater', 'Oriental Theatre-CO', $denver, $denver ) );
+		$this->assertTrue( VenueMergeHelper::names_are_similar( 'Oriental Theater', 'Oriental Theatre-Denver-CO', $denver, $denver ) );
+		$this->assertTrue( VenueMergeHelper::names_are_similar( 'HQ', 'HQ Denver', $denver, $denver ) );
+		$this->assertTrue( VenueMergeHelper::names_are_similar( 'Red Rocks Amphitheater', 'Red Rocks Amphitheatre', $denver, $denver ) );
+		$this->assertTrue(
+			VenueMergeHelper::names_are_similar(
+				'Example Venue',
+				'Example Venue-NY',
+				array( 'state' => 'New York' ),
+				array( 'state' => 'NY' )
+			)
+		);
+		$this->assertFalse( VenueMergeHelper::names_are_similar( 'HQ', 'HQ Denver' ) );
+		$this->assertFalse(
+			VenueMergeHelper::names_are_similar(
+				'HQ',
+				'HQ Denver',
+				$denver,
+				array(
+					'city'    => 'Denver',
+					'state'   => 'TX',
+					'country' => 'US',
+				)
+			)
+		);
+	}
+
+	public function test_alias_address_normalization_uses_stored_geography(): void {
+		$this->assertSame(
+			VenueMergeHelper::normalize_address_for_alias_matching( '4335 W. 44th Ave.', 'Denver', 'CO' ),
+			VenueMergeHelper::normalize_address_for_alias_matching( '4335 W. 44th Ave., Denver, Colorado', 'Denver', 'CO' )
+		);
+		$this->assertNotSame(
+			VenueMergeHelper::normalize_address_for_alias_matching( '100 West Street', 'Denver', 'CO' ),
+			VenueMergeHelper::normalize_address_for_alias_matching( '100 W Street', 'Denver', 'CO' )
+		);
+		$this->assertSame(
+			VenueMergeHelper::normalize_address_for_alias_matching( '60 South Broadway', 'Denver', 'CO' ),
+			VenueMergeHelper::normalize_address_for_alias_matching( '60 S Broadway', 'Denver', 'Colorado' )
+		);
+		$this->assertSame(
+			VenueMergeHelper::normalize_address_for_alias_matching( '100 West 44th Street', 'Denver', 'CO' ),
+			VenueMergeHelper::normalize_address_for_alias_matching( '100 W 44th Street', 'Denver', 'Colorado' )
+		);
 	}
 
 	/**
@@ -434,8 +511,6 @@ class VenueMergeHelperTest extends WP_UnitTestCase {
 		$pairs = array(
 			// Rule 1 (exact normalized) — case-only variant.
 			array( 'Hi-Fi Indianapolis', 'HI-FI Indianapolis' ),
-			// Rule 2 (substring) — annex/suffix variant.
-			array( 'The Abbey', 'The Abbey-Orlando' ),
 			// Rule 1 — ampersand collapses to "and" via the existing
 			// normalize_venue_name_for_matching() pipeline so both sides
 			// reduce to the identical normalized string.
@@ -598,10 +673,56 @@ class VenueMergeHelperTest extends WP_UnitTestCase {
 		);
 	}
 
-	public function test_name_cluster_unchanged(): void {
-		// Regression guard: name-only clusters (no shared address) still
-		// match by normalized-name equality, which IS Rule 1 of
-		// names_are_similar. The fix must not affect this path.
+	public function test_address_clusters_include_confirmed_denver_aliases(): void {
+		$pairs = array(
+			array( 'Bluebird Theater', '3317 E Colfax Ave', 'Bluebird Theatre', '3317 E. Colfax Avenue' ),
+			array( 'Oriental Theater', '4335 W. 44th Ave.', 'Oriental Theatre-CO', '4335 W. 44th Ave., Denver, CO' ),
+			array( 'HQ', '60 South Broadway', 'HQ Denver', '60 S Broadway' ),
+		);
+		$expected_pairs = array();
+
+		foreach ( $pairs as $pair ) {
+			$expected_pairs[] = array(
+				$this->make_venue(
+					$pair[0],
+					array(
+						'_venue_address' => $pair[1],
+						'_venue_city'    => 'Denver',
+						'_venue_state'   => 'Colorado',
+						'_venue_country' => 'United States',
+					)
+				),
+				$this->make_venue(
+					$pair[2],
+					array(
+						'_venue_address' => $pair[3],
+						'_venue_city'    => 'Denver',
+						'_venue_state'   => 'CO',
+						'_venue_country' => 'US',
+					)
+				),
+			);
+		}
+
+		$cmd        = new CheckMergeDuplicateVenuesCommand();
+		$reflection = new \ReflectionClass( $cmd );
+		$method     = $reflection->getMethod( 'find_clusters' );
+		$method->setAccessible( true );
+		$clusters = $method->invoke( $cmd );
+
+		foreach ( $expected_pairs as $expected ) {
+			$found = false;
+			foreach ( $clusters as $cluster ) {
+				if ( in_array( $expected[0], $cluster['term_ids'], true ) && in_array( $expected[1], $cluster['term_ids'], true ) ) {
+					$found = true;
+					break;
+				}
+			}
+			$this->assertTrue( $found, sprintf( 'Expected venue terms %d and %d to cluster.', $expected[0], $expected[1] ) );
+		}
+	}
+
+	public function test_name_only_cluster_requires_physical_identity(): void {
 		$winner = $this->make_venue( 'Hook and Ladder Theater' );
 		$loser  = $this->make_venue( 'Hook & Ladder Theater' );
 
@@ -614,8 +735,7 @@ class VenueMergeHelperTest extends WP_UnitTestCase {
 		$found = false;
 		foreach ( $clusters as $cluster ) {
 			if (
-				str_starts_with( $cluster['key'], 'name:' )
-				&& in_array( $winner, $cluster['term_ids'], true )
+				in_array( $winner, $cluster['term_ids'], true )
 				&& in_array( $loser, $cluster['term_ids'], true )
 			) {
 				$found = true;
@@ -623,9 +743,9 @@ class VenueMergeHelperTest extends WP_UnitTestCase {
 			}
 		}
 
-		$this->assertTrue(
+		$this->assertFalse(
 			$found,
-			'Name-cluster for ampersand variant must survive the address-cluster guard.'
+			'Name similarity alone must not authorize a destructive venue merge.'
 		);
 	}
 }


### PR DESCRIPTION
## Summary
- reconcile venue aliases only when normalized physical location and conservative name identity agree
- support theater/theatre, amphitheater/amphitheatre, geography-qualified suffixes, redundant address geography, and bounded directional forms
- remove unsafe global name-only and fuzzy substring/Jaccard merge authorization while protecting distinct same-address rooms

## Production evidence
- worktree code was loaded read-only against `events.extrachill.com`
- dry run returned 13 conservative clusters with no writes
- confirmed Bluebird `15312/25827`, Oriental `21946/21953`, and HQ `23754/42216`
- excluded known same-address false positives including V Theater/Saxe Theater, rooftops, basements, back rooms, and differing host qualifiers

## Verification
- PHP syntax: passed
- PHPCS: passed
- PHPStan level 7: passed
- `git diff --check`: passed
- focused PHPUnit: blocked before test execution by the known WP Codebox MySQL Docker provisioning defect tracked in Extra-Chill/homeboy-extensions#2422

Closes #596
Closes #598