### PR TITLE
fix: require authority for map geo sync

### DIFF
--- a/inc/Blocks/Calendar/src/frontend.test.ts
+++ b/inc/Blocks/Calendar/src/frontend.test.ts
@@ -214,6 +214,7 @@ describe( 'calendar frontend month-grid integration', () => {
 					bounds: { swLat: 32, swLng: -80, neLat: 33, neLng: -79 },
 					zoom: 10,
 					center: { lat: 32.78, lng: -79.93 },
+					authority: 'user-interaction',
 				},
 			} )
 		);
@@ -262,6 +263,7 @@ describe( 'calendar frontend month-grid integration', () => {
 					bounds: { swLat: 32, swLng: -80, neLat: 33, neLng: -79 },
 					zoom: 10,
 					center: { lat: 32.78, lng: -79.93 },
+					authority: 'user-interaction',
 				},
 			} )
 		);

--- a/inc/Blocks/Calendar/src/modules/geo-sync.test.ts
+++ b/inc/Blocks/Calendar/src/modules/geo-sync.test.ts
@@ -1,0 +1,87 @@
+jest.mock( './api-client', () => ( {
+	buildCalendarRequest: jest.fn( () => new URLSearchParams() ),
+	fetchCalendarEvents: jest.fn( () => Promise.resolve() ),
+} ) );
+
+const mockUpdateUrl = jest.fn();
+const mockSaveGeoToStorage = jest.fn();
+
+jest.mock( './filter-state', () => ( {
+	getFilterState: jest.fn( () => ( {
+		getArchiveContext: jest.fn( () => ( {} ) ),
+		updateUrl: mockUpdateUrl,
+		saveGeoToStorage: mockSaveGeoToStorage,
+	} ) ),
+} ) );
+
+import { fetchCalendarEvents } from './api-client';
+import { destroyGeoSync, initGeoSync } from './geo-sync';
+
+const mockFetchCalendarEvents = fetchCalendarEvents as jest.Mock;
+
+function dispatchBounds( authority?: string ): void {
+	document.dispatchEvent(
+		new CustomEvent( 'data-machine-map-bounds-changed', {
+			detail: {
+				bounds: { swLat: 32, swLng: -80, neLat: 33, neLng: -79 },
+				zoom: 10,
+				center: { lat: 32.7765, lng: -79.9311 },
+				authority,
+			},
+		} )
+	);
+}
+
+describe( 'calendar geo authority', () => {
+	let calendar: HTMLElement;
+
+	beforeEach( () => {
+		jest.useFakeTimers();
+		calendar = document.createElement( 'div' );
+		mockUpdateUrl.mockClear();
+		mockSaveGeoToStorage.mockClear();
+		mockFetchCalendarEvents.mockClear();
+		initGeoSync( calendar );
+	} );
+
+	afterEach( () => {
+		destroyGeoSync( calendar );
+		jest.useRealTimers();
+	} );
+
+	it.each( [
+		[ 'denied geolocation fallback', undefined ],
+		[ 'prompt/unresolved geolocation fallback', undefined ],
+		[ 'timeout/unavailable geolocation fallback', undefined ],
+		[ 'initial programmatic map movement', undefined ],
+		[ 'unknown layout source', 'fallback' ],
+	] )( 'ignores %s', ( _label, authority ) => {
+		dispatchBounds( authority );
+		jest.advanceTimersByTime( 300 );
+
+		expect( mockUpdateUrl ).not.toHaveBeenCalled();
+		expect( mockSaveGeoToStorage ).not.toHaveBeenCalled();
+		expect( mockFetchCalendarEvents ).not.toHaveBeenCalled();
+	} );
+
+	it.each( [
+		'server',
+		'user-location',
+		'external',
+		'manual-search',
+		'user-interaction',
+	] )( 'persists and fetches %s geo intent', async ( authority ) => {
+		dispatchBounds( authority );
+		jest.advanceTimersByTime( 300 );
+		await Promise.resolve();
+
+		expect( mockUpdateUrl ).toHaveBeenCalledTimes( 1 );
+		expect( mockSaveGeoToStorage ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				lat: '32.7765',
+				lng: '-79.9311',
+			} )
+		);
+		expect( mockFetchCalendarEvents ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/inc/Blocks/Calendar/src/modules/geo-sync.ts
+++ b/inc/Blocks/Calendar/src/modules/geo-sync.ts
@@ -33,7 +33,21 @@ interface BoundsChangedDetail {
 	};
 	zoom: number;
 	center: { lat: number; lng: number };
+	authority?:
+		| 'server'
+		| 'user-location'
+		| 'external'
+		| 'manual-search'
+		| 'user-interaction';
 }
+
+const GEO_AUTHORITY_SOURCES = new Set( [
+	'server',
+	'user-location',
+	'external',
+	'manual-search',
+	'user-interaction',
+] );
 
 /**
  * Per-calendar state for the geo sync listener.
@@ -123,14 +137,16 @@ export function updateCalendarGeo(
 /*  Internal helpers                                                   */
 /* ------------------------------------------------------------------ */
 
-function createBoundsHandler(
-	calendar: HTMLElement
-): ( e: Event ) => void {
+function createBoundsHandler( calendar: HTMLElement ): ( e: Event ) => void {
 	let debounceTimer: ReturnType< typeof setTimeout >;
 
 	return function ( e: Event ): void {
 		const detail = ( e as CustomEvent< BoundsChangedDetail > ).detail;
-		if ( ! detail?.center ) {
+		if (
+			! detail?.center ||
+			! detail.authority ||
+			! GEO_AUTHORITY_SOURCES.has( detail.authority )
+		) {
 			return;
 		}
 
@@ -258,4 +274,3 @@ function boundsToRadius(
 	// Clamp to reasonable range.
 	return Math.max( 1, Math.min( 500, Math.round( distance ) ) );
 }
-

--- a/inc/Blocks/EventsMap/package.json
+++ b/inc/Blocks/EventsMap/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "wp-scripts build",
     "lint:js": "eslint src",
-    "start": "wp-scripts start"
+    "start": "wp-scripts start",
+    "test": "wp-scripts test-unit-js"
   },
   "dependencies": {
     "@types/leaflet.markercluster": "^1.5.6",

--- a/inc/Blocks/EventsMap/src/frontend.tsx
+++ b/inc/Blocks/EventsMap/src/frontend.tsx
@@ -38,6 +38,7 @@ import 'leaflet.markercluster/dist/MarkerCluster.Default.css';
  * Internal dependencies
  */
 import { fetchVenues } from './api-client';
+import { createGeoAuthorityTracker, resolveInitialView } from './geo-authority';
 import { TILE_URLS } from './types';
 import type {
 	Venue,
@@ -46,6 +47,7 @@ import type {
 	MapBounds,
 	BoundsChangedEvent,
 } from './types';
+import type { GeoAuthoritySource } from './geo-authority';
 
 import './frontend.css';
 
@@ -285,7 +287,10 @@ function getBoundsFromMap( map: L.Map ): MapBounds {
 	};
 }
 
-function dispatchBoundsChanged( map: L.Map ): void {
+function dispatchBoundsChanged(
+	map: L.Map,
+	authority: GeoAuthoritySource
+): void {
 	const bounds = getBoundsFromMap( map );
 	const center = map.getCenter();
 
@@ -293,6 +298,7 @@ function dispatchBoundsChanged( map: L.Map ): void {
 		bounds,
 		zoom: map.getZoom(),
 		center: { lat: center.lat, lng: center.lng },
+		authority,
 	};
 
 	document.dispatchEvent(
@@ -303,13 +309,13 @@ function dispatchBoundsChanged( map: L.Map ): void {
 /* ---------- debounce ---------- */
 
 function debounce(
-	fn: ( map: L.Map ) => void,
+	fn: ( map: L.Map, authority: GeoAuthoritySource | null ) => void,
 	ms: number
-): ( map: L.Map ) => void {
+): ( map: L.Map, authority: GeoAuthoritySource | null ) => void {
 	let timer: ReturnType< typeof setTimeout >;
-	return ( map: L.Map ) => {
+	return ( map: L.Map, authority: GeoAuthoritySource | null ) => {
 		clearTimeout( timer );
-		timer = setTimeout( () => fn( map ), ms );
+		timer = setTimeout( () => fn( map, authority ), ms );
 	};
 }
 
@@ -459,6 +465,7 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 	const clusterGroupRef = useRef< L.MarkerClusterGroup | null >( null );
 	const markerMapRef = useRef< Map< number, L.Marker > >( new Map() );
 	const userMarkerRef = useRef< L.Marker | null >( null );
+	const geoAuthorityRef = useRef( createGeoAuthorityTracker() );
 	// Single L.polyline holding the chronological route. Recreated from
 	// scratch whenever venues change so we don't manage segment-level
 	// diffing — the route is at most a few dozen points.
@@ -511,10 +518,12 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 	/* --- debounced bounds handler --- */
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	const debouncedFetch = useCallback(
-		debounce( ( map: L.Map ) => {
+		debounce( ( map: L.Map, authority: GeoAuthoritySource | null ) => {
 			const bounds = getBoundsFromMap( map );
 			loadVenues( bounds );
-			dispatchBoundsChanged( map );
+			if ( authority ) {
+				dispatchBoundsChanged( map, authority );
+			}
 		}, 500 ),
 		[ loadVenues ]
 	);
@@ -527,15 +536,16 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 		}
 
 		const markerMap = markerMapRef.current;
-		let initialLat = 30.2672; // fallback: Austin, TX
-		let initialLon = -97.7431;
-		if ( hasCenter ) {
-			initialLat = centerLat!;
-			initialLon = centerLon!;
-		} else if ( venues.length > 0 ) {
-			initialLat = venues[ 0 ].lat;
-			initialLon = venues[ 0 ].lon;
-		}
+		const initialView = resolveInitialView( {
+			center: hasCenter ? { lat: centerLat!, lng: centerLon! } : null,
+			userLocation: hasUserLocation
+				? { lat: userLat!, lng: userLon! }
+				: null,
+			venueLocation:
+				venues.length > 0
+					? { lat: venues[ 0 ].lat, lng: venues[ 0 ].lon }
+					: null,
+		} );
 
 		const isTouch = isTouchDevice();
 
@@ -546,7 +556,45 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 			// scrolls the page. Users pinch-zoom or use two fingers.
 			dragging: ! isTouch,
 			tap: ! isTouch,
-		} as L.MapOptions ).setView( [ initialLat, initialLon ], zoom );
+		} as L.MapOptions ).setView(
+			[ initialView.center.lat, initialView.center.lng ],
+			zoom
+		);
+
+		const markUserInteraction = () => {
+			geoAuthorityRef.current.mark( 'user-interaction' );
+		};
+		map.on( 'dragstart boxzoomstart', markUserInteraction );
+		el.addEventListener( 'dblclick', markUserInteraction );
+		el.addEventListener( 'keydown', ( event: KeyboardEvent ) => {
+			if (
+				[
+					'ArrowUp',
+					'ArrowDown',
+					'ArrowLeft',
+					'ArrowRight',
+					'+',
+					'-',
+					'=',
+				].includes( event.key )
+			) {
+				markUserInteraction();
+			}
+		} );
+		el.addEventListener(
+			'click',
+			( event: MouseEvent ) => {
+				const target = event.target as Element | null;
+				if (
+					target?.closest(
+						'.leaflet-control-zoom-in, .leaflet-control-zoom-out, .marker-cluster'
+					)
+				) {
+					markUserInteraction();
+				}
+			},
+			true
+		);
 
 		if ( isTouch ) {
 			// Show gesture hint when user tries single-finger drag.
@@ -573,6 +621,7 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 						showGestureHint();
 					} else if ( e.touches.length >= 2 ) {
 						// Two-finger gesture — enable dragging temporarily.
+						markUserInteraction();
 						map.dragging.enable();
 					}
 				},
@@ -594,6 +643,7 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 				( e: WheelEvent ) => {
 					if ( e.ctrlKey || e.metaKey ) {
 						e.preventDefault();
+						markUserInteraction();
 						map.scrollWheelZoom.enable();
 					}
 				},
@@ -621,6 +671,7 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 			chunkInterval: 100,
 			chunkDelay: 10,
 		} );
+		clusterGroup.on( 'clusterclick', markUserInteraction );
 		map.addLayer( clusterGroup );
 		clusterGroupRef.current = clusterGroup;
 
@@ -632,7 +683,9 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 		// viewport would drop venues that the user just panned away from,
 		// mid-route. Skip the moveend refetch for it.
 		if ( ! chronologicalRouteMode ) {
-			map.on( 'moveend', () => debouncedFetch( map ) );
+			map.on( 'moveend', () => {
+				debouncedFetch( map, geoAuthorityRef.current.consume() );
+			} );
 		}
 
 		// Force a resize check after mount.
@@ -669,7 +722,9 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 					? undefined
 					: getBoundsFromMap( map );
 				loadVenues( bounds );
-				dispatchBoundsChanged( map );
+				if ( initialView.authority ) {
+					dispatchBoundsChanged( map, initialView.authority );
+				}
 			}, 200 );
 		}
 
@@ -708,6 +763,7 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 				return;
 			}
 
+			geoAuthorityRef.current.mark( 'external' );
 			map.setView(
 				[ detail.lat, detail.lng ],
 				detail.zoom ?? map.getZoom()
@@ -1010,6 +1066,7 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 			return;
 		}
 
+		geoAuthorityRef.current.mark( 'manual-search' );
 		map.setView( [ lat, lng ], 12 );
 
 		// Update URL for shareability.

--- a/inc/Blocks/EventsMap/src/geo-authority.test.ts
+++ b/inc/Blocks/EventsMap/src/geo-authority.test.ts
@@ -1,0 +1,79 @@
+import {
+	createGeoAuthorityTracker,
+	resolveInitialView,
+	VISUAL_FALLBACK,
+} from './geo-authority';
+
+describe( 'map geo authority', () => {
+	it( 'keeps an initial no-center mount neutral', () => {
+		expect(
+			resolveInitialView( {
+				center: null,
+				userLocation: null,
+				venueLocation: null,
+			} )
+		).toEqual( { center: VISUAL_FALLBACK, authority: null } );
+	} );
+
+	it( 'keeps venue fallback layout neutral', () => {
+		expect(
+			resolveInitialView( {
+				center: null,
+				userLocation: null,
+				venueLocation: { lat: 40.7128, lng: -74.006 },
+			} )
+		).toEqual( {
+			center: { lat: 40.7128, lng: -74.006 },
+			authority: null,
+		} );
+	} );
+
+	it.each( [
+		[
+			'explicit server coordinates',
+			{ lat: 32.7765, lng: -79.9311 },
+			null,
+			'server',
+		],
+		[
+			'granted user location',
+			null,
+			{ lat: 32.7765, lng: -79.9311 },
+			'user-location',
+		],
+	] )(
+		'recognizes %s as authoritative',
+		( _label, center, userLocation, authority ) => {
+			expect(
+				resolveInitialView( {
+					center,
+					userLocation,
+					venueLocation: null,
+				} )
+			).toEqual( {
+				center: { lat: 32.7765, lng: -79.9311 },
+				authority,
+			} );
+		}
+	);
+
+	it( 'does not let unmarked programmatic movement masquerade as intent', () => {
+		const tracker = createGeoAuthorityTracker();
+
+		expect( tracker.consume() ).toBeNull();
+		tracker.mark( 'user-interaction' );
+		expect( tracker.consume() ).toBe( 'user-interaction' );
+		expect( tracker.consume() ).toBeNull();
+	} );
+
+	it.each( [ 'external', 'manual-search', 'user-interaction' ] as const )(
+		'preserves one %s movement',
+		( source ) => {
+			const tracker = createGeoAuthorityTracker();
+			tracker.mark( source );
+
+			expect( tracker.consume() ).toBe( source );
+			expect( tracker.consume() ).toBeNull();
+		}
+	);
+} );

--- a/inc/Blocks/EventsMap/src/geo-authority.ts
+++ b/inc/Blocks/EventsMap/src/geo-authority.ts
@@ -1,0 +1,73 @@
+/**
+ * Sources allowed to turn a map viewport into calendar geo intent.
+ */
+export type GeoAuthoritySource =
+	| 'server'
+	| 'user-location'
+	| 'external'
+	| 'manual-search'
+	| 'user-interaction';
+
+/**
+ * A map needs coordinates to render even when no location has been chosen.
+ * This fallback is deliberately neutral and never carries geo authority.
+ */
+export const VISUAL_FALLBACK = { lat: 0, lng: 0 } as const;
+
+/**
+ * Resolve the initial viewport and whether it represents location intent.
+ *
+ * Venue and visual fallbacks are layout inputs only. Explicit server
+ * coordinates and a server-provided user location are authoritative.
+ *
+ * @param root0               Initial location candidates.
+ * @param root0.center        Explicit server-provided map center.
+ * @param root0.userLocation  Explicit server-provided user location.
+ * @param root0.venueLocation First venue used only for visual layout.
+ */
+export function resolveInitialView( {
+	center,
+	userLocation,
+	venueLocation,
+}: {
+	center: { lat: number; lng: number } | null;
+	userLocation: { lat: number; lng: number } | null;
+	venueLocation: { lat: number; lng: number } | null;
+} ): {
+	center: { lat: number; lng: number };
+	authority: GeoAuthoritySource | null;
+} {
+	if ( center ) {
+		return { center, authority: 'server' };
+	}
+
+	if ( userLocation ) {
+		return { center: userLocation, authority: 'user-location' };
+	}
+
+	return {
+		center: venueLocation ?? VISUAL_FALLBACK,
+		authority: null,
+	};
+}
+
+/**
+ * Hold authority for exactly one completed map movement.
+ */
+export function createGeoAuthorityTracker(): {
+	mark: ( source: GeoAuthoritySource ) => void;
+	consume: () => GeoAuthoritySource | null;
+} {
+	let pending: GeoAuthoritySource | null = null;
+
+	return {
+		mark( source ) {
+			pending = source;
+		},
+		consume() {
+			const source = pending;
+			pending = null;
+			return source;
+		},
+	};
+}

--- a/inc/Blocks/EventsMap/src/types.ts
+++ b/inc/Blocks/EventsMap/src/types.ts
@@ -117,6 +117,12 @@ export interface BoundsChangedEvent {
 	bounds: MapBounds;
 	zoom: number;
 	center: { lat: number; lng: number };
+	authority:
+		| 'server'
+		| 'user-location'
+		| 'external'
+		| 'manual-search'
+		| 'user-interaction';
 }
 
 /**


### PR DESCRIPTION
## Summary
- keep no-center and venue-derived map layout visual-only, with a neutral internal fallback instead of a hard-coded city
- emit map bounds intent only for explicit server/user coordinates, external recenter requests, successful manual searches, or deliberate map interaction
- require Calendar geo sync to validate that authority before writing URL/storage state or fetching geo-filtered results

## Root cause
EventsMap treated every completed viewport layout as user intent. Its unconditional initial bounds event exposed the internal fallback center to Calendar, and Calendar had no source metadata with which to distinguish layout from authoritative geo intent. EventsMap also did not prioritize a server-provided user location when choosing the initial viewport.

The existing map events, Calendar geo-sync, filter-state URL/storage hierarchy, server center/user-location filters, and manual-search path were inspected first. None carried an authoritative-source primitive, so this change adds only the missing event metadata and one-movement ownership tracking at that boundary.

## Authority model
Authoritative sources are explicit server coordinates (including account-scoped market centers), server-provided user location, external recenter requests such as granted browser geolocation, successful manual search, and deliberate user pan/zoom. Initial no-center mounts, venue-derived layout, resize/invalidation, and untagged or unknown bounds events remain non-authoritative.

Denied, prompt/unresolved, unavailable, and timeout geolocation states therefore cannot create URL params, persisted geo state, or calendar filtering from the map's visual fallback.

## Compatibility
Existing server centers, granted user locations, account-market centers, manual search, external recenter events, and user map interaction continue to synchronize the Calendar. `updateCalendarGeo()` remains unchanged for orchestrators that already push explicit geo directly. Consumers that manually synthesize `data-machine-map-bounds-changed` must now provide one of the recognized authority values; untagged synthetic layout events intentionally fail closed.

## Tests
- `EventsMap: npm test -- --runInBand` (8 tests passed)
- `Calendar: npm test -- --runInBand` (39 tests passed)
- touched EventsMap and Calendar ESLint checks passed
- `EventsMap: npm run build` passed
- `Calendar: npm run build` passed
- `git diff --check` passed
- `composer test` could not start because this checkout has no Composer lock/vendor PHPUnit and no system `phpunit` binary; no PHP files changed
- full package lint remains blocked by existing package-wide dependency/format findings outside the touched-file lint scope

Fixes #595