### PR TITLE
chore: clear block JavaScript lint baseline

### DIFF
--- a/inc/Blocks/Calendar/src/modules/carousel.ts
+++ b/inc/Blocks/Calendar/src/modules/carousel.ts
@@ -31,8 +31,7 @@ export function initCarousel( calendar: HTMLElement ): void {
 			return;
 		}
 
-		const eventCount =
-			parseInt( group.dataset.eventCount || '0', 10 ) || 0;
+		const eventCount = parseInt( group.dataset.eventCount || '0', 10 ) || 0;
 		if ( eventCount <= 1 ) {
 			return;
 		}
@@ -48,8 +47,7 @@ export function initCarousel( calendar: HTMLElement ): void {
 		let holdInterval: ReturnType< typeof setInterval > | null = null;
 
 		const scrollByCard = function ( direction: number ): void {
-			const cardWidth =
-				events[ 0 ]?.getBoundingClientRect().width || 300;
+			const cardWidth = events[ 0 ]?.getBoundingClientRect().width || 300;
 			wrapper.scrollBy( {
 				left: cardWidth * direction,
 				behavior: 'smooth',
@@ -95,11 +93,11 @@ export function initCarousel( calendar: HTMLElement ): void {
 				{ passive: false }
 			);
 
-			( [ 'mouseup', 'mouseleave', 'touchend', 'touchcancel' ] as const ).forEach(
-				function ( event ) {
-					chevron.addEventListener( event, stopHold );
-				}
-			);
+			(
+				[ 'mouseup', 'mouseleave', 'touchend', 'touchcancel' ] as const
+			 ).forEach( function ( event ) {
+				chevron.addEventListener( event, stopHold );
+			} );
 		};
 
 		const updateIndicators = function (): void {
@@ -162,8 +160,7 @@ export function initCarousel( calendar: HTMLElement ): void {
 					const halfWindow = Math.floor( MAX_VISIBLE_DOTS / 2 );
 					const dotUnit = DOT_WIDTH + DOT_GAP;
 					const totalDotsWidth =
-						totalEvents * DOT_WIDTH +
-						( totalEvents - 1 ) * DOT_GAP;
+						totalEvents * DOT_WIDTH + ( totalEvents - 1 ) * DOT_GAP;
 					const visibleWidth =
 						MAX_VISIBLE_DOTS * DOT_WIDTH +
 						( MAX_VISIBLE_DOTS - 1 ) * DOT_GAP;
@@ -173,17 +170,13 @@ export function initCarousel( calendar: HTMLElement ): void {
 
 					if ( activeIndex <= halfWindow ) {
 						shift = 0;
-					} else if (
-						activeIndex >=
-						totalEvents - halfWindow
-					) {
+					} else if ( activeIndex >= totalEvents - halfWindow ) {
 						shift = maxShift;
 					} else {
 						shift = ( activeIndex - halfWindow ) * dotUnit;
 					}
 
-					track.style.transform =
-						'translateX(-' + shift + 'px)';
+					track.style.transform = 'translateX(-' + shift + 'px)';
 				} else {
 					track.style.transform = '';
 				}
@@ -192,8 +185,7 @@ export function initCarousel( calendar: HTMLElement ): void {
 				const useDesktopCollapsed =
 					totalEvents > DESKTOP_MAX_VISIBLE_DOTS;
 
-				const maxScroll =
-					wrapper.scrollWidth - wrapper.clientWidth;
+				const maxScroll = wrapper.scrollWidth - wrapper.clientWidth;
 				const scrollProgress =
 					maxScroll > 0 ? wrapper.scrollLeft / maxScroll : 0;
 				const visibleCards = Math.floor(
@@ -214,15 +206,13 @@ export function initCarousel( calendar: HTMLElement ): void {
 
 				if ( useDesktopCollapsed ) {
 					const rangeMidpoint =
-						firstActiveIndex +
-						Math.floor( visibleCards / 2 );
+						firstActiveIndex + Math.floor( visibleCards / 2 );
 					const halfWindow = Math.floor(
 						DESKTOP_MAX_VISIBLE_DOTS / 2
 					);
 					const dotUnit = DOT_WIDTH + DOT_GAP;
 					const totalDotsWidth =
-						totalEvents * DOT_WIDTH +
-						( totalEvents - 1 ) * DOT_GAP;
+						totalEvents * DOT_WIDTH + ( totalEvents - 1 ) * DOT_GAP;
 					const visibleWidth =
 						DESKTOP_MAX_VISIBLE_DOTS * DOT_WIDTH +
 						( DESKTOP_MAX_VISIBLE_DOTS - 1 ) * DOT_GAP;
@@ -231,18 +221,13 @@ export function initCarousel( calendar: HTMLElement ): void {
 					let shift: number;
 					if ( rangeMidpoint <= halfWindow ) {
 						shift = 0;
-					} else if (
-						rangeMidpoint >=
-						totalEvents - halfWindow
-					) {
+					} else if ( rangeMidpoint >= totalEvents - halfWindow ) {
 						shift = maxShift;
 					} else {
-						shift =
-							( rangeMidpoint - halfWindow ) * dotUnit;
+						shift = ( rangeMidpoint - halfWindow ) * dotUnit;
 					}
 
-					track.style.transform =
-						'translateX(-' + shift + 'px)';
+					track.style.transform = 'translateX(-' + shift + 'px)';
 				} else {
 					track.style.transform = '';
 				}
@@ -263,8 +248,7 @@ export function initCarousel( calendar: HTMLElement ): void {
 		};
 
 		const setupIndicators = function (): void {
-			const hasOverflow =
-				wrapper.scrollWidth > wrapper.clientWidth;
+			const hasOverflow = wrapper.scrollWidth > wrapper.clientWidth;
 
 			indicators = group.querySelector< HTMLElement >(
 				'.data-machine-carousel-indicators'
@@ -298,15 +282,13 @@ export function initCarousel( calendar: HTMLElement ): void {
 
 			if ( ! indicators ) {
 				indicators = document.createElement( 'div' );
-				indicators.className =
-					'data-machine-carousel-indicators';
+				indicators.className = 'data-machine-carousel-indicators';
 				group.appendChild( indicators );
 			}
 			indicators.innerHTML = '';
 
-			const isMobileScreen = window.matchMedia(
-				'(max-width: 768px)'
-			).matches;
+			const isMobileScreen =
+				window.matchMedia( '(max-width: 768px)' ).matches;
 			const maxDotsForViewport = isMobileScreen
 				? MAX_VISIBLE_DOTS
 				: DESKTOP_MAX_VISIBLE_DOTS;

--- a/inc/Blocks/Calendar/src/modules/date-group-renderer.ts
+++ b/inc/Blocks/Calendar/src/modules/date-group-renderer.ts
@@ -37,10 +37,7 @@
  */
 import { renderEventCard } from './event-renderer';
 
-import type {
-	CalendarEventItem,
-	CalendarEventOccurrence,
-} from '../types';
+import type { CalendarEventItem, CalendarEventOccurrence } from '../types';
 
 /**
  * Render a complete date group with its embedded event cards.

--- a/inc/Blocks/Calendar/src/modules/day-loader.ts
+++ b/inc/Blocks/Calendar/src/modules/day-loader.ts
@@ -293,9 +293,7 @@ function getDateFromWrapper( wrapper: HTMLElement ): string | null {
 	return dateGroup?.dataset.date || null;
 }
 
-function getArchiveContext(
-	calendar: HTMLElement
-): Partial< ArchiveContext > {
+function getArchiveContext( calendar: HTMLElement ): Partial< ArchiveContext > {
 	const taxonomy = calendar.dataset.archiveTaxonomy || '';
 	const termId = calendar.dataset.archiveTermId || '';
 

--- a/inc/Blocks/Calendar/src/modules/event-renderer.ts
+++ b/inc/Blocks/Calendar/src/modules/event-renderer.ts
@@ -134,7 +134,8 @@ export function renderEventCard(
 	// Server-filtered class list (runs `data_machine_events_more_info_button_classes`),
 	// falling back to the default class only when absent. See #381.
 	moreInfo.className =
-		( event.button_classes || '' ).trim() || 'data-machine-more-info-button';
+		( event.button_classes || '' ).trim() ||
+		'data-machine-more-info-button';
 	moreInfo.textContent = 'More Info';
 	meta.appendChild( moreInfo );
 

--- a/inc/Blocks/Calendar/src/modules/filter-modal.test.ts
+++ b/inc/Blocks/Calendar/src/modules/filter-modal.test.ts
@@ -79,16 +79,25 @@ describe( 'dynamic filter modal requests', () => {
 	it( 'sends search, scope, date, geo, and opaque scope token constraints', async () => {
 		mockFetch.mockResolvedValue( response( 'Matching venue' ) );
 		initFilterModal( calendar, jest.fn(), jest.fn() );
-		calendar.querySelector< HTMLButtonElement >( '.data-machine-taxonomy-filter-btn' )!.click();
+		calendar
+			.querySelector< HTMLButtonElement >(
+				'.data-machine-taxonomy-filter-btn'
+			)!
+			.click();
 		await flush();
 
-		const url = new URL( mockFetch.mock.calls[ 0 ][ 0 ], window.location.origin );
+		const url = new URL(
+			mockFetch.mock.calls[ 0 ][ 0 ],
+			window.location.origin
+		);
 		expect( url.searchParams.get( 'event_search' ) ).toBe( 'jam' );
 		expect( url.searchParams.get( 'scope' ) ).toBe( 'this-week' );
 		expect( url.searchParams.get( 'date_start' ) ).toBe( '2026-07-19' );
 		expect( url.searchParams.get( 'date_end' ) ).toBe( '2026-07-20' );
 		expect( url.searchParams.get( 'lat' ) ).toBe( '32.78' );
-		expect( url.searchParams.get( 'scope_token' ) ).toBe( 'opaque.signed.token' );
+		expect( url.searchParams.get( 'scope_token' ) ).toBe(
+			'opaque.signed.token'
+		);
 	} );
 
 	it( 'aborts the previous request and ignores its out-of-order response', async () => {
@@ -104,7 +113,8 @@ describe( 'dynamic filter modal requests', () => {
 		trigger.click();
 		trigger.click();
 
-		const firstSignal = mockFetch.mock.calls[ 0 ][ 1 ].signal as AbortSignal;
+		const firstSignal = mockFetch.mock.calls[ 0 ][ 1 ]
+			.signal as AbortSignal;
 		expect( firstSignal.aborted ).toBe( true );
 		latest.resolve( response( 'Latest venue', 2 ) );
 		await flush();
@@ -114,23 +124,34 @@ describe( 'dynamic filter modal requests', () => {
 		expect( calendar.textContent ).toContain( 'Latest venue' );
 		expect( calendar.textContent ).not.toContain( 'Stale venue' );
 		expect(
-			calendar.querySelector< HTMLElement >( '.data-machine-filter-loading' )!
-				.style.display
+			calendar.querySelector< HTMLElement >(
+				'.data-machine-filter-loading'
+			)!.style.display
 		).toBe( 'none' );
 	} );
 
 	it( 'retains prior options and offers retry after a refresh failure', async () => {
 		mockFetch.mockResolvedValueOnce( response( 'Usable venue' ) );
 		initFilterModal( calendar, jest.fn(), jest.fn() );
-		calendar.querySelector< HTMLButtonElement >( '.data-machine-taxonomy-filter-btn' )!.click();
+		calendar
+			.querySelector< HTMLButtonElement >(
+				'.data-machine-taxonomy-filter-btn'
+			)!
+			.click();
 		await flush();
 
 		mockFetch.mockRejectedValueOnce( new Error( 'network failure' ) );
-		calendar.querySelector< HTMLInputElement >( '.data-machine-term-checkbox' )!.click();
+		calendar
+			.querySelector< HTMLInputElement >( '.data-machine-term-checkbox' )!
+			.click();
 		await flush();
 
 		expect( calendar.textContent ).toContain( 'Usable venue' );
-		expect( calendar.textContent ).toContain( 'Previous options are still available' );
-		expect( calendar.querySelector( '.data-machine-filter-retry' ) ).not.toBeNull();
+		expect( calendar.textContent ).toContain(
+			'Previous options are still available'
+		);
+		expect(
+			calendar.querySelector( '.data-machine-filter-retry' )
+		).not.toBeNull();
 	} );
 } );

--- a/inc/Blocks/Calendar/src/modules/filter-modal.ts
+++ b/inc/Blocks/Calendar/src/modules/filter-modal.ts
@@ -118,9 +118,7 @@ export function initFilterModal(
 		const target = e.target as HTMLElement;
 		if (
 			target === modal ||
-			target.classList.contains(
-				'data-machine-taxonomy-modal-overlay'
-			)
+			target.classList.contains( 'data-machine-taxonomy-modal-overlay' )
 		) {
 			closeModal();
 		}
@@ -220,10 +218,7 @@ export function destroyFilterModal( calendar: HTMLElement ): void {
 
 	if ( modal._closeBtns && modal._closeModalHandler ) {
 		modal._closeBtns.forEach( function ( btn ) {
-			btn.removeEventListener(
-				'click',
-				modal._closeModalHandler!
-			);
+			btn.removeEventListener( 'click', modal._closeModalHandler! );
 		} );
 	}
 
@@ -239,17 +234,11 @@ export function destroyFilterModal( calendar: HTMLElement ): void {
 	}
 
 	if ( modal._applyBtn && modal._applyHandler ) {
-		modal._applyBtn.removeEventListener(
-			'click',
-			modal._applyHandler
-		);
+		modal._applyBtn.removeEventListener( 'click', modal._applyHandler );
 	}
 
 	if ( modal._resetBtn && modal._resetHandler ) {
-		modal._resetBtn.removeEventListener(
-			'click',
-			modal._resetHandler
-		);
+		modal._resetBtn.removeEventListener( 'click', modal._resetHandler );
 	}
 
 	delete modal._openModalHandler;
@@ -372,7 +361,8 @@ async function loadFilters(
 function cancelFilterRequest( modal: ModalElement ): void {
 	modal._filterAbortController?.abort();
 	modal._filterAbortController = undefined;
-	modal._filterRequestGeneration = ( modal._filterRequestGeneration ?? 0 ) + 1;
+	modal._filterRequestGeneration =
+		( modal._filterRequestGeneration ?? 0 ) + 1;
 	const loading = modal.querySelector< HTMLElement >(
 		'.data-machine-filter-loading'
 	);
@@ -388,7 +378,8 @@ function renderFilterError(
 	container.querySelector( '.data-machine-filter-error' )?.remove();
 	const error = document.createElement( 'div' );
 	error.className = 'data-machine-filter-error';
-	error.innerHTML = '<p>Could not refresh filters. Previous options are still available.</p>';
+	error.innerHTML =
+		'<p>Could not refresh filters. Previous options are still available.</p>';
 	const retry = document.createElement( 'button' );
 	retry.type = 'button';
 	retry.className = 'data-machine-filter-retry';
@@ -502,9 +493,7 @@ function flattenHierarchy(
 	terms.forEach( ( term ) => {
 		flat.push( { ...term, level } );
 		if ( term.children && term.children.length > 0 ) {
-			flat = flat.concat(
-				flattenHierarchy( term.children, level + 1 )
-			);
+			flat = flat.concat( flattenHierarchy( term.children, level + 1 ) );
 		}
 	} );
 

--- a/inc/Blocks/Calendar/src/modules/filter-state.ts
+++ b/inc/Blocks/Calendar/src/modules/filter-state.ts
@@ -59,9 +59,7 @@ class FilterStateManager {
 		const filters: TaxFilters = {};
 
 		params.forEach( ( value, key ) => {
-			const match = key.match(
-				/^tax_filter\[([^\]]+)\]\[(?:\d+)?\]$/
-			);
+			const match = key.match( /^tax_filter\[([^\]]+)\]\[(?:\d+)?\]$/ );
 			if ( match ) {
 				const taxonomy = match[ 1 ];
 				if ( ! filters[ taxonomy ] ) {
@@ -104,8 +102,9 @@ class FilterStateManager {
 				lng: urlLng,
 				radius: parseInt( params.get( 'radius' ) || '25', 10 ) || 25,
 				radius_unit:
-					( params.get( 'radius_unit' ) as GeoContext[ 'radius_unit' ] ) ||
-					'mi',
+					( params.get(
+						'radius_unit'
+					) as GeoContext[ 'radius_unit' ] ) || 'mi',
 			};
 		}
 
@@ -120,8 +119,8 @@ class FilterStateManager {
 					parseInt( this.calendar.dataset.geoRadius || '25', 10 ) ||
 					25,
 				radius_unit:
-					( this.calendar.dataset.geoRadiusUnit as GeoContext[ 'radius_unit' ] ) ||
-					'mi',
+					( this.calendar.dataset
+						.geoRadiusUnit as GeoContext[ 'radius_unit' ] ) || 'mi',
 			};
 		}
 
@@ -182,13 +181,14 @@ class FilterStateManager {
 	 * Reads from: search input, date picker, filter checkboxes, location input.
 	 * @param datePicker
 	 */
-	buildParams( datePicker: FlatpickrInstance | null = null ): URLSearchParams {
+	buildParams(
+		datePicker: FlatpickrInstance | null = null
+	): URLSearchParams {
 		const params = new URLSearchParams();
 
-		const searchInput =
-			this.calendar.querySelector< HTMLInputElement >(
-				'.data-machine-events-search-input'
-			);
+		const searchInput = this.calendar.querySelector< HTMLInputElement >(
+			'.data-machine-events-search-input'
+		);
 		if ( searchInput?.value ) {
 			params.set( 'event_search', searchInput.value );
 		}
@@ -214,7 +214,10 @@ class FilterStateManager {
 			}
 		}
 
-		if ( datePicker?.selectedDates?.length && datePicker.selectedDates.length > 0 ) {
+		if (
+			datePicker?.selectedDates?.length &&
+			datePicker.selectedDates.length > 0
+		) {
 			const startDate = datePicker.selectedDates[ 0 ];
 			const endDate = datePicker.selectedDates[ 1 ] || startDate;
 
@@ -424,10 +427,7 @@ class FilterStateManager {
 	saveGeoToStorage( geo: StoredGeo ): void {
 		try {
 			if ( geo.lat && geo.lng ) {
-				localStorage.setItem(
-					GEO_STORAGE_KEY,
-					JSON.stringify( geo )
-				);
+				localStorage.setItem( GEO_STORAGE_KEY, JSON.stringify( geo ) );
 			} else {
 				localStorage.removeItem( GEO_STORAGE_KEY );
 			}

--- a/inc/Blocks/Calendar/src/modules/lazy-render.ts
+++ b/inc/Blocks/Calendar/src/modules/lazy-render.ts
@@ -33,9 +33,7 @@ export function initLazyRender( calendar: HTMLElement ): void {
 			function ( entries ) {
 				entries.forEach( function ( entry ) {
 					if ( entry.isIntersecting ) {
-						hydratePlaceholder(
-							entry.target as HTMLElement
-						);
+						hydratePlaceholder( entry.target as HTMLElement );
 						observer.unobserve( entry.target );
 					}
 				} );
@@ -155,9 +153,7 @@ function hydratePlaceholder( placeholder: HTMLElement ): void {
 		'<a href="' +
 		escapeAttr( data.permalink ) +
 		'" class="' +
-		escapeAttr(
-			data.button_classes || 'data-machine-more-info-button'
-		) +
+		escapeAttr( data.button_classes || 'data-machine-more-info-button' ) +
 		'">More Info</a>' +
 		'</div>' +
 		'</div>';

--- a/inc/Blocks/Calendar/src/modules/load-more.ts
+++ b/inc/Blocks/Calendar/src/modules/load-more.ts
@@ -195,10 +195,7 @@ function readPaginationBounds( nav: HTMLElement ): {
 		'.page-numbers.current'
 	);
 	if ( currentEl ) {
-		const parsed = parseInt(
-			( currentEl.textContent || '' ).trim(),
-			10
-		);
+		const parsed = parseInt( ( currentEl.textContent || '' ).trim(), 10 );
 		if ( ! isNaN( parsed ) && parsed > 0 ) {
 			currentPage = parsed;
 		}
@@ -240,14 +237,8 @@ function createClickHandler(
 	return async function ( e: Event ): Promise< void > {
 		e.preventDefault();
 
-		const currentPage = parseInt(
-			button.dataset.currentPage || '1',
-			10
-		);
-		const totalPages = parseInt(
-			button.dataset.totalPages || '1',
-			10
-		);
+		const currentPage = parseInt( button.dataset.currentPage || '1', 10 );
+		const totalPages = parseInt( button.dataset.totalPages || '1', 10 );
 
 		if ( currentPage >= totalPages ) {
 			button.hidden = true;
@@ -387,10 +378,7 @@ async function fetchPage(
  * @param calendar
  * @param data
  */
-function appendPage(
-	calendar: HTMLElement,
-	data: CalendarDataResponse
-): void {
+function appendPage( calendar: HTMLElement, data: CalendarDataResponse ): void {
 	const content = calendar.querySelector< HTMLElement >(
 		'.data-machine-events-content'
 	);
@@ -523,7 +511,11 @@ function isPastMode( calendar: HTMLElement ): boolean {
  * @param value
  */
 function cssEscape( value: string ): string {
-	if ( typeof window !== 'undefined' && typeof window.CSS !== 'undefined' && typeof window.CSS.escape === 'function' ) {
+	if (
+		typeof window !== 'undefined' &&
+		typeof window.CSS !== 'undefined' &&
+		typeof window.CSS.escape === 'function'
+	) {
 		return window.CSS.escape( value );
 	}
 	return value.replace( /[^a-zA-Z0-9_-]/g, ( ch ) => '\\' + ch );

--- a/inc/Blocks/Calendar/src/modules/month-grid-renderer.ts
+++ b/inc/Blocks/Calendar/src/modules/month-grid-renderer.ts
@@ -85,26 +85,23 @@ export function renderMonthGrid(
 	baseUrl: string
 ): HTMLElement {
 	const today = formatLocalDate( new Date() );
-	const parsedMonth = parseMonth( month ) ?? parseMonth( today.slice( 0, 7 ) );
+	const parsedMonth =
+		parseMonth( month ) ?? parseMonth( today.slice( 0, 7 ) );
 	const visibleMonthLabel = parsedMonth
 		? new Date( parsedMonth.year, parsedMonth.month0, 1 ).toLocaleString(
 				undefined,
 				{ month: 'long', year: 'numeric' }
-			)
+		  )
 		: '';
 
 	const monthString = parsedMonth
 		? `${ String( parsedMonth.year ).padStart( 4, '0' ) }-${ String(
 				parsedMonth.month0 + 1
-			).padStart( 2, '0' ) }`
+		  ).padStart( 2, '0' ) }`
 		: today.slice( 0, 7 );
 
-	const prevMonth = parsedMonth
-		? shiftMonth( parsedMonth, -1 )
-		: monthString;
-	const nextMonth = parsedMonth
-		? shiftMonth( parsedMonth, 1 )
-		: monthString;
+	const prevMonth = parsedMonth ? shiftMonth( parsedMonth, -1 ) : monthString;
+	const nextMonth = parsedMonth ? shiftMonth( parsedMonth, 1 ) : monthString;
 	const todayMonth = today.slice( 0, 7 );
 
 	const eventsById = new Map< number, CalendarEventItem >();
@@ -243,12 +240,7 @@ function buildRows(
 			} );
 		}
 
-		const ribbons = buildRowRibbons(
-			rowStart,
-			rowEnd,
-			byDate,
-			eventsById
-		);
+		const ribbons = buildRowRibbons( rowStart, rowEnd, byDate, eventsById );
 
 		rows.push( {
 			start_date: formatLocalDate( rowStart ),
@@ -369,11 +361,7 @@ function parseDateOnly( s: string ): Date | null {
 	if ( ! m ) {
 		return null;
 	}
-	return new Date(
-		Number( m[ 1 ] ),
-		Number( m[ 2 ] ) - 1,
-		Number( m[ 3 ] )
-	);
+	return new Date( Number( m[ 1 ] ), Number( m[ 2 ] ) - 1, Number( m[ 3 ] ) );
 }
 
 /* ------------------------------------------------------------------ */
@@ -457,7 +445,10 @@ function renderRow( row: RowPayload, rowIndex: number ): HTMLElement {
 		( max, r ) => Math.max( max, r.lane + 1 ),
 		0
 	);
-	el.style.setProperty( '--data-machine-month-grid-lanes', String( laneCount ) );
+	el.style.setProperty(
+		'--data-machine-month-grid-lanes',
+		String( laneCount )
+	);
 
 	row.cells.forEach( ( cell ) => {
 		el.appendChild( renderCell( cell ) );

--- a/inc/Blocks/Calendar/src/modules/navigation.ts
+++ b/inc/Blocks/Calendar/src/modules/navigation.ts
@@ -85,5 +85,3 @@ function initPastUpcomingButtons(
 		}
 	} );
 }
-
-

--- a/inc/Blocks/EventDetails/package-lock.json
+++ b/inc/Blocks/EventDetails/package-lock.json
@@ -7,6 +7,12 @@
     "": {
       "name": "dm-events-event-details",
       "version": "0.12.1",
+      "dependencies": {
+        "@wordpress/block-editor": "^16.0.0",
+        "@wordpress/blocks": "^15.24.0",
+        "@wordpress/components": "^37.0.0",
+        "@wordpress/i18n": "^6.24.0"
+      },
       "devDependencies": {
         "@wordpress/eslint-plugin": "^25.7.0",
         "@wordpress/scripts": "31.1.0",
@@ -27,11 +33,98 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@ariakit/components": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@ariakit/components/-/components-0.1.8.tgz",
+      "integrity": "sha512-Lwqh7wCjgQxNPYP8fU4mAXXtEVoN6Zv5jwd+sRYlPf61l7SUbFCEnrXy3+M2FJYOx/3QWUOp/co/OQrDVPid4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/store": "0.1.7",
+        "@ariakit/utils": "0.1.5"
+      }
+    },
+    "node_modules/@ariakit/react": {
+      "version": "0.4.35",
+      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.35.tgz",
+      "integrity": "sha512-f/bCg+kw7YgBM5sElc5eHeACb8OxP54mN5w3igu6vg/JBFstDUBnhMeTWZU6NhOqMPUrZIgJYhry9i0Gl9TrVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/react-components": "0.3.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ariakit"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@ariakit/react-components": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@ariakit/react-components/-/react-components-0.3.4.tgz",
+      "integrity": "sha512-jEfVkDQi99Zdv9SGnTRWGxfvhLXMHHuKXRw57D/uCA8ziKzMNH0+0ZhNDNKnskfPxBsZjbhtSsBXsCeMp1W1ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/components": "0.1.8",
+        "@ariakit/react-store": "0.1.8",
+        "@ariakit/react-utils": "0.2.3",
+        "@ariakit/store": "0.1.7",
+        "@ariakit/utils": "0.1.5",
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@ariakit/react-store": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@ariakit/react-store/-/react-store-0.1.8.tgz",
+      "integrity": "sha512-VYZ1LTUVMrNUi4jP37Npvhe3mcAzKdznqnBSVeh1Jjsbcgw0JlN88oy6UpdoJPvLKWOZHVYr62Sqn7xE0GrsqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/react-utils": "0.2.3",
+        "@ariakit/store": "0.1.7",
+        "@ariakit/utils": "0.1.5",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@ariakit/react-utils": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@ariakit/react-utils/-/react-utils-0.2.3.tgz",
+      "integrity": "sha512-fDaheb/7QEusanZb2oRT7mO55GTpQUyBOdjvQF5RPh3/CM15lm0TejLKN5bl1obmU5HRuByvckQmQvSyr8n/dw==",
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/store": "0.1.7",
+        "@ariakit/utils": "0.1.5"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@ariakit/store": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@ariakit/store/-/store-0.1.7.tgz",
+      "integrity": "sha512-/GcxscA9QTo2F+IFbFPvoyj1N8hzXBnaYsQt9UxRiJgCFPQ2jIe4i6QgPXdOZEZUuqYdyuvjcQrg7MDm9vpvCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/utils": "0.1.5"
+      }
+    },
+    "node_modules/@ariakit/utils": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@ariakit/utils/-/utils-0.1.5.tgz",
+      "integrity": "sha512-BQebYH9nV1VZttZwoq/fsxcxIJjc8oW2bNV6yJDHLZ8OF8UtM15drFN0JOL8Jwn7jeeD7Ev+tIC8pUijJEditQ==",
+      "license": "MIT"
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
       "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.27.1",
@@ -106,7 +199,6 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
       "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.28.5",
@@ -210,7 +302,6 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -234,7 +325,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
       "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.27.1",
@@ -339,7 +429,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -349,7 +438,6 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -398,7 +486,6 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
       "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.5"
@@ -1916,11 +2003,19 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
       "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
@@ -1935,7 +2030,6 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
       "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
@@ -1954,7 +2048,6 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
       "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -1962,6 +2055,66 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@base-ui/react": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.6.0.tgz",
+      "integrity": "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@base-ui/utils": "0.3.1",
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@date-fns/tz": "^1.2.0",
+        "@types/react": "^17 || ^18 || ^19",
+        "date-fns": "^4.0.0",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@date-fns/tz": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@base-ui/utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.1.tgz",
+      "integrity": "sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@floating-ui/utils": "^0.2.11",
+        "reselect": "^5.2.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -1975,7 +2128,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.6.tgz",
       "integrity": "sha512-7e8SScMocHxcAb8YhtkbMhGG+EKLRIficb1F5sjvhSYsWTZGxvg4KIDp8kgxnV2PUJ3ddPe6J9QESjKvBWRDkg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@cacheable/utils": "^2.3.2",
@@ -1988,7 +2141,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.0.tgz",
       "integrity": "sha512-KT01GjzV6AQD5+IYrcpoYLkCu1Jod3nau1Z7EsEuViO3TZGRacSbO9MfHmbJ1WaOXFtWLxPVj169cn2WNKPkIg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "hashery": "^1.2.0",
@@ -2005,7 +2158,7 @@
       "version": "5.5.5",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.5.tgz",
       "integrity": "sha512-FA5LmZVF1VziNc0bIdCSA1IoSVnDCqE8HJIZZv2/W8YmoAM50+tnUgJR/gQZwEeIMleuIOnRnHA/UaZRNeV4iQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
@@ -2015,7 +2168,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.3.2.tgz",
       "integrity": "sha512-8kGE2P+HjfY8FglaOiW+y8qxcaQAfAhVML+i66XJR3YX5FtyDqn6Txctr3K2FrbxLKixRRYYBWMbuGciOhYNDg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "hashery": "^1.2.0",
@@ -2026,7 +2179,7 @@
       "version": "5.5.5",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.5.tgz",
       "integrity": "sha512-FA5LmZVF1VziNc0bIdCSA1IoSVnDCqE8HJIZZv2/W8YmoAM50+tnUgJR/gQZwEeIMleuIOnRnHA/UaZRNeV4iQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
@@ -2036,7 +2189,7 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
       "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2059,7 +2212,7 @@
       "version": "1.0.21",
       "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.21.tgz",
       "integrity": "sha512-plP8N8zKfEZ26figX4Nvajx8DuzfuRpLTqglQ5d0chfnt35Qt3X+m6ASZ+rG0D0kxe/upDVNwSIVJP5n4FuNfw==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2079,7 +2232,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
       "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2119,6 +2272,18 @@
         "@csstools/css-tokenizer": "^3.0.1"
       }
     },
+    "node_modules/@date-fns/tz": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.5.0.tgz",
+      "integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==",
+      "license": "MIT"
+    },
+    "node_modules/@date-fns/utc": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@date-fns/utc/-/utc-2.1.1.tgz",
+      "integrity": "sha512-SlJDfG6RPeEX8wEVv6ZB3kak4MmbtyiI2qX/5zuKdordbrhB/iaJ58GVMZgJ6P1sJaM1gMgENFYYeg1JWrCFrA==",
+      "license": "MIT"
+    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -2133,7 +2298,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.2.1.tgz",
       "integrity": "sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2173,6 +2338,180 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/css": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
+      "integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.13.5",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/react": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/styled": {
+      "version": "11.14.1",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
+      "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/is-prop-valid": "^1.3.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0-rc.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+      "license": "MIT"
     },
     "node_modules/@es-joy/jsdoccomment": {
       "version": "0.50.2",
@@ -2479,6 +2818,44 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.8.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+      "license": "MIT"
     },
     "node_modules/@formatjs/ecma402-abstract": {
       "version": "2.3.6",
@@ -3053,7 +3430,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -3064,7 +3440,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -3085,14 +3460,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -3103,7 +3476,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
       "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@leichtgewicht/ip-codec": {
@@ -3140,7 +3513,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -3154,7 +3527,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -3164,7 +3537,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -4180,6 +4553,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@preact/signals": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.3.4.tgz",
+      "integrity": "sha512-TPMkStdT0QpSc8FpB63aOwXoSiZyIrPsP9Uj347KopdS6olZdAYeeird/5FZv/M1Yc1ge5qstub2o8VDbvkT4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@preact/signals-core": "^1.7.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact": "10.x"
+      }
+    },
+    "node_modules/@preact/signals-core": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.4.tgz",
+      "integrity": "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/@prisma/instrumentation": {
       "version": "6.11.1",
       "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-6.11.1.tgz",
@@ -4227,6 +4626,392 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.23.tgz",
+      "integrity": "sha512-Ksw4WeROkO4rC9k/onilX/Ao2Cr1ku1unMNH+XSCcP4jSXYu7HDsg9n4ojMjVb22XpYjAQ9qfrFlVbru1vXDUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
+      "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-effect-event": "0.0.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
+      "integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
+      "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+      "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
+      "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
+      "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+      "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-spring/animated": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.5.tgz",
+      "integrity": "sha512-Tqrwz7pIlsSDITzxoLS3n/v/YCUHQdOIKtOJf4yL6kYVSDTSmVK1LI1Q3M/uu2Sx4X3pIWF3xLUhlsA6SPNTNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/core": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.7.5.tgz",
+      "integrity": "sha512-rmEqcxRcu7dWh7MnCcMXLvrf6/SDlSokLaLTxiPlAYi11nN3B5oiCUAblO72o+9z/87j2uzxa2Inm8UbLjXA+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~9.7.5",
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-spring/donate"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/rafz": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.7.5.tgz",
+      "integrity": "sha512-5ZenDQMC48wjUzPAm1EtwQ5Ot3bLIAwwqP2w2owG5KoNdNHpEJV263nGhCeKKmuA3vG2zLLOdu3or6kuDjA6Aw==",
+      "license": "MIT"
+    },
+    "node_modules/@react-spring/shared": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.7.5.tgz",
+      "integrity": "sha512-wdtoJrhUeeyD/PP/zo+np2s1Z820Ohr/BbuVYv+3dVLW7WctoiN7std8rISoYoHpUXtbkpesSKuPIw/6U1w1Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/rafz": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/types": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.7.5.tgz",
+      "integrity": "sha512-HVj7LrZ4ReHWBimBvu2SKND3cDVUPWKLqRTmWe/fNY6o1owGOX0cAHbdPDTMelgBlVbrTKrre6lFkhqGZErK/g==",
+      "license": "MIT"
+    },
+    "node_modules/@react-spring/web": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-9.7.5.tgz",
+      "integrity": "sha512-lmvqGwpe+CSttsWNZVr+Dg62adtKhauGwLyGE/RRyZ8AAMLgb9x3NDMA5RMElXo+IMyTkPp7nxTB8ZQlmhb6JQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~9.7.5",
+        "@react-spring/core": "~9.7.5",
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -4665,11 +5450,19 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/@tabby_ai/hijri-converter": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@tabby_ai/hijri-converter/-/hijri-converter-1.0.5.tgz",
+      "integrity": "sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@tannin/compile": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.1.0.tgz",
       "integrity": "sha512-n8m9eNDfoNZoxdvWiTfW/hSPhehzLJ3zW7f8E7oT6mCROoMNWCB4TYtv041+2FMAxweiE0j7i1jubQU4MEC/Gg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tannin/evaluate": "^1.2.0",
@@ -4680,14 +5473,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.2.0.tgz",
       "integrity": "sha512-3ioXvNowbO/wSrxsDG5DKIMxC81P0QrQTYai8zFNY+umuoHWRPbQ/TuuDEOju9E+jQDXmj6yI5GyejNuh8I+eg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tannin/plural-forms": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.1.0.tgz",
       "integrity": "sha512-xl9R2mDZO/qiHam1AgMnAES6IKIg7OBhcXqy6eDsRCdXuxAFPcjrej9HMjyCLE0DJ/8cHf0i5OQTstuBRhpbHw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tannin/compile": "^1.1.0"
@@ -4697,14 +5488,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.1.0.tgz",
       "integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tannin/sprintf": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@tannin/sprintf/-/sprintf-1.3.3.tgz",
       "integrity": "sha512-RwARl+hFwhzy0tg9atWcchLFvoQiOh4rrP7uG2N5E4W80BPCUX0ElcUR9St43fxB9EfjsW2df9Qp+UsTbvQDjA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tootallnate/once": {
@@ -4832,6 +5621,21 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/dom-mediacapture-transform": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-transform/-/dom-mediacapture-transform-0.1.12.tgz",
+      "integrity": "sha512-d7/QsLRwF864A5mgIM/YrfiglHoYn7zgCcAoJgW404r+2DwnNr7EBbLnCWpmOMgH8y0te73L1AV6H1bmauaWFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/dom-webcodecs": "*"
+      }
+    },
+    "node_modules/@types/dom-webcodecs": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.13.tgz",
+      "integrity": "sha512-O5hkiFIcjjszPIYyUSyvScyvrBoV3NOEEZx/pMlsu44TKzWNkLVBBxnxJz42in5n3QIolYOcBYFCPZZ0h8SkwQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -4909,6 +5713,18 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/gradient-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-1.1.0.tgz",
+      "integrity": "sha512-SaEcbgQscHtGJ1QL+ajgDTmmqU2f6T+00jZRcFlVHUW2Asivc84LNUev/UQFyu117AsdyrtI+qpwLvgjJXJxmw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/highlight-words-core": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/highlight-words-core/-/highlight-words-core-1.2.3.tgz",
+      "integrity": "sha512-PWNU/NR0CaYEsK38mcCTyDzeS2TlEGK9kRhRMz1i86jVAe836ZlA3gl6QYpu+CG6IpfNKTgWpEnJuRededvC0g==",
+      "license": "MIT"
     },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
@@ -4998,7 +5814,6 @@
       "version": "1.6.15",
       "resolved": "https://registry.npmjs.org/@types/mousetrap/-/mousetrap-1.6.15.tgz",
       "integrity": "sha512-qL0hyIMNPow317QWW/63RvL1x5MVMV+Ru3NaY9f/CuEpCqrmb7WeuK2071ZY5hczOnm38qExWM2i2WtkXLSqFw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/mysql": {
@@ -5042,7 +5857,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/pg": {
@@ -5071,7 +5885,6 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -5092,7 +5905,6 @@
       "version": "18.3.31",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -5103,7 +5915,6 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -5816,6 +6627,24 @@
         "win32"
       ]
     },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
+      }
+    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
@@ -6024,6 +6853,30 @@
         }
       }
     },
+    "node_modules/@wordpress/a11y": {
+      "version": "4.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.51.0.tgz",
+      "integrity": "sha512-ophPwL3J31JOA46koDonBz7EL1dMfpKLEj8crD2uCK5IYzvqlYJrLA0o+RfPUUHrbXa51qGBSZ/+Bprb6nao+g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/dom-ready": "^4.51.0",
+        "@wordpress/i18n": "^6.24.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/autop": {
+      "version": "4.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.51.0.tgz",
+      "integrity": "sha512-AjGhrqyBsAXOgLn1pN1+B11s6/Kkt7HnP5pk/FyFxQUxRZc0uRxTDt5dPoUdS+oyBAeW3tfKMos4/4s9+X5B+A==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
     "node_modules/@wordpress/babel-preset-default": {
       "version": "8.51.0",
       "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.51.0.tgz",
@@ -6059,6 +6912,185 @@
         "npm": ">=8.19.2"
       }
     },
+    "node_modules/@wordpress/blob": {
+      "version": "4.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.51.0.tgz",
+      "integrity": "sha512-x+Iti+wnsGTwCLwr8/Tbg/DyyWVnJ5OAQnUCCNLKM8nmEFApO4GY5feCSD9zkVCQZ3p7k+FMeJgUVuGa/d0beg==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/block-editor": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-16.0.0.tgz",
+      "integrity": "sha512-hH7w5gbgjwsYLPTw1JFqNTtEe+O2kHvbzoht4g5sUHGThKR7NrVMHuLnNS7iOcz+k1VZpVRjXrWJlBsEj2en2g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@react-spring/web": "^9.4.5",
+        "@wordpress/a11y": "^4.51.0",
+        "@wordpress/base-styles": "^11.0.0",
+        "@wordpress/blob": "^4.51.0",
+        "@wordpress/block-serialization-default-parser": "^5.51.0",
+        "@wordpress/blocks": "^15.24.0",
+        "@wordpress/commands": "^1.51.0",
+        "@wordpress/components": "^37.0.0",
+        "@wordpress/compose": "^8.4.0",
+        "@wordpress/data": "^10.51.0",
+        "@wordpress/dataviews": "^17.2.0",
+        "@wordpress/date": "^5.51.0",
+        "@wordpress/deprecated": "^4.51.0",
+        "@wordpress/dom": "^4.51.0",
+        "@wordpress/element": "^8.3.0",
+        "@wordpress/escape-html": "^3.51.0",
+        "@wordpress/global-styles-engine": "^1.18.0",
+        "@wordpress/hooks": "^4.51.0",
+        "@wordpress/html-entities": "^4.51.0",
+        "@wordpress/i18n": "^6.24.0",
+        "@wordpress/icons": "^15.2.0",
+        "@wordpress/image-cropper": "^1.15.0",
+        "@wordpress/interactivity": "^6.51.0",
+        "@wordpress/is-shallow-equal": "^5.51.0",
+        "@wordpress/keyboard-shortcuts": "^5.51.0",
+        "@wordpress/keycodes": "^4.51.0",
+        "@wordpress/notices": "^5.51.0",
+        "@wordpress/preferences": "^4.51.0",
+        "@wordpress/priority-queue": "^3.51.0",
+        "@wordpress/private-apis": "^1.51.0",
+        "@wordpress/rich-text": "^7.51.0",
+        "@wordpress/style-engine": "^2.51.0",
+        "@wordpress/token-list": "^3.51.0",
+        "@wordpress/ui": "^0.18.0",
+        "@wordpress/upload-media": "^0.36.0",
+        "@wordpress/url": "^4.51.0",
+        "@wordpress/warning": "^3.51.0",
+        "@wordpress/wordcount": "^4.51.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.9.3",
+        "deepmerge": "^4.3.1",
+        "diff": "^8.0.3",
+        "fast-deep-equal": "^3.1.3",
+        "memize": "^2.1.0",
+        "parsel-js": "^1.1.2",
+        "postcss": "^8.4.38",
+        "postcss-prefix-selector": "^1.16.0",
+        "postcss-urlrebase": "^1.4.0",
+        "react-autosize-textarea": "^7.1.0",
+        "react-easy-crop": "^5.4.2",
+        "remove-accents": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/block-editor/node_modules/@wordpress/base-styles": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-11.0.0.tgz",
+      "integrity": "sha512-w+n/AWSNfDx5RhPIpKCi7Iptn+8+Sll8uJhyx6X62zkkHDX51H2vZTU2XaXOQGx5U7xQcaVTbHjVDgYBwkU4Vg==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/block-editor/node_modules/react-autosize-textarea": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-7.1.0.tgz",
+      "integrity": "sha512-BHpjCDkuOlllZn3nLazY2F8oYO1tS2jHnWhcjTWQdcKiiMU6gHLNt/fzmqMSyerR0eTdKtfSIqtSeTtghNwS+g==",
+      "license": "MIT",
+      "dependencies": {
+        "autosize": "^4.0.2",
+        "line-height": "^0.3.1",
+        "prop-types": "^15.5.6"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
+        "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@wordpress/block-serialization-default-parser": {
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.51.0.tgz",
+      "integrity": "sha512-zcuJptrIG7VWP3N7uw3ACBS5Mdykhy3zAxZ+dMym8291b2O+dJf1JVlnr65G4AYhxahWA5MsmLENBLhwBgOH8w==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/blocks": {
+      "version": "15.24.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.24.0.tgz",
+      "integrity": "sha512-C/OseZS0Znx7Wqd/RGJdVXnn4z9lLfJ/SNehzyJ1ViiBTktDNS5RWiYAYJ+kwJ5unBbTy1KDXC9PGzR0Ib4Y5g==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/autop": "^4.51.0",
+        "@wordpress/blob": "^4.51.0",
+        "@wordpress/block-serialization-default-parser": "^5.51.0",
+        "@wordpress/data": "^10.51.0",
+        "@wordpress/deprecated": "^4.51.0",
+        "@wordpress/dom": "^4.51.0",
+        "@wordpress/element": "^8.3.0",
+        "@wordpress/hooks": "^4.51.0",
+        "@wordpress/html-entities": "^4.51.0",
+        "@wordpress/i18n": "^6.24.0",
+        "@wordpress/is-shallow-equal": "^5.51.0",
+        "@wordpress/private-apis": "^1.51.0",
+        "@wordpress/rich-text": "^7.51.0",
+        "@wordpress/shortcode": "^4.51.0",
+        "@wordpress/warning": "^3.51.0",
+        "change-case": "^4.1.2",
+        "colord": "^2.9.3",
+        "fast-deep-equal": "^3.1.3",
+        "hpq": "^1.3.0",
+        "is-plain-object": "^5.0.0",
+        "marked": "^18.0.3",
+        "memize": "^2.1.0",
+        "react-is": "^18.3.0",
+        "remove-accents": "^0.5.0",
+        "simple-html-tokenizer": "^0.5.7",
+        "uuid": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/blocks/node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
     "node_modules/@wordpress/browserslist-config": {
       "version": "6.51.0",
       "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.51.0.tgz",
@@ -6070,11 +7102,149 @@
         "npm": ">=8.19.2"
       }
     },
+    "node_modules/@wordpress/commands": {
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.51.0.tgz",
+      "integrity": "sha512-qn38b/rl1W84IHmcc9KOLSOmuXDwBMYcD7uPUKCChziy/NCb3e7njQzklKgK5sBC3JcgZrl1V5C605ejofd7lQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/base-styles": "^11.0.0",
+        "@wordpress/components": "^37.0.0",
+        "@wordpress/data": "^10.51.0",
+        "@wordpress/element": "^8.3.0",
+        "@wordpress/i18n": "^6.24.0",
+        "@wordpress/icons": "^15.2.0",
+        "@wordpress/keyboard-shortcuts": "^5.51.0",
+        "@wordpress/preferences": "^4.51.0",
+        "@wordpress/private-apis": "^1.51.0",
+        "@wordpress/warning": "^3.51.0",
+        "clsx": "^2.1.1",
+        "cmdk": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      }
+    },
+    "node_modules/@wordpress/commands/node_modules/@wordpress/base-styles": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-11.0.0.tgz",
+      "integrity": "sha512-w+n/AWSNfDx5RhPIpKCi7Iptn+8+Sll8uJhyx6X62zkkHDX51H2vZTU2XaXOQGx5U7xQcaVTbHjVDgYBwkU4Vg==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/components": {
+      "version": "37.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-37.0.0.tgz",
+      "integrity": "sha512-Lol3iUujNnn4uHxI4VARDVEJIFUKlBtZUMcSFWofiYRZc8aV5BplyKC+sRAhKm+KFNBQjZtqd4PdixtaOHuX6w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.32",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/styled": "^11.14.1",
+        "@emotion/utils": "^1.4.2",
+        "@floating-ui/react-dom": "^2.0.8",
+        "@types/gradient-parser": "^1.1.0",
+        "@types/highlight-words-core": "^1.2.1",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.51.0",
+        "@wordpress/base-styles": "^11.0.0",
+        "@wordpress/compose": "^8.4.0",
+        "@wordpress/date": "^5.51.0",
+        "@wordpress/deprecated": "^4.51.0",
+        "@wordpress/dom": "^4.51.0",
+        "@wordpress/element": "^8.3.0",
+        "@wordpress/escape-html": "^3.51.0",
+        "@wordpress/hooks": "^4.51.0",
+        "@wordpress/html-entities": "^4.51.0",
+        "@wordpress/i18n": "^6.24.0",
+        "@wordpress/icons": "^15.2.0",
+        "@wordpress/is-shallow-equal": "^5.51.0",
+        "@wordpress/keycodes": "^4.51.0",
+        "@wordpress/primitives": "^4.51.0",
+        "@wordpress/private-apis": "^1.51.0",
+        "@wordpress/rich-text": "^7.51.0",
+        "@wordpress/style-runtime": "^0.7.0",
+        "@wordpress/ui": "^0.18.0",
+        "@wordpress/warning": "^3.51.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.9.3",
+        "csstype": "^3.2.3",
+        "date-fns": "^4.1.0",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "^1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/components/node_modules/@wordpress/base-styles": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-11.0.0.tgz",
+      "integrity": "sha512-w+n/AWSNfDx5RhPIpKCi7Iptn+8+Sll8uJhyx6X62zkkHDX51H2vZTU2XaXOQGx5U7xQcaVTbHjVDgYBwkU4Vg==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/components/node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "license": "MIT"
+    },
+    "node_modules/@wordpress/components/node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
     "node_modules/@wordpress/compose": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.4.0.tgz",
       "integrity": "sha512-oVmRQ05Rlzh+W7oFb6CGmNm9SDozd3VEVYhXO4CcTpz0vkn7bEcwIMIdaKq49X8vORW1htJa/myBbYJATpamNg==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/mousetrap": "^1.6.8",
@@ -6102,6 +7272,111 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@wordpress/data": {
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.51.0.tgz",
+      "integrity": "sha512-KwlrgU+PGd+l4QyrwuCvbHE5HUC1CU6pqD19WZr+yOD1XRmIWZ+LZNwrEdFlhCu8aOG9+e131k1zmAMZign/mA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/compose": "^8.4.0",
+        "@wordpress/deprecated": "^4.51.0",
+        "@wordpress/element": "^8.3.0",
+        "@wordpress/is-shallow-equal": "^5.51.0",
+        "@wordpress/priority-queue": "^3.51.0",
+        "@wordpress/private-apis": "^1.51.0",
+        "@wordpress/redux-routine": "^5.51.0",
+        "deepmerge": "^4.3.1",
+        "equivalent-key-map": "^0.2.2",
+        "is-plain-object": "^5.0.0",
+        "is-promise": "^4.0.0",
+        "redux": "^5.0.1",
+        "rememo": "^4.0.2",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/dataviews": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-17.2.0.tgz",
+      "integrity": "sha512-EMLKjLmqoK7+TaFaqoFI2qSxichJO82NOUNh7a1B6UGvLN/XhLs7HGVFOrIBCHxgBC1ijo3EVgZ+JtiBMCE0aw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.32",
+        "@wordpress/a11y": "^4.51.0",
+        "@wordpress/base-styles": "^11.0.0",
+        "@wordpress/components": "^37.0.0",
+        "@wordpress/compose": "^8.4.0",
+        "@wordpress/data": "^10.51.0",
+        "@wordpress/date": "^5.51.0",
+        "@wordpress/deprecated": "^4.51.0",
+        "@wordpress/element": "^8.3.0",
+        "@wordpress/i18n": "^6.24.0",
+        "@wordpress/icons": "^15.2.0",
+        "@wordpress/keycodes": "^4.51.0",
+        "@wordpress/primitives": "^4.51.0",
+        "@wordpress/private-apis": "^1.51.0",
+        "@wordpress/rich-text": "^7.51.0",
+        "@wordpress/ui": "^0.18.0",
+        "@wordpress/warning": "^3.51.0",
+        "clsx": "^2.1.1",
+        "colord": "^2.9.3",
+        "date-fns": "^4.1.0",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "remove-accents": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/dataviews/node_modules/@wordpress/base-styles": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-11.0.0.tgz",
+      "integrity": "sha512-w+n/AWSNfDx5RhPIpKCi7Iptn+8+Sll8uJhyx6X62zkkHDX51H2vZTU2XaXOQGx5U7xQcaVTbHjVDgYBwkU4Vg==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/date": {
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.51.0.tgz",
+      "integrity": "sha512-clBSLSnP799BYGq97i9JX8oqNMAK37omFGig1+OFDxKqHj6iuM4UA9teOBlUFkHuldLc4I4MQcuLi/Ic6AF7fg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/deprecated": "^4.51.0",
+        "moment": "^2.29.4",
+        "moment-timezone": "^0.5.40"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/dependency-extraction-webpack-plugin": {
@@ -6132,7 +7407,6 @@
       "version": "4.51.0",
       "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.51.0.tgz",
       "integrity": "sha512-6pgnUvz7oQRwpJh+aM/dPBs5GBPTyOj+XKGeyzKPKHqbaWeSzkHVI9bhgs+Ajamn/jERK5TgH+VAq/gwfvfO+g==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@wordpress/hooks": "^4.51.0"
@@ -6146,11 +7420,20 @@
       "version": "4.51.0",
       "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.51.0.tgz",
       "integrity": "sha512-POkQoNBzLFlHaVzJakgF5X/xj4nERsLa5uTAvt3i7YFr9tep3uLtOFCJiiZM1vzO5iVtYSBWxmWyDkJPsOSy6g==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@wordpress/deprecated": "^4.51.0"
       },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/dom-ready": {
+      "version": "4.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.51.0.tgz",
+      "integrity": "sha512-O/ivmzG+o44CicTW+c17KBXlmjRoVp4VGIyyEQDD52H5YH+gX7i15FuEPk6G2e7Rqz4DCvCS5yD7eY9Zb3z1WA==",
+      "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
@@ -6181,7 +7464,6 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.3.0.tgz",
       "integrity": "sha512-D6Oawyq9RNL01RbpmBkx5dcE2CawU7p2cPxfeNVZkh/zEV5w9pi7HAwvFFqQA1jRT0sV4B62JcAAzuILALcQQw==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.3.27",
@@ -6202,7 +7484,6 @@
       "version": "3.51.0",
       "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.51.0.tgz",
       "integrity": "sha512-0jPCm9WqpB7S+mdhkjjikBzGo06xAgvmgwtSP1v44P5tKNGujcbsvKj+JW0m60FJxNBmaZPvGu2e/DlY4iljVQ==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -6319,11 +7600,42 @@
         "node": ">=10"
       }
     },
+    "node_modules/@wordpress/global-styles-engine": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/global-styles-engine/-/global-styles-engine-1.18.0.tgz",
+      "integrity": "sha512-kCZhrQwoYNpi4jds9bKVAIxD1c5PLDIIzaspnlsy5oOrYbH57wbfe1KTPNId6o0M0Fr7aszCI7wuyM/S4/tJ4Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/blocks": "^15.24.0",
+        "@wordpress/data": "^10.51.0",
+        "@wordpress/i18n": "^6.24.0",
+        "@wordpress/private-apis": "^1.51.0",
+        "@wordpress/style-engine": "^2.51.0",
+        "colord": "^2.9.3",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
     "node_modules/@wordpress/hooks": {
       "version": "4.51.0",
       "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.51.0.tgz",
       "integrity": "sha512-pTVZRT9mjEdrNNt7TyKw5hQhFUqntfTXVs/fboEDpmAi+PFWXoD8rPs3oZyRCVr/MDyE6OCv1mwEibI6AsRk3Q==",
-      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/html-entities": {
+      "version": "4.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.51.0.tgz",
+      "integrity": "sha512-rkWpUWbO7FlGzicae0tAlmDj6gTTh/SLXbuRKlPLvG4W8dokSuv+q491aes14VvDY9u4sFeRduQt+nXivfxpfQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -6334,7 +7646,6 @@
       "version": "6.24.0",
       "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.24.0.tgz",
       "integrity": "sha512-K4XmCyyyDOKH/5ea75P2L36ZiAvQTy4Hsa73Na3n6NzVjAwrrKZm4JJGf0t+OlThUG4D4GyfEv5szs5EeCA0lA==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@tannin/sprintf": "^1.3.2",
@@ -6351,11 +7662,77 @@
         "npm": ">=8.19.2"
       }
     },
+    "node_modules/@wordpress/icons": {
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-15.2.0.tgz",
+      "integrity": "sha512-g/1a4eTNH/mCluvmryNcYAg1GxsjY6xGjfGJRq3z44SEcB8jAZyEQtqdcGQ+o2kHelKhmmqS8WAowxif44ZgNQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^8.3.0",
+        "@wordpress/primitives": "^4.51.0",
+        "change-case": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/image-cropper": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/image-cropper/-/image-cropper-1.15.0.tgz",
+      "integrity": "sha512-DnKg7Rk2nSYxV3ndnO2KEVw8qielFtZDbMhsKuegP4gc37jRsxBY2rE4Vm7IiJkBkrLUnezGXEPsPoe6ogtJFA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/components": "^37.0.0",
+        "@wordpress/element": "^8.3.0",
+        "@wordpress/i18n": "^6.24.0",
+        "clsx": "^2.1.1",
+        "dequal": "^2.0.3",
+        "react-easy-crop": "^5.4.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/interactivity": {
+      "version": "6.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.51.0.tgz",
+      "integrity": "sha512-E1pSus/56YowcoP5jIdfV4bvd03JL12gHWr+/wjSHeoZxIvvJ72OP6u1EcuirtBaNa9O0F0qPiIsrzyhUV9qPA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@preact/signals": "^1.3.0",
+        "@preact/signals-core": "^1.7.0",
+        "preact": "^10.29.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
     "node_modules/@wordpress/is-shallow-equal": {
       "version": "5.51.0",
       "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.51.0.tgz",
       "integrity": "sha512-Ivyf85r9trFfl/rRaDMgghFZ+gzw8yIl7/vDPagYkvq9Xnqw8KecPy91BqIIvco1jIOh3RXPP6cbVu3dTqZDMA==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -6398,11 +7775,34 @@
         "jest": ">=29"
       }
     },
+    "node_modules/@wordpress/keyboard-shortcuts": {
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.51.0.tgz",
+      "integrity": "sha512-CSrUZLOdXGax8SAmQs/r0aBIV8Oi7bfmkqRWqdoJDCO2k11LyUP/BzTbtIAxCaapocc4jRjT9qeN8/bpz1XQYg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/data": "^10.51.0",
+        "@wordpress/element": "^8.3.0",
+        "@wordpress/keycodes": "^4.51.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@wordpress/keycodes": {
       "version": "4.51.0",
       "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.51.0.tgz",
       "integrity": "sha512-C9CZq2WCWVacjsHhFgM0GVIQmTUxo/oX7U+Qj0kr3vWHZu6cmEDJ94PX+f02M3b+iHnCk4oHCvnXGANwKQwsSw==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@wordpress/i18n": "^6.24.0"
@@ -6413,6 +7813,31 @@
       },
       "peerDependencies": {
         "@types/react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/notices": {
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.51.0.tgz",
+      "integrity": "sha512-mOOPEnjmkvscs4gNEYNiowsSF371HnO5euFOmBRIcnuRjn/dW7VqUfGXUbsu3HGXqjMBWBWPW0hzEjaatEVhGA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/a11y": "^4.51.0",
+        "@wordpress/components": "^37.0.0",
+        "@wordpress/data": "^10.51.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -6453,6 +7878,49 @@
         "postcss": "^8.0.0"
       }
     },
+    "node_modules/@wordpress/preferences": {
+      "version": "4.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.51.0.tgz",
+      "integrity": "sha512-JOwER9FIdfllWTZ6gWABN6lrcrMFpYg5YblVzFgdrS/mvA4O4C6yfgsEhC6xN2gbfODtnd49Meo/Df/Ka0983Q==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/a11y": "^4.51.0",
+        "@wordpress/base-styles": "^11.0.0",
+        "@wordpress/components": "^37.0.0",
+        "@wordpress/compose": "^8.4.0",
+        "@wordpress/data": "^10.51.0",
+        "@wordpress/deprecated": "^4.51.0",
+        "@wordpress/element": "^8.3.0",
+        "@wordpress/i18n": "^6.24.0",
+        "@wordpress/icons": "^15.2.0",
+        "@wordpress/private-apis": "^1.51.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/preferences/node_modules/@wordpress/base-styles": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-11.0.0.tgz",
+      "integrity": "sha512-w+n/AWSNfDx5RhPIpKCi7Iptn+8+Sll8uJhyx6X62zkkHDX51H2vZTU2XaXOQGx5U7xQcaVTbHjVDgYBwkU4Vg==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
     "node_modules/@wordpress/prettier-config": {
       "version": "4.51.0",
       "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.51.0.tgz",
@@ -6467,11 +7935,33 @@
         "prettier": ">=3"
       }
     },
+    "node_modules/@wordpress/primitives": {
+      "version": "4.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.51.0.tgz",
+      "integrity": "sha512-vSg8XYGyBL9+s1h67Fhx8vV718iM9jto8/Tx5tyEdPHXuvY9F8hi3FLZ8k/DQ7qGy+o3ljDsfl1dq9DHP/Fs0A==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^8.3.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@wordpress/priority-queue": {
       "version": "3.51.0",
       "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.51.0.tgz",
       "integrity": "sha512-Mgm6DFRW4ZqgkVTQNe6LdtWzah19u6531Uf1L5q1LwYd/eekKeRsNB9dJnqBg2Kn/jgfPbZnTaHToDvnOZQgcA==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "requestidlecallback": "^0.3.0"
@@ -6485,11 +7975,61 @@
       "version": "1.51.0",
       "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.51.0.tgz",
       "integrity": "sha512-x3FeBDGegBAKveYHNmgZgTbEwuwVMxGouTR2fKP94Myn5PzF5EkZK1CZJrDnfNjzTl73nCwsd4IXACdtYfnnAQ==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/redux-routine": {
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.51.0.tgz",
+      "integrity": "sha512-L5wLAEMPXjE7HvyD2ErH7HL0vgAhXGN9if0yc/r42nnyt9Mq/5B7MOjGJL7qpBb0VoBsUvqPoLEIZmIPU+OF+A==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "is-plain-object": "^5.0.0",
+        "is-promise": "^4.0.0",
+        "rungen": "^0.3.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "redux": ">=4"
+      }
+    },
+    "node_modules/@wordpress/rich-text": {
+      "version": "7.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.51.0.tgz",
+      "integrity": "sha512-SYe7N6GMTZ3DMwNrC69EuFc/tv0KJNfWKoLJWOepIJuuseWj+JVrSAUO13Dv1c8Q0syr8zR2RJvS5G4jiMgAsA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/a11y": "^4.51.0",
+        "@wordpress/compose": "^8.4.0",
+        "@wordpress/data": "^10.51.0",
+        "@wordpress/deprecated": "^4.51.0",
+        "@wordpress/dom": "^4.51.0",
+        "@wordpress/element": "^8.3.0",
+        "@wordpress/escape-html": "^3.51.0",
+        "@wordpress/i18n": "^6.24.0",
+        "@wordpress/keycodes": "^4.51.0",
+        "@wordpress/private-apis": "^1.51.0",
+        "colord": "^2.9.3",
+        "memize": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/scripts": {
@@ -7545,11 +9085,44 @@
         "typescript": ">=4.2.0"
       }
     },
+    "node_modules/@wordpress/shortcode": {
+      "version": "4.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.51.0.tgz",
+      "integrity": "sha512-60PB1Q6Q0f96RreaX3ht+VpFOw6Qi/u3AoJ41Wgsmaqa57BCDeN/MgNDHn7FBF5fQ3fDSfIzdtf7JN/YNB/dNA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "memize": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/style-engine": {
+      "version": "2.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.51.0.tgz",
+      "integrity": "sha512-T1DlSG1ZUPS8NolfTzTjuVB0XRTezwJKZtqb5TWCv8fQu6+A5QFF8msN2JuFeJ1CEn2psJB0aHSW5QAsIuXKCw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "change-case": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@wordpress/style-runtime": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.7.0.tgz",
       "integrity": "sha512-PeAcF7qoIMg9ChS5SfkRrLLcUx9D7Te6weRcQmoKYgxE7jSzzXpoaiy3Z+Us+ChyisolF4xhTg5DblMBPL1iug==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=20.10.0",
@@ -7576,14 +9149,190 @@
         "stylelint-scss": "^6.4.0"
       }
     },
+    "node_modules/@wordpress/token-list": {
+      "version": "3.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.51.0.tgz",
+      "integrity": "sha512-e4rzOgy4R0CavnA3XoK5NxQTt/0vSeHfgzoj49MUemv6MIiWjq/oNaewk7pDT1sl7XRqlzOQwLPzIEEIjPrIzQ==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/ui": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.18.0.tgz",
+      "integrity": "sha512-TIMsjaRl5/QJEjKbtoa0YAhzVdcvAk/FmA9rgJVR6oG/l6+s0WgoebGASEVyRyoOstq45xB7PzYMdjVs7iS0zg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@base-ui/react": "^1.6.0",
+        "@wordpress/a11y": "^4.51.0",
+        "@wordpress/compose": "^8.4.0",
+        "@wordpress/element": "^8.3.0",
+        "@wordpress/i18n": "^6.24.0",
+        "@wordpress/icons": "^15.2.0",
+        "@wordpress/keycodes": "^4.51.0",
+        "@wordpress/primitives": "^4.51.0",
+        "@wordpress/private-apis": "^1.51.0",
+        "@wordpress/style-runtime": "^0.7.0",
+        "@wordpress/theme": "^1.0.0",
+        "clsx": "^2.1.1",
+        "tabbable": "^6.4.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.13.0",
+        "npm": ">=10.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/ui/node_modules/@wordpress/theme": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-1.0.0.tgz",
+      "integrity": "sha512-zPwDgv7xx3f4h+lLCq95szofMAMjSIlkIIfR7U2cxQws5J6XnnTsOxHWJTE6V4jPzS19vzFdQdZ9wiR/X3c0Lw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/compose": "^8.4.0",
+        "@wordpress/deprecated": "^4.51.0",
+        "@wordpress/element": "^8.3.0",
+        "@wordpress/private-apis": "^1.51.0",
+        "@wordpress/style-runtime": "^0.7.0",
+        "colorjs.io": "^0.6.0",
+        "memize": "^2.1.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.13.0",
+        "npm": ">=10.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "esbuild": "^0.27.2",
+        "postcss": "^8.0.0",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19",
+        "stylelint": "^16.8.2",
+        "vite": "^7.3.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "stylelint": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@wordpress/undo-manager": {
       "version": "1.51.0",
       "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.51.0.tgz",
       "integrity": "sha512-w/vUyQX2m+X2xDYCdxu/ALHJdE5S0vkWbxFhUJJeBJG66IFs/DGk/NmLCOudUFLFMQYSXFyIm1XsIPT0UdjhCA==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@wordpress/is-shallow-equal": "^5.51.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/upload-media": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/upload-media/-/upload-media-0.36.0.tgz",
+      "integrity": "sha512-Dl1IIVrSoSuoOBp2vyncgi7lFHJpAac104WR6t66wf0YyCg7xih0XDVneISw1N3ivZ8fEZHXSz2TZ5gz6GmSqQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/blob": "^4.51.0",
+        "@wordpress/compose": "^8.4.0",
+        "@wordpress/data": "^10.51.0",
+        "@wordpress/element": "^8.3.0",
+        "@wordpress/i18n": "^6.24.0",
+        "@wordpress/preferences": "^4.51.0",
+        "@wordpress/private-apis": "^1.51.0",
+        "@wordpress/url": "^4.51.0",
+        "@wordpress/video-conversion": "^0.2.0",
+        "@wordpress/vips": "^2.4.0",
+        "uuid": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/upload-media/node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/@wordpress/url": {
+      "version": "4.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.51.0.tgz",
+      "integrity": "sha512-lPjifvknjTfBl8OSS76jsALotvuSWvb5lE8YKeFJ+zwV09q0ZHgQTeMKHrL47DwMl+PlPhmoLrjHav+KLBwTCA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "remove-accents": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/video-conversion": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/video-conversion/-/video-conversion-0.2.0.tgz",
+      "integrity": "sha512-nvDFi73tWm7qxVC2kBCBnR7PP9fIrCF7NetznVH10vXArkh0xlXqPez6gFTH7Q9r31uPmYOhFFeeBvvdWeu69w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/worker-threads": "^1.11.0",
+        "mediabunny": "^1.45.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/vips": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/vips/-/vips-2.4.0.tgz",
+      "integrity": "sha512-VOpP5RK+FyuxB3uzNsruAl9Np71pgzpLcUuz7LSoh4UUL+S2xI1UEPU9Dki6/3COSca/2vqocwjOrAYFEf/Y1w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/worker-threads": "^1.11.0",
+        "wasm-vips": "^0.0.18"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -7594,8 +9343,30 @@
       "version": "3.51.0",
       "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.51.0.tgz",
       "integrity": "sha512-wWeM6pjAWbMhdNfgCaxi5yhLzomj6/trcIjGPi2Q4kaIuxUula8Ybq0ZPn5lYuc19ICkcGYcAnWNYz/4mYCHdA==",
-      "dev": true,
       "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/wordcount": {
+      "version": "4.51.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.51.0.tgz",
+      "integrity": "sha512-EWMxWgyO9uPlCwLlvWXrPup6EX9myPj2NRE7278cPSmmEmFkUSfZwykcw7rQTpM7egm649wt1ELQepso3eFFQg==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/worker-threads": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/worker-threads/-/worker-threads-1.11.0.tgz",
+      "integrity": "sha512-ABD1L//g1SvQtxxFTLzb03rI0Az29MH6qudR+5Mi8ay7da1aeO3z1cfBD1/3O3oXd2dcMRW6XQKvoztnDaoKZg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "comctx": "^1.4.3"
+      },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
@@ -7888,7 +9659,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7898,7 +9669,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -7942,6 +9713,18 @@
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/aria-query": {
@@ -8015,7 +9798,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8175,7 +9958,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8245,6 +10028,12 @@
       "peerDependencies": {
         "postcss": "^8.1.0"
       }
+    },
+    "node_modules/autosize": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/autosize/-/autosize-4.0.4.tgz",
+      "integrity": "sha512-5yxLQ22O0fCRGoxGfeLSNt3J8LB1v+umtpMnPW6XjkTWXKoN0AmXAIhelJcDtFT/Y/wYWmfE+oqU10Q0b8FhaQ==",
+      "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -8365,6 +10154,37 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/babel-plugin-macros/node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
@@ -8718,7 +10538,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -8840,7 +10660,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.1.tgz",
       "integrity": "sha512-yr+FSHWn1ZUou5LkULX/S+jhfgfnLbuKQjE40tyEd4fxGZVMbBL5ifno0J0OauykS8UiCSgHi+DV/YD+rjFxFg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@cacheable/memory": "^2.0.6",
@@ -8854,7 +10674,7 @@
       "version": "5.5.5",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.5.tgz",
       "integrity": "sha512-FA5LmZVF1VziNc0bIdCSA1IoSVnDCqE8HJIZZv2/W8YmoAM50+tnUgJR/gQZwEeIMleuIOnRnHA/UaZRNeV4iQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
@@ -8914,7 +10734,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8924,7 +10743,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
       "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pascal-case": "^3.1.2",
@@ -9010,7 +10828,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
       "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
@@ -9039,7 +10856,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
       "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "camel-case": "^4.1.2",
@@ -9228,6 +11044,31 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -9250,7 +11091,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -9263,14 +11104,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/colord": {
       "version": "2.9.3",
       "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
       "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/colorette": {
@@ -9284,7 +11124,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.6.1.tgz",
       "integrity": "sha512-8lyR2wHzuIykCpqHKgluGsqQi5iDm3/a2IgP2GBZrasn2sBRkE4NOGsglZxWLs/jZQoNkmA/KM/8NV16rLUdBg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -9303,6 +11142,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/comctx": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/comctx/-/comctx-1.7.5.tgz",
+      "integrity": "sha512-0fsxsxr1Hg2T99wOIteUbsJOX6jMmnhAJepcVRqNRMWpcbxRhbm2+0R8qEuQEaE4gWjfdXaKeAGYAn0yeElylQ==",
+      "license": "MIT"
     },
     "node_modules/commander": {
       "version": "12.1.0",
@@ -9380,6 +11225,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/computed-style": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/computed-style/-/computed-style-0.1.4.tgz",
+      "integrity": "sha512-WpAmaKbMNmS3OProfHIdJiNleNJdgUrJfbKArXua28QF7+0CoZjlLn0lp6vlc+dl5r2/X9GQiQRQQU4BzSa69w=="
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -9420,7 +11270,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
       "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
@@ -9700,7 +11549,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.2.3.tgz",
       "integrity": "sha512-IQOkD3hbR5KrN93MtcYuad6YPuTSUhntLHDuLEbFWE+ff2/XSZNdZG+LcbbIW5AXKg/WFIfYItIzVoHngHXZzA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12 || >=16"
@@ -9776,7 +11625,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
       "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "mdn-data": "2.12.2",
@@ -9803,7 +11652,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -9958,7 +11807,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cwd": {
@@ -10061,6 +11909,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/date-fns": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-jalali": {
+      "version": "4.1.0-0",
+      "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
+      "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
+      "license": "MIT"
+    },
     "node_modules/debounce": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
@@ -10072,7 +11936,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -10166,7 +12029,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10266,6 +12128,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -10308,12 +12179,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
     "node_modules/devtools-protocol": {
       "version": "0.0.1507524",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1507524.tgz",
       "integrity": "sha512-OjaNE7qpk6GRTXtqQjAE5bGx6+c4F1zZH0YXtpZQLM92HNXx4zMAaqlKhP4T52DosG6hDW8gPMNhGOF8xbwk/w==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -10329,7 +12215,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
       "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "path-type": "^4.0.0"
@@ -10441,7 +12327,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
       "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
@@ -10557,7 +12442,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.6.2"
@@ -10618,7 +12502,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10637,11 +12521,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/equivalent-key-map": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/equivalent-key-map/-/equivalent-key-map-0.2.2.tgz",
+      "integrity": "sha512-xvHeyCDbZzkpN4VHQj/n+j2lOwL0VWszG30X4cOrc9Y7Tuo2qCdZK/0AMod23Z5dCtNUbaju6p0rwOhHUk05ew==",
+      "license": "MIT"
+    },
     "node_modules/error-ex": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
       "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -10862,7 +12751,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -11894,7 +13782,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -11915,7 +13802,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -11932,7 +13819,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -11959,7 +13846,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -11976,7 +13863,7 @@
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
       "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4.9.1"
@@ -11986,7 +13873,7 @@
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
       "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -12070,7 +13957,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -12181,6 +14068,12 @@
         "find-process": "bin/find-process.js"
       }
     },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "license": "MIT"
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -12223,7 +14116,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
@@ -12334,6 +14227,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -12387,7 +14307,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -12477,6 +14396,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-package-type": {
@@ -12592,7 +14520,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
       "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "encoding": "^0.1.12",
@@ -12731,7 +14658,7 @@
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
       "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "array-union": "^2.1.0",
@@ -12752,7 +14679,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
       "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/gopd": {
@@ -12774,6 +14701,14 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/gradient-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-1.2.0.tgz",
+      "integrity": "sha512-6ABGa9CR7WR/0pAJicBy5SJkiikbFM6kf/JjykwX7x+t+s8ORWVnlbi6FkHeFFb36yWsjUpHqSYrygd7ofEUqA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -12832,7 +14767,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12900,7 +14835,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.3.0.tgz",
       "integrity": "sha512-fWltioiy5zsSAs9ouEnvhsVJeAXRybGCNNv0lvzpzNOSDbULXRy7ivFWwCCv4I5Am6kSo75hmbsCduOoc2/K4w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "hookified": "^1.13.0"
@@ -12913,7 +14848,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -12926,7 +14860,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
       "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "capital-case": "^1.0.4",
@@ -12950,6 +14883,27 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/highlight-words-core": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/highlight-words-core/-/highlight-words-core-1.2.3.tgz",
+      "integrity": "sha512-m1O9HW3/GNHxzSIXWw1wCNXXsgLlxrP0OI6+ycGUhiUHkikqW3OrwVHz+lxeNBe5yqLESdIcj8PowHQ2zLvUvQ==",
+      "license": "MIT"
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -12967,7 +14921,7 @@
       "version": "1.14.0",
       "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.14.0.tgz",
       "integrity": "sha512-pi1ynXIMFx/uIIwpWJ/5CEtOHLGtnUB0WhGeeYT+fKcQ+WCQbm3/rrkAXnpfph++PgepNqPdTC2WTj8A6k6zoQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/hosted-git-info": {
@@ -13056,6 +15010,12 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/hpq": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/hpq/-/hpq-1.4.0.tgz",
+      "integrity": "sha512-ycJQMRaRPBcfnoT1gS5I1XCvbbw9KO94Y0vkwksuOjcJMqNZtb03MF2tCItLI2mQbkZWSSeFinoRDPmjzv4tKg==",
+      "license": "MIT"
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
@@ -13097,7 +15057,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
       "integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13234,7 +15194,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -13281,7 +15240,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -13342,7 +15301,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -13359,7 +15317,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -13415,7 +15372,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -13442,7 +15399,7 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/internal-slot": {
@@ -13535,7 +15492,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-async-function": {
@@ -13667,7 +15623,6 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -13744,7 +15699,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -13770,7 +15725,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13810,7 +15765,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -13849,7 +15804,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -13899,7 +15854,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -13910,6 +15864,12 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
     "node_modules/is-regex": {
@@ -14117,7 +16077,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/isobject": {
@@ -14899,7 +16859,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -14976,7 +16935,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -14996,7 +16954,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -15103,7 +17060,7 @@
       "version": "0.37.0",
       "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz",
       "integrity": "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/language-subtag-registry": {
@@ -15382,11 +17339,22 @@
         "url": "https://github.com/sponsors/antonk52"
       }
     },
+    "node_modules/line-height": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/line-height/-/line-height-0.3.1.tgz",
+      "integrity": "sha512-YExecgqPwnp5gplD2+Y8e8A5+jKpr25+DzMbFdI1/1UAr0FJrTFv4VkHLf8/6B590i1wUPJWMKKldkd/bdQ//w==",
+      "license": "MIT",
+      "dependencies": {
+        "computed-style": "~0.1.3"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/linkify-it": {
@@ -15480,7 +17448,7 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
       "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/lodash.uniq": {
@@ -15532,7 +17500,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -15545,7 +17512,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
       "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
@@ -15763,6 +17729,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/marked": {
+      "version": "18.0.7",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.7.tgz",
+      "integrity": "sha512-iDVQ5ldaiKXn6b2JroX5kgRfmwgqolW7NpaEzTl1k/2Zh1njIEN9yniyLV/mOvWwtsE8OGgkjsCYvijuPk1dtA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/marky": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
@@ -15784,7 +17762,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
       "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -15795,7 +17773,7 @@
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
       "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "CC0-1.0"
     },
     "node_modules/mdurl": {
@@ -15815,6 +17793,24 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mediabunny": {
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/mediabunny/-/mediabunny-1.51.0.tgz",
+      "integrity": "sha512-u327374xU8Ho0gCaMII7fUK8t0PnqkabCox1k8uUwvgvGb9o6YQGZEG2Qr4DTe7nTMpzfL7ukgnHDvDROySZ+Q==",
+      "license": "MPL-2.0",
+      "workspaces": [
+        ".",
+        "packages/*"
+      ],
+      "dependencies": {
+        "@types/dom-mediacapture-transform": "^0.1.11",
+        "@types/dom-webcodecs": "0.1.13"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/Vanilagy"
+      }
+    },
     "node_modules/memfs": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.3.tgz",
@@ -15832,7 +17828,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
       "integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/meow": {
@@ -15921,7 +17916,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -15948,7 +17943,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -16151,11 +18146,46 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.48",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
+      "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
+    },
     "node_modules/mousetrap": {
       "version": "1.6.5",
       "resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
       "integrity": "sha512-QNo4kEepaIBwiT8CDhP98umTetp+JNfQYBWvC1pc6/OAibuXtRcxZ58Qz8skvEHYvURne/7R8T5VoOI7rDsEUA==",
-      "dev": true,
       "license": "Apache-2.0 WITH LLVM-exception"
     },
     "node_modules/mrmime": {
@@ -16172,7 +18202,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/multicast-dns": {
@@ -16193,7 +18222,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -16262,7 +18290,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
       "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lower-case": "^2.0.2",
@@ -16337,11 +18364,17 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/normalize-wheel": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-wheel/-/normalize-wheel-1.0.1.tgz",
+      "integrity": "sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/npm-bundled": {
       "version": "1.1.2",
@@ -16482,7 +18515,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -16883,7 +18915,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
       "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dot-case": "^3.0.4",
@@ -16894,7 +18925,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -16923,7 +18953,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -16981,6 +19010,22 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/parsel-js": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/parsel-js/-/parsel-js-1.2.3.tgz",
+      "integrity": "sha512-kJHFmSNnujpusFfVEXjNaoJ09VYHF8Ih0aVUn7Clu+Ug8AFoA2wx7Ezh17JfW4+vhm/lauAd9A+//uFkmydZtQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/LeaVerou"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/leaverou"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -16995,7 +19040,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
       "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
@@ -17006,7 +19050,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
       "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dot-case": "^3.0.4",
@@ -17037,7 +19080,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
@@ -17085,7 +19127,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -17136,14 +19177,13 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -17356,7 +19396,6 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -17918,6 +19957,15 @@
         "postcss": "^8.4.31"
       }
     },
+    "node_modules/postcss-prefix-selector": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/postcss-prefix-selector/-/postcss-prefix-selector-1.16.1.tgz",
+      "integrity": "sha512-Umxu+FvKMwlY6TyDzGFoSUnzW+NOfMBLyC1tAkIjgX+Z/qGspJeRjVC903D7mx7TuBpJlwti2ibXtWuA7fKMeQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "postcss": ">4 <9"
+      }
+    },
     "node_modules/postcss-reduce-initial": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-6.1.0.tgz",
@@ -17955,14 +20003,14 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.6.tgz",
       "integrity": "sha512-0sglIs9Wmkzbr8lQwEyIzlDOOC9bGmfVKcJTaxv3vMmd3uo4o4DerC3En0bnmgceeql9BfC8hRkp7cg0fjdVqw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/postcss-safe-parser": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
       "integrity": "sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -18059,11 +20107,22 @@
         "postcss": "^8.4.31"
       }
     },
+    "node_modules/postcss-urlrebase": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/postcss-urlrebase/-/postcss-urlrebase-1.4.0.tgz",
+      "integrity": "sha512-rRaxMmWvXrn8Rk1PqsxmaJwldRHsr0WbbASKKCZYxXwotHkM/5X/6IrwaEe8pdzpbNGCEY86yhYMN0MhgOkADA==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3.0"
+      }
+    },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/postgres-array": {
@@ -18107,6 +20166,24 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.7",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.7.tgz",
+      "integrity": "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
       }
     },
     "node_modules/prelude-ls": {
@@ -18212,7 +20289,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -18224,7 +20300,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/proxy-addr": {
@@ -18406,7 +20481,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/qified/-/qified-0.5.3.tgz",
       "integrity": "sha512-kXuQdQTB6oN3KhI6V4acnBSZx8D2I4xzZvn9+wFLLFCoBNQY/sFnCW6c43OL7pOQ2HvGV4lnWIXNmgfp7cTWhQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "hookified": "^1.13.0"
@@ -18442,7 +20517,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -18518,11 +20593,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/re-resizable": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.11.2.tgz",
+      "integrity": "sha512-2xI2P3OHs5qw7K0Ud1aLILK6MQxW50TcO+DetD9eIV58j84TqYeHoZcL9H4GXFXXIh7afhH8mv5iUCXII7OW7A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -18531,11 +20615,42 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-colorful": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.8.0.tgz",
+      "integrity": "sha512-Wy9OzPfjSN9bF12OB8N7UQvlsZ0I+7wHxpN+bV5BjNQGxOj6IiwkRjevJK9yOBjJWGQvAaf1OXtn8rUeEatAng==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/react-day-picker": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.14.0.tgz",
+      "integrity": "sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@date-fns/tz": "^1.4.1",
+        "@tabby_ai/hijri-converter": "1.0.5",
+        "date-fns": "^4.1.0",
+        "date-fns-jalali": "4.1.0-0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -18545,11 +20660,24 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-easy-crop": {
+      "version": "5.5.7",
+      "resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-5.5.7.tgz",
+      "integrity": "sha512-kYo4NtMeXFQB7h1U+h5yhUkE46WQbQdq7if54uDlbMdZHdRgNehfvaFrXnFw5NR1PNoUOJIfTwLnWmEx/MaZnA==",
+      "license": "MIT",
+      "dependencies": {
+        "normalize-wheel": "^1.0.1",
+        "tslib": "^2.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.4.0",
+        "react-dom": ">=16.4.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-refresh": {
@@ -18560,6 +20688,75 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/read-cache": {
@@ -18712,6 +20909,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -18814,11 +21017,22 @@
         "regjsparser": "bin/parser"
       }
     },
+    "node_modules/rememo": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
+      "integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ==",
+      "license": "MIT"
+    },
+    "node_modules/remove-accents": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
+      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
+      "license": "MIT"
+    },
     "node_modules/requestidlecallback": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
       "integrity": "sha512-TWHFkT7S9p7IxLC5A1hYmAYQx2Eb9w1skrXmQ+dS1URyvR8tenMLl4lHbqEOUnpEYxNKpkVMXUgknVpBZWXXfQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/require-directory": {
@@ -18835,7 +21049,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -18873,11 +21087,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
       "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.1",
@@ -18935,7 +21154,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -18975,7 +21194,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -19060,7 +21279,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -19079,6 +21298,12 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rungen": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/rungen/-/rungen-0.3.2.tgz",
+      "integrity": "sha512-zWl10xu2D7zoR8zSC2U6bg5bYF6T/Wk7rxwp8IPaJH7f0Ge21G03kNHVgHR7tyVkSSfAOG0Rqf/Cl38JftSmtw==",
+      "license": "MIT"
     },
     "node_modules/rxjs": {
       "version": "7.8.2",
@@ -19114,7 +21339,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -19170,7 +21394,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/sass": {
@@ -19252,7 +21475,6 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -19405,7 +21627,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
       "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
@@ -19746,6 +21967,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/simple-html-tokenizer": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11.tgz",
+      "integrity": "sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==",
+      "license": "MIT"
+    },
     "node_modules/sirv": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
@@ -19772,7 +21999,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -19782,7 +22009,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
       "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -19811,7 +22038,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
       "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dot-case": "^3.0.4",
@@ -19884,7 +22110,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -20165,7 +22390,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -20180,7 +22405,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/string.prototype.includes": {
@@ -20300,7 +22525,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -20423,7 +22648,7 @@
       "version": "16.26.1",
       "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.26.1.tgz",
       "integrity": "sha512-v20V59/crfc8sVTAtge0mdafI3AdnzQ2KsWe6v523L4OA1bJO02S7MO2oyXDCS6iWb9ckIPnqAFVItqSBQr7jw==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -20578,7 +22803,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.3.tgz",
       "integrity": "sha512-HAYH7d3TLRHDOUQK4mZKf9k9Ph/m8Akstg66ywKR4SFAigjs3yBiUeZtFxywiTm5moZMAp/5W/ZuFnNXXYLuuQ==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -20602,7 +22827,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
       "integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -20625,21 +22850,21 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "Python-2.0"
     },
     "node_modules/stylelint/node_modules/balanced-match": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
       "integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/stylelint/node_modules/cosmiconfig": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "env-paths": "^2.2.1",
@@ -20666,7 +22891,7 @@
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.1.tgz",
       "integrity": "sha512-TPVFSDE7q91Dlk1xpFLvFllf8r0HyOMOlnWy7Z2HBku5H3KhIeOGInexrIeg2D64DosVB/JXkrrk6N/7Wriq4A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "flat-cache": "^6.1.19"
@@ -20676,7 +22901,7 @@
       "version": "6.1.19",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.19.tgz",
       "integrity": "sha512-l/K33newPTZMTGAnnzaiqSl6NnH7Namh8jBNjrgjprWxGmZUuxx/sJNIRaijOh3n7q7ESbhNZC+pvVZMFdeU4A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "cacheable": "^2.2.0",
@@ -20688,7 +22913,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
       "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "global-prefix": "^3.0.0"
@@ -20701,7 +22926,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
       "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ini": "^1.3.5",
@@ -20716,7 +22941,7 @@
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -20726,7 +22951,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -20739,7 +22964,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -20749,7 +22974,7 @@
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
       "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -20762,7 +22987,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -20776,7 +23001,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -20789,7 +23014,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -20802,7 +23027,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
       "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
@@ -20812,11 +23037,17 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -20829,7 +23060,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
       "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0",
@@ -20846,7 +23077,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -20866,7 +23096,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
       "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/svgo": {
       "version": "3.3.2",
@@ -20948,11 +23178,17 @@
         "url": "https://opencollective.com/synckit"
       }
     },
+    "node_modules/tabbable": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+      "license": "MIT"
+    },
     "node_modules/table": {
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
       "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "ajv": "^8.0.1",
@@ -20969,7 +23205,7 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -20986,14 +23222,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tannin": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/tannin/-/tannin-1.2.0.tgz",
       "integrity": "sha512-U7GgX/RcSeUETbV7gYgoz8PD7Ni4y95pgIP/Z6ayI3CfhSujwKEBlGFTCRN+Aqnuyf4AN2yHL+L8x+TCGjb9uA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tannin/plural-forms": "^1.1.0"
@@ -21336,7 +23571,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -21490,7 +23725,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsutils": {
@@ -21655,7 +23889,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -21868,7 +24102,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
       "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
@@ -21878,7 +24111,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
       "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
@@ -21952,21 +24184,72 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/use-memo-one": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
       "integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/utils-merge": {
@@ -22087,6 +24370,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/wasm-vips": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/wasm-vips/-/wasm-vips-0.0.18.tgz",
+      "integrity": "sha512-AJyCvxZj/3qceKNnh+YyEobu/IaJFoPN7x7SxyyHmYBS3kASMqJqxQEuN0ZHKQDWsCJ8armfx4Tq3uKrNc+nMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=17.0.0"
       }
     },
     "node_modules/watchpack": {
@@ -22825,7 +25117,6 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 6"

--- a/inc/Blocks/EventDetails/package.json
+++ b/inc/Blocks/EventDetails/package.json
@@ -24,5 +24,11 @@
   "overrides": {
     "rimraf": "^4.4.1",
     "glob": "^9.3.5"
+  },
+  "dependencies": {
+    "@wordpress/block-editor": "^16.0.0",
+    "@wordpress/blocks": "^15.24.0",
+    "@wordpress/components": "^37.0.0",
+    "@wordpress/i18n": "^6.24.0"
   }
 }

--- a/inc/Blocks/EventDetails/src/add-to-calendar.js
+++ b/inc/Blocks/EventDetails/src/add-to-calendar.js
@@ -20,7 +20,7 @@
 
 /* global Element, requestAnimationFrame */
 
-(function () {
+( function () {
 	'use strict';
 
 	if ( typeof document === 'undefined' ) {
@@ -47,7 +47,9 @@
 	}
 
 	function getItems( menu ) {
-		return Array.prototype.slice.call( menu.querySelectorAll( ITEM_SELECTOR ) );
+		return Array.prototype.slice.call(
+			menu.querySelectorAll( ITEM_SELECTOR )
+		);
 	}
 
 	function isOpen( toggle ) {

--- a/inc/Blocks/EventDetails/src/index.js
+++ b/inc/Blocks/EventDetails/src/index.js
@@ -3,36 +3,33 @@
  */
 import { registerBlockType } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
-import { 
-    useBlockProps,
-    InnerBlocks
-} from '@wordpress/block-editor';
-import { 
-    TextControl, 
-    Notice
-} from '@wordpress/components';
+import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+import { TextControl, Notice } from '@wordpress/components';
 
 const ALLOWED_BLOCKS = [
-    'core/paragraph',
-    'core/heading',
-    'core/image',
-    'core/list',
-    'core/quote',
-    'core/gallery',
-    'core/video',
-    'core/audio',
-    'core/embed',
-    'core/separator',
-    'core/spacer',
-    'core/columns',
-    'core/column',
-    'core/group',
-    'core/freeform',
-    'core/html'
+	'core/paragraph',
+	'core/heading',
+	'core/image',
+	'core/list',
+	'core/quote',
+	'core/gallery',
+	'core/video',
+	'core/audio',
+	'core/embed',
+	'core/separator',
+	'core/spacer',
+	'core/columns',
+	'core/column',
+	'core/group',
+	'core/freeform',
+	'core/html',
 ];
 
 const DESCRIPTION_TEMPLATE = [
-    ['core/paragraph', { placeholder: __('Add event description…', 'data-machine-events') }]
+	[
+		'core/paragraph',
+		{ placeholder: __( 'Add event description…', 'data-machine-events' ) },
+	],
 ];
 
 /**
@@ -40,175 +37,255 @@ const DESCRIPTION_TEMPLATE = [
  *
  * Block for event data storage with InnerBlocks support.
  */
-registerBlockType('data-machine-events/event-details', {
-    /**
-     * Block editor component with comprehensive event data fields and InnerBlocks support
-     * @param {Object}   root0               Block editor properties.
-     * @param {Object}   root0.attributes    Event detail attributes.
-     * @param {Function} root0.setAttributes Updates event detail attributes.
-     * @param {string}   root0.clientId      Unique block client ID.
-     */
-    edit: function Edit({ attributes, setAttributes, clientId }) {
-        const {
-            startDate,
-            endDate,
-            startTime,
-            endTime,
-            venue,
-            address,
-            price,
-            ticketUrl,
-            performer,
-            organizer,
-            organizerUrl,
-        } = attributes;
+registerBlockType( 'data-machine-events/event-details', {
+	/**
+	 * Block editor component with comprehensive event data fields and InnerBlocks support
+	 * @param {Object}   root0               Block editor properties.
+	 * @param {Object}   root0.attributes    Event detail attributes.
+	 * @param {Function} root0.setAttributes Updates event detail attributes.
+	 * @param {string}   root0.clientId      Unique block client ID.
+	 */
+	edit: function Edit( { attributes, setAttributes, clientId } ) {
+		const {
+			startDate,
+			endDate,
+			startTime,
+			endTime,
+			venue,
+			address,
+			price,
+			ticketUrl,
+			performer,
+			organizer,
+			organizerUrl,
+		} = attributes;
 
-        const blockProps = useBlockProps({
-            className: 'data-machine-event-details-block'
-        });
+		const blockProps = useBlockProps( {
+			className: 'data-machine-event-details-block',
+		} );
 
-        const handleAttributeChange = (field, value) => {
-            setAttributes({ [field]: value });
-        };
+		const handleAttributeChange = ( field, value ) => {
+			setAttributes( { [ field ]: value } );
+		};
 
-        const handleTimeChange = (field, value) => {
-            setAttributes({ [field]: value });
-        };
+		const handleTimeChange = ( field, value ) => {
+			setAttributes( { [ field ]: value } );
+		};
 
-        return (
-            <div {...blockProps}>
-                    <div className="data-machine-event-details-editor">
-                        <div className="event-description-area">
-                            <h4>{__('Event Description', 'data-machine-events')}</h4>
-                            <div className="event-description-inner">
-                                <InnerBlocks
-                                    allowedBlocks={ALLOWED_BLOCKS}
-                                    template={DESCRIPTION_TEMPLATE}
-                                    templateLock={false}
-                                />
-                            </div>
-                        </div>
-                        
-                        <div className="event-dates">
-                            <h4>{__('Event Dates & Times', 'data-machine-events')}</h4>
-                            <div className="date-time-grid">
-                                <div className="date-time-field">
-                                    <label htmlFor={`event-start-date-${clientId}`}>
-                                        {__('Start Date', 'data-machine-events')}
-                                    </label>
-                                    <input
-                                        id={`event-start-date-${clientId}`}
-                                        type="date"
-                                        value={startDate}
-                                        onChange={(e) => handleAttributeChange('startDate', e.target.value)}
-                                    />
-                                </div>
-                                <div className="date-time-field">
-                                    <label htmlFor={`event-start-time-${clientId}`}>
-                                        {__('Start Time', 'data-machine-events')}
-                                    </label>
-                                    <input
-                                        id={`event-start-time-${clientId}`}
-                                        type="time"
-                                        value={startTime}
-                                        onChange={(e) => handleTimeChange('startTime', e.target.value)}
-                                    />
-                                </div>
-                                <div className="date-time-field">
-                                    <label htmlFor={`event-end-date-${clientId}`}>
-                                        {__('End Date', 'data-machine-events')}
-                                    </label>
-                                    <input
-                                        id={`event-end-date-${clientId}`}
-                                        type="date"
-                                        value={endDate}
-                                        onChange={(e) => handleAttributeChange('endDate', e.target.value)}
-                                    />
-                                </div>
-                                <div className="date-time-field">
-                                    <label htmlFor={`event-end-time-${clientId}`}>
-                                        {__('End Time', 'data-machine-events')}
-                                    </label>
-                                    <input
-                                        id={`event-end-time-${clientId}`}
-                                        type="time"
-                                        value={endTime}
-                                        onChange={(e) => handleTimeChange('endTime', e.target.value)}
-                                    />
-                                </div>
-                            </div>
-                        </div>
+		return (
+			<div { ...blockProps }>
+				<div className="data-machine-event-details-editor">
+					<div className="event-description-area">
+						<h4>
+							{ __( 'Event Description', 'data-machine-events' ) }
+						</h4>
+						<div className="event-description-inner">
+							<InnerBlocks
+								allowedBlocks={ ALLOWED_BLOCKS }
+								template={ DESCRIPTION_TEMPLATE }
+								templateLock={ false }
+							/>
+						</div>
+					</div>
 
-                        <div className="event-location">
-                            <h4>{__('Location', 'data-machine-events')}</h4>
-                            <TextControl
-                                label={__('Venue', 'data-machine-events')}
-                                value={venue}
-                                onChange={(value) => setAttributes({ venue: value })}
-                            />
-                            <TextControl
-                                label={__('Address', 'data-machine-events')}
-                                value={address}
-                                onChange={(value) => setAttributes({ address: value })}
-                            />
-                        </div>
+					<div className="event-dates">
+						<h4>
+							{ __(
+								'Event Dates & Times',
+								'data-machine-events'
+							) }
+						</h4>
+						<div className="date-time-grid">
+							<div className="date-time-field">
+								<label
+									htmlFor={ `event-start-date-${ clientId }` }
+								>
+									{ __(
+										'Start Date',
+										'data-machine-events'
+									) }
+								</label>
+								<input
+									id={ `event-start-date-${ clientId }` }
+									type="date"
+									value={ startDate }
+									onChange={ ( e ) =>
+										handleAttributeChange(
+											'startDate',
+											e.target.value
+										)
+									}
+								/>
+							</div>
+							<div className="date-time-field">
+								<label
+									htmlFor={ `event-start-time-${ clientId }` }
+								>
+									{ __(
+										'Start Time',
+										'data-machine-events'
+									) }
+								</label>
+								<input
+									id={ `event-start-time-${ clientId }` }
+									type="time"
+									value={ startTime }
+									onChange={ ( e ) =>
+										handleTimeChange(
+											'startTime',
+											e.target.value
+										)
+									}
+								/>
+							</div>
+							<div className="date-time-field">
+								<label
+									htmlFor={ `event-end-date-${ clientId }` }
+								>
+									{ __( 'End Date', 'data-machine-events' ) }
+								</label>
+								<input
+									id={ `event-end-date-${ clientId }` }
+									type="date"
+									value={ endDate }
+									onChange={ ( e ) =>
+										handleAttributeChange(
+											'endDate',
+											e.target.value
+										)
+									}
+								/>
+							</div>
+							<div className="date-time-field">
+								<label
+									htmlFor={ `event-end-time-${ clientId }` }
+								>
+									{ __( 'End Time', 'data-machine-events' ) }
+								</label>
+								<input
+									id={ `event-end-time-${ clientId }` }
+									type="time"
+									value={ endTime }
+									onChange={ ( e ) =>
+										handleTimeChange(
+											'endTime',
+											e.target.value
+										)
+									}
+								/>
+							</div>
+						</div>
+					</div>
 
-                        <div className="event-details">
-                            <h4>{__('Event Details', 'data-machine-events')}</h4>
-                            <TextControl
-                                label={__('Price', 'data-machine-events')}
-                                value={price}
-                                onChange={(value) => handleAttributeChange('price', value)}
-                            />
-                            <TextControl
-                                label={__('Ticket URL', 'data-machine-events')}
-                                value={ticketUrl}
-                                onChange={(value) => handleAttributeChange('ticketUrl', value)}
-                                type="url"
-                            />
-                        </div>
+					<div className="event-location">
+						<h4>{ __( 'Location', 'data-machine-events' ) }</h4>
+						<TextControl
+							label={ __( 'Venue', 'data-machine-events' ) }
+							value={ venue }
+							onChange={ ( value ) =>
+								setAttributes( { venue: value } )
+							}
+						/>
+						<TextControl
+							label={ __( 'Address', 'data-machine-events' ) }
+							value={ address }
+							onChange={ ( value ) =>
+								setAttributes( { address: value } )
+							}
+						/>
+					</div>
 
-                        <div className="event-schema">
-                            <h4>{__('Schema Information', 'data-machine-events')}</h4>
-                            <TextControl
-                                label={__('Performer/Artist', 'data-machine-events')}
-                                value={performer}
-                                onChange={(value) => setAttributes({ performer: value })}
-                                help={__('Name of the performing artist or group', 'data-machine-events')}
-                            />
-                            <TextControl
-                                label={__('Organizer', 'data-machine-events')}
-                                value={organizer}
-                                onChange={(value) => setAttributes({ organizer: value })}
-                                help={__('Name of the event organizer', 'data-machine-events')}
-                            />
-                            <TextControl
-                                label={__('Organizer URL', 'data-machine-events')}
-                                value={organizerUrl}
-                                onChange={(value) => setAttributes({ organizerUrl: value })}
-                                type="url"
-                                help={__('Website of the event organizer', 'data-machine-events')}
-                            />
-                        </div>
+					<div className="event-details">
+						<h4>
+							{ __( 'Event Details', 'data-machine-events' ) }
+						</h4>
+						<TextControl
+							label={ __( 'Price', 'data-machine-events' ) }
+							value={ price }
+							onChange={ ( value ) =>
+								handleAttributeChange( 'price', value )
+							}
+						/>
+						<TextControl
+							label={ __( 'Ticket URL', 'data-machine-events' ) }
+							value={ ticketUrl }
+							onChange={ ( value ) =>
+								handleAttributeChange( 'ticketUrl', value )
+							}
+							type="url"
+						/>
+					</div>
 
-                        <Notice status="info" isDismissible={false}>
-                            {__('This block is the primary data store for event information. Changes here are automatically saved to the event.', 'data-machine-events')}
-                        </Notice>
-                    </div>
-                </div>
-        );
-    },
+					<div className="event-schema">
+						<h4>
+							{ __(
+								'Schema Information',
+								'data-machine-events'
+							) }
+						</h4>
+						<TextControl
+							label={ __(
+								'Performer/Artist',
+								'data-machine-events'
+							) }
+							value={ performer }
+							onChange={ ( value ) =>
+								setAttributes( { performer: value } )
+							}
+							help={ __(
+								'Name of the performing artist or group',
+								'data-machine-events'
+							) }
+						/>
+						<TextControl
+							label={ __( 'Organizer', 'data-machine-events' ) }
+							value={ organizer }
+							onChange={ ( value ) =>
+								setAttributes( { organizer: value } )
+							}
+							help={ __(
+								'Name of the event organizer',
+								'data-machine-events'
+							) }
+						/>
+						<TextControl
+							label={ __(
+								'Organizer URL',
+								'data-machine-events'
+							) }
+							value={ organizerUrl }
+							onChange={ ( value ) =>
+								setAttributes( { organizerUrl: value } )
+							}
+							type="url"
+							help={ __(
+								'Website of the event organizer',
+								'data-machine-events'
+							) }
+						/>
+					</div>
 
-    /**
-     * Block save component
-     * Returns InnerBlocks.Content for persistence with server-side rendering
-     */
-    save: function Save() {
-        const blockProps = useBlockProps.save();
-        return (
-            <div {...blockProps}>
-                <InnerBlocks.Content />
-            </div>
-        );
-    }
-});
+					<Notice status="info" isDismissible={ false }>
+						{ __(
+							'This block is the primary data store for event information. Changes here are automatically saved to the event.',
+							'data-machine-events'
+						) }
+					</Notice>
+				</div>
+			</div>
+		);
+	},
+
+	/**
+	 * Block save component
+	 * Returns InnerBlocks.Content for persistence with server-side rendering
+	 */
+	save: function Save() {
+		const blockProps = useBlockProps.save();
+		return (
+			<div { ...blockProps }>
+				<InnerBlocks.Content />
+			</div>
+		);
+	},
+} );


### PR DESCRIPTION
## Summary

- apply each block package's configured ESLint fixer to clear formatting-only JavaScript lint debt
- declare EventDetails' four existing WordPress imports as direct dependencies and refresh its lockfile, resolving the four non-auto-fixable import findings
- leave EventsMap source unchanged because its release-preflight baseline was already clean

## Findings

| Package | Before | After |
| --- | ---: | ---: |
| Calendar | 62 errors | 0 errors |
| EventDetails | 188 errors (184 auto-fixable) | 0 errors |
| EventsMap | 0 errors | 0 errors |

## Changed Files

- Calendar: 11 source/test files formatted by ESLint
- EventDetails: 2 source files formatted by ESLint
- EventDetails: `package.json` and `package-lock.json` updated for `@wordpress/block-editor`, `@wordpress/blocks`, `@wordpress/components`, and `@wordpress/i18n`
- EventsMap: no committed changes

## Tests And Builds

- `Calendar: npm run lint:js` passes
- `Calendar: npm test` passes (10 suites, 52 tests)
- `Calendar: npm run build` passes
- `EventDetails: npm run lint:js` passes
- `EventDetails: npm run test:unit` passes with no tests found, as configured by `--passWithNoTests`
- `EventDetails: npm run build` passes
- `EventsMap: npm run lint:js` passes
- `EventsMap: npm test` passes (2 suites, 26 tests)
- `EventsMap: npm run build` passes
- `git diff --check` passes

## Follow-up

The scaffolded EventDetails `npm run test:e2e` command fails before test discovery because `@wordpress/scripts@31.1.0` resolves the removed `puppeteer-core/install` entry point. This unrelated pre-existing runner defect is tracked in #608; the package currently has no E2E test files.

Fixes #606