### PR TITLE
fix: make calendar controls accessible

### DIFF
--- a/inc/Blocks/Calendar/package-lock.json
+++ b/inc/Blocks/Calendar/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.12.1",
       "license": "GPL-2.0-or-later",
       "dependencies": {
+        "@wordpress/i18n": "^6.24.0",
         "flatpickr": "^4.6.13"
       },
       "devDependencies": {
@@ -4673,7 +4674,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.1.0.tgz",
       "integrity": "sha512-n8m9eNDfoNZoxdvWiTfW/hSPhehzLJ3zW7f8E7oT6mCROoMNWCB4TYtv041+2FMAxweiE0j7i1jubQU4MEC/Gg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tannin/evaluate": "^1.2.0",
@@ -4684,14 +4684,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.2.0.tgz",
       "integrity": "sha512-3ioXvNowbO/wSrxsDG5DKIMxC81P0QrQTYai8zFNY+umuoHWRPbQ/TuuDEOju9E+jQDXmj6yI5GyejNuh8I+eg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tannin/plural-forms": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.1.0.tgz",
       "integrity": "sha512-xl9R2mDZO/qiHam1AgMnAES6IKIg7OBhcXqy6eDsRCdXuxAFPcjrej9HMjyCLE0DJ/8cHf0i5OQTstuBRhpbHw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tannin/compile": "^1.1.0"
@@ -4701,14 +4699,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.1.0.tgz",
       "integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tannin/sprintf": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@tannin/sprintf/-/sprintf-1.3.3.tgz",
       "integrity": "sha512-RwARl+hFwhzy0tg9atWcchLFvoQiOh4rrP7uG2N5E4W80BPCUX0ElcUR9St43fxB9EfjsW2df9Qp+UsTbvQDjA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tootallnate/once": {
@@ -6327,7 +6323,6 @@
       "version": "4.51.0",
       "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.51.0.tgz",
       "integrity": "sha512-pTVZRT9mjEdrNNt7TyKw5hQhFUqntfTXVs/fboEDpmAi+PFWXoD8rPs3oZyRCVr/MDyE6OCv1mwEibI6AsRk3Q==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -6338,7 +6333,6 @@
       "version": "6.24.0",
       "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.24.0.tgz",
       "integrity": "sha512-K4XmCyyyDOKH/5ea75P2L36ZiAvQTy4Hsa73Na3n6NzVjAwrrKZm4JJGf0t+OlThUG4D4GyfEv5szs5EeCA0lA==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@tannin/sprintf": "^1.3.2",
@@ -10561,7 +10555,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.6.2"
@@ -12602,7 +12595,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
       "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "encoding": "^0.1.12",
@@ -13244,7 +13236,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -15842,7 +15833,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
       "integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/meow": {
@@ -19124,7 +19114,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -19180,7 +19169,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/sass": {
@@ -21003,7 +20991,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/tannin/-/tannin-1.2.0.tgz",
       "integrity": "sha512-U7GgX/RcSeUETbV7gYgoz8PD7Ni4y95pgIP/Z6ayI3CfhSujwKEBlGFTCRN+Aqnuyf4AN2yHL+L8x+TCGjb9uA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tannin/plural-forms": "^1.1.0"

--- a/inc/Blocks/Calendar/package.json
+++ b/inc/Blocks/Calendar/package.json
@@ -23,6 +23,7 @@
     "eslint": "^9.0.0"
   },
   "dependencies": {
+    "@wordpress/i18n": "^6.24.0",
     "flatpickr": "^4.6.13"
   },
   "overrides": {

--- a/inc/Blocks/Calendar/src/flatpickr-theme.css
+++ b/inc/Blocks/Calendar/src/flatpickr-theme.css
@@ -68,6 +68,12 @@
     fill: var(--data-machine-text-accent);
 }
 
+.flatpickr-months .flatpickr-prev-month:focus-visible,
+.flatpickr-months .flatpickr-next-month:focus-visible {
+    outline: 2px solid var(--data-machine-text-accent);
+    outline-offset: -2px;
+}
+
 /* Weekday Headers */
 .flatpickr-weekdays {
     background: var(--data-machine-background-secondary);

--- a/inc/Blocks/Calendar/src/modules/date-picker.test.ts
+++ b/inc/Blocks/Calendar/src/modules/date-picker.test.ts
@@ -1,0 +1,138 @@
+jest.mock(
+	'@wordpress/i18n',
+	() => ( {
+		__: jest.fn( ( text: string ) => text ),
+	} ),
+	{ virtual: true }
+);
+
+const mockFlatpickr = jest.fn();
+
+jest.mock( 'flatpickr', () => ( {
+	__esModule: true,
+	default: ( input: HTMLInputElement, options: FlatpickrOptions ) =>
+		mockFlatpickr( input, options ),
+} ) );
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { destroyDatePicker, initDatePicker } from './date-picker';
+
+interface FlatpickrOptions {
+	onReady: (
+		selectedDates: Date[],
+		dateStr: string,
+		instance: MockFlatpickrInstance
+	) => void;
+}
+
+interface MockFlatpickrInstance {
+	selectedDates: Date[];
+	prevMonthNav: HTMLElement;
+	nextMonthNav: HTMLElement;
+	clear: jest.Mock;
+	setDate: jest.Mock;
+	destroy: jest.Mock;
+}
+
+const mockTranslate = __ as jest.Mock;
+
+function calendarMarkup( id: string ): string {
+	return `<div class="data-machine-events-calendar" id="${ id }">
+		<input class="data-machine-events-date-range-input">
+		<button class="data-machine-events-date-clear-btn"></button>
+	</div>`;
+}
+
+describe( 'Flatpickr month navigation accessibility', () => {
+	beforeEach( () => {
+		document.body.innerHTML = calendarMarkup( 'first' );
+		mockFlatpickr.mockReset();
+		mockTranslate.mockClear();
+		mockFlatpickr.mockImplementation(
+			( input: HTMLInputElement, options: FlatpickrOptions ) => {
+				const instance: MockFlatpickrInstance = {
+					selectedDates: [],
+					prevMonthNav: document.createElement( 'span' ),
+					nextMonthNav: document.createElement( 'span' ),
+					clear: jest.fn(),
+					setDate: jest.fn(),
+					destroy: jest.fn(),
+				};
+				input.after( instance.prevMonthNav, instance.nextMonthNav );
+				options.onReady( [], '', instance );
+				return instance;
+			}
+		);
+	} );
+
+	it( 'names and keyboard-enables each instance navigation control', () => {
+		document.body.insertAdjacentHTML(
+			'beforeend',
+			calendarMarkup( 'second' )
+		);
+		const calendars = document.querySelectorAll< HTMLElement >(
+			'.data-machine-events-calendar'
+		);
+		calendars.forEach( ( calendar ) =>
+			initDatePicker( calendar, jest.fn() )
+		);
+
+		calendars.forEach( ( calendar ) => {
+			const controls = calendar.querySelectorAll< HTMLElement >( 'span' );
+			const previousClick = jest.fn();
+			const nextClick = jest.fn();
+			controls[ 0 ].addEventListener( 'click', previousClick );
+			controls[ 1 ].addEventListener( 'click', nextClick );
+
+			expect( controls[ 0 ].getAttribute( 'role' ) ).toBe( 'button' );
+			expect( controls[ 0 ].tabIndex ).toBe( 0 );
+			expect( controls[ 0 ].getAttribute( 'aria-label' ) ).toBe(
+				'Previous month'
+			);
+			expect( controls[ 1 ].getAttribute( 'aria-label' ) ).toBe(
+				'Next month'
+			);
+
+			controls[ 0 ].dispatchEvent(
+				new KeyboardEvent( 'keydown', { key: 'Enter', bubbles: true } )
+			);
+			controls[ 1 ].dispatchEvent(
+				new KeyboardEvent( 'keydown', { key: ' ', bubbles: true } )
+			);
+			expect( previousClick ).toHaveBeenCalledTimes( 1 );
+			expect( nextClick ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		expect( mockTranslate ).toHaveBeenCalledWith(
+			'Previous month',
+			'data-machine-events'
+		);
+		expect( mockTranslate ).toHaveBeenCalledWith(
+			'Next month',
+			'data-machine-events'
+		);
+	} );
+
+	it( 'removes custom keyboard handlers when destroyed', () => {
+		const calendar = document.querySelector< HTMLElement >( '#first' )!;
+		const picker = initDatePicker( calendar, jest.fn() );
+		const previous = calendar.querySelector< HTMLElement >( 'span' )!;
+		const click = jest.fn();
+		previous.addEventListener( 'click', click );
+
+		destroyDatePicker( calendar );
+		previous.dispatchEvent(
+			new KeyboardEvent( 'keydown', { key: 'Enter', bubbles: true } )
+		);
+
+		expect( click ).not.toHaveBeenCalled();
+		expect( picker!.destroy ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/inc/Blocks/Calendar/src/modules/date-picker.ts
+++ b/inc/Blocks/Calendar/src/modules/date-picker.ts
@@ -8,6 +8,11 @@
 import flatpickr from 'flatpickr';
 
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import type { FlatpickrInstance } from '../types';
@@ -16,9 +21,37 @@ interface DatePickerData {
 	picker: FlatpickrInstance;
 	clearBtn: HTMLElement | null;
 	clearHandler: () => void;
+	navControls: AccessibleNavControl[];
+}
+
+interface AccessibleNavControl {
+	element: HTMLElement;
+	keydownHandler: ( event: KeyboardEvent ) => void;
 }
 
 const datePickers = new Map< HTMLElement, DatePickerData >();
+
+function makeNavigationControlAccessible(
+	element: HTMLElement,
+	label: string
+): AccessibleNavControl {
+	element.setAttribute( 'role', 'button' );
+	element.setAttribute( 'tabindex', '0' );
+	element.setAttribute( 'aria-label', label );
+
+	const keydownHandler = ( event: KeyboardEvent ): void => {
+		if ( event.key !== 'Enter' && event.key !== ' ' ) {
+			return;
+		}
+
+		event.preventDefault();
+		element.click();
+	};
+
+	element.addEventListener( 'keydown', keydownHandler );
+
+	return { element, keydownHandler };
+}
 
 export function initDatePicker(
 	calendar: HTMLElement,
@@ -45,10 +78,10 @@ export function initDatePicker(
 	let defaultDate: string | string[] | undefined;
 
 	if ( initialStart ) {
-		defaultDate = initialEnd
-			? [ initialStart, initialEnd ]
-			: initialStart;
+		defaultDate = initialEnd ? [ initialStart, initialEnd ] : initialStart;
 	}
+
+	let navControls: AccessibleNavControl[] = [];
 
 	const picker = flatpickr( dateRangeInput, {
 		mode: 'range',
@@ -57,6 +90,18 @@ export function initDatePicker(
 		allowInput: false,
 		clickOpens: true,
 		defaultDate,
+		onReady( _selectedDates, _dateStr, instance ) {
+			navControls = [
+				makeNavigationControlAccessible(
+					instance.prevMonthNav,
+					__( 'Previous month', 'data-machine-events' )
+				),
+				makeNavigationControlAccessible(
+					instance.nextMonthNav,
+					__( 'Next month', 'data-machine-events' )
+				),
+			];
+		},
 		onChange( selectedDates: Date[] ) {
 			if ( onChange ) {
 				onChange( selectedDates );
@@ -84,13 +129,14 @@ export function initDatePicker(
 		picker.clear();
 	};
 
-	datePickers.set( calendar, { picker, clearBtn, clearHandler } );
+	datePickers.set( calendar, {
+		picker,
+		clearBtn,
+		clearHandler,
+		navControls,
+	} );
 
-	if (
-		picker.selectedDates &&
-		picker.selectedDates.length > 0 &&
-		clearBtn
-	) {
+	if ( picker.selectedDates && picker.selectedDates.length > 0 && clearBtn ) {
 		clearBtn.classList.add( 'visible' );
 	}
 
@@ -104,11 +150,15 @@ export function initDatePicker(
 export function destroyDatePicker( calendar: HTMLElement ): void {
 	const data = datePickers.get( calendar );
 	if ( data ) {
-		const { picker, clearBtn, clearHandler } = data;
+		const { picker, clearBtn, clearHandler, navControls } = data;
 
 		if ( clearBtn && clearHandler ) {
 			clearBtn.removeEventListener( 'click', clearHandler );
 		}
+
+		navControls.forEach( ( { element, keydownHandler } ) => {
+			element.removeEventListener( 'keydown', keydownHandler );
+		} );
 
 		if ( picker ) {
 			try {

--- a/inc/Blocks/Calendar/style.css
+++ b/inc/Blocks/Calendar/style.css
@@ -1927,8 +1927,8 @@
 .data-machine-month-grid__ribbon.data-machine-day-friday    { background: var(--data-machine-day-friday-rgba); }
 .data-machine-month-grid__ribbon.data-machine-day-saturday  { background: var(--data-machine-day-saturday-rgba); }
 
-/* Hide the prev-month / next-month `screen-reader-text` only for AT. */
-.data-machine-month-grid .screen-reader-text {
+/* Keep calendar control labels available only to assistive technology. */
+.data-machine-events-calendar .screen-reader-text {
     clip: rect(1px, 1px, 1px, 1px);
     clip-path: inset(50%);
     height: 1px;

--- a/inc/Blocks/Calendar/templates/filter-bar.php
+++ b/inc/Blocks/Calendar/templates/filter-bar.php
@@ -59,18 +59,20 @@ $scope_preset_slugs = $show_scope_presets
 <div class="data-machine-events-filter-bar">
 	<div class="data-machine-events-filter-row">
 		<div class="data-machine-events-search">
+			<label class="screen-reader-text" for="<?php echo esc_attr( $search_id ); ?>"><?php esc_html_e( 'Search events', 'data-machine-events' ); ?></label>
 			<input type="text" 
 					id="<?php echo esc_attr( $search_id ); ?>" 
 					value="<?php echo esc_attr( $search_value ); ?>"
 					placeholder="<?php esc_html_e( 'Search events...', 'data-machine-events' ); ?>" 
 					class="data-machine-events-search-input">
-			<button type="button" class="data-machine-events-search-btn">
-				<span class="dashicons dashicons-search"></span>
+			<button type="button" class="data-machine-events-search-btn" aria-label="<?php esc_attr_e( 'Search events', 'data-machine-events' ); ?>">
+				<span class="dashicons dashicons-search" aria-hidden="true"></span>
 			</button>
 		</div>
 		
 		<div class="data-machine-events-date-filter">
 			<div class="data-machine-events-date-range-wrapper">
+				<label class="screen-reader-text" for="<?php echo esc_attr( $date_range_id ); ?>"><?php esc_html_e( 'Filter by date range', 'data-machine-events' ); ?></label>
 				<input type="text" 
 						id="<?php echo esc_attr( $date_range_id ); ?>"
 						class="data-machine-events-date-range-input" data-date-start="<?php echo esc_attr( $date_start ); ?>" data-date-end="<?php echo esc_attr( $date_end ); ?>" 

--- a/tests/Unit/CalendarBlockTest.php
+++ b/tests/Unit/CalendarBlockTest.php
@@ -177,6 +177,25 @@ class CalendarBlockTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'data-filter-persistence="0"', $scoped_html );
 	}
 
+	public function test_filter_controls_have_unique_associated_labels_and_button_name() {
+		$first_html  = $this->render_calendar();
+		$second_html = $this->render_calendar();
+		$html        = $first_html . $second_html;
+
+		preg_match_all( '/<label class="screen-reader-text" for="([^"]+)">([^<]+)<\/label>/', $html, $label_matches );
+
+		$this->assertCount( 4, $label_matches[1] );
+		$this->assertCount( 4, array_unique( $label_matches[1] ), 'Each label should target a unique control ID.' );
+		$this->assertSame( array( 'Search events', 'Filter by date range', 'Search events', 'Filter by date range' ), $label_matches[2] );
+
+		foreach ( $label_matches[1] as $control_id ) {
+			$this->assertSame( 1, substr_count( $html, 'id="' . $control_id . '"' ) );
+		}
+
+		$this->assertSame( 2, substr_count( $html, 'class="data-machine-events-search-btn" aria-label="Search events"' ) );
+		$this->assertSame( 2, substr_count( $html, 'class="dashicons dashicons-search" aria-hidden="true"' ) );
+	}
+
 	public function test_calendar_renders_no_events_state() {
 		// Create a mock render with no events
 		$block_registry = \WP_Block_Type_Registry::get_instance();


### PR DESCRIPTION
## Summary
- add persistent, translated labels for calendar search and date-range inputs and an accessible name for the icon-only search button
- make Flatpickr previous/next month controls focusable, translated, keyboard operable with Enter/Space, and visibly focused without replacing Flatpickr behavior
- cover unique multi-instance labels, navigation naming/activation, localization, and listener teardown

## Root cause
The filter template relied on placeholders for input identification and rendered the search action as an unnamed icon-only button. Flatpickr 4.6.13 renders previous/next month navigation as clickable spans, so those controls had neither button semantics nor keyboard activation.

## Accessibility behavior
Inputs now use associated visually hidden labels backed by per-instance IDs. Decorative search icon content is hidden from assistive technology. Existing Flatpickr controls receive translated names, button roles, tab stops, Enter/Space activation, and focus-visible outlines, with instance-scoped listeners removed during destroy.

## Compatibility
The change keeps existing placeholders, classes, click handlers, query behavior, responsive styling, and Flatpickr instances intact. It augments Flatpickr's own navigation nodes rather than replacing or wrapping them, and supports multiple calendars independently.

## Test results
- `npm test -- --runInBand` (31 tests passed)
- `npx eslint src/modules/date-picker.ts src/modules/date-picker.test.ts` (passed)
- `npm run build` (passed)
- `php -l inc/Blocks/Calendar/templates/filter-bar.php` (passed)
- `php -l tests/Unit/CalendarBlockTest.php` (passed)
- WordPress PHPUnit suite unavailable locally because the worktree has no configured WordPress test library (`WP_UnitTestCase` not found)
- full `npm run lint:js` remains blocked by pre-existing Prettier failures in unrelated calendar source files; changed files pass focused lint

Fixes #586