### PR TITLE
fix: harden map geo synchronization

### DIFF
--- a/.github/workflows/homeboy.yml
+++ b/.github/workflows/homeboy.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Run Homeboy ${{ matrix.command }}
         env:
-          HOMEBOY_SETTINGS_JSON: '{"database_type":"mysql","validation_dependencies":["/tmp/data-machine"],"wp_codebox_multisite":true,"wp_codebox_phpunit_bootstrap_mode":"managed","wp_codebox_prepare_steps":[{"command":"npm","args":["ci"],"cwd":"inc/Blocks/Calendar"},{"command":"npm","args":["run","build"],"cwd":"inc/Blocks/Calendar"},{"command":"npm","args":["ci"],"cwd":"inc/Blocks/EventDetails"},{"command":"npm","args":["run","build"],"cwd":"inc/Blocks/EventDetails"},{"command":"npm","args":["ci"],"cwd":"inc/Blocks/EventsMap"},{"command":"npm","args":["run","build"],"cwd":"inc/Blocks/EventsMap"}]}'
+          HOMEBOY_SETTINGS_JSON: '{"database_type":"mysql","wp_codebox_multisite":true,"wp_codebox_phpunit_bootstrap_mode":"managed","wp_codebox_prepare_steps":[{"command":"npm","args":["ci"],"cwd":"inc/Blocks/Calendar"},{"command":"npm","args":["run","build"],"cwd":"inc/Blocks/Calendar"},{"command":"npm","args":["ci"],"cwd":"inc/Blocks/EventDetails"},{"command":"npm","args":["run","build"],"cwd":"inc/Blocks/EventDetails"},{"command":"npm","args":["ci"],"cwd":"inc/Blocks/EventsMap"},{"command":"npm","args":["run","build"],"cwd":"inc/Blocks/EventsMap"}]}'
           HOMEBOY_WORDPRESS_DEPENDENCY_PATHS: /tmp/data-machine
           HOMEBOY_WORDPRESS_MULTISITE: '1'
         uses: Extra-Chill/homeboy-action@v2

--- a/docs/integration-api.md
+++ b/docs/integration-api.md
@@ -88,6 +88,7 @@ signatures are stable.
 | `data_machine_events_modal_button_classes` | `(array $classes, string $variant)` | Modify CSS classes on filter modal buttons. `$variant` is `'primary'` or `'secondary'`. |
 | `data_machine_events_calendar_request_args` | `(array $query_args, array $context)` | Add contextual calendar defaults immediately before `CalendarRequest` parsing. Request and block values are already assembled, so consumers should add only missing keys; all returned values are sanitized by `CalendarRequest`. Context contains `attributes`, resolved `display_mode`, and `archive_term` (`WP_Term|null`). Parsed taxonomy and geo values automatically reach the initial query, rendered state, controls, and existing frontend REST round-trips. |
 | `data_machine_events_calendar_query_args` | `(array $args, array $params)` | Modify the WP_Query args used by the calendar block. |
+| `data_machine_events_calendar_map_sync_id` | `(string $sync_id, array $context)` | Target this calendar at the Events Map with the same stable sync ID. Required when a page contains multiple maps; a single map is paired automatically. |
 
 ### Event Details block filters
 
@@ -106,10 +107,17 @@ signatures are stable.
 |---|---|---|
 | `data_machine_events_map_center` | `(array $center, array $context)` | Override the map's initial center coordinates. |
 | `data_machine_events_map_user_location` | `(?array $location, array $context)` | Provide a default user location override. |
+| `data_machine_events_map_sync_id` | `(string $sync_id, array $context)` | Set the map's stable generic synchronization ID. Defaults to the generated map ID. Use the same value with `data_machine_events_calendar_map_sync_id` for multi-map pages. |
 | `data_machine_events_map_show_location_search` | `(bool $show, array $context)` | Toggle the location search input. |
 | `data_machine_events_map_summary` | `(string $html, array $venues, array $context)` | Inject custom summary HTML above the map. |
 | `data_machine_events_map_query_args` | `(array $query_args, array $params)` | Modify the resolved venue-map query args before the database query runs. `$query_args['include_ids']` is the candidate venue term ID set (null = unrestricted, empty array = zero results, array of ints = intersected with existing filters). Mirrors `data_machine_events_calendar_query_args`. |
 | `data_machine_events_map_venues` | `(array $venues, array $params)` | Modify the final venue array before it is returned to the caller. Runs after sort + cap. Consumers may mutate per-venue fields, inject `upcoming_events_at_venue` payloads from custom sources (when the built-in `include_events` + taxonomy/term gating does not apply), re-order, or remove venues. Cannot expand beyond `MAX_VENUES`. |
+
+### Map synchronization events
+
+`data-machine-map-recenter` accepts `{ syncId, lat, lng, zoom?, authority? }`. `syncId` targets one map; an omitted target is accepted only when exactly one map exists for backward compatibility. `authority` may be `external` or `user-location` and defaults to `external`.
+
+`data-machine-map-bounds-changed` emits `{ syncId, generation, authority, bounds, center, zoom }`. Calendar instances ignore events for other sync IDs, unknown authorities, and malformed generations. Layout-only movement never emits this event.
 
 ### Event Details / button-row actions
 

--- a/inc/Blocks/Calendar/render.php
+++ b/inc/Blocks/Calendar/render.php
@@ -310,8 +310,20 @@ $filter_persistence_enabled = ( $attributes['showFilters'] ?? true )
 	&& ( $attributes['showSearch'] ?? true )
 	&& '' === $scope_token_value;
 $filter_persistence_attr    = sprintf( ' data-filter-persistence="%d"', $filter_persistence_enabled ? 1 : 0 );
+$map_sync_id                = (string) apply_filters(
+	'data_machine_events_calendar_map_sync_id',
+	'',
+	array(
+		'attributes'   => $attributes,
+		'display_mode' => $display_mode,
+		'archive_term' => $archive_term,
+	)
+);
+$map_sync_attr              = '' !== $map_sync_id
+	? sprintf( ' data-map-sync-id="%s"', esc_attr( $map_sync_id ) )
+	: '';
 ?>
