### PR TITLE
fix: guarantee unique calendar control IDs

### DIFF
--- a/inc/Blocks/Calendar/render.php
+++ b/inc/Blocks/Calendar/render.php
@@ -256,8 +256,7 @@ if ( ! empty( $archive_context['taxonomy'] ) && ! empty( $archive_context['term_
 
 \DataMachineEvents\Blocks\Calendar\Template_Loader::init();
 
-$block_id           = isset( $block ) && isset( $block->clientId ) ? (string) $block->clientId : uniqid( 'dm', true );
-$instance_id        = 'data-machine-calendar-' . substr( preg_replace( '/[^a-z0-9]/', '', strtolower( $block_id ) ), 0, 12 );
+$instance_id        = wp_unique_id( 'data-machine-calendar-' );
 $wrapper_class      = $is_month_grid_mode
 	? 'data-machine-events-calendar data-machine-events-date-grouped data-machine-events-month-grid-mode'
 	: 'data-machine-events-calendar data-machine-events-date-grouped';

--- a/inc/Blocks/Calendar/src/modules/date-picker.integration.test.ts
+++ b/inc/Blocks/Calendar/src/modules/date-picker.integration.test.ts
@@ -1,0 +1,110 @@
+jest.mock(
+	'@wordpress/i18n',
+	() => ( {
+		__: jest.fn( ( text: string ) => {
+			const translations: Record< string, string > = {
+				'Previous month': 'Mes anterior',
+				'Next month': 'Mes siguiente',
+			};
+			return translations[ text ] || text;
+		} ),
+	} ),
+	{ virtual: true }
+);
+
+/**
+ * External dependencies
+ */
+import type { Instance } from 'flatpickr/dist/types/instance';
+
+/**
+ * Internal dependencies
+ */
+import { destroyDatePicker, initDatePicker } from './date-picker';
+
+function calendarMarkup( id: string ): string {
+	return `<div class="data-machine-events-calendar" id="${ id }">
+		<input class="data-machine-events-date-range-input" data-date-start="2026-07-01">
+		<button class="data-machine-events-date-clear-btn"></button>
+	</div>`;
+}
+
+function expectAccessibleNavigation( picker: Instance ): void {
+	expect( picker.prevMonthNav.getAttribute( 'role' ) ).toBe( 'button' );
+	expect( picker.prevMonthNav.getAttribute( 'aria-label' ) ).toBe(
+		'Mes anterior'
+	);
+	expect( picker.prevMonthNav.tabIndex ).toBe( 0 );
+	expect( picker.nextMonthNav.getAttribute( 'role' ) ).toBe( 'button' );
+	expect( picker.nextMonthNav.getAttribute( 'aria-label' ) ).toBe(
+		'Mes siguiente'
+	);
+	expect( picker.nextMonthNav.tabIndex ).toBe( 0 );
+}
+
+describe( 'real Flatpickr navigation lifecycle', () => {
+	beforeEach( () => {
+		document.body.innerHTML =
+			calendarMarkup( 'first' ) + calendarMarkup( 'second' );
+	} );
+
+	afterEach( () => {
+		document
+			.querySelectorAll< HTMLElement >( '.data-machine-events-calendar' )
+			.forEach( destroyDatePicker );
+	} );
+
+	it( 'keeps localized keyboard controls accessible across instances and redraws', () => {
+		const calendars = document.querySelectorAll< HTMLElement >(
+			'.data-machine-events-calendar'
+		);
+		const first = initDatePicker( calendars[ 0 ], jest.fn() ) as Instance;
+		const second = initDatePicker( calendars[ 1 ], jest.fn() ) as Instance;
+
+		expect( first ).not.toBe( second );
+		expect( first.prevMonthNav ).not.toBe( second.prevMonthNav );
+		expectAccessibleNavigation( first );
+		expectAccessibleNavigation( second );
+
+		const firstMonth = first.currentYear * 12 + first.currentMonth;
+		first.nextMonthNav.dispatchEvent(
+			new KeyboardEvent( 'keydown', { key: 'Enter', bubbles: true } )
+		);
+		expect( first.currentYear * 12 + first.currentMonth ).toBe(
+			firstMonth + 1
+		);
+
+		const secondMonth = second.currentYear * 12 + second.currentMonth;
+		second.prevMonthNav.dispatchEvent(
+			new KeyboardEvent( 'keydown', { key: ' ', bubbles: true } )
+		);
+		expect( second.currentYear * 12 + second.currentMonth ).toBe(
+			secondMonth - 1
+		);
+
+		first.redraw();
+		second.redraw();
+		expectAccessibleNavigation( first );
+		expectAccessibleNavigation( second );
+
+		const detachedNext = first.nextMonthNav;
+		const detachedClick = jest.fn();
+		detachedNext.addEventListener( 'click', detachedClick );
+		destroyDatePicker( calendars[ 0 ] );
+		detachedNext.dispatchEvent(
+			new KeyboardEvent( 'keydown', { key: 'Enter', bubbles: true } )
+		);
+		expect( detachedClick ).not.toHaveBeenCalled();
+		expect( document.body.contains( first.calendarContainer ) ).toBe(
+			false
+		);
+
+		const remainingMonth = second.currentYear * 12 + second.currentMonth;
+		second.nextMonthNav.dispatchEvent(
+			new KeyboardEvent( 'keydown', { key: 'Enter', bubbles: true } )
+		);
+		expect( second.currentYear * 12 + second.currentMonth ).toBe(
+			remainingMonth + 1
+		);
+	} );
+} );

--- a/tests/Unit/CalendarBlockTest.php
+++ b/tests/Unit/CalendarBlockTest.php
@@ -182,14 +182,29 @@ class CalendarBlockTest extends WP_UnitTestCase {
 		$second_html = $this->render_calendar();
 		$html        = $first_html . $second_html;
 
+		preg_match_all( '/data-instance-id="([^"]+)"/', $html, $instance_matches );
+		preg_match_all( '/<input type="text"\s+id="([^"]+)"[^>]+class="data-machine-events-search-input">/', $html, $search_matches );
+		preg_match_all( '/<input type="text"\s+id="([^"]+)"\s+class="data-machine-events-date-range-input"/', $html, $date_matches );
 		preg_match_all( '/<label class="screen-reader-text" for="([^"]+)">([^<]+)<\/label>/', $html, $label_matches );
 
+		$this->assertCount( 2, $instance_matches[1] );
+		$this->assertCount( 2, array_unique( $instance_matches[1] ), 'Each calendar should have a unique root instance ID.' );
+		$this->assertCount( 2, $search_matches[1] );
+		$this->assertCount( 2, $date_matches[1] );
 		$this->assertCount( 4, $label_matches[1] );
-		$this->assertCount( 4, array_unique( $label_matches[1] ), 'Each label should target a unique control ID.' );
+
+		$control_ids = array_merge( $search_matches[1], $date_matches[1] );
+		$this->assertCount( 4, array_unique( $control_ids ), 'Every input ID should be unique across calendar instances.' );
+		$this->assertEqualsCanonicalizing( $control_ids, $label_matches[1], 'Each input should have exactly one associated label.' );
 		$this->assertSame( array( 'Search events', 'Filter by date range', 'Search events', 'Filter by date range' ), $label_matches[2] );
 
-		foreach ( $label_matches[1] as $control_id ) {
+		foreach ( $control_ids as $control_id ) {
 			$this->assertSame( 1, substr_count( $html, 'id="' . $control_id . '"' ) );
+		}
+		foreach ( $instance_matches[1] as $instance_id ) {
+			$this->assertStringStartsWith( 'data-machine-calendar-', $instance_id );
+			$this->assertStringContainsString( 'data-machine-events-search-' . $instance_id, $html );
+			$this->assertStringContainsString( 'data-machine-events-date-range-' . $instance_id, $html );
 		}
 
 		$this->assertSame( 2, substr_count( $html, 'class="data-machine-events-search-btn" aria-label="Search events"' ) );


### PR DESCRIPTION
## Summary
- replace truncated block/`uniqid()` calendar instance IDs with WordPress core's request-scoped `wp_unique_id( 'data-machine-calendar-' )`
- strengthen PHP multi-instance coverage across calendar roots, search/date inputs, associated labels, and per-instance relationships
- add an integration test against real Flatpickr covering localized names, roles, tab stops, Enter/Space month navigation, redraw persistence, multiple instances, and teardown isolation

## Root cause
The calendar renderer derived IDs from a block value and truncated the normalized result to 12 characters. Multiple renders of the registered calendar block could therefore reuse the same instance prefix, causing labels in later calendars to target controls in the first calendar. The regression was introduced in merged PR #601 while fixing #586.

## Compatibility
`wp_unique_id()` is WordPress core's canonical request-scoped unique-ID primitive. Existing ID prefixes and selectors remain unchanged; only the collision-prone suffix source changes. Flatpickr production behavior is unchanged by this follow-up.

## Test results
- `npm test -- --runInBand` (42 tests passed across 9 suites)
- `npx eslint src/modules/date-picker.integration.test.ts` (passed)
- `npm run build` (passed)
- PHP syntax checks for the renderer and `CalendarBlockTest` (passed)
- Homeboy audit and changed-file lint CI (passed)
- managed WordPress PHPUnit: 671 tests, 2501 assertions, 2 skipped; the calendar regression passed and the sole failure is the unrelated existing `VenueMergeHelperTest::test_address_cluster_includes_similar_names` baseline at `tests/Unit/VenueMergeHelperTest.php:616`
- full local calendar `npm run lint:js` still reports 64 pre-existing Prettier errors in unrelated files; the changed JavaScript test passes focused lint and Homeboy changed-file lint passes

Follow-up to #601 and #586.