-<div data-instance-id="<?php echo esc_attr( $instance_id ); ?>"<?php echo $archive_data_attrs; ?><?php echo $geo_data_attrs; ?><?php echo $scope_data_attr; ?><?php echo $scope_token_data_attr; ?><?php echo $filter_persistence_attr; ?><?php echo $display_mode_attr; ?> <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Attribute fragments are escaped when assembled; wrapper attributes come from WordPress core. ?>>
+<div data-instance-id="<?php echo esc_attr( $instance_id ); ?>"<?php echo $archive_data_attrs; ?><?php echo $geo_data_attrs; ?><?php echo $scope_data_attr; ?><?php echo $scope_token_data_attr; ?><?php echo $filter_persistence_attr; ?><?php echo $map_sync_attr; ?><?php echo $display_mode_attr; ?> <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Attribute fragments are escaped when assembled; wrapper attributes come from WordPress core. ?>>
 	<?php
 	\DataMachineEvents\Blocks\Calendar\Template_Loader::include_template(
 		'filter-bar',

--- a/inc/Blocks/Calendar/src/frontend.test.ts
+++ b/inc/Blocks/Calendar/src/frontend.test.ts
@@ -99,7 +99,11 @@ function deferredResponse(): {
 
 function calendarMarkup( withMap = false, mode = 'month-grid' ): string {
 	return `
-		${ withMap ? '<div class="data-machine-events-map-root"></div>' : '' }
+		${
+			withMap
+				? '<div id="map-a" class="data-machine-events-map-root" data-sync-id="map-a"></div>'
+				: ''
+		}
 		<div class="data-machine-events-calendar" data-display-mode="${ mode }"
 			data-scope="tonight" data-scope-token="opaque-token"
 			data-archive-taxonomy="location" data-archive-term-id="12">
@@ -211,6 +215,8 @@ describe( 'calendar frontend month-grid integration', () => {
 		document.dispatchEvent(
 			new CustomEvent( 'data-machine-map-bounds-changed', {
 				detail: {
+					syncId: 'map-a',
+					generation: 1,
 					bounds: { swLat: 32, swLng: -80, neLat: 33, neLng: -79 },
 					zoom: 10,
 					center: { lat: 32.78, lng: -79.93 },
@@ -260,6 +266,8 @@ describe( 'calendar frontend month-grid integration', () => {
 		document.dispatchEvent(
 			new CustomEvent( 'data-machine-map-bounds-changed', {
 				detail: {
+					syncId: 'map-a',
+					generation: 1,
 					bounds: { swLat: 32, swLng: -80, neLat: 33, neLng: -79 },
 					zoom: 10,
 					center: { lat: 32.78, lng: -79.93 },

--- a/inc/Blocks/Calendar/src/frontend.ts
+++ b/inc/Blocks/Calendar/src/frontend.ts
@@ -145,9 +145,10 @@ export function initCalendarInstance( calendar: HTMLElement ): void {
 	} );
 
 	// Auto-detect map block on page and enable geo sync.
-	if ( hasMapBlockOnPage() ) {
+	const mapSyncId = resolveMapSyncId( calendar );
+	if ( mapSyncId ) {
 		if ( gridMode ) {
-			initGeoSync( calendar, async function ( geo ) {
+			initGeoSync( calendar, mapSyncId, async function ( geo ) {
 				const params = getFilterState( calendar ).buildParams(
 					getDatePicker( calendar )
 				);
@@ -165,7 +166,7 @@ export function initCalendarInstance( calendar: HTMLElement ): void {
 					: false;
 			} );
 		} else {
-			initGeoSync( calendar );
+			initGeoSync( calendar, mapSyncId );
 		}
 	}
 
@@ -339,9 +340,22 @@ function navigateToUrl( params: URLSearchParams ): void {
 /**
  * Check if an events-map block exists on the current page.
  * When present, the calendar auto-enables geo sync mode.
+ * @param calendar
  */
-function hasMapBlockOnPage(): boolean {
-	return document.querySelector( '.data-machine-events-map-root' ) !== null;
+function resolveMapSyncId( calendar: HTMLElement ): string {
+	const explicitTarget = calendar.dataset.mapSyncId || '';
+	if ( explicitTarget ) {
+		return explicitTarget;
+	}
+
+	const maps = document.querySelectorAll< HTMLElement >(
+		'.data-machine-events-map-root'
+	);
+	if ( maps.length !== 1 ) {
+		return '';
+	}
+
+	return maps[ 0 ].dataset.syncId || maps[ 0 ].id || '';
 }
 
 window.addEventListener( 'beforeunload', function () {

--- a/inc/Blocks/Calendar/src/frontend.ts
+++ b/inc/Blocks/Calendar/src/frontend.ts
@@ -148,23 +148,30 @@ export function initCalendarInstance( calendar: HTMLElement ): void {
 	const mapSyncId = resolveMapSyncId( calendar );
 	if ( mapSyncId ) {
 		if ( gridMode ) {
-			initGeoSync( calendar, mapSyncId, async function ( geo ) {
-				const params = getFilterState( calendar ).buildParams(
-					getDatePicker( calendar )
-				);
-				params.set( 'lat', geo.lat );
-				params.set( 'lng', geo.lng );
-				if ( geo.radius !== undefined ) {
-					params.set( 'radius', String( geo.radius ) );
+			initGeoSync(
+				calendar,
+				mapSyncId,
+				async function ( geo, signal, isCurrent ) {
+					const params = getFilterState( calendar ).buildParams(
+						getDatePicker( calendar )
+					);
+					params.set( 'lat', geo.lat );
+					params.set( 'lng', geo.lng );
+					if ( geo.radius !== undefined ) {
+						params.set( 'radius', String( geo.radius ) );
+					}
+					if ( geo.radius_unit ) {
+						params.set( 'radius_unit', geo.radius_unit );
+					}
+					const controller = getMonthGridController( calendar );
+					return controller
+						? controller.handleFilterChange( params, {
+								signal,
+								shouldApply: isCurrent,
+						  } )
+						: false;
 				}
-				if ( geo.radius_unit ) {
-					params.set( 'radius_unit', geo.radius_unit );
-				}
-				const controller = getMonthGridController( calendar );
-				return controller
-					? controller.handleFilterChange( params )
-					: false;
-			} );
+			);
 		} else {
 			initGeoSync( calendar, mapSyncId );
 		}

--- a/inc/Blocks/Calendar/src/modules/api-client.test.ts
+++ b/inc/Blocks/Calendar/src/modules/api-client.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import { fetchCalendarEvents } from './api-client';
 
 function calendarMarkup(): HTMLElement {

--- a/inc/Blocks/Calendar/src/modules/api-client.test.ts
+++ b/inc/Blocks/Calendar/src/modules/api-client.test.ts
@@ -1,0 +1,73 @@
+import { fetchCalendarEvents } from './api-client';
+
+function calendarMarkup(): HTMLElement {
+	const calendar = document.createElement( 'div' );
+	calendar.innerHTML =
+		'<div class="data-machine-events-content">current</div>';
+	return calendar;
+}
+
+describe( 'calendar response lifecycle', () => {
+	it( 'does not apply a response superseded before JSON resolves', async () => {
+		let resolveResponse!: ( response: Response ) => void;
+		global.fetch = jest.fn(
+			() =>
+				new Promise< Response >( ( resolve ) => {
+					resolveResponse = resolve;
+				} )
+		);
+		const calendar = calendarMarkup();
+		let current = true;
+		const request = fetchCalendarEvents(
+			calendar,
+			new URLSearchParams(),
+			{},
+			{ shouldApply: () => current }
+		);
+
+		current = false;
+		resolveResponse( {
+			ok: true,
+			json: async () => ( {
+				success: true,
+				html: '<p>stale</p>',
+				pagination: null,
+				counter: null,
+				navigation: null,
+			} ),
+		} as Response );
+		await request;
+
+		expect(
+			calendar.querySelector( '.data-machine-events-content' )!
+				.textContent
+		).toBe( 'current' );
+	} );
+
+	it( 'does not render an error after teardown aborts a request', async () => {
+		global.fetch = jest.fn( ( _url, options ) => {
+			return new Promise< Response >( ( _resolve, reject ) => {
+				( options?.signal as AbortSignal ).addEventListener(
+					'abort',
+					() => reject( new DOMException( 'Aborted', 'AbortError' ) )
+				);
+			} );
+		} );
+		const calendar = calendarMarkup();
+		const controller = new AbortController();
+		const request = fetchCalendarEvents(
+			calendar,
+			new URLSearchParams(),
+			{},
+			{ signal: controller.signal }
+		);
+
+		controller.abort();
+		await request;
+
+		expect(
+			calendar.querySelector( '.data-machine-events-content' )!
+				.textContent
+		).toBe( 'current' );
+	} );
+} );

--- a/inc/Blocks/Calendar/src/modules/api-client.ts
+++ b/inc/Blocks/Calendar/src/modules/api-client.ts
@@ -145,14 +145,24 @@ export function buildCalendarRequest(
 export async function fetchCalendarEvents(
 	calendar: HTMLElement,
 	params: URLSearchParams,
-	archiveContext: Partial< ArchiveContext > = {}
+	archiveContext: Partial< ArchiveContext > = {},
+	options: {
+		signal?: AbortSignal;
+		shouldApply?: () => boolean;
+	} = {}
 ): Promise< CalendarResponse > {
 	const content = calendar.querySelector< HTMLElement >(
 		'.data-machine-events-content'
 	);
 
 	if ( ! content ) {
-		return { success: false, html: '', pagination: null, counter: null, navigation: null };
+		return {
+			success: false,
+			html: '',
+			pagination: null,
+			counter: null,
+			navigation: null,
+		};
 	}
 
 	content.classList.add( 'loading' );
@@ -167,6 +177,7 @@ export async function fetchCalendarEvents(
 
 		const response = await fetch( apiUrl, {
 			method: 'GET',
+			signal: options.signal,
 			headers: {
 				'Content-Type': 'application/json',
 				Accept: 'application/json',
@@ -186,6 +197,9 @@ export async function fetchCalendarEvents(
 		}
 
 		const data: CalendarResponse = await response.json();
+		if ( options.signal?.aborted || options.shouldApply?.() === false ) {
+			return data;
+		}
 
 		if ( data.success ) {
 			content.innerHTML = data.html;
@@ -208,6 +222,19 @@ export async function fetchCalendarEvents(
 
 		return data;
 	} catch ( error ) {
+		if (
+			options.signal?.aborted ||
+			options.shouldApply?.() === false ||
+			( error as Error ).name === 'AbortError'
+		) {
+			return {
+				success: false,
+				html: '',
+				pagination: null,
+				counter: null,
+				navigation: null,
+			};
+		}
 		window.console.error( 'Error fetching filtered events:', error );
 		content.innerHTML =
 			'<div class="data-machine-events-error"><p>Error loading events. Please try again.</p></div>';
@@ -219,7 +246,9 @@ export async function fetchCalendarEvents(
 			navigation: null,
 		};
 	} finally {
-		content.classList.remove( 'loading' );
+		if ( options.shouldApply?.() !== false ) {
+			content.classList.remove( 'loading' );
+		}
 	}
 }
 

--- a/inc/Blocks/Calendar/src/modules/geo-sync.test.ts
+++ b/inc/Blocks/Calendar/src/modules/geo-sync.test.ts
@@ -14,6 +14,9 @@ jest.mock( './filter-state', () => ( {
 	} ) ),
 } ) );
 
+/**
+ * Internal dependencies
+ */
 import { fetchCalendarEvents } from './api-client';
 import { destroyGeoSync, initGeoSync } from './geo-sync';
 
@@ -97,6 +100,31 @@ describe( 'calendar geo authority', () => {
 		expect( secondSignal.aborted ).toBe( false );
 		destroyGeoSync( calendar );
 		expect( secondSignal.aborted ).toBe( true );
+	} );
+
+	it( 'invalidates an active response as soon as newer authority is accepted', async () => {
+		let resolveOld!: () => void;
+		mockFetchCalendarEvents.mockImplementationOnce(
+			() =>
+				new Promise( ( resolve ) => {
+					resolveOld = () => resolve( {} );
+				} )
+		);
+		dispatchBounds( 'external', 'map-a', 10 );
+		jest.advanceTimersByTime( 300 );
+		const oldOptions = mockFetchCalendarEvents.mock.calls[ 0 ][ 3 ];
+		mockUpdateUrl.mockClear();
+		mockSaveGeoToStorage.mockClear();
+
+		dispatchBounds( 'user-interaction', 'map-a', 11 );
+		expect( oldOptions.signal.aborted ).toBe( true );
+		expect( oldOptions.shouldApply() ).toBe( false );
+		resolveOld();
+		await Promise.resolve();
+
+		expect( mockFetchCalendarEvents ).toHaveBeenCalledTimes( 1 );
+		expect( mockUpdateUrl ).not.toHaveBeenCalled();
+		expect( mockSaveGeoToStorage ).not.toHaveBeenCalled();
 	} );
 
 	it( 'ignores replayed and out-of-order map generations', () => {

--- a/inc/Blocks/Calendar/src/modules/geo-sync.test.ts
+++ b/inc/Blocks/Calendar/src/modules/geo-sync.test.ts
@@ -19,10 +19,16 @@ import { destroyGeoSync, initGeoSync } from './geo-sync';
 
 const mockFetchCalendarEvents = fetchCalendarEvents as jest.Mock;
 
-function dispatchBounds( authority?: string ): void {
+function dispatchBounds(
+	authority?: string,
+	syncId = 'map-a',
+	generation = 1
+): void {
 	document.dispatchEvent(
 		new CustomEvent( 'data-machine-map-bounds-changed', {
 			detail: {
+				syncId,
+				generation,
 				bounds: { swLat: 32, swLng: -80, neLat: 33, neLng: -79 },
 				zoom: 10,
 				center: { lat: 32.7765, lng: -79.9311 },
@@ -41,7 +47,67 @@ describe( 'calendar geo authority', () => {
 		mockUpdateUrl.mockClear();
 		mockSaveGeoToStorage.mockClear();
 		mockFetchCalendarEvents.mockClear();
-		initGeoSync( calendar );
+		initGeoSync( calendar, 'map-a' );
+	} );
+
+	it( 'ignores bounds from an unrelated map instance', () => {
+		dispatchBounds( 'user-interaction', 'map-b' );
+		jest.advanceTimersByTime( 300 );
+
+		expect( mockFetchCalendarEvents ).not.toHaveBeenCalled();
+	} );
+
+	it( 'routes simultaneous map events to their targeted calendars', () => {
+		const calendarB = document.createElement( 'div' );
+		initGeoSync( calendarB, 'map-b' );
+
+		dispatchBounds( 'external', 'map-a', 2 );
+		dispatchBounds( 'user-interaction', 'map-b', 3 );
+		jest.advanceTimersByTime( 300 );
+
+		expect( mockFetchCalendarEvents ).toHaveBeenCalledTimes( 2 );
+		expect(
+			new Set(
+				mockFetchCalendarEvents.mock.calls.map( ( call ) => call[ 0 ] )
+			)
+		).toEqual( new Set( [ calendar, calendarB ] ) );
+		destroyGeoSync( calendarB );
+	} );
+
+	it( 'cancels queued work during teardown', () => {
+		dispatchBounds( 'external' );
+		destroyGeoSync( calendar );
+		jest.advanceTimersByTime( 300 );
+
+		expect( mockFetchCalendarEvents ).not.toHaveBeenCalled();
+	} );
+
+	it( 'aborts superseded and destroyed calendar requests', () => {
+		dispatchBounds( 'external', 'map-a', 4 );
+		jest.advanceTimersByTime( 300 );
+		const firstSignal = mockFetchCalendarEvents.mock.calls[ 0 ][ 3 ]
+			.signal as AbortSignal;
+
+		dispatchBounds( 'user-interaction', 'map-a', 5 );
+		jest.advanceTimersByTime( 300 );
+		const secondSignal = mockFetchCalendarEvents.mock.calls[ 1 ][ 3 ]
+			.signal as AbortSignal;
+
+		expect( firstSignal.aborted ).toBe( true );
+		expect( secondSignal.aborted ).toBe( false );
+		destroyGeoSync( calendar );
+		expect( secondSignal.aborted ).toBe( true );
+	} );
+
+	it( 'ignores replayed and out-of-order map generations', () => {
+		dispatchBounds( 'external', 'map-a', 8 );
+		dispatchBounds( 'user-interaction', 'map-a', 7 );
+		jest.advanceTimersByTime( 300 );
+
+		expect( mockFetchCalendarEvents ).toHaveBeenCalledTimes( 1 );
+		expect( mockSaveGeoToStorage ).toHaveBeenCalledWith(
+			expect.objectContaining( { lat: '32.7765' } )
+		);
 	} );
 
 	afterEach( () => {

--- a/inc/Blocks/Calendar/src/modules/geo-sync.ts
+++ b/inc/Blocks/Calendar/src/modules/geo-sync.ts
@@ -25,6 +25,8 @@ import type { GeoContext } from '../types';
  * Shape of the custom event dispatched by the EventsMap block.
  */
 interface BoundsChangedDetail {
+	syncId: string;
+	generation: number;
 	bounds: {
 		swLat: number;
 		swLng: number;
@@ -54,8 +56,14 @@ const GEO_AUTHORITY_SOURCES = new Set( [
  */
 interface GeoSyncState {
 	handler: ( e: Event ) => void;
+	syncId: string;
 	currentGeo: GeoContext | null;
 	onGridUpdate?: ( geo: GeoContext ) => Promise< boolean >;
+	debounceTimer: ReturnType< typeof setTimeout > | null;
+	abortController: AbortController | null;
+	requestGeneration: number;
+	lastMapGeneration: number;
+	destroyed: boolean;
 }
 
 const instances = new WeakMap< HTMLElement, GeoSyncState >();
@@ -66,20 +74,28 @@ const instances = new WeakMap< HTMLElement, GeoSyncState >();
  * Listens for map bounds-changed events and re-fetches the calendar
  * via REST, updating the DOM in-place.
  * @param calendar
+ * @param syncId
  * @param onGridUpdate
  */
 export function initGeoSync(
 	calendar: HTMLElement,
+	syncId: string,
 	onGridUpdate?: ( geo: GeoContext ) => Promise< boolean >
 ): void {
-	if ( instances.has( calendar ) ) {
+	if ( instances.has( calendar ) || ! syncId ) {
 		return;
 	}
 
 	const state: GeoSyncState = {
 		handler: createBoundsHandler( calendar ),
+		syncId,
 		currentGeo: null,
 		onGridUpdate,
+		debounceTimer: null,
+		abortController: null,
+		requestGeneration: 0,
+		lastMapGeneration: 0,
+		destroyed: false,
 	};
 
 	instances.set( calendar, state );
@@ -109,6 +125,17 @@ export function destroyGeoSync( calendar: HTMLElement ): void {
 		'data-machine-map-bounds-changed',
 		state.handler
 	);
+	state.destroyed = true;
+	state.requestGeneration++;
+	if ( state.debounceTimer ) {
+		clearTimeout( state.debounceTimer );
+		state.debounceTimer = null;
+	}
+	state.abortController?.abort();
+	state.abortController = null;
+	calendar
+		.querySelector( '.data-machine-events-content' )
+		?.classList.remove( 'loading' );
 
 	instances.delete( calendar );
 }
@@ -128,6 +155,8 @@ export function updateCalendarGeo(
 	const state = instances.get( calendar );
 	if ( state ) {
 		state.currentGeo = geo;
+		startGeoRequest( calendar, state, geo );
+		return;
 	}
 
 	void fetchAndUpdate( calendar, geo );
@@ -138,21 +167,32 @@ export function updateCalendarGeo(
 /* ------------------------------------------------------------------ */
 
 function createBoundsHandler( calendar: HTMLElement ): ( e: Event ) => void {
-	let debounceTimer: ReturnType< typeof setTimeout >;
-
 	return function ( e: Event ): void {
 		const detail = ( e as CustomEvent< BoundsChangedDetail > ).detail;
+		const state = instances.get( calendar );
 		if (
+			! state ||
+			state.destroyed ||
 			! detail?.center ||
+			detail.syncId !== state.syncId ||
+			! Number.isInteger( detail.generation ) ||
+			detail.generation <= state.lastMapGeneration ||
 			! detail.authority ||
 			! GEO_AUTHORITY_SOURCES.has( detail.authority )
 		) {
 			return;
 		}
+		state.lastMapGeneration = detail.generation;
 
-		clearTimeout( debounceTimer );
+		if ( state.debounceTimer ) {
+			clearTimeout( state.debounceTimer );
+		}
 
-		debounceTimer = setTimeout( () => {
+		state.debounceTimer = setTimeout( () => {
+			state.debounceTimer = null;
+			if ( state.destroyed || instances.get( calendar ) !== state ) {
+				return;
+			}
 			// Derive radius from viewport bounds — the map zoom IS the radius.
 			const radius = boundsToRadius( detail.bounds, detail.center );
 
@@ -163,30 +203,58 @@ function createBoundsHandler( calendar: HTMLElement ): ( e: Event ) => void {
 				radius_unit: 'mi',
 			};
 
-			const state = instances.get( calendar );
-			if ( state ) {
-				state.currentGeo = geo;
-			}
+			state.currentGeo = geo;
 
-			void fetchAndUpdate( calendar, geo );
+			startGeoRequest( calendar, state, geo );
 		}, 300 );
 	};
+}
+
+function startGeoRequest(
+	calendar: HTMLElement,
+	state: GeoSyncState,
+	geo: GeoContext
+): void {
+	state.abortController?.abort();
+	state.abortController = new AbortController();
+	const requestGeneration = ++state.requestGeneration;
+	void fetchAndUpdate(
+		calendar,
+		geo,
+		state,
+		requestGeneration,
+		state.abortController.signal
+	);
 }
 
 /**
  * Fetch calendar data via REST API and update the DOM.
  * @param calendar
  * @param geo
+ * @param state
+ * @param requestGeneration
+ * @param signal
  */
 async function fetchAndUpdate(
 	calendar: HTMLElement,
-	geo: GeoContext
+	geo: GeoContext,
+	state?: GeoSyncState,
+	requestGeneration?: number,
+	signal?: AbortSignal
 ): Promise< void > {
+	const isCurrent = (): boolean =>
+		! state ||
+		( ! state.destroyed &&
+			instances.get( calendar ) === state &&
+			state.requestGeneration === requestGeneration &&
+			! signal?.aborted );
+	if ( ! isCurrent() ) {
+		return;
+	}
 	const filterState = getFilterState( calendar );
-	const state = instances.get( calendar );
 	if ( state?.onGridUpdate ) {
 		const updated = await state.onGridUpdate( geo );
-		if ( updated ) {
+		if ( updated && isCurrent() ) {
 			filterState.saveGeoToStorage( {
 				lat: geo.lat,
 				lng: geo.lng,
@@ -233,7 +301,10 @@ async function fetchAndUpdate(
 	// updates flow into Load More through the URL (pushed by
 	// `filterState.updateUrl()` above) — the next Load More click reads
 	// fresh geo via `buildCalendarRequest()`.
-	await fetchCalendarEvents( calendar, params, archiveContext );
+	await fetchCalendarEvents( calendar, params, archiveContext, {
+		signal,
+		shouldApply: isCurrent,
+	} );
 }
 
 /**

--- a/inc/Blocks/Calendar/src/modules/geo-sync.ts
+++ b/inc/Blocks/Calendar/src/modules/geo-sync.ts
@@ -58,7 +58,11 @@ interface GeoSyncState {
 	handler: ( e: Event ) => void;
 	syncId: string;
 	currentGeo: GeoContext | null;
-	onGridUpdate?: ( geo: GeoContext ) => Promise< boolean >;
+	onGridUpdate?: (
+		geo: GeoContext,
+		signal: AbortSignal,
+		isCurrent: () => boolean
+	) => Promise< boolean >;
 	debounceTimer: ReturnType< typeof setTimeout > | null;
 	abortController: AbortController | null;
 	requestGeneration: number;
@@ -80,7 +84,11 @@ const instances = new WeakMap< HTMLElement, GeoSyncState >();
 export function initGeoSync(
 	calendar: HTMLElement,
 	syncId: string,
-	onGridUpdate?: ( geo: GeoContext ) => Promise< boolean >
+	onGridUpdate?: (
+		geo: GeoContext,
+		signal: AbortSignal,
+		isCurrent: () => boolean
+	) => Promise< boolean >
 ): void {
 	if ( instances.has( calendar ) || ! syncId ) {
 		return;
@@ -155,6 +163,7 @@ export function updateCalendarGeo(
 	const state = instances.get( calendar );
 	if ( state ) {
 		state.currentGeo = geo;
+		invalidateActiveRequest( state );
 		startGeoRequest( calendar, state, geo );
 		return;
 	}
@@ -183,6 +192,7 @@ function createBoundsHandler( calendar: HTMLElement ): ( e: Event ) => void {
 			return;
 		}
 		state.lastMapGeneration = detail.generation;
+		invalidateActiveRequest( state );
 
 		if ( state.debounceTimer ) {
 			clearTimeout( state.debounceTimer );
@@ -215,7 +225,6 @@ function startGeoRequest(
 	state: GeoSyncState,
 	geo: GeoContext
 ): void {
-	state.abortController?.abort();
 	state.abortController = new AbortController();
 	const requestGeneration = ++state.requestGeneration;
 	void fetchAndUpdate(
@@ -225,6 +234,12 @@ function startGeoRequest(
 		requestGeneration,
 		state.abortController.signal
 	);
+}
+
+function invalidateActiveRequest( state: GeoSyncState ): void {
+	state.requestGeneration++;
+	state.abortController?.abort();
+	state.abortController = null;
 }
 
 /**
@@ -253,7 +268,7 @@ async function fetchAndUpdate(
 	}
 	const filterState = getFilterState( calendar );
 	if ( state?.onGridUpdate ) {
-		const updated = await state.onGridUpdate( geo );
+		const updated = await state.onGridUpdate( geo, signal!, isCurrent );
 		if ( updated && isCurrent() ) {
 			filterState.saveGeoToStorage( {
 				lat: geo.lat,

--- a/inc/Blocks/Calendar/src/modules/month-grid-nav.test.ts
+++ b/inc/Blocks/Calendar/src/modules/month-grid-nav.test.ts
@@ -236,4 +236,44 @@ describe( 'month-grid state synchronization', () => {
 		expect( window.location.search ).toContain( 'event_search=latest' );
 		expect( window.location.search ).not.toContain( 'event_search=stale' );
 	} );
+
+	it( 'blocks stale render and history after geo supersession', async () => {
+		const deferred = deferredResponse();
+		mockFetch.mockImplementationOnce( () => deferred.promise );
+		const pushState = jest.spyOn( window.history, 'pushState' );
+		const abortController = new AbortController();
+		initMonthGridNav( calendar );
+		const request = getMonthGridController( calendar )!.handleFilterChange(
+			new URLSearchParams( 'event_search=stale' ),
+			{
+				signal: abortController.signal,
+				shouldApply: () => ! abortController.signal.aborted,
+			}
+		);
+
+		abortController.abort();
+		deferred.resolve();
+		await request;
+
+		expect( mockRenderMonthGridResponse ).not.toHaveBeenCalled();
+		expect( pushState ).not.toHaveBeenCalled();
+		expect( calendar.dataset.geoLat ).toBeUndefined();
+	} );
+
+	it( 'blocks a late response after controller teardown', async () => {
+		const deferred = deferredResponse();
+		mockFetch.mockImplementationOnce( () => deferred.promise );
+		const pushState = jest.spyOn( window.history, 'pushState' );
+		initMonthGridNav( calendar );
+		const request = getMonthGridController( calendar )!.handleFilterChange(
+			new URLSearchParams( 'event_search=destroyed' )
+		);
+
+		destroyMonthGridNav( calendar );
+		deferred.resolve();
+		await request;
+
+		expect( mockRenderMonthGridResponse ).not.toHaveBeenCalled();
+		expect( pushState ).not.toHaveBeenCalled();
+	} );
 } );

--- a/inc/Blocks/Calendar/src/modules/month-grid-nav.ts
+++ b/inc/Blocks/Calendar/src/modules/month-grid-nav.ts
@@ -101,9 +101,7 @@ class MonthGridController {
 		this.onPopState?.( params );
 		const month = params.get( 'month' );
 		void this.navigateToMonth(
-			month && /^\d{4}-\d{2}$/.test( month )
-				? month
-				: this.initialMonth,
+			month && /^\d{4}-\d{2}$/.test( month ) ? month : this.initialMonth,
 			params,
 			false
 		);
@@ -113,13 +111,23 @@ class MonthGridController {
 	 * Public entry point called by frontend.ts when a filter changes
 	 * in grid mode.
 	 * @param params
+	 * @param requestOptions
+	 * @param requestOptions.signal
+	 * @param requestOptions.shouldApply
 	 */
-	async handleFilterChange( params: URLSearchParams ): Promise< boolean > {
+	async handleFilterChange(
+		params: URLSearchParams,
+		requestOptions: {
+			signal?: AbortSignal;
+			shouldApply?: () => boolean;
+		} = {}
+	): Promise< boolean > {
 		return this.navigateToMonth(
 			this.getCurrentMonth(),
 			params,
 			true,
-			true
+			true,
+			requestOptions
 		);
 	}
 
@@ -130,12 +138,19 @@ class MonthGridController {
 	 * @param source
 	 * @param pushHistory
 	 * @param syncGeoState
+	 * @param requestOptions
+	 * @param requestOptions.signal
+	 * @param requestOptions.shouldApply
 	 */
 	async navigateToMonth(
 		month: string,
 		source: URLSearchParams = new URLSearchParams( window.location.search ),
 		pushHistory = true,
-		syncGeoState = false
+		syncGeoState = false,
+		requestOptions: {
+			signal?: AbortSignal;
+			shouldApply?: () => boolean;
+		} = {}
 	): Promise< boolean > {
 		const requestId = ++this.requestSequence;
 		const publicParams = this.buildPublicParams( source, month );
@@ -190,6 +205,7 @@ class MonthGridController {
 			const apiUrl = `/wp-json/datamachine/v1/events/calendar?${ params.toString() }`;
 			const response = await fetch( apiUrl, {
 				method: 'GET',
+				signal: requestOptions.signal,
 				headers: {
 					'Content-Type': 'application/json',
 					Accept: 'application/json',
@@ -205,7 +221,11 @@ class MonthGridController {
 			if ( ! data?.success ) {
 				throw new Error( 'Calendar response not successful' );
 			}
-			if ( requestId !== this.requestSequence ) {
+			if (
+				requestId !== this.requestSequence ||
+				requestOptions.signal?.aborted ||
+				requestOptions.shouldApply?.() === false
+			) {
 				return false;
 			}
 
@@ -235,12 +255,21 @@ class MonthGridController {
 			);
 			return true;
 		} catch ( error ) {
-			if ( requestId === this.requestSequence ) {
+			if (
+				requestId === this.requestSequence &&
+				! requestOptions.signal?.aborted &&
+				requestOptions.shouldApply?.() !== false &&
+				( error as Error ).name !== 'AbortError'
+			) {
 				window.console.error( 'Month-grid fetch failed:', error );
 			}
 			return false;
 		} finally {
-			if ( requestId === this.requestSequence ) {
+			if (
+				requestId === this.requestSequence &&
+				! requestOptions.signal?.aborted &&
+				requestOptions.shouldApply?.() !== false
+			) {
 				const refreshedGrid = this.calendar.querySelector(
 					'.data-machine-month-grid'
 				);

--- a/inc/Blocks/EventsMap/package-lock.json
+++ b/inc/Blocks/EventsMap/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@types/leaflet.markercluster": "^1.5.6",
+        "@wordpress/element": "^6.40.0",
+        "@wordpress/i18n": "^6.24.0",
         "leaflet": "^1.9.4",
         "leaflet.markercluster": "^1.5.3"
       },
@@ -16,7 +18,9 @@
         "@types/leaflet": "^1.9.17",
         "@wordpress/eslint-plugin": "^25.7.0",
         "@wordpress/scripts": "31.1.0",
-        "eslint": "^9.0.0"
+        "eslint": "^9.0.0",
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4686,7 +4690,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.1.0.tgz",
       "integrity": "sha512-n8m9eNDfoNZoxdvWiTfW/hSPhehzLJ3zW7f8E7oT6mCROoMNWCB4TYtv041+2FMAxweiE0j7i1jubQU4MEC/Gg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tannin/evaluate": "^1.2.0",
@@ -4697,14 +4700,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.2.0.tgz",
       "integrity": "sha512-3ioXvNowbO/wSrxsDG5DKIMxC81P0QrQTYai8zFNY+umuoHWRPbQ/TuuDEOju9E+jQDXmj6yI5GyejNuh8I+eg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tannin/plural-forms": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.1.0.tgz",
       "integrity": "sha512-xl9R2mDZO/qiHam1AgMnAES6IKIg7OBhcXqy6eDsRCdXuxAFPcjrej9HMjyCLE0DJ/8cHf0i5OQTstuBRhpbHw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tannin/compile": "^1.1.0"
@@ -4714,14 +4715,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.1.0.tgz",
       "integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tannin/sprintf": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@tannin/sprintf/-/sprintf-1.3.3.tgz",
       "integrity": "sha512-RwARl+hFwhzy0tg9atWcchLFvoQiOh4rrP7uG2N5E4W80BPCUX0ElcUR9St43fxB9EfjsW2df9Qp+UsTbvQDjA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tootallnate/once": {
@@ -5112,7 +5111,6 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -5133,7 +5131,6 @@
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -5144,7 +5141,6 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -6244,7 +6240,6 @@
       "version": "6.40.0",
       "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.40.0.tgz",
       "integrity": "sha512-OhU8B2xEGg7c41rh/VRiJLOz6TnM/r5r8sraAg5ISc2bF7s2oAFqLwvlR0/U6ervyYwbK644osWZGQxFyL3huA==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.3.27",
@@ -6264,7 +6259,6 @@
       "version": "3.51.0",
       "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.51.0.tgz",
       "integrity": "sha512-0jPCm9WqpB7S+mdhkjjikBzGo06xAgvmgwtSP1v44P5tKNGujcbsvKj+JW0m60FJxNBmaZPvGu2e/DlY4iljVQ==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -6406,7 +6400,6 @@
       "version": "4.51.0",
       "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.51.0.tgz",
       "integrity": "sha512-pTVZRT9mjEdrNNt7TyKw5hQhFUqntfTXVs/fboEDpmAi+PFWXoD8rPs3oZyRCVr/MDyE6OCv1mwEibI6AsRk3Q==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -6417,7 +6410,6 @@
       "version": "6.24.0",
       "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.24.0.tgz",
       "integrity": "sha512-K4XmCyyyDOKH/5ea75P2L36ZiAvQTy4Hsa73Na3n6NzVjAwrrKZm4JJGf0t+OlThUG4D4GyfEv5szs5EeCA0lA==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@tannin/sprintf": "^1.3.2",
@@ -9037,7 +9029,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
       "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pascal-case": "^3.1.2",
@@ -9123,7 +9114,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
       "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
@@ -9152,7 +9142,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
       "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "camel-case": "^4.1.2",
@@ -9533,7 +9522,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
       "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
@@ -10071,7 +10059,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cwd": {
@@ -10551,7 +10538,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
       "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
@@ -10667,7 +10653,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.6.2"
@@ -12708,7 +12693,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
       "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "encoding": "^0.1.12",
@@ -13043,7 +13027,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
       "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "capital-case": "^1.0.4",
@@ -13351,7 +13334,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -14016,7 +13998,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -15016,7 +14997,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -15664,7 +15644,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -15677,7 +15656,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
       "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
@@ -15964,7 +15942,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
       "integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/meow": {
@@ -16394,7 +16371,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
       "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lower-case": "^2.0.2",
@@ -17034,7 +17010,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
       "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dot-case": "^3.0.4",
@@ -17146,7 +17121,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
       "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
@@ -17157,7 +17131,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
       "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dot-case": "^3.0.4",
@@ -18673,7 +18646,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -18686,7 +18658,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -19265,7 +19236,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -19321,7 +19291,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/sass": {
@@ -19403,7 +19372,6 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -19556,7 +19524,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
       "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
@@ -19953,7 +19920,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
       "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dot-case": "^3.0.4",
@@ -21135,7 +21101,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/tannin/-/tannin-1.2.0.tgz",
       "integrity": "sha512-U7GgX/RcSeUETbV7gYgoz8PD7Ni4y95pgIP/Z6ayI3CfhSujwKEBlGFTCRN+Aqnuyf4AN2yHL+L8x+TCGjb9uA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tannin/plural-forms": "^1.1.0"
@@ -21643,7 +21608,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsutils": {
@@ -22021,7 +21985,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
       "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
@@ -22031,7 +21994,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
       "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"

--- a/inc/Blocks/EventsMap/package.json
+++ b/inc/Blocks/EventsMap/package.json
@@ -11,6 +11,8 @@
   },
   "dependencies": {
     "@types/leaflet.markercluster": "^1.5.6",
+    "@wordpress/element": "^6.40.0",
+    "@wordpress/i18n": "^6.24.0",
     "leaflet": "^1.9.4",
     "leaflet.markercluster": "^1.5.3"
   },
@@ -18,7 +20,9 @@
     "@types/leaflet": "^1.9.17",
     "@wordpress/eslint-plugin": "^25.7.0",
     "@wordpress/scripts": "31.1.0",
-    "eslint": "^9.0.0"
+    "eslint": "^9.0.0",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0"
   },
   "overrides": {
     "rimraf": "^4.4.1",

--- a/inc/Blocks/EventsMap/render.php
+++ b/inc/Blocks/EventsMap/render.php
@@ -65,6 +65,10 @@ $center = apply_filters( 'data_machine_events_map_center', $center, $context );
 $user_location = apply_filters( 'data_machine_events_map_user_location', null, $context );
 
 $map_id  = wp_unique_id( 'dm-events-map-' );
+$sync_id = (string) apply_filters( 'data_machine_events_map_sync_id', $map_id, $context );
+if ( '' === $sync_id ) {
+	$sync_id = $map_id;
+}
 $wrapper = get_block_wrapper_attributes( array(
 	'class' => 'data-machine-events-map-block',
 ) );
@@ -181,6 +185,7 @@ $hide_label = __( 'Hide map', 'data-machine-events' );
 		<?php endif; ?>
 		<?php endif; ?>
 		data-height="<?php echo esc_attr( $height ); ?>"
+		data-sync-id="<?php echo esc_attr( $sync_id ); ?>"
 		data-zoom="<?php echo esc_attr( $zoom ); ?>"
 		data-map-type="<?php echo esc_attr( $map_type ); ?>"
 		data-center-lat="<?php echo esc_attr( $center['lat'] ?? '' ); ?>"

--- a/inc/Blocks/EventsMap/src/api-client.ts
+++ b/inc/Blocks/EventsMap/src/api-client.ts
@@ -13,6 +13,7 @@
 import type { MapBounds, VenueListResponse } from './types';
 
 interface FetchVenuesParams {
+	signal?: AbortSignal;
 	bounds?: MapBounds;
 	lat?: number;
 	lng?: number;
@@ -94,6 +95,7 @@ export async function fetchVenues(
 
 	const response = await fetch( url.toString(), {
 		headers: { Accept: 'application/json' },
+		signal: params.signal,
 	} );
 
 	if ( ! response.ok ) {

--- a/inc/Blocks/EventsMap/src/frontend.test.tsx
+++ b/inc/Blocks/EventsMap/src/frontend.test.tsx
@@ -396,17 +396,30 @@ describe( 'EventsMap geo authority integration', () => {
 		bounds.remove();
 	} );
 
-	it( 'keeps cancelled gestures neutral through later invalidation', () => {
+	it( 'cancels an unmoved drag before its trailing moveend', () => {
+		const bounds = collectBoundsEvents();
+		const { root, map } = renderMap( props() );
+
+		act( () => {
+			map.fire( 'dragstart' );
+			map.fire( 'dragend' );
+			map.fire( 'moveend' );
+		} );
+
+		expect( bounds.events ).toEqual( [] );
+		act( () => root.unmount() );
+		bounds.remove();
+	} );
+
+	it( 'cancels box zoom authority through Leaflet Escape handling', () => {
 		const bounds = collectBoundsEvents();
 		const { root, map } = renderMap( props() );
 
 		act( () => {
 			map.fire( 'boxzoomstart' );
-			map.fire( 'boxzoomcancel' );
-			map.invalidateSize();
-			map.fire( 'dragstart' );
-			map.fire( 'dragend' );
-			jest.advanceTimersByTime( 0 );
+			document.dispatchEvent(
+				new KeyboardEvent( 'keydown', { key: 'Escape' } )
+			);
 			map.invalidateSize();
 		} );
 

--- a/inc/Blocks/EventsMap/src/frontend.test.tsx
+++ b/inc/Blocks/EventsMap/src/frontend.test.tsx
@@ -371,6 +371,30 @@ describe( 'EventsMap geo authority integration', () => {
 		bounds.remove();
 	} );
 
+	it( 'does not apply box zoom Escape cancellation to a moved drag', () => {
+		const bounds = collectBoundsEvents();
+		const { root, map } = renderMap( props() );
+
+		act( () => {
+			map.fire( 'dragstart' );
+			map.fire( 'move' );
+			document.dispatchEvent(
+				new KeyboardEvent( 'keydown', { key: 'Escape' } )
+			);
+			map.center = { lat: 40.7128, lng: -74.006 };
+			map.fire( 'moveend' );
+		} );
+
+		expect( bounds.events ).toEqual( [
+			expect.objectContaining( {
+				authority: 'user-interaction',
+				center: { lat: 40.7128, lng: -74.006 },
+			} ),
+		] );
+		act( () => root.unmount() );
+		bounds.remove();
+	} );
+
 	it( 'emits deliberate user zoom authority', () => {
 		const bounds = collectBoundsEvents();
 		const { root, host, map } = renderMap( props() );

--- a/inc/Blocks/EventsMap/src/frontend.test.tsx
+++ b/inc/Blocks/EventsMap/src/frontend.test.tsx
@@ -1,0 +1,423 @@
+const mockMapInstances: any[] = [];
+
+jest.mock( 'leaflet', () => {
+	class MockMap {
+		center = { lat: 0, lng: 0 };
+		zoom = 12;
+		handlers = new Map< string, Set< () => void > >();
+		dragging = { enable: jest.fn(), disable: jest.fn() };
+		scrollWheelZoom = { enable: jest.fn(), disable: jest.fn() };
+		removed = false;
+
+		setView( [ lat, lng ]: [ number, number ], zoom: number ): this {
+			const changed =
+				this.center.lat !== lat ||
+				this.center.lng !== lng ||
+				this.zoom !== zoom;
+			if ( changed && this.handlers.size > 0 ) {
+				this.fire( 'movestart' );
+			}
+			this.center = { lat, lng };
+			this.zoom = zoom;
+			if ( changed && this.handlers.size > 0 ) {
+				this.fire( 'moveend' );
+			}
+			return this;
+		}
+
+		on( names: string, handler: () => void ): this {
+			names.split( ' ' ).forEach( ( name ) => {
+				if ( ! this.handlers.has( name ) ) {
+					this.handlers.set( name, new Set() );
+				}
+				this.handlers.get( name )!.add( handler );
+			} );
+			return this;
+		}
+
+		off( names: string, handler: () => void ): this {
+			names
+				.split( ' ' )
+				.forEach(
+					( name ) => this.handlers.get( name )?.delete( handler )
+				);
+			return this;
+		}
+
+		fire( name: string ): this {
+			[ ...( this.handlers.get( name ) ?? [] ) ].forEach( ( handler ) =>
+				handler()
+			);
+			return this;
+		}
+
+		getCenter(): { lat: number; lng: number } {
+			return this.center;
+		}
+
+		getZoom(): number {
+			return this.zoom;
+		}
+
+		getBounds() {
+			return {
+				getSouthWest: () => ( {
+					lat: this.center.lat - 0.5,
+					lng: this.center.lng - 0.5,
+				} ),
+				getNorthEast: () => ( {
+					lat: this.center.lat + 0.5,
+					lng: this.center.lng + 0.5,
+				} ),
+			};
+		}
+
+		invalidateSize(): this {
+			this.fire( 'movestart' );
+			this.fire( 'moveend' );
+			return this;
+		}
+
+		addLayer(): this {
+			return this;
+		}
+
+		removeLayer(): this {
+			return this;
+		}
+
+		remove(): void {
+			this.removed = true;
+			this.handlers.clear();
+		}
+	}
+
+	const cluster = () => ( {
+		on: jest.fn(),
+		off: jest.fn(),
+		addLayers: jest.fn(),
+		removeLayers: jest.fn(),
+		clearLayers: jest.fn(),
+		getLayers: jest.fn( () => [] ),
+	} );
+	const marker = () => ( {
+		addTo: jest.fn().mockReturnThis(),
+		bindPopup: jest.fn().mockReturnThis(),
+		setPopupContent: jest.fn(),
+	} );
+	const leaflet = {
+		map: jest.fn( () => {
+			const map = new MockMap();
+			mockMapInstances.push( map );
+			return map;
+		} ),
+		tileLayer: jest.fn( () => ( { addTo: jest.fn() } ) ),
+		markerClusterGroup: jest.fn( cluster ),
+		marker: jest.fn( marker ),
+		divIcon: jest.fn( () => ( {} ) ),
+	};
+
+	return { __esModule: true, default: leaflet };
+} );
+jest.mock( 'leaflet.markercluster', () => ( {} ) );
+
+import { createRoot } from '@wordpress/element';
+import { act } from 'react';
+
+import { EventsMap } from './frontend';
+
+import type { MapProps } from './types';
+
+(
+	globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+ ).IS_REACT_ACT_ENVIRONMENT = true;
+
+function props( overrides: Partial< MapProps > = {} ): MapProps {
+	return {
+		containerId: 'map-a-container',
+		syncId: 'map-a',
+		height: 400,
+		zoom: 12,
+		mapType: 'osm-standard',
+		centerLat: null,
+		centerLon: null,
+		userLat: null,
+		userLon: null,
+		venues: [],
+		taxonomy: '',
+		termId: 0,
+		restUrl: '',
+		nonce: '',
+		showLocationSearch: false,
+		geocodeUrl: '',
+		chronologicalRouteMode: false,
+		scopeToken: '',
+		...overrides,
+	};
+}
+
+function renderMap( mapProps: MapProps ) {
+	const host = document.createElement( 'div' );
+	document.body.appendChild( host );
+	const root = createRoot( host );
+	act( () => root.render( <EventsMap { ...mapProps } /> ) );
+	return { host, root, map: mockMapInstances.at( -1 ) };
+}
+
+function collectBoundsEvents(): {
+	events: any[];
+	remove: () => void;
+} {
+	const events: any[] = [];
+	const handler = ( event: Event ) => {
+		events.push( ( event as CustomEvent ).detail );
+	};
+	document.addEventListener( 'data-machine-map-bounds-changed', handler );
+	return {
+		events,
+		remove: () =>
+			document.removeEventListener(
+				'data-machine-map-bounds-changed',
+				handler
+			),
+	};
+}
+
+describe( 'EventsMap geo authority integration', () => {
+	beforeEach( () => {
+		jest.useFakeTimers();
+		mockMapInstances.length = 0;
+		document.body.innerHTML = '';
+	} );
+
+	afterEach( () => {
+		jest.runOnlyPendingTimers();
+		jest.useRealTimers();
+	} );
+
+	it.each( [ 'denied', 'prompt', 'unavailable', 'timeout' ] )(
+		'keeps %s/no-center initial mount neutral',
+		() => {
+			const bounds = collectBoundsEvents();
+			const { root, map } = renderMap( props() );
+
+			act( () => jest.advanceTimersByTime( 1000 ) );
+			expect( map.getCenter() ).toEqual( { lat: 0, lng: 0 } );
+			expect( bounds.events ).toEqual( [] );
+			act( () => root.unmount() );
+			bounds.remove();
+		}
+	);
+
+	it.each( [
+		[
+			'explicit/account center',
+			{ centerLat: 32.7765, centerLon: -79.9311 },
+			'server',
+		],
+		[
+			'granted location',
+			{ userLat: 32.7765, userLon: -79.9311 },
+			'user-location',
+		],
+	] )(
+		'emits targeted authority for %s',
+		( _label, overrides, authority ) => {
+			const bounds = collectBoundsEvents();
+			const { root } = renderMap( props( overrides ) );
+
+			act( () => jest.advanceTimersByTime( 200 ) );
+			expect( bounds.events ).toEqual( [
+				expect.objectContaining( { syncId: 'map-a', authority } ),
+			] );
+			act( () => root.unmount() );
+			bounds.remove();
+		}
+	);
+
+	it( 'handles external no-op before later neutral movement', () => {
+		const bounds = collectBoundsEvents();
+		const { root, map } = renderMap(
+			props( { centerLat: 32.7765, centerLon: -79.9311 } )
+		);
+		act( () => jest.advanceTimersByTime( 200 ) );
+		bounds.events.length = 0;
+
+		act( () => {
+			document.dispatchEvent(
+				new CustomEvent( 'data-machine-map-recenter', {
+					detail: {
+						syncId: 'map-a',
+						lat: 32.7765,
+						lng: -79.9311,
+						zoom: 12,
+					},
+				} )
+			);
+			map.invalidateSize();
+		} );
+
+		expect( bounds.events ).toHaveLength( 1 );
+		expect( bounds.events[ 0 ].authority ).toBe( 'external' );
+		act( () => root.unmount() );
+		bounds.remove();
+	} );
+
+	it( 'does not let delayed initial authority override an early user pan', () => {
+		const bounds = collectBoundsEvents();
+		const { root, map } = renderMap(
+			props( { centerLat: 32.7765, centerLon: -79.9311 } )
+		);
+
+		act( () => {
+			map.fire( 'dragstart' );
+			map.center = { lat: 40.7128, lng: -74.006 };
+			map.fire( 'moveend' );
+			jest.advanceTimersByTime( 200 );
+		} );
+
+		expect( bounds.events ).toEqual( [
+			expect.objectContaining( {
+				authority: 'user-interaction',
+				center: { lat: 40.7128, lng: -74.006 },
+			} ),
+		] );
+		act( () => root.unmount() );
+		bounds.remove();
+	} );
+
+	it( 'emits manual-search authority after successful geocoding', async () => {
+		const bounds = collectBoundsEvents();
+		global.fetch = jest.fn().mockResolvedValue( {
+			ok: true,
+			json: async () => ( {
+				success: true,
+				results: [
+					{
+						lat: '32.7765',
+						lon: '-79.9311',
+						display_name: 'Charleston, South Carolina',
+					},
+				],
+			} ),
+		} as Response );
+		const { root, host } = renderMap(
+			props( { showLocationSearch: true, geocodeUrl: '/geocode' } )
+		);
+		const input = host.querySelector< HTMLInputElement >(
+			'.data-machine-events-map-location-input'
+		)!;
+		const form = host.querySelector< HTMLFormElement >(
+			'.data-machine-events-map-location-form'
+		)!;
+
+		await act( async () => {
+			const valueSetter = Object.getOwnPropertyDescriptor(
+				HTMLInputElement.prototype,
+				'value'
+			)!.set!;
+			valueSetter.call( input, 'Charleston' );
+			input.dispatchEvent( new Event( 'input', { bubbles: true } ) );
+		} );
+		await act( async () => {
+			form.dispatchEvent(
+				new Event( 'submit', { bubbles: true, cancelable: true } )
+			);
+			await Promise.resolve();
+			await Promise.resolve();
+		} );
+
+		expect( bounds.events.at( -1 ) ).toEqual(
+			expect.objectContaining( {
+				syncId: 'map-a',
+				authority: 'manual-search',
+				center: { lat: 32.7765, lng: -79.9311 },
+			} )
+		);
+		act( () => root.unmount() );
+		bounds.remove();
+	} );
+
+	it( 'emits deliberate user pan without neutral debounce cancellation', () => {
+		const bounds = collectBoundsEvents();
+		const { root, map } = renderMap( props() );
+		act( () => jest.advanceTimersByTime( 200 ) );
+
+		act( () => {
+			map.fire( 'dragstart' );
+			map.center = { lat: 40.7128, lng: -74.006 };
+			map.fire( 'moveend' );
+			map.invalidateSize();
+		} );
+
+		expect( bounds.events ).toEqual( [
+			expect.objectContaining( {
+				syncId: 'map-a',
+				authority: 'user-interaction',
+				center: { lat: 40.7128, lng: -74.006 },
+			} ),
+		] );
+		act( () => root.unmount() );
+		bounds.remove();
+	} );
+
+	it( 'emits deliberate user zoom authority', () => {
+		const bounds = collectBoundsEvents();
+		const { root, host, map } = renderMap( props() );
+		const zoomButton = document.createElement( 'button' );
+		zoomButton.className = 'leaflet-control-zoom-in';
+		host.querySelector( '.data-machine-events-map' )!.append( zoomButton );
+
+		act( () => {
+			zoomButton.click();
+			map.fire( 'movestart' );
+			map.zoom = 13;
+			map.fire( 'moveend' );
+		} );
+
+		expect( bounds.events ).toEqual( [
+			expect.objectContaining( {
+				syncId: 'map-a',
+				authority: 'user-interaction',
+				zoom: 13,
+			} ),
+		] );
+		act( () => root.unmount() );
+		bounds.remove();
+	} );
+
+	it( 'targets one of two maps and tears listeners down on unmount', () => {
+		const bounds = collectBoundsEvents();
+		const first = renderMap( props() );
+		const second = renderMap(
+			props( { containerId: 'map-b-container', syncId: 'map-b' } )
+		);
+
+		act( () => {
+			document.dispatchEvent(
+				new CustomEvent( 'data-machine-map-recenter', {
+					detail: { syncId: 'map-b', lat: 34.05, lng: -118.24 },
+				} )
+			);
+		} );
+		expect( first.map.getCenter() ).toEqual( { lat: 0, lng: 0 } );
+		expect( second.map.getCenter() ).toEqual( {
+			lat: 34.05,
+			lng: -118.24,
+		} );
+		expect( bounds.events.at( -1 ).syncId ).toBe( 'map-b' );
+
+		act( () => second.root.unmount() );
+		const count = bounds.events.length;
+		document.dispatchEvent(
+			new CustomEvent( 'data-machine-map-recenter', {
+				detail: { syncId: 'map-b', lat: 1, lng: 1 },
+			} )
+		);
+		act( () => jest.runOnlyPendingTimers() );
+		expect( bounds.events ).toHaveLength( count );
+		expect( second.map.removed ).toBe( true );
+		act( () => first.root.unmount() );
+		bounds.remove();
+	} );
+} );

--- a/inc/Blocks/EventsMap/src/frontend.test.tsx
+++ b/inc/Blocks/EventsMap/src/frontend.test.tsx
@@ -121,9 +121,19 @@ jest.mock( 'leaflet', () => {
 } );
 jest.mock( 'leaflet.markercluster', () => ( {} ) );
 
+/**
+ * WordPress dependencies
+ */
 import { createRoot } from '@wordpress/element';
+
+/**
+ * External dependencies
+ */
 import { act } from 'react';
 
+/**
+ * Internal dependencies
+ */
 import { EventsMap } from './frontend';
 
 import type { MapProps } from './types';
@@ -382,6 +392,25 @@ describe( 'EventsMap geo authority integration', () => {
 				zoom: 13,
 			} ),
 		] );
+		act( () => root.unmount() );
+		bounds.remove();
+	} );
+
+	it( 'keeps cancelled gestures neutral through later invalidation', () => {
+		const bounds = collectBoundsEvents();
+		const { root, map } = renderMap( props() );
+
+		act( () => {
+			map.fire( 'boxzoomstart' );
+			map.fire( 'boxzoomcancel' );
+			map.invalidateSize();
+			map.fire( 'dragstart' );
+			map.fire( 'dragend' );
+			jest.advanceTimersByTime( 0 );
+			map.invalidateSize();
+		} );
+
+		expect( bounds.events ).toEqual( [] );
 		act( () => root.unmount() );
 		bounds.remove();
 	} );

--- a/inc/Blocks/EventsMap/src/frontend.tsx
+++ b/inc/Blocks/EventsMap/src/frontend.tsx
@@ -650,6 +650,7 @@ export function EventsMap( props: MapProps ): JSX.Element | null {
 		const cleanupCallbacks: Array< () => void > = [];
 		let activeGestureGeneration: number | null = null;
 		let activeGestureMoved = false;
+		let activeGestureType: 'drag' | 'boxzoom' | null = null;
 		const prepareUserInteraction = () => {
 			const operation = authority.prepare( 'user-interaction' );
 			const timer = setTimeout( () => {
@@ -658,16 +659,20 @@ export function EventsMap( props: MapProps ): JSX.Element | null {
 			}, 750 );
 			interactionAbandonTimers.add( timer );
 		};
-		const activateUserInteraction = () => {
+		const activateUserInteraction = ( type: 'drag' | 'boxzoom' ) => {
 			activeGestureMoved = false;
+			activeGestureType = type;
 			activeGestureGeneration =
 				authority.activate( 'user-interaction' ).generation;
 		};
+		const handleDragStart = () => activateUserInteraction( 'drag' );
+		const handleBoxZoomStart = () => activateUserInteraction( 'boxzoom' );
 		const cancelActiveGesture = () => {
 			if ( activeGestureGeneration !== null ) {
 				authority.cancel( activeGestureGeneration );
 				activeGestureGeneration = null;
 				activeGestureMoved = false;
+				activeGestureType = null;
 			}
 		};
 		const handleMove = () => {
@@ -690,6 +695,7 @@ export function EventsMap( props: MapProps ): JSX.Element | null {
 				if ( activeGestureGeneration === operation.generation ) {
 					activeGestureGeneration = null;
 					activeGestureMoved = false;
+					activeGestureType = null;
 				}
 				dispatchBoundsChanged( map, syncId, operation );
 			}
@@ -710,7 +716,7 @@ export function EventsMap( props: MapProps ): JSX.Element | null {
 			}
 		};
 		const handleDocumentKeyDown = ( event: KeyboardEvent ) => {
-			if ( event.key === 'Escape' ) {
+			if ( event.key === 'Escape' && activeGestureType === 'boxzoom' ) {
 				cancelActiveGesture();
 			}
 		};
@@ -729,7 +735,8 @@ export function EventsMap( props: MapProps ): JSX.Element | null {
 		map.on( 'movestart', handleMoveStart );
 		map.on( 'move', handleMove );
 		map.on( 'moveend', handleMoveEnd );
-		map.on( 'dragstart boxzoomstart', activateUserInteraction );
+		map.on( 'dragstart', handleDragStart );
+		map.on( 'boxzoomstart', handleBoxZoomStart );
 		map.on( 'dragend', handleDragEnd );
 		el.addEventListener( 'dblclick', handleDoubleClick, true );
 		el.addEventListener( 'keydown', handleKeyDown, true );
@@ -885,7 +892,8 @@ export function EventsMap( props: MapProps ): JSX.Element | null {
 			map.off( 'movestart', handleMoveStart );
 			map.off( 'move', handleMove );
 			map.off( 'moveend', handleMoveEnd );
-			map.off( 'dragstart boxzoomstart', activateUserInteraction );
+			map.off( 'dragstart', handleDragStart );
+			map.off( 'boxzoomstart', handleBoxZoomStart );
 			map.off( 'dragend', handleDragEnd );
 			el.removeEventListener( 'dblclick', handleDoubleClick, true );
 			el.removeEventListener( 'keydown', handleKeyDown, true );

--- a/inc/Blocks/EventsMap/src/frontend.tsx
+++ b/inc/Blocks/EventsMap/src/frontend.tsx
@@ -47,7 +47,10 @@ import type {
 	MapBounds,
 	BoundsChangedEvent,
 } from './types';
-import type { GeoAuthoritySource } from './geo-authority';
+import type {
+	GeoAuthoritySource,
+	GeoAuthorityOperation,
+} from './geo-authority';
 
 import './frontend.css';
 
@@ -289,16 +292,19 @@ function getBoundsFromMap( map: L.Map ): MapBounds {
 
 function dispatchBoundsChanged(
 	map: L.Map,
-	authority: GeoAuthoritySource
+	syncId: string,
+	operation: GeoAuthorityOperation
 ): void {
 	const bounds = getBoundsFromMap( map );
 	const center = map.getCenter();
 
 	const detail: BoundsChangedEvent = {
+		syncId,
+		generation: operation.generation,
 		bounds,
 		zoom: map.getZoom(),
 		center: { lat: center.lat, lng: center.lng },
-		authority,
+		authority: operation.source,
 	};
 
 	document.dispatchEvent(
@@ -306,16 +312,60 @@ function dispatchBoundsChanged(
 	);
 }
 
+function moveWithAuthority(
+	map: L.Map,
+	syncId: string,
+	tracker: ReturnType< typeof createGeoAuthorityTracker >,
+	source: GeoAuthoritySource,
+	lat: number,
+	lng: number,
+	zoom: number
+): void {
+	const operation = tracker.prepare( source );
+	map.setView( [ lat, lng ], zoom );
+	const noOp = tracker.completeNoop( operation.generation );
+	if ( noOp ) {
+		dispatchBoundsChanged( map, syncId, noOp );
+	}
+}
+
+function isTargetedToMap(
+	targetSyncId: string | undefined,
+	syncId: string
+): boolean {
+	if ( targetSyncId ) {
+		return targetSyncId === syncId;
+	}
+
+	return (
+		document.querySelectorAll( '.data-machine-events-map-root' ).length ===
+		1
+	);
+}
+
 /* ---------- debounce ---------- */
 
-function debounce(
-	fn: ( map: L.Map, authority: GeoAuthoritySource | null ) => void,
+function createDebounce(
+	fn: ( map: L.Map ) => void,
 	ms: number
-): ( map: L.Map, authority: GeoAuthoritySource | null ) => void {
-	let timer: ReturnType< typeof setTimeout >;
-	return ( map: L.Map, authority: GeoAuthoritySource | null ) => {
-		clearTimeout( timer );
-		timer = setTimeout( () => fn( map, authority ), ms );
+): { schedule: ( map: L.Map ) => void; cancel: () => void } {
+	let timer: ReturnType< typeof setTimeout > | null = null;
+	return {
+		schedule( map ) {
+			if ( timer ) {
+				clearTimeout( timer );
+			}
+			timer = setTimeout( () => {
+				timer = null;
+				fn( map );
+			}, ms );
+		},
+		cancel() {
+			if ( timer ) {
+				clearTimeout( timer );
+				timer = null;
+			}
+		},
 	};
 }
 
@@ -340,6 +390,11 @@ function LocationSearch( {
 	const [ placeholder, setPlaceholder ] = useState(
 		'Enter a city or address...'
 	);
+	const requestRef = useRef< AbortController | null >( null );
+
+	useEffect( () => {
+		return () => requestRef.current?.abort();
+	}, [] );
 
 	const handleSubmit = useCallback(
 		async ( e: React.FormEvent ) => {
@@ -352,6 +407,9 @@ function LocationSearch( {
 
 			setLoading( true );
 			setError( '' );
+			requestRef.current?.abort();
+			const controller = new AbortController();
+			requestRef.current = controller;
 
 			try {
 				const url = `${ geocodeUrl }?query=${ encodeURIComponent(
@@ -359,6 +417,7 @@ function LocationSearch( {
 				) }`;
 				const response = await fetch( url, {
 					headers: { Accept: 'application/json' },
+					signal: controller.signal,
 				} );
 
 				if ( ! response.ok ) {
@@ -391,12 +450,18 @@ function LocationSearch( {
 				setQuery( '' );
 
 				onLocationFound( lat, lng, label );
-			} catch {
+			} catch ( fetchError ) {
+				if ( ( fetchError as Error ).name === 'AbortError' ) {
+					return;
+				}
 				setError(
 					'Could not look up that location. Please try again.'
 				);
 			} finally {
-				setLoading( false );
+				if ( requestRef.current === controller ) {
+					requestRef.current = null;
+					setLoading( false );
+				}
 			}
 		},
 		[ query, geocodeUrl, onLocationFound ]
@@ -440,9 +505,10 @@ function LocationSearch( {
 
 /* ---------- React component ---------- */
 
-function EventsMap( props: MapProps ): JSX.Element | null {
+export function EventsMap( props: MapProps ): JSX.Element | null {
 	const {
 		containerId,
+		syncId,
 		height,
 		zoom,
 		mapType,
@@ -466,6 +532,7 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 	const markerMapRef = useRef< Map< number, L.Marker > >( new Map() );
 	const userMarkerRef = useRef< L.Marker | null >( null );
 	const geoAuthorityRef = useRef( createGeoAuthorityTracker() );
+	const venueRequestRef = useRef< AbortController | null >( null );
 	// Single L.polyline holding the chronological route. Recreated from
 	// scratch whenever venues change so we don't manage segment-level
 	// diffing — the route is at most a few dozen points.
@@ -491,8 +558,13 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 				return;
 			}
 
+			venueRequestRef.current?.abort();
+			const controller = new AbortController();
+			venueRequestRef.current = controller;
+
 			try {
 				const result = await fetchVenues( restUrl, nonce, {
+					signal: controller.signal,
 					bounds,
 					taxonomy: taxonomy || undefined,
 					termId: termId || undefined,
@@ -506,10 +578,19 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 					// endpoint returns the full venue set.
 					scopeToken: scopeToken || undefined,
 				} );
-				setVenues( result.venues );
+				if ( venueRequestRef.current === controller ) {
+					setVenues( result.venues );
+				}
 			} catch ( err ) {
+				if ( ( err as Error ).name === 'AbortError' ) {
+					return;
+				}
 				// eslint-disable-next-line no-console
 				console.error( 'Events map: failed to fetch venues', err );
+			} finally {
+				if ( venueRequestRef.current === controller ) {
+					venueRequestRef.current = null;
+				}
 			}
 		},
 		[ restUrl, nonce, taxonomy, termId, chronologicalRouteMode, scopeToken ]
@@ -518,12 +599,9 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 	/* --- debounced bounds handler --- */
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	const debouncedFetch = useCallback(
-		debounce( ( map: L.Map, authority: GeoAuthoritySource | null ) => {
+		createDebounce( ( map: L.Map ) => {
 			const bounds = getBoundsFromMap( map );
 			loadVenues( bounds );
-			if ( authority ) {
-				dispatchBoundsChanged( map, authority );
-			}
 		}, 500 ),
 		[ loadVenues ]
 	);
@@ -561,12 +639,37 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 			zoom
 		);
 
-		const markUserInteraction = () => {
-			geoAuthorityRef.current.mark( 'user-interaction' );
+		const authority = geoAuthorityRef.current;
+		const initialOperation = initialView.authority
+			? authority.immediate( initialView.authority )
+			: null;
+		const interactionAbandonTimers = new Set<
+			ReturnType< typeof setTimeout >
+		>();
+		const mountTimers = new Set< ReturnType< typeof setTimeout > >();
+		const cleanupCallbacks: Array< () => void > = [];
+		const prepareUserInteraction = () => {
+			const operation = authority.prepare( 'user-interaction' );
+			const timer = setTimeout( () => {
+				authority.abandon( operation.generation );
+				interactionAbandonTimers.delete( timer );
+			}, 750 );
+			interactionAbandonTimers.add( timer );
 		};
-		map.on( 'dragstart boxzoomstart', markUserInteraction );
-		el.addEventListener( 'dblclick', markUserInteraction );
-		el.addEventListener( 'keydown', ( event: KeyboardEvent ) => {
+		const activateUserInteraction = () => {
+			authority.activate( 'user-interaction' );
+		};
+		const handleMoveStart = () => authority.movementStarted();
+		const handleMoveEnd = () => {
+			if ( ! chronologicalRouteMode ) {
+				debouncedFetch.schedule( map );
+			}
+			const operation = authority.movementEnded();
+			if ( operation ) {
+				dispatchBoundsChanged( map, syncId, operation );
+			}
+		};
+		const handleKeyDown = ( event: KeyboardEvent ) => {
 			if (
 				[
 					'ArrowUp',
@@ -578,23 +681,27 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 					'=',
 				].includes( event.key )
 			) {
-				markUserInteraction();
+				prepareUserInteraction();
 			}
-		} );
-		el.addEventListener(
-			'click',
-			( event: MouseEvent ) => {
-				const target = event.target as Element | null;
-				if (
-					target?.closest(
-						'.leaflet-control-zoom-in, .leaflet-control-zoom-out, .marker-cluster'
-					)
-				) {
-					markUserInteraction();
-				}
-			},
-			true
-		);
+		};
+		const handleClick = ( event: MouseEvent ) => {
+			const target = event.target as Element | null;
+			if (
+				target?.closest(
+					'.leaflet-control-zoom-in, .leaflet-control-zoom-out, .marker-cluster'
+				)
+			) {
+				prepareUserInteraction();
+			}
+		};
+		const handleDoubleClick = () => prepareUserInteraction();
+
+		map.on( 'movestart', handleMoveStart );
+		map.on( 'moveend', handleMoveEnd );
+		map.on( 'dragstart boxzoomstart', activateUserInteraction );
+		el.addEventListener( 'dblclick', handleDoubleClick, true );
+		el.addEventListener( 'keydown', handleKeyDown, true );
+		el.addEventListener( 'click', handleClick, true );
 
 		if ( isTouch ) {
 			// Show gesture hint when user tries single-finger drag.
@@ -614,42 +721,43 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 				}, 1500 );
 			};
 
-			el.addEventListener(
-				'touchstart',
-				( e: TouchEvent ) => {
-					if ( e.touches.length === 1 ) {
-						showGestureHint();
-					} else if ( e.touches.length >= 2 ) {
-						// Two-finger gesture — enable dragging temporarily.
-						markUserInteraction();
-						map.dragging.enable();
-					}
-				},
-				{ passive: true }
-			);
+			const handleTouchStart = ( e: TouchEvent ) => {
+				if ( e.touches.length === 1 ) {
+					showGestureHint();
+				} else if ( e.touches.length >= 2 ) {
+					// Two-finger gesture — enable dragging temporarily.
+					prepareUserInteraction();
+					map.dragging.enable();
+				}
+			};
 
-			el.addEventListener(
-				'touchend',
-				() => {
-					// Re-disable dragging after gesture ends.
-					map.dragging.disable();
-				},
-				{ passive: true }
-			);
+			const handleTouchEnd = () => map.dragging.disable();
+			el.addEventListener( 'touchstart', handleTouchStart, {
+				passive: true,
+			} );
+			el.addEventListener( 'touchend', handleTouchEnd, {
+				passive: true,
+			} );
+			cleanupCallbacks.push( () => {
+				el.removeEventListener( 'touchstart', handleTouchStart );
+				el.removeEventListener( 'touchend', handleTouchEnd );
+			} );
 		} else {
 			// Desktop: Ctrl/Cmd + scroll to zoom.
-			el.addEventListener(
-				'wheel',
-				( e: WheelEvent ) => {
-					if ( e.ctrlKey || e.metaKey ) {
-						e.preventDefault();
-						markUserInteraction();
-						map.scrollWheelZoom.enable();
-					}
-				},
-				{ passive: false }
-			);
-			map.on( 'mouseout', () => map.scrollWheelZoom.disable() );
+			const handleWheel = ( e: WheelEvent ) => {
+				if ( e.ctrlKey || e.metaKey ) {
+					e.preventDefault();
+					prepareUserInteraction();
+					map.scrollWheelZoom.enable();
+				}
+			};
+			const handleMouseOut = () => map.scrollWheelZoom.disable();
+			el.addEventListener( 'wheel', handleWheel, { passive: false } );
+			map.on( 'mouseout', handleMouseOut );
+			cleanupCallbacks.push( () => {
+				el.removeEventListener( 'wheel', handleWheel );
+				map.off( 'mouseout', handleMouseOut );
+			} );
 		}
 
 		// Tile layer.
@@ -671,7 +779,6 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 			chunkInterval: 100,
 			chunkDelay: 10,
 		} );
-		clusterGroup.on( 'clusterclick', markUserInteraction );
 		map.addLayer( clusterGroup );
 		clusterGroupRef.current = clusterGroup;
 
@@ -682,14 +789,8 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 		// term's events) — the full set is already small and refetching by
 		// viewport would drop venues that the user just panned away from,
 		// mid-route. Skip the moveend refetch for it.
-		if ( ! chronologicalRouteMode ) {
-			map.on( 'moveend', () => {
-				debouncedFetch( map, geoAuthorityRef.current.consume() );
-			} );
-		}
-
 		// Force a resize check after mount.
-		setTimeout( () => map.invalidateSize(), 100 );
+		const resizeTimer = setTimeout( () => map.invalidateSize(), 100 );
 
 		// Collapsible support: when the block is rendered inside a
 		// collapsible region, the container can be hidden (display:none /
@@ -713,7 +814,7 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 		// Fetch venues on mount and notify other blocks (e.g. calendar geo-sync).
 		if ( initialVenues.length === 0 ) {
 			// Small delay so map is fully sized first.
-			setTimeout( () => {
+			const mountTimer = setTimeout( () => {
 				// Chronological-route mode wants the full bounded set
 				// regardless of the default viewport, then it auto-fits
 				// to those points. Passing bounds here would clip the
@@ -722,13 +823,39 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 					? undefined
 					: getBoundsFromMap( map );
 				loadVenues( bounds );
-				if ( initialView.authority ) {
-					dispatchBoundsChanged( map, initialView.authority );
+				if (
+					initialOperation &&
+					authority.isLatest( initialOperation.generation ) &&
+					map.getCenter().lat === initialView.center.lat &&
+					map.getCenter().lng === initialView.center.lng
+				) {
+					dispatchBoundsChanged( map, syncId, initialOperation );
 				}
 			}, 200 );
+			mountTimers.add( mountTimer );
 		}
 
 		return () => {
+			clearTimeout( resizeTimer );
+			mountTimers.forEach( clearTimeout );
+			mountTimers.clear();
+			interactionAbandonTimers.forEach( clearTimeout );
+			interactionAbandonTimers.clear();
+			if ( gestureTimeoutRef.current ) {
+				clearTimeout( gestureTimeoutRef.current );
+				gestureTimeoutRef.current = null;
+			}
+			debouncedFetch.cancel();
+			venueRequestRef.current?.abort();
+			venueRequestRef.current = null;
+			authority.destroy();
+			map.off( 'movestart', handleMoveStart );
+			map.off( 'moveend', handleMoveEnd );
+			map.off( 'dragstart boxzoomstart', activateUserInteraction );
+			el.removeEventListener( 'dblclick', handleDoubleClick, true );
+			el.removeEventListener( 'keydown', handleKeyDown, true );
+			el.removeEventListener( 'click', handleClick, true );
+			cleanupCallbacks.forEach( ( cleanup ) => cleanup() );
 			el.removeEventListener(
 				'data-machine-map-invalidate-size',
 				handleInvalidateSize
@@ -756,16 +883,27 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 					lat: number;
 					lng: number;
 					zoom?: number;
+					syncId?: string;
+					authority?: 'external' | 'user-location';
 				} >
 			 ).detail;
 
-			if ( ! detail?.lat || ! detail?.lng ) {
+			if (
+				! detail ||
+				! Number.isFinite( detail.lat ) ||
+				! Number.isFinite( detail.lng ) ||
+				! isTargetedToMap( detail.syncId, syncId )
+			) {
 				return;
 			}
 
-			geoAuthorityRef.current.mark( 'external' );
-			map.setView(
-				[ detail.lat, detail.lng ],
+			moveWithAuthority(
+				map,
+				syncId,
+				geoAuthorityRef.current,
+				detail.authority ?? 'external',
+				detail.lat,
+				detail.lng,
 				detail.zoom ?? map.getZoom()
 			);
 		};
@@ -777,7 +915,7 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 				handler
 			);
 		};
-	}, [] );
+	}, [ syncId ] );
 
 	/* --- listen for external user-location updates (e.g. geolocation) --- */
 	useEffect( () => {
@@ -791,10 +929,16 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 				e as CustomEvent< {
 					lat: number;
 					lng: number;
+					syncId?: string;
 				} >
 			 ).detail;
 
-			if ( ! detail?.lat || ! detail?.lng ) {
+			if (
+				! detail ||
+				! Number.isFinite( detail.lat ) ||
+				! Number.isFinite( detail.lng ) ||
+				! isTargetedToMap( detail.syncId, syncId )
+			) {
 				return;
 			}
 
@@ -823,7 +967,7 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 				handler
 			);
 		};
-	}, [] );
+	}, [ syncId ] );
 
 	/* --- update markers when venues change (with diffing) --- */
 	useEffect( () => {
@@ -1060,21 +1204,31 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 	}, [ userLat, userLon ] );
 
 	/* --- handle location search result --- */
-	const handleLocationFound = useCallback( ( lat: number, lng: number ) => {
-		const map = mapRef.current;
-		if ( ! map ) {
-			return;
-		}
+	const handleLocationFound = useCallback(
+		( lat: number, lng: number ) => {
+			const map = mapRef.current;
+			if ( ! map ) {
+				return;
+			}
 
-		geoAuthorityRef.current.mark( 'manual-search' );
-		map.setView( [ lat, lng ], 12 );
+			moveWithAuthority(
+				map,
+				syncId,
+				geoAuthorityRef.current,
+				'manual-search',
+				lat,
+				lng,
+				12
+			);
 
-		// Update URL for shareability.
-		const url = new URL( window.location.href );
-		url.searchParams.set( 'lat', lat.toFixed( 6 ) );
-		url.searchParams.set( 'lng', lng.toFixed( 6 ) );
-		window.history.replaceState( {}, '', url.toString() );
-	}, [] );
+			// Update URL for shareability.
+			const url = new URL( window.location.href );
+			url.searchParams.set( 'lat', lat.toFixed( 6 ) );
+			url.searchParams.set( 'lng', lng.toFixed( 6 ) );
+			window.history.replaceState( {}, '', url.toString() );
+		},
+		[ syncId ]
+	);
 
 	return (
 		<>
@@ -1109,6 +1263,7 @@ function EventsMap( props: MapProps ): JSX.Element | null {
 
 function parseMapProps( container: HTMLElement ): MapProps {
 	const data = container.dataset;
+	const generatedId = container.id || `dm-events-map-${ Date.now() }`;
 
 	const parseOptionalFloat = ( val?: string ): number | null => {
 		if ( ! val || val === '' ) {
@@ -1119,7 +1274,8 @@ function parseMapProps( container: HTMLElement ): MapProps {
 	};
 
 	return {
-		containerId: container.id || `dm-events-map-${ Date.now() }`,
+		containerId: generatedId,
+		syncId: data.syncId || generatedId,
 		height: parseInt( data.height || '400', 10 ),
 		zoom: parseInt( data.zoom || '12', 10 ),
 		mapType: ( data.mapType || 'osm-standard' ) as MapType,

--- a/inc/Blocks/EventsMap/src/frontend.tsx
+++ b/inc/Blocks/EventsMap/src/frontend.tsx
@@ -646,9 +646,6 @@ export function EventsMap( props: MapProps ): JSX.Element | null {
 		const interactionAbandonTimers = new Set<
 			ReturnType< typeof setTimeout >
 		>();
-		const gestureCancelTimers = new Set<
-			ReturnType< typeof setTimeout >
-		>();
 		const mountTimers = new Set< ReturnType< typeof setTimeout > >();
 		const cleanupCallbacks: Array< () => void > = [];
 		let activeGestureGeneration: number | null = null;
@@ -679,19 +676,9 @@ export function EventsMap( props: MapProps ): JSX.Element | null {
 			}
 		};
 		const handleDragEnd = () => {
-			const generation = activeGestureGeneration;
-			if ( generation === null || activeGestureMoved ) {
-				return;
+			if ( activeGestureGeneration !== null && ! activeGestureMoved ) {
+				cancelActiveGesture();
 			}
-			const timer = setTimeout( () => {
-				authority.cancel( generation );
-				if ( activeGestureGeneration === generation ) {
-					activeGestureGeneration = null;
-					activeGestureMoved = false;
-				}
-				gestureCancelTimers.delete( timer );
-			}, 0 );
-			gestureCancelTimers.add( timer );
 		};
 		const handleMoveStart = () => authority.movementStarted();
 		const handleMoveEnd = () => {
@@ -722,6 +709,11 @@ export function EventsMap( props: MapProps ): JSX.Element | null {
 				prepareUserInteraction();
 			}
 		};
+		const handleDocumentKeyDown = ( event: KeyboardEvent ) => {
+			if ( event.key === 'Escape' ) {
+				cancelActiveGesture();
+			}
+		};
 		const handleClick = ( event: MouseEvent ) => {
 			const target = event.target as Element | null;
 			if (
@@ -739,10 +731,10 @@ export function EventsMap( props: MapProps ): JSX.Element | null {
 		map.on( 'moveend', handleMoveEnd );
 		map.on( 'dragstart boxzoomstart', activateUserInteraction );
 		map.on( 'dragend', handleDragEnd );
-		map.on( 'boxzoomcancel', cancelActiveGesture );
 		el.addEventListener( 'dblclick', handleDoubleClick, true );
 		el.addEventListener( 'keydown', handleKeyDown, true );
 		el.addEventListener( 'click', handleClick, true );
+		document.addEventListener( 'keydown', handleDocumentKeyDown, true );
 
 		if ( isTouch ) {
 			// Show gesture hint when user tries single-finger drag.
@@ -882,8 +874,6 @@ export function EventsMap( props: MapProps ): JSX.Element | null {
 			mountTimers.clear();
 			interactionAbandonTimers.forEach( clearTimeout );
 			interactionAbandonTimers.clear();
-			gestureCancelTimers.forEach( clearTimeout );
-			gestureCancelTimers.clear();
 			if ( gestureTimeoutRef.current ) {
 				clearTimeout( gestureTimeoutRef.current );
 				gestureTimeoutRef.current = null;
@@ -897,10 +887,14 @@ export function EventsMap( props: MapProps ): JSX.Element | null {
 			map.off( 'moveend', handleMoveEnd );
 			map.off( 'dragstart boxzoomstart', activateUserInteraction );
 			map.off( 'dragend', handleDragEnd );
-			map.off( 'boxzoomcancel', cancelActiveGesture );
 			el.removeEventListener( 'dblclick', handleDoubleClick, true );
 			el.removeEventListener( 'keydown', handleKeyDown, true );
 			el.removeEventListener( 'click', handleClick, true );
+			document.removeEventListener(
+				'keydown',
+				handleDocumentKeyDown,
+				true
+			);
 			cleanupCallbacks.forEach( ( cleanup ) => cleanup() );
 			el.removeEventListener(
 				'data-machine-map-invalidate-size',

--- a/inc/Blocks/EventsMap/src/frontend.tsx
+++ b/inc/Blocks/EventsMap/src/frontend.tsx
@@ -646,8 +646,13 @@ export function EventsMap( props: MapProps ): JSX.Element | null {
 		const interactionAbandonTimers = new Set<
 			ReturnType< typeof setTimeout >
 		>();
+		const gestureCancelTimers = new Set<
+			ReturnType< typeof setTimeout >
+		>();
 		const mountTimers = new Set< ReturnType< typeof setTimeout > >();
 		const cleanupCallbacks: Array< () => void > = [];
+		let activeGestureGeneration: number | null = null;
+		let activeGestureMoved = false;
 		const prepareUserInteraction = () => {
 			const operation = authority.prepare( 'user-interaction' );
 			const timer = setTimeout( () => {
@@ -657,7 +662,36 @@ export function EventsMap( props: MapProps ): JSX.Element | null {
 			interactionAbandonTimers.add( timer );
 		};
 		const activateUserInteraction = () => {
-			authority.activate( 'user-interaction' );
+			activeGestureMoved = false;
+			activeGestureGeneration =
+				authority.activate( 'user-interaction' ).generation;
+		};
+		const cancelActiveGesture = () => {
+			if ( activeGestureGeneration !== null ) {
+				authority.cancel( activeGestureGeneration );
+				activeGestureGeneration = null;
+				activeGestureMoved = false;
+			}
+		};
+		const handleMove = () => {
+			if ( activeGestureGeneration !== null ) {
+				activeGestureMoved = true;
+			}
+		};
+		const handleDragEnd = () => {
+			const generation = activeGestureGeneration;
+			if ( generation === null || activeGestureMoved ) {
+				return;
+			}
+			const timer = setTimeout( () => {
+				authority.cancel( generation );
+				if ( activeGestureGeneration === generation ) {
+					activeGestureGeneration = null;
+					activeGestureMoved = false;
+				}
+				gestureCancelTimers.delete( timer );
+			}, 0 );
+			gestureCancelTimers.add( timer );
 		};
 		const handleMoveStart = () => authority.movementStarted();
 		const handleMoveEnd = () => {
@@ -666,6 +700,10 @@ export function EventsMap( props: MapProps ): JSX.Element | null {
 			}
 			const operation = authority.movementEnded();
 			if ( operation ) {
+				if ( activeGestureGeneration === operation.generation ) {
+					activeGestureGeneration = null;
+					activeGestureMoved = false;
+				}
 				dispatchBoundsChanged( map, syncId, operation );
 			}
 		};
@@ -697,8 +735,11 @@ export function EventsMap( props: MapProps ): JSX.Element | null {
 		const handleDoubleClick = () => prepareUserInteraction();
 
 		map.on( 'movestart', handleMoveStart );
+		map.on( 'move', handleMove );
 		map.on( 'moveend', handleMoveEnd );
 		map.on( 'dragstart boxzoomstart', activateUserInteraction );
+		map.on( 'dragend', handleDragEnd );
+		map.on( 'boxzoomcancel', cancelActiveGesture );
 		el.addEventListener( 'dblclick', handleDoubleClick, true );
 		el.addEventListener( 'keydown', handleKeyDown, true );
 		el.addEventListener( 'click', handleClick, true );
@@ -841,6 +882,8 @@ export function EventsMap( props: MapProps ): JSX.Element | null {
 			mountTimers.clear();
 			interactionAbandonTimers.forEach( clearTimeout );
 			interactionAbandonTimers.clear();
+			gestureCancelTimers.forEach( clearTimeout );
+			gestureCancelTimers.clear();
 			if ( gestureTimeoutRef.current ) {
 				clearTimeout( gestureTimeoutRef.current );
 				gestureTimeoutRef.current = null;
@@ -850,8 +893,11 @@ export function EventsMap( props: MapProps ): JSX.Element | null {
 			venueRequestRef.current = null;
 			authority.destroy();
 			map.off( 'movestart', handleMoveStart );
+			map.off( 'move', handleMove );
 			map.off( 'moveend', handleMoveEnd );
 			map.off( 'dragstart boxzoomstart', activateUserInteraction );
+			map.off( 'dragend', handleDragEnd );
+			map.off( 'boxzoomcancel', cancelActiveGesture );
 			el.removeEventListener( 'dblclick', handleDoubleClick, true );
 			el.removeEventListener( 'keydown', handleKeyDown, true );
 			el.removeEventListener( 'click', handleClick, true );

--- a/inc/Blocks/EventsMap/src/geo-authority.test.ts
+++ b/inc/Blocks/EventsMap/src/geo-authority.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import {
 	createGeoAuthorityTracker,
 	resolveInitialView,
@@ -112,5 +115,14 @@ describe( 'map geo authority', () => {
 
 		expect( tracker.isLatest( initial.generation ) ).toBe( false );
 		expect( tracker.isLatest( user.generation ) ).toBe( true );
+	} );
+
+	it( 'cancels active gesture authority before neutral movement', () => {
+		const tracker = createGeoAuthorityTracker();
+		const gesture = tracker.activate( 'user-interaction' );
+		tracker.cancel( gesture.generation );
+
+		tracker.movementStarted();
+		expect( tracker.movementEnded() ).toBeNull();
 	} );
 } );

--- a/inc/Blocks/EventsMap/src/geo-authority.test.ts
+++ b/inc/Blocks/EventsMap/src/geo-authority.test.ts
@@ -57,23 +57,60 @@ describe( 'map geo authority', () => {
 		}
 	);
 
-	it( 'does not let unmarked programmatic movement masquerade as intent', () => {
+	it( 'binds authority to a started movement generation', () => {
 		const tracker = createGeoAuthorityTracker();
+		const operation = tracker.prepare( 'external' );
 
-		expect( tracker.consume() ).toBeNull();
-		tracker.mark( 'user-interaction' );
-		expect( tracker.consume() ).toBe( 'user-interaction' );
-		expect( tracker.consume() ).toBeNull();
+		expect( tracker.movementEnded() ).toBeNull();
+		tracker.movementStarted();
+		expect( tracker.movementEnded() ).toEqual( operation );
+		expect( tracker.movementEnded() ).toBeNull();
 	} );
 
-	it.each( [ 'external', 'manual-search', 'user-interaction' ] as const )(
-		'preserves one %s movement',
-		( source ) => {
-			const tracker = createGeoAuthorityTracker();
-			tracker.mark( source );
+	it( 'completes authoritative no-op requests explicitly', () => {
+		const tracker = createGeoAuthorityTracker();
+		const operation = tracker.prepare( 'manual-search' );
 
-			expect( tracker.consume() ).toBe( source );
-			expect( tracker.consume() ).toBeNull();
-		}
-	);
+		expect( tracker.completeNoop( operation.generation ) ).toEqual(
+			operation
+		);
+		expect( tracker.movementEnded() ).toBeNull();
+	} );
+
+	it( 'clears abandoned marks before later neutral movement', () => {
+		const tracker = createGeoAuthorityTracker();
+		const abandoned = tracker.prepare( 'user-interaction' );
+		tracker.abandon( abandoned.generation );
+
+		tracker.movementStarted();
+		expect( tracker.movementEnded() ).toBeNull();
+	} );
+
+	it( 'does not let neutral movement cancel completed authority', () => {
+		const tracker = createGeoAuthorityTracker();
+		const operation = tracker.activate( 'user-interaction' );
+
+		expect( tracker.movementEnded() ).toEqual( operation );
+		tracker.movementStarted();
+		expect( tracker.movementEnded() ).toBeNull();
+	} );
+
+	it( 'supersedes an unstarted operation with a newer generation', () => {
+		const tracker = createGeoAuthorityTracker();
+		const oldOperation = tracker.prepare( 'external' );
+		const currentOperation = tracker.prepare( 'manual-search' );
+
+		expect( tracker.completeNoop( oldOperation.generation ) ).toBeNull();
+		tracker.movementStarted();
+		expect( tracker.movementEnded() ).toEqual( currentOperation );
+	} );
+
+	it( 'lets user intent supersede delayed initial authority', () => {
+		const tracker = createGeoAuthorityTracker();
+		const initial = tracker.immediate( 'server' );
+		const user = tracker.activate( 'user-interaction' );
+
+		expect( tracker.isLatest( initial.generation ) ).toBe( false );
+		expect( tracker.isLatest( user.generation ) ).toBe( true );
+	} );
 } );

--- a/inc/Blocks/EventsMap/src/geo-authority.ts
+++ b/inc/Blocks/EventsMap/src/geo-authority.ts
@@ -8,6 +8,11 @@ export type GeoAuthoritySource =
 	| 'manual-search'
 	| 'user-interaction';
 
+export interface GeoAuthorityOperation {
+	generation: number;
+	source: GeoAuthoritySource;
+}
+
 /**
  * A map needs coordinates to render even when no location has been chosen.
  * This fallback is deliberately neutral and never carries geo authority.
@@ -52,22 +57,74 @@ export function resolveInitialView( {
 }
 
 /**
- * Hold authority for exactly one completed map movement.
+ * Bind authority to one concrete map movement generation.
  */
 export function createGeoAuthorityTracker(): {
-	mark: ( source: GeoAuthoritySource ) => void;
-	consume: () => GeoAuthoritySource | null;
+	prepare: ( source: GeoAuthoritySource ) => GeoAuthorityOperation;
+	activate: ( source: GeoAuthoritySource ) => GeoAuthorityOperation;
+	movementStarted: () => void;
+	movementEnded: () => GeoAuthorityOperation | null;
+	completeNoop: ( generation: number ) => GeoAuthorityOperation | null;
+	abandon: ( generation: number ) => void;
+	immediate: ( source: GeoAuthoritySource ) => GeoAuthorityOperation;
+	isLatest: ( generation: number ) => boolean;
+	destroy: () => void;
 } {
-	let pending: GeoAuthoritySource | null = null;
+	let generation = 0;
+	let awaitingStart: GeoAuthorityOperation | null = null;
+	let active: GeoAuthorityOperation | null = null;
+
+	const next = ( source: GeoAuthoritySource ): GeoAuthorityOperation => ( {
+		generation: ++generation,
+		source,
+	} );
 
 	return {
-		mark( source ) {
-			pending = source;
+		prepare( source ) {
+			const operation = next( source );
+			awaitingStart = operation;
+			active = null;
+			return operation;
 		},
-		consume() {
-			const source = pending;
-			pending = null;
-			return source;
+		activate( source ) {
+			const operation = next( source );
+			awaitingStart = null;
+			active = operation;
+			return operation;
+		},
+		movementStarted() {
+			if ( awaitingStart ) {
+				active = awaitingStart;
+				awaitingStart = null;
+			}
+		},
+		movementEnded() {
+			const operation = active;
+			active = null;
+			return operation;
+		},
+		completeNoop( operationGeneration ) {
+			if ( awaitingStart?.generation !== operationGeneration ) {
+				return null;
+			}
+			const operation = awaitingStart;
+			awaitingStart = null;
+			return operation;
+		},
+		abandon( operationGeneration ) {
+			if ( awaitingStart?.generation === operationGeneration ) {
+				awaitingStart = null;
+			}
+		},
+		immediate( source ) {
+			return next( source );
+		},
+		isLatest( operationGeneration ) {
+			return generation === operationGeneration;
+		},
+		destroy() {
+			awaitingStart = null;
+			active = null;
 		},
 	};
 }

--- a/inc/Blocks/EventsMap/src/geo-authority.ts
+++ b/inc/Blocks/EventsMap/src/geo-authority.ts
@@ -66,6 +66,7 @@ export function createGeoAuthorityTracker(): {
 	movementEnded: () => GeoAuthorityOperation | null;
 	completeNoop: ( generation: number ) => GeoAuthorityOperation | null;
 	abandon: ( generation: number ) => void;
+	cancel: ( generation: number ) => void;
 	immediate: ( source: GeoAuthoritySource ) => GeoAuthorityOperation;
 	isLatest: ( generation: number ) => boolean;
 	destroy: () => void;
@@ -114,6 +115,14 @@ export function createGeoAuthorityTracker(): {
 		abandon( operationGeneration ) {
 			if ( awaitingStart?.generation === operationGeneration ) {
 				awaitingStart = null;
+			}
+		},
+		cancel( operationGeneration ) {
+			if ( awaitingStart?.generation === operationGeneration ) {
+				awaitingStart = null;
+			}
+			if ( active?.generation === operationGeneration ) {
+				active = null;
 			}
 		},
 		immediate( source ) {

--- a/inc/Blocks/EventsMap/src/types.ts
+++ b/inc/Blocks/EventsMap/src/types.ts
@@ -75,6 +75,7 @@ export interface MapAttributes {
  */
 export interface MapProps {
 	containerId: string;
+	syncId: string;
 	height: number;
 	zoom: number;
 	mapType: MapType;
@@ -114,6 +115,8 @@ export interface MapBounds {
  * Custom event dispatched when map bounds change.
  */
 export interface BoundsChangedEvent {
+	syncId: string;
+	generation: number;
 	bounds: MapBounds;
 	zoom: number;
 	center: { lat: number; lng: number };


### PR DESCRIPTION
## Summary
- bind map geo authority to concrete movement generations, including explicit no-op completion, abandoned-operation cleanup, and neutral-movement isolation
- target map/calendar synchronization by stable generic sync IDs so multiple instances cannot cross-wire
- cancel map timers/listeners/fetches and abort or generation-guard stale Calendar responses during supersession and teardown
- add real React/Leaflet-mocked integration coverage for neutral permission outcomes, initial centers, geolocation, manual search, pan/zoom, no-op ordering, multiple instances, and cleanup

## Context
Post-merge hardening for #595 after #602 merged before its requested-changes review was delivered. This PR treats merged #602 as baseline and addresses every review blocker without reverting or rewriting `main`.

## Authority and ordering
Each authoritative operation receives a monotonically increasing generation. Programmatic recenter/search calls prepare a generation before `setView`; `movestart` latches that exact generation and `moveend` completes it. Calls that do not move complete immediately as authoritative no-ops. Deliberate interaction operations expire if no movement begins, and neutral layout movement only drives venue loading, so it cannot consume, cancel, or replay authority. Calendar instances reject malformed, replayed, and out-of-order generations.

## Instance identity
Events Map emits `syncId` on bounds events and accepts targeted recenter/user-location events. Calendar instances resolve an explicit `data_machine_events_calendar_map_sync_id` target, automatically pair only when exactly one map exists, and fail closed on ambiguous multi-map pages. `data_machine_events_map_sync_id` provides the matching generic map-side seam.

## Lifecycle safety
- map resize/mount/gesture/debounce timers and named DOM/Leaflet listeners are removed on teardown
- venue and geocode fetches abort when superseded or unmounted
- Calendar geo requests abort on supersession/destroy and use request-generation predicates before applying DOM, URL-adjacent persistence, or response lifecycle updates
- stale/aborted Calendar responses do not replace content or render errors

## Verification
- EventsMap full lint: passed
- EventsMap tests: 22 passed
- EventsMap production build: passed
- Calendar touched-file lint: passed
- Calendar tests: 48 passed
- Calendar production build: passed
- PHP syntax for both modified renderers: passed
- `git diff --check`: passed
- repository Homeboy umbrella could not start because host resource policy rejected local execution at load 12-14 with no Lab runner available; no code-stage failure was reported

References #595 and merged #602.