### PR TITLE
feat: add atomic source-owned event updates

### DIFF
--- a/inc/Abilities/EventUpdateAbilities.php
+++ b/inc/Abilities/EventUpdateAbilities.php
@@ -16,15 +16,16 @@ namespace DataMachineEvents\Abilities;
 use DataMachineEvents\Core\DateTimeParser;
 use DataMachineEvents\Core\Event_Post_Type;
 use DataMachineEvents\Core\EventSchemaProvider;
+use DataMachineEvents\Steps\Upsert\Events\EventUpsert;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 class EventUpdateAbilities {
+	public const SOURCE_ABILITY_NAME = 'data-machine-events/update-source-event';
 
-	private const BLOCK_NAME = 'data-machine-events/event-details';
-
+	private const BLOCK_NAME       = 'data-machine-events/event-details';
 	private const UPDATABLE_FIELDS = array(
 		'startDate',
 		'startTime',
@@ -47,6 +48,12 @@ class EventUpdateAbilities {
 	);
 
 	private static bool $registered = false;
+
+	/** @var array|null Active source-owned transaction context. */
+	private $source_context;
+
+	/** @var bool Whether the source-owned transaction is active. */
+	private $source_transaction_active = false;
 
 	public function __construct() {
 		if ( ! self::$registered ) {
@@ -168,9 +175,139 @@ class EventUpdateAbilities {
 					'meta'                => array( 'show_in_rest' => true ),
 				)
 			);
+			wp_register_ability(
+				self::SOURCE_ABILITY_NAME,
+				array(
+					'label'               => __( 'Update Source-Owned Event', 'data-machine-events' ),
+					'description'         => __( 'Atomically updates one exact source-owned canonical event.', 'data-machine-events' ),
+					'category'            => 'datamachine-events-events',
+					'input_schema'        => $this->getSourceInputSchema(),
+					'output_schema'       => $this->getSourceOutputSchema(),
+					'execute_callback'    => array( $this, 'executeUpdateSourceEvent' ),
+					'permission_callback' => array( $this, 'canUpdateSourceEvent' ),
+					'meta'                => array(
+						'show_in_rest' => true,
+						'mcp'          => array( 'public' => true ),
+						'annotations'  => array(
+							'readonly'    => false,
+							'destructive' => true,
+							'idempotent'  => true,
+						),
+					),
+				)
+			);
 		};
 
 		add_action( 'wp_abilities_api_init', $register_callback );
+	}
+
+	/**
+	 * Check the narrow source-owned update boundary.
+	 *
+	 * Consumers grant only source identities they own. The execute callback
+	 * repeats this check so direct WP_Ability execution cannot bypass it.
+	 */
+	public function canUpdateSourceEvent( array $input = array() ): bool {
+		/**
+		 * Filter permission for one exact source-owned canonical event update.
+		 *
+		 * @param bool  $allowed Whether this operation is allowed. Default false.
+		 * @param array $input   Validated source-event update input.
+		 */
+		return (bool) apply_filters( 'datamachine_events_update_source_event_permission', false, $input );
+	}
+
+	/** Atomically update one event after exact source and fingerprint verification. */
+	public function executeUpdateSourceEvent( array $input ): array|\WP_Error {
+		if ( ! $this->canUpdateSourceEvent( $input ) ) {
+			return new \WP_Error(
+				'source_event_update_forbidden',
+				'You are not authorized to update this source-owned event.',
+				array(
+					'status'    => 403,
+					'retryable' => false,
+				)
+			);
+		}
+
+		$verified = $this->verifySourceInput( $input );
+		if ( is_wp_error( $verified ) ) {
+			return $verified;
+		}
+
+		$update = array( 'event' => $verified['event_id'] );
+		foreach ( array_merge( self::UPDATABLE_FIELDS, array( 'venue', 'description' ) ) as $field ) {
+			if ( array_key_exists( $field, $input ) ) {
+				$update[ $field ] = $input[ $field ];
+			}
+		}
+
+		$this->source_context = array(
+			'event_id'             => $verified['event_id'],
+			'source'               => $verified['source'],
+			'source_id'            => $verified['source_id'],
+			'source_identity'      => $verified['source_identity'],
+			'expected_fingerprint' => $verified['fingerprint'],
+		);
+		try {
+			$result = $this->updateSingleEvent( $update );
+		} catch ( \Throwable $throwable ) {
+			$error = new \WP_Error(
+				'source_event_update_exception',
+				'The source-owned event update failed unexpectedly.',
+				array(
+					'status'    => 500,
+					'retryable' => true,
+					'cause'     => get_class( $throwable ),
+				)
+			);
+			if ( $this->source_transaction_active ) {
+				$rollback = $this->rollbackSourceTransaction( $verified['event_id'] );
+				if ( is_wp_error( $rollback ) ) {
+					$error = $rollback;
+				}
+			}
+			$post   = get_post( $verified['event_id'] );
+			$result = $post instanceof \WP_Post ? $this->updateErrorResult( $post, $error ) : array(
+				'status'       => 'failed',
+				'error'        => $error->get_error_message(),
+				'error_code'   => $error->get_error_code(),
+				'error_status' => (int) ( $error->get_error_data()['status'] ?? 500 ),
+				'error_data'   => (array) $error->get_error_data(),
+			);
+		} finally {
+			if ( $this->source_transaction_active ) {
+				$this->rollbackSourceTransaction( $verified['event_id'] );
+			}
+			$this->source_context = null;
+		}
+
+		if ( 'failed' === ( $result['status'] ?? '' ) ) {
+			$data              = (array) ( $result['error_data'] ?? array() );
+			$data['status']    = (int) ( $result['error_status'] ?? $data['status'] ?? 500 );
+			$data['retryable'] = ! empty( $data['retryable'] ) || $data['status'] >= 500;
+			if ( ! isset( $data['fingerprint'] ) ) {
+				$current = $this->eventFingerprint( $verified['event_id'], $verified['source'], $verified['source_id'], $verified['source_identity'] );
+				if ( ! is_wp_error( $current ) ) {
+					$data['fingerprint'] = $current;
+				}
+			}
+			return new \WP_Error( (string) ( $result['error_code'] ?? 'source_event_update_failed' ), (string) ( $result['error'] ?? 'Source-owned event update failed.' ), $data );
+		}
+
+		$fingerprint = $this->eventFingerprint( $verified['event_id'], $verified['source'], $verified['source_id'], $verified['source_identity'] );
+		if ( is_wp_error( $fingerprint ) ) {
+			return $fingerprint;
+		}
+
+		return array(
+			'success'              => true,
+			'event_id'             => $verified['event_id'],
+			'action'               => 'no_change' === ( $result['status'] ?? '' ) ? 'no_change' : 'updated',
+			'previous_fingerprint' => $verified['fingerprint'],
+			'fingerprint'          => $fingerprint,
+			'updated_fields'       => array_values( (array) ( $result['updated_fields'] ?? array() ) ),
+		);
 	}
 
 	/**
@@ -275,15 +412,13 @@ class EventUpdateAbilities {
 			);
 		}
 
-		$venue_requested   = array_key_exists( 'venue', $event_update );
-		$content_requested = array_key_exists( 'description', $event_update )
-			|| ! empty( array_intersect( self::UPDATABLE_FIELDS, array_keys( $event_update ) ) );
-		if ( $venue_requested && $content_requested ) {
+		$venue_requested = array_key_exists( 'venue', $event_update );
+		if ( ! is_array( $this->source_context ) && $venue_requested && count( $event_update ) > 2 ) {
 			return $this->updateErrorResult(
 				$post,
 				new \WP_Error(
 					'event_update_mixed_venue_content_unsupported',
-					'Venue and event content must be updated in separate operations.',
+					'Combined venue and event-detail updates require the source-owned atomic update ability.',
 					array( 'status' => 409 )
 				)
 			);
@@ -310,8 +445,10 @@ class EventUpdateAbilities {
 		if ( array_key_exists( 'description', $event_update ) ) {
 			$description_value = $event_update['description'] ?? '';
 			$inner_blocks      = $this->generateDescriptionInnerBlocks( $description_value );
-			$this->updateBlockInnerBlocks( $blocks[ $block_index ], $inner_blocks );
-			$updated_fields[] = 'description';
+			if ( ( $blocks[ $block_index ]['innerBlocks'] ?? array() ) !== $inner_blocks ) {
+				$this->updateBlockInnerBlocks( $blocks[ $block_index ], $inner_blocks );
+				$updated_fields[] = 'description';
+			}
 		}
 
 		$requested_venue_id = $venue_requested ? absint( $event_update['venue'] ) : 0;
@@ -336,8 +473,9 @@ class EventUpdateAbilities {
 		if ( $venue_requested && $requested_venue_term && ! is_wp_error( $requested_venue_term ) ) {
 			$next_venue_id = $requested_venue_id;
 		}
+		$venue_changed = $venue_requested && array( $requested_venue_id ) !== $previous_venue_ids;
 
-		if ( empty( $updated_fields ) && ! $venue_requested ) {
+		if ( empty( $updated_fields ) && ! $venue_changed && ! is_array( $this->source_context ) ) {
 			return array(
 				'post_id' => $post_id,
 				'title'   => $post->post_title,
@@ -365,13 +503,20 @@ class EventUpdateAbilities {
 				$lifecycle_result = $this->updateErrorResult( $post, $preflight );
 				return $lifecycle_result;
 			}
+			if ( is_array( $this->source_context ) ) {
+				$transaction = $this->beginSourceTransaction( $post_id );
+				if ( is_wp_error( $transaction ) ) {
+					$lifecycle_result = $this->updateErrorResult( $post, $transaction );
+					return $lifecycle_result;
+				}
+			}
 
-			if ( $venue_requested ) {
+			if ( $venue_changed ) {
 				$venue_result = $this->updateVenue( $post_id, $requested_venue_id );
 				if ( ! $venue_result['success'] ) {
 					$error            = $venue_result['error'] ?? new \WP_Error( 'event_venue_assignment_failed', (string) ( $venue_result['warning'] ?? 'Failed to assign venue.' ) );
 					$lifecycle_result = $this->updateErrorResult( $post, $error );
-					return $lifecycle_result;
+					return $this->rollbackSourceResult( $post_id, $lifecycle_result );
 				}
 				$updated_fields[] = 'venue';
 			}
@@ -379,27 +524,48 @@ class EventUpdateAbilities {
 			if ( ! empty( array_diff( $updated_fields, array( 'venue' ) ) ) ) {
 				$blocks[ $block_index ]['attrs'] = $new_attrs;
 				$new_content                     = serialize_blocks( $blocks );
-				$update_result                   = wp_update_post(
-					array(
-						'ID'           => $post_id,
-						'post_content' => $new_content,
-					),
-					true
-				);
+				$dates_error                     = null;
+				$capture_dates_error             = static function ( \WP_Error $error, int $failed_post_id ) use ( &$dates_error, $post_id ): void {
+					if ( $post_id === $failed_post_id ) {
+						$dates_error = $error;
+					}
+				};
+				add_action( 'datamachine_event_dates_sync_failed', $capture_dates_error, 10, 2 );
+				try {
+					$update_result = wp_update_post(
+						array(
+							'ID'           => $post_id,
+							'post_content' => $new_content,
+						),
+						true
+					);
+				} finally {
+					remove_action( 'datamachine_event_dates_sync_failed', $capture_dates_error, 10 );
+				}
 
 				if ( is_wp_error( $update_result ) ) {
 					$lifecycle_result = $this->updateErrorResult( $post, $update_result, 'Failed to update post: ' );
-					return $lifecycle_result;
+					return $this->rollbackSourceResult( $post_id, $lifecycle_result );
+				}
+				if ( $dates_error instanceof \WP_Error ) {
+					$lifecycle_result = $this->updateErrorResult( $post, $dates_error );
+					return $this->rollbackSourceResult( $post_id, $lifecycle_result );
 				}
 			}
 
 			$lifecycle_result = array(
 				'post_id'        => $post_id,
 				'title'          => $post->post_title,
-				'status'         => 'updated',
+				'status'         => empty( $updated_fields ) ? 'no_change' : 'updated',
 				'updated_fields' => $updated_fields,
 				'warnings'       => $warnings,
 			);
+			if ( $this->source_transaction_active ) {
+				$committed = $this->commitSourceTransaction( $post_id );
+				if ( is_wp_error( $committed ) ) {
+					$lifecycle_result = $this->updateErrorResult( $post, $committed );
+				}
+			}
 			return $lifecycle_result;
 		} finally {
 			do_action( 'datamachine_events_after_event_update_persistence', $context, $lifecycle_result );
@@ -460,8 +626,11 @@ class EventUpdateAbilities {
 			// Handle array fields (like occurrenceDates)
 			if ( 'occurrenceDates' === $field ) {
 				if ( is_array( $value ) ) {
-					$new_attrs[ $field ] = array_values( array_filter( $value, 'is_string' ) );
-					$updated_fields[]    = $field;
+					$value = array_values( array_filter( $value, 'is_string' ) );
+					if ( ( $existing_attrs[ $field ] ?? array() ) !== $value ) {
+						$new_attrs[ $field ] = $value;
+						$updated_fields[]    = $field;
+					}
 				}
 				continue;
 			}
@@ -500,8 +669,10 @@ class EventUpdateAbilities {
 				continue;
 			}
 
-			$new_attrs[ $field ] = $value;
-			$updated_fields[]    = $field;
+			if ( ( $existing_attrs[ $field ] ?? null ) !== $value ) {
+				$new_attrs[ $field ] = $value;
+				$updated_fields[]    = $field;
+			}
 		}
 
 		return $new_attrs;
@@ -522,9 +693,18 @@ class EventUpdateAbilities {
 		$term = get_term( $venue_id, 'venue' );
 
 		if ( ! $term || is_wp_error( $term ) ) {
+			$error = new \WP_Error(
+				'event_venue_assignment_failed',
+				"Venue ID {$venue_id} was not found.",
+				array(
+					'status'    => 400,
+					'retryable' => false,
+				)
+			);
 			return array(
 				'success' => false,
-				'warning' => "Venue ID {$venue_id} not found, skipped venue assignment",
+				'warning' => $error->get_error_message(),
+				'error'   => $error,
 			);
 		}
 
@@ -601,13 +781,382 @@ class EventUpdateAbilities {
 		}
 	}
 
-	/**
-	 * Build summary message for results.
-	 *
-	 * @param int $updated Number of successfully updated events
-	 * @param int $failed Number of failed updates
-	 * @return string Human-readable summary
-	 */
+	/** Verify immutable source ownership and the caller's exact observed state. */
+	private function verifySourceInput( array $input ) {
+		$event_id    = absint( $input['event'] ?? 0 );
+		$source      = trim( (string) ( $input['source'] ?? '' ) );
+		$source_id   = trim( (string) ( $input['source_id'] ?? '' ) );
+		$identity    = strtolower( trim( (string) ( $input['source_identity'] ?? '' ) ) );
+		$fingerprint = strtolower( trim( (string) ( $input['expected_fingerprint'] ?? '' ) ) );
+		$post        = get_post( $event_id );
+
+		if ( $event_id < 1 || ! $post || Event_Post_Type::POST_TYPE !== $post->post_type ) {
+			return new \WP_Error(
+				'source_event_not_found',
+				'The source-owned event was not found.',
+				array(
+					'status'    => 404,
+					'retryable' => false,
+				)
+			);
+		}
+		if ( '' === $source || '' === $source_id || ! preg_match( '/^[a-f0-9]{64}$/', $identity ) || ! preg_match( '/^[a-f0-9]{64}$/', $fingerprint ) ) {
+			return new \WP_Error(
+				'source_event_update_input_invalid',
+				'Source, source_id, source_identity, and a SHA-256 expected fingerprint are required.',
+				array(
+					'status'    => 400,
+					'retryable' => false,
+				)
+			);
+		}
+		foreach ( array( 'startDate', 'endDate' ) as $field ) {
+			if ( isset( $input[ $field ] ) && '' !== (string) $input[ $field ] && empty( DateTimeParser::parse( (string) $input[ $field ] )['date'] ) ) {
+				return new \WP_Error( 'source_event_update_input_invalid', "{$field} is not a valid date.", array(
+					'status'    => 400,
+					'retryable' => false,
+				) );
+			}
+		}
+		foreach ( array( 'startTime', 'endTime' ) as $field ) {
+			if ( isset( $input[ $field ] ) && '' !== (string) $input[ $field ] && empty( DateTimeParser::parse( '2000-01-01 ' . (string) $input[ $field ] )['time'] ) ) {
+				return new \WP_Error( 'source_event_update_input_invalid', "{$field} is not a valid time.", array(
+					'status'    => 400,
+					'retryable' => false,
+				) );
+			}
+		}
+		foreach ( (array) ( $input['occurrenceDates'] ?? array() ) as $date ) {
+			if ( ! is_string( $date ) || empty( DateTimeParser::parse( $date )['date'] ) ) {
+				return new \WP_Error( 'source_event_update_input_invalid', 'occurrenceDates contains an invalid date.', array(
+					'status'    => 400,
+					'retryable' => false,
+				) );
+			}
+		}
+		if ( ! hash_equals( hash( 'sha256', $source . "\0" . $source_id ), $identity )
+			|| get_post_meta( $event_id, EventUpsert::SOURCE_NAME_META_KEY, true ) !== $source
+			|| get_post_meta( $event_id, EventUpsert::SOURCE_ID_META_KEY, true ) !== $source_id
+			|| get_post_meta( $event_id, EventUpsert::SOURCE_IDENTITY_META_KEY, true ) !== $identity ) {
+			return new \WP_Error(
+				'source_event_identity_mismatch',
+				'The event does not belong to the supplied source identity.',
+				array(
+					'status'    => 409,
+					'retryable' => false,
+				)
+			);
+		}
+		$current = $this->eventFingerprint( $event_id, $source, $source_id, $identity );
+		if ( is_wp_error( $current ) ) {
+			return $current;
+		}
+		if ( ! hash_equals( $current, $fingerprint ) ) {
+			return new \WP_Error( 'source_event_fingerprint_conflict', 'The event changed since the caller observed it.', array(
+				'status'      => 409,
+				'retryable'   => false,
+				'fingerprint' => $current,
+			) );
+		}
+
+		return array(
+			'event_id'        => $event_id,
+			'source'          => $source,
+			'source_id'       => $source_id,
+			'source_identity' => $identity,
+			'fingerprint'     => $current,
+		);
+	}
+
+	/** Begin the transaction after publication preflight has acquired its lock. */
+	private function beginSourceTransaction( int $post_id ) {
+		global $wpdb;
+		if ( false === $this->transactionQuery( 'START TRANSACTION' ) ) {
+			return $this->sourceTransactionError( 'source_event_transaction_start_failed', 'The atomic event update could not start.' );
+		}
+		$this->source_transaction_active = true;
+		$locked                          = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE ID = %d FOR UPDATE", $post_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact event transaction lock.
+		if ( $post_id !== (int) $locked || '' !== (string) $wpdb->last_error ) {
+			$rollback = $this->rollbackSourceTransaction( $post_id );
+			return is_wp_error( $rollback ) ? $rollback : $this->sourceTransactionError( 'source_event_lock_failed', 'The source-owned event could not be locked.' );
+		}
+		$wpdb->get_col( $wpdb->prepare( "SELECT meta_id FROM {$wpdb->postmeta} WHERE post_id = %d FOR UPDATE", $post_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Lock source identity metadata and manual event metadata until commit.
+		$wpdb->get_col( $wpdb->prepare( "SELECT object_id FROM {$wpdb->term_relationships} WHERE object_id = %d FOR UPDATE", $post_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Lock current venue relationship until commit.
+		if ( '' !== (string) $wpdb->last_error ) {
+			$rollback = $this->rollbackSourceTransaction( $post_id );
+			return is_wp_error( $rollback ) ? $rollback : $this->sourceTransactionError( 'source_event_lock_failed', 'The source-owned event state could not be locked.' );
+		}
+		clean_post_cache( $post_id );
+		$verified = $this->verifySourceInput(
+			array(
+				'event'                => $post_id,
+				'source'               => $this->source_context['source'],
+				'source_id'            => $this->source_context['source_id'],
+				'source_identity'      => $this->source_context['source_identity'],
+				'expected_fingerprint' => $this->source_context['expected_fingerprint'],
+			)
+		);
+		if ( is_wp_error( $verified ) ) {
+			$rollback = $this->rollbackSourceTransaction( $post_id );
+			return is_wp_error( $rollback ) ? $rollback : $verified;
+		}
+		return true;
+	}
+
+	/** Build a stable retryable database-control failure. */
+	private function sourceTransactionError( string $code, string $message ): \WP_Error {
+		global $wpdb;
+		return new \WP_Error(
+			$code,
+			$message,
+			array(
+				'status'         => 503,
+				'retryable'      => true,
+				'database_error' => $wpdb->last_error,
+			)
+		);
+	}
+
+	/** Commit without guessing after an uncertain database result. */
+	private function commitSourceTransaction( int $post_id ) {
+		global $wpdb;
+		$result                          = $this->transactionQuery( 'COMMIT' );
+		$this->source_transaction_active = false;
+		clean_post_cache( $post_id );
+		if ( false !== $result ) {
+			return true;
+		}
+		$quarantine = $this->quarantineSourceConnection( $post_id );
+		return new \WP_Error(
+			'source_event_commit_uncertain',
+			'The atomic event update outcome could not be confirmed; read the event fingerprint before retrying.',
+			array(
+				'status'               => 503,
+				'retryable'            => true,
+				'database_error'       => $wpdb->last_error,
+				'connection_closed'    => $quarantine['closed'],
+				'connection_recovered' => $quarantine['recovered'],
+			)
+		);
+	}
+
+	/** Roll back one active source update and invalidate rolled-back caches. */
+	private function rollbackSourceTransaction( int $post_id ) {
+		global $wpdb;
+		if ( $this->source_transaction_active ) {
+			$result                          = $this->transactionQuery( 'ROLLBACK' );
+			$this->source_transaction_active = false;
+			if ( false === $result ) {
+				$quarantine = $this->quarantineSourceConnection( $post_id );
+				return new \WP_Error(
+					'source_event_rollback_uncertain',
+					'The database did not confirm the atomic event rollback; read the event fingerprint before retrying.',
+					array(
+						'status'               => 503,
+						'retryable'            => true,
+						'database_error'       => $wpdb->last_error,
+						'connection_closed'    => $quarantine['closed'],
+						'connection_recovered' => $quarantine['recovered'],
+					)
+				);
+			}
+		}
+		clean_post_cache( $post_id );
+		clean_object_term_cache( $post_id, Event_Post_Type::POST_TYPE );
+		return true;
+	}
+
+	/** Roll back before returning an existing structured update failure. */
+	private function rollbackSourceResult( int $post_id, array $result ): array {
+		$rollback = $this->rollbackSourceTransaction( $post_id );
+		if ( ! is_wp_error( $rollback ) ) {
+			return $result;
+		}
+		$post = get_post( $post_id );
+		return $post ? $this->updateErrorResult( $post, $rollback ) : $result;
+	}
+
+	/** Execute transaction control SQL through an overridable test seam. */
+	protected function transactionQuery( string $sql ) {
+		global $wpdb;
+		// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
+		return $wpdb->query( $sql );
+		// phpcs:enable WordPress.DB.PreparedSQL
+	}
+
+	/** Close an uncertain database session before attempting a fresh connection. */
+	private function quarantineSourceConnection( int $post_id ): array {
+		global $wpdb;
+		$closed    = empty( $wpdb->dbh ) || ( is_callable( array( $wpdb, 'close' ) ) && true === $wpdb->close() );
+		$recovered = $closed && true === $wpdb->check_connection( false );
+		if ( $recovered ) {
+			clean_post_cache( $post_id );
+			clean_object_term_cache( $post_id, Event_Post_Type::POST_TYPE );
+		}
+		return array(
+			'closed'    => $closed,
+			'recovered' => $recovered,
+		);
+	}
+
+	/** Build a stable fingerprint for all persisted event and source ownership state. */
+	public static function fingerprintForEvent( int $event_id, string $source, string $source_id, string $source_identity = '' ) {
+		$post = get_post( $event_id );
+		if ( ! $post || Event_Post_Type::POST_TYPE !== $post->post_type ) {
+			return new \WP_Error(
+				'source_event_not_found',
+				'The source-owned event was not found.',
+				array(
+					'status'    => 404,
+					'retryable' => false,
+				)
+			);
+		}
+		$stored_source   = (string) get_post_meta( $event_id, EventUpsert::SOURCE_NAME_META_KEY, true );
+		$stored_id       = (string) get_post_meta( $event_id, EventUpsert::SOURCE_ID_META_KEY, true );
+		$stored_identity = (string) get_post_meta( $event_id, EventUpsert::SOURCE_IDENTITY_META_KEY, true );
+		$source_identity = '' === $source_identity ? hash( 'sha256', $source . "\0" . $source_id ) : $source_identity;
+		if ( $stored_source !== $source || $stored_id !== $source_id || ! hash_equals( $stored_identity, $source_identity ) ) {
+			return new \WP_Error(
+				'source_event_identity_mismatch',
+				'The event does not belong to the supplied source identity.',
+				array(
+					'status'    => 409,
+					'retryable' => false,
+				)
+			);
+		}
+		$venues = wp_get_object_terms( $event_id, 'venue', array( 'fields' => 'ids' ) );
+		if ( is_wp_error( $venues ) ) {
+			return new \WP_Error( 'source_event_venue_read_failed', 'The event venue could not be fingerprinted.', array(
+				'status'    => 503,
+				'retryable' => true,
+				'cause'     => $venues->get_error_code(),
+			) );
+		}
+		$venues = array_values( array_unique( array_map( 'absint', (array) $venues ) ) );
+		sort( $venues, SORT_NUMERIC );
+		$payload = wp_json_encode(
+			array(
+				'event_id'        => $event_id,
+				'post_status'     => $post->post_status,
+				'post_title'      => $post->post_title,
+				'post_content'    => $post->post_content,
+				'venue_ids'       => $venues,
+				'source'          => $stored_source,
+				'source_id'       => $stored_id,
+				'source_identity' => $stored_identity,
+			)
+		);
+		return false === $payload ? new \WP_Error( 'source_event_fingerprint_failed', 'The event fingerprint could not be encoded.', array(
+			'status'    => 500,
+			'retryable' => true,
+		) ) : hash( 'sha256', $payload );
+	}
+
+	/** Instance wrapper for the public fingerprint helper. */
+	private function eventFingerprint( int $event_id, string $source, string $source_id, string $source_identity ) {
+		return self::fingerprintForEvent( $event_id, $source, $source_id, $source_identity );
+	}
+
+	/** Return the strict source-owned update input contract. */
+	private function getSourceInputSchema(): array {
+		$string = array( 'type' => 'string' );
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'event'                => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+				),
+				'source'               => array(
+					'type'      => 'string',
+					'minLength' => 1,
+				),
+				'source_id'            => array(
+					'type'      => 'string',
+					'minLength' => 1,
+				),
+				'source_identity'      => array(
+					'type'    => 'string',
+					'pattern' => '^[a-f0-9]{64}$',
+				),
+				'expected_fingerprint' => array(
+					'type'    => 'string',
+					'pattern' => '^[a-f0-9]{64}$',
+				),
+				'startDate'            => $string,
+				'startTime'            => $string,
+				'endDate'              => $string,
+				'endTime'              => $string,
+				'occurrenceDates'      => array(
+					'type'  => 'array',
+					'items' => $string,
+				),
+				'venue'                => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+				),
+				'description'          => $string,
+				'price'                => $string,
+				'priceCurrency'        => $string,
+				'ticketUrl'            => array(
+					'type'   => 'string',
+					'format' => 'uri',
+				),
+				'offerAvailability'    => $string,
+				'validFrom'            => $string,
+				'performer'            => $string,
+				'performerType'        => array(
+					'type' => 'string',
+					'enum' => array( 'Person', 'PerformingGroup', 'MusicGroup' ),
+				),
+				'organizer'            => $string,
+				'organizerType'        => $string,
+				'organizerUrl'         => array(
+					'type'   => 'string',
+					'format' => 'uri',
+				),
+				'eventStatus'          => array(
+					'type' => 'string',
+					'enum' => array( 'EventScheduled', 'EventPostponed', 'EventCancelled', 'EventRescheduled' ),
+				),
+				'previousStartDate'    => $string,
+				'eventType'            => array(
+					'type' => 'string',
+					'enum' => array( 'Event', 'MusicEvent', 'Festival', 'ComedyEvent', 'DanceEvent', 'TheaterEvent', 'SportsEvent', 'ExhibitionEvent' ),
+				),
+			),
+			'required'             => array( 'event', 'source', 'source_id', 'source_identity', 'expected_fingerprint' ),
+			'minProperties'        => 6,
+			'additionalProperties' => false,
+		);
+	}
+
+	/** Return the stable source-owned update result contract. */
+	private function getSourceOutputSchema(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'success'              => array( 'type' => 'boolean' ),
+				'event_id'             => array( 'type' => 'integer' ),
+				'action'               => array(
+					'type' => 'string',
+					'enum' => array( 'updated', 'no_change' ),
+				),
+				'previous_fingerprint' => array( 'type' => 'string' ),
+				'fingerprint'          => array( 'type' => 'string' ),
+				'updated_fields'       => array(
+					'type'     => 'array',
+					'items'    => array( 'type' => 'string' ),
+					'maxItems' => 30,
+				),
+			),
+			'required'             => array( 'success', 'event_id', 'action', 'previous_fingerprint', 'fingerprint', 'updated_fields' ),
+			'additionalProperties' => false,
+		);
+	}
+
 	private function buildSummaryMessage( int $updated, int $failed ): string {
 		$parts = array();
 

--- a/inc/Abilities/EventUpsertAbilities.php
+++ b/inc/Abilities/EventUpsertAbilities.php
@@ -137,18 +137,23 @@ class EventUpsertAbilities {
 		$venue_term  = ! is_wp_error( $venue_terms ) && ! empty( $venue_terms ) ? $venue_terms[0] : null;
 		$post        = get_post( $post_id );
 		$dates       = \DataMachineEvents\Core\EventDatesTable::get( $post_id );
+		$fingerprint = EventUpdateAbilities::fingerprintForEvent( $post_id, $source, $source_id, $event['source_identity'] );
+		if ( is_wp_error( $fingerprint ) ) {
+			return $fingerprint;
+		}
 
 		return array(
-			'success'    => true,
-			'event_id'   => $post_id,
-			'event_url'  => (string) ( $result['data']['post_url'] ?? get_permalink( $post_id ) ),
-			'action'     => (string) $result['data']['action'],
-			'source'     => array(
+			'success'     => true,
+			'event_id'    => $post_id,
+			'event_url'   => (string) ( $result['data']['post_url'] ?? get_permalink( $post_id ) ),
+			'action'      => (string) $result['data']['action'],
+			'fingerprint' => $fingerprint,
+			'source'      => array(
 				'name'     => $source,
 				'id'       => $source_id,
 				'identity' => $event['source_identity'],
 			),
-			'normalized' => array(
+			'normalized'  => array(
 				'title'          => $post instanceof \WP_Post ? $post->post_title : (string) ( $event['title'] ?? '' ),
 				'post_status'    => $post instanceof \WP_Post ? $post->post_status : $config['post_status'],
 				'start_datetime' => $dates ? (string) $dates->start_datetime : '',
@@ -267,16 +272,17 @@ class EventUpsertAbilities {
 	private function getOutputSchema(): array {
 		return array(
 			'type'       => 'object',
-			'required'   => array( 'success', 'event_id', 'event_url', 'action', 'source', 'normalized' ),
+			'required'   => array( 'success', 'event_id', 'event_url', 'action', 'fingerprint', 'source', 'normalized' ),
 			'properties' => array(
-				'success'    => array( 'type' => 'boolean' ),
-				'event_id'   => array( 'type' => 'integer' ),
-				'event_url'  => array( 'type' => 'string' ),
-				'action'     => array(
+				'success'     => array( 'type' => 'boolean' ),
+				'event_id'    => array( 'type' => 'integer' ),
+				'event_url'   => array( 'type' => 'string' ),
+				'action'      => array(
 					'type' => 'string',
 					'enum' => array( 'created', 'updated', 'no_change' ),
 				),
-				'source'     => array(
+				'fingerprint' => array( 'type' => 'string' ),
+				'source'      => array(
 					'type'       => 'object',
 					'required'   => array( 'name', 'id', 'identity' ),
 					'properties' => array(
@@ -285,7 +291,7 @@ class EventUpsertAbilities {
 						'identity' => array( 'type' => 'string' ),
 					),
 				),
-				'normalized' => array(
+				'normalized'  => array(
 					'type'       => 'object',
 					'required'   => array( 'title', 'post_status', 'start_datetime', 'end_datetime', 'venue', 'venue_id' ),
 					'properties' => array(

--- a/inc/Core/EventDatesTable.php
+++ b/inc/Core/EventDatesTable.php
@@ -122,7 +122,7 @@ class EventDatesTable {
 			$post_status = get_post_status( $post_id ) ?: 'publish';
 		}
 
-		$wpdb->replace(
+		$result = $wpdb->replace(
 			self::table_name(),
 			array(
 				'post_id'        => $post_id,
@@ -133,7 +133,7 @@ class EventDatesTable {
 			array( '%d', '%s', $end_datetime ? '%s' : null, '%s' )
 		);
 
-		return true;
+		return false !== $result;
 	}
 
 	/**
@@ -177,17 +177,23 @@ class EventDatesTable {
 	 * Delete an event's dates from the table.
 	 *
 	 * @param int $post_id Post ID.
+	 * @return bool True when the delete was confirmed.
 	 */
-	public static function delete( int $post_id ): void {
+	public static function delete( int $post_id ): bool {
 		global $wpdb;
 
-		$wpdb->delete(
+		$result = $wpdb->delete(
 			self::table_name(),
 			array( 'post_id' => $post_id ),
 			array( '%d' )
 		);
 
-		do_action( 'datamachine_event_dates_deleted', $post_id );
+		if ( false !== $result ) {
+			do_action( 'datamachine_event_dates_deleted', $post_id );
+			return true;
+		}
+
+		return false;
 	}
 
 	/**

--- a/inc/Core/event-dates-sync.php
+++ b/inc/Core/event-dates-sync.php
@@ -211,6 +211,23 @@ function data_machine_events_sync_datetime_meta( $post_id, $post, $update ) {
 	if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 		return;
 	}
+	$delete_dates = static function ( int $event_id ): void {
+		if ( EventDatesTable::delete( $event_id ) ) {
+			return;
+		}
+		do_action(
+			'datamachine_event_dates_sync_failed',
+			new \WP_Error(
+				'event_dates_delete_failed',
+				'The derived event dates could not be deleted.',
+				array(
+					'status'    => 503,
+					'retryable' => true,
+				)
+			),
+			$event_id
+		);
+	};
 
 	// Parse blocks to extract event details from Event Details block.
 	$blocks              = parse_blocks( $post->post_content );
@@ -301,21 +318,34 @@ function data_machine_events_sync_datetime_meta( $post_id, $post, $update ) {
 					$end_datetime_val = null;
 				}
 
-				EventDatesTable::upsert( $post_id, $datetime, $end_datetime_val );
-
-				/**
-				 * Fires after event dates are written to the event_dates table.
-				 *
-				 * Replaces the `updated_post_meta`/`added_post_meta` hooks that
-				 * previously fired from update_post_meta() calls.
-				 *
-				 * @param int         $post_id        Post ID.
-				 * @param string      $start_datetime Start datetime.
-				 * @param string|null $end_datetime   End datetime or null.
-				 */
-				do_action( 'datamachine_event_dates_updated', $post_id, $datetime, $end_datetime_val );
+				if ( EventDatesTable::upsert( $post_id, $datetime, $end_datetime_val ) ) {
+					/**
+					 * Fires after event dates are written to the event_dates table.
+					 *
+					 * Replaces the `updated_post_meta`/`added_post_meta` hooks that
+					 * previously fired from update_post_meta() calls.
+					 *
+					 * @param int         $post_id        Post ID.
+					 * @param string      $start_datetime Start datetime.
+					 * @param string|null $end_datetime   End datetime or null.
+					 */
+					do_action( 'datamachine_event_dates_updated', $post_id, $datetime, $end_datetime_val );
+				} else {
+					do_action(
+						'datamachine_event_dates_sync_failed',
+						new \WP_Error(
+							'event_dates_write_failed',
+							'The derived event dates could not be persisted.',
+							array(
+								'status'    => 503,
+								'retryable' => true,
+							)
+						),
+						$post_id
+					);
+				}
 			} else {
-				EventDatesTable::delete( $post_id );
+				$delete_dates( $post_id );
 			}
 
 			// Sync ticket URL for duplicate detection queries.
@@ -331,7 +361,7 @@ function data_machine_events_sync_datetime_meta( $post_id, $post, $update ) {
 	}
 
 	if ( ! $event_details_found ) {
-		EventDatesTable::delete( $post_id );
+		$delete_dates( $post_id );
 		delete_post_meta( $post_id, EVENT_TICKET_URL_META_KEY );
 	}
 }

--- a/tests/Integration/EventSourceUpdateMySqlAtomicityTest.php
+++ b/tests/Integration/EventSourceUpdateMySqlAtomicityTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Real MySQL atomic source-update coverage.
+ *
+ * @package DataMachineEvents\Tests\Integration
+ */
+
+namespace DataMachineEvents\Tests\Integration;
+
+use DataMachineEvents\Abilities\EventUpdateAbilities;
+use DataMachineEvents\Core\Event_Post_Type;
+use DataMachineEvents\Core\Venue_Taxonomy;
+use WP_UnitTestCase;
+
+class EventSourceUpdateMySqlAtomicityTest extends WP_UnitTestCase {
+
+	public function setUp(): void {
+		parent::setUp();
+		global $wpdb;
+		if ( ! $wpdb->dbh instanceof \mysqli ) {
+			$this->markTestSkipped( 'Atomic update integration skipped: WordPress is not using MySQL.' );
+		}
+		if ( ! post_type_exists( Event_Post_Type::POST_TYPE ) ) {
+			Event_Post_Type::register();
+		}
+		if ( ! taxonomy_exists( 'venue' ) ) {
+			Venue_Taxonomy::register();
+		}
+	}
+
+	public function tearDown(): void {
+		remove_all_filters( 'datamachine_events_update_source_event_permission' );
+		remove_all_actions( 'datamachine_events_after_event_venue_mutation' );
+		parent::tearDown();
+	}
+
+	public function test_second_connection_never_observes_combined_update_half_applied(): void {
+		global $table_prefix;
+		add_filter( 'datamachine_events_update_source_event_permission', '__return_true' );
+		$previous = wp_insert_term( 'Atomic Previous ' . uniqid(), 'venue' );
+		$next     = wp_insert_term( 'Atomic Next ' . uniqid(), 'venue' );
+		$this->assertNotWPError( $previous );
+		$this->assertNotWPError( $next );
+		$event_id = self::factory()->post->create(
+			array(
+				'post_type'    => Event_Post_Type::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:data-machine-events/event-details {"startDate":"2027-01-01","startTime":"20:00"} --><div></div><!-- /wp:data-machine-events/event-details -->',
+			)
+		);
+		wp_set_post_terms( $event_id, array( $previous['term_id'] ), 'venue' );
+		$identity = hash( 'sha256', "booking\0booking-atomic" );
+		update_post_meta( $event_id, '_datamachine_event_source', 'booking' );
+		update_post_meta( $event_id, '_datamachine_event_source_id', 'booking-atomic' );
+		update_post_meta( $event_id, '_datamachine_event_source_identity', $identity );
+		$observed = null;
+
+		add_action(
+			'datamachine_events_after_event_venue_mutation',
+			static function () use ( &$observed, $event_id, $table_prefix ): void {
+				$reader = new \wpdb( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST );
+				$reader->set_prefix( $table_prefix );
+				$content = $reader->get_var( $reader->prepare( "SELECT post_content FROM {$reader->posts} WHERE ID = %d", $event_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Independent connection proves transaction isolation.
+				$terms = $reader->get_col(
+					$reader->prepare(
+						"SELECT tt.term_id FROM {$reader->term_relationships} tr INNER JOIN {$reader->term_taxonomy} tt ON tt.term_taxonomy_id = tr.term_taxonomy_id WHERE tr.object_id = %d AND tt.taxonomy = 'venue'",
+						$event_id
+					)
+				); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Independent connection proves transaction isolation.
+				$observed = array( (string) $content, array_map( 'intval', $terms ) );
+				$reader->close();
+			},
+			10,
+			0
+		);
+
+		$result = ( new EventUpdateAbilities() )->executeUpdateSourceEvent(
+			array(
+				'event'                => $event_id,
+				'source'               => 'booking',
+				'source_id'            => 'booking-atomic',
+				'source_identity'      => $identity,
+				'expected_fingerprint' => EventUpdateAbilities::fingerprintForEvent( $event_id, 'booking', 'booking-atomic', $identity ),
+				'venue'                => (int) $next['term_id'],
+				'startTime'            => '21:00',
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertStringContainsString( '"startTime":"20:00"', $observed[0] );
+		$this->assertSame( array( (int) $previous['term_id'] ), $observed[1] );
+		$this->assertStringContainsString( '"startTime":"21:00"', get_post( $event_id )->post_content );
+		$this->assertSame( array( (int) $next['term_id'] ), wp_get_object_terms( $event_id, 'venue', array( 'fields' => 'ids' ) ) );
+	}
+}

--- a/tests/Unit/EventUpdateAbilitiesTest.php
+++ b/tests/Unit/EventUpdateAbilitiesTest.php
@@ -25,6 +25,7 @@ class EventUpdateAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function tearDown(): void {
+		remove_all_filters( 'datamachine_events_update_source_event_permission' );
 		remove_all_filters( 'datamachine_events_before_event_venue_mutation' );
 		remove_all_actions( 'datamachine_events_after_event_venue_mutation' );
 		remove_all_filters( 'datamachine_events_before_event_update_persistence' );
@@ -32,6 +33,228 @@ class EventUpdateAbilitiesTest extends WP_UnitTestCase {
 		remove_all_filters( 'wp_insert_post_empty_content' );
 		$this->registerEventObjects();
 		parent::tearDown();
+	}
+
+	public function test_source_update_requires_narrow_delegated_permission(): void {
+		$event_id = $this->makeSourceEvent();
+		$result   = $this->ability->executeUpdateSourceEvent( $this->sourceInput( $event_id, array( 'startTime' => '21:00' ) ) );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'source_event_update_forbidden', $result->get_error_code() );
+		$this->assertSame( '20:00', parse_blocks( get_post( $event_id )->post_content )[0]['attrs']['startTime'] );
+	}
+
+	public function test_registered_ability_execution_cannot_bypass_scoped_permission(): void {
+		do_action( 'wp_abilities_api_init' );
+		$registered = wp_get_ability( EventUpdateAbilities::SOURCE_ABILITY_NAME );
+		$this->assertNotNull( $registered );
+		$result = $registered->execute( $this->sourceInput( $this->makeSourceEvent(), array( 'startTime' => '21:00' ) ) );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'source_event_update_forbidden', $result->get_error_code() );
+	}
+
+	public function test_source_update_rejects_wrong_identity_event_and_stale_fingerprint(): void {
+		add_filter( 'datamachine_events_update_source_event_permission', '__return_true' );
+		$event_id = $this->makeSourceEvent();
+
+		$wrong_source           = $this->sourceInput( $event_id, array( 'startTime' => '21:00' ) );
+		$wrong_source['source'] = 'other-source';
+		$result                 = $this->ability->executeUpdateSourceEvent( $wrong_source );
+		$this->assertWPError( $result );
+		$this->assertSame( 'source_event_identity_mismatch', $result->get_error_code() );
+
+		$wrong_source_id              = $this->sourceInput( $event_id, array( 'startTime' => '21:00' ) );
+		$wrong_source_id['source_id'] = 'other-id';
+		$result                       = $this->ability->executeUpdateSourceEvent( $wrong_source_id );
+		$this->assertWPError( $result );
+		$this->assertSame( 'source_event_identity_mismatch', $result->get_error_code() );
+
+		$wrong_identity                    = $this->sourceInput( $event_id, array( 'startTime' => '21:00' ) );
+		$wrong_identity['source_identity'] = str_repeat( 'b', 64 );
+		$result                            = $this->ability->executeUpdateSourceEvent( $wrong_identity );
+		$this->assertWPError( $result );
+		$this->assertSame( 'source_event_identity_mismatch', $result->get_error_code() );
+
+		$wrong_event          = $this->sourceInput( $event_id, array( 'startTime' => '21:00' ) );
+		$wrong_event['event'] = self::factory()->post->create( array( 'post_type' => 'post' ) );
+		$result               = $this->ability->executeUpdateSourceEvent( $wrong_event );
+		$this->assertWPError( $result );
+		$this->assertSame( 'source_event_not_found', $result->get_error_code() );
+
+		$stale                         = $this->sourceInput( $event_id, array( 'startTime' => '21:00' ) );
+		$stale['expected_fingerprint'] = str_repeat( 'a', 64 );
+		$result                        = $this->ability->executeUpdateSourceEvent( $stale );
+		$this->assertWPError( $result );
+		$this->assertSame( 'source_event_fingerprint_conflict', $result->get_error_code() );
+		$this->assertSame( 409, $result->get_error_data()['status'] );
+		$this->assertFalse( $result->get_error_data()['retryable'] );
+		$this->assertMatchesRegularExpression( '/^[a-f0-9]{64}$/', $result->get_error_data()['fingerprint'] );
+
+		$result = $this->ability->executeUpdateSourceEvent( $this->sourceInput( $event_id, array( 'venue' => PHP_INT_MAX ) ) );
+		$this->assertWPError( $result );
+		$this->assertSame( 'event_venue_assignment_failed', $result->get_error_code() );
+		$this->assertSame( array(), wp_get_object_terms( $event_id, 'venue', array( 'fields' => 'ids' ) ) );
+
+		$result = $this->ability->executeUpdateSourceEvent( $this->sourceInput( $event_id, array( 'startDate' => '2027-99-99' ) ) );
+		$this->assertWPError( $result );
+		$this->assertSame( 'source_event_update_input_invalid', $result->get_error_code() );
+		$this->assertSame( '2027-01-01', parse_blocks( get_post( $event_id )->post_content )[0]['attrs']['startDate'] );
+	}
+
+	public function test_source_update_atomically_changes_venue_and_time_through_lifecycle(): void {
+		add_filter( 'datamachine_events_update_source_event_permission', '__return_true' );
+		$event_id = $this->makeSourceEvent();
+		$previous = $this->makeVenue( 'Source Previous Venue' );
+		$next     = $this->makeVenue( 'Source Next Venue' );
+		$observed = array();
+		wp_set_post_terms( $event_id, array( $previous ), 'venue' );
+		$fingerprint = EventUpdateAbilities::fingerprintForEvent( $event_id, 'booking', 'booking-123' );
+
+		add_filter(
+			'datamachine_events_before_event_update_persistence',
+			static function ( $allowed, array $context ) use ( &$observed ) {
+				$observed[] = array( 'before', $context['next_venue_id'], $context['event']['startTime'] );
+				return $allowed;
+			},
+			10,
+			2
+		);
+		add_action(
+			'datamachine_events_after_event_update_persistence',
+			static function ( array $context, array $result ) use ( &$observed ): void {
+				$observed[] = array( 'after', $result['status'] );
+			},
+			10,
+			2
+		);
+
+		$result = $this->ability->executeUpdateSourceEvent(
+			array(
+				'event'                => $event_id,
+				'source'               => 'booking',
+				'source_id'            => 'booking-123',
+				'source_identity'      => hash( 'sha256', "booking\0booking-123" ),
+				'expected_fingerprint' => $fingerprint,
+				'venue'                => $next,
+				'startTime'            => '21:30',
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'updated', $result['action'] );
+		$this->assertSame( array( 'startTime', 'venue' ), $result['updated_fields'] );
+		$this->assertNotSame( $fingerprint, $result['fingerprint'] );
+		$this->assertSame( array( $next ), wp_get_object_terms( $event_id, 'venue', array( 'fields' => 'ids' ) ) );
+		$this->assertSame( '21:30', parse_blocks( get_post( $event_id )->post_content )[0]['attrs']['startTime'] );
+		$this->assertSame( 'Manual title retained', get_post( $event_id )->post_title );
+		$this->assertSame( array( array( 'before', $next, '21:30' ), array( 'after', 'updated' ) ), $observed );
+	}
+
+	public function test_source_update_rolls_back_venue_when_content_write_fails(): void {
+		add_filter( 'datamachine_events_update_source_event_permission', '__return_true' );
+		$event_id = $this->makeSourceEvent();
+		$previous = $this->makeVenue( 'Rollback Previous Venue' );
+		$next     = $this->makeVenue( 'Rollback Next Venue' );
+		wp_set_post_terms( $event_id, array( $previous ), 'venue' );
+		$input = $this->sourceInput( $event_id, array( 'venue' => $next, 'startTime' => '22:00' ) );
+		add_filter( 'wp_insert_post_empty_content', '__return_true' );
+
+		$result = $this->ability->executeUpdateSourceEvent( $input );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'empty_content', $result->get_error_code() );
+		$this->assertSame( array( $previous ), wp_get_object_terms( $event_id, 'venue', array( 'fields' => 'ids' ) ) );
+		$this->assertSame( '20:00', parse_blocks( get_post( $event_id )->post_content )[0]['attrs']['startTime'] );
+		$this->assertSame( $input['expected_fingerprint'], EventUpdateAbilities::fingerprintForEvent( $event_id, 'booking', 'booking-123' ) );
+	}
+
+	public function test_source_update_rolls_back_when_derived_date_write_fails(): void {
+		add_filter( 'datamachine_events_update_source_event_permission', '__return_true' );
+		$event_id = $this->makeSourceEvent();
+		$input    = $this->sourceInput( $event_id, array( 'startTime' => '22:30' ) );
+		$fail_date_replace = static function ( string $query ): string {
+			return str_contains( $query, 'REPLACE INTO' ) && str_contains( $query, 'datamachine_event_dates' )
+				? 'INVALID EVENT DATE WRITE'
+				: $query;
+		};
+		add_filter( 'query', $fail_date_replace );
+
+		try {
+			$result = $this->ability->executeUpdateSourceEvent( $input );
+		} finally {
+			remove_filter( 'query', $fail_date_replace );
+		}
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'event_dates_write_failed', $result->get_error_code() );
+		$this->assertTrue( $result->get_error_data()['retryable'] );
+		$this->assertSame( '20:00', parse_blocks( get_post( $event_id )->post_content )[0]['attrs']['startTime'] );
+		$this->assertSame( $input['expected_fingerprint'], EventUpdateAbilities::fingerprintForEvent( $event_id, 'booking', 'booking-123' ) );
+	}
+
+	public function test_source_update_rolls_back_when_derived_date_delete_fails(): void {
+		add_filter( 'datamachine_events_update_source_event_permission', '__return_true' );
+		$event_id = $this->makeSourceEvent();
+		$input    = $this->sourceInput( $event_id, array( 'startDate' => '' ) );
+		$fail_date_delete = static function ( string $query ): string {
+			return str_contains( $query, 'DELETE FROM' ) && str_contains( $query, 'datamachine_event_dates' )
+				? 'INVALID EVENT DATE DELETE'
+				: $query;
+		};
+		add_filter( 'query', $fail_date_delete );
+
+		try {
+			$result = $this->ability->executeUpdateSourceEvent( $input );
+		} finally {
+			remove_filter( 'query', $fail_date_delete );
+		}
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'event_dates_delete_failed', $result->get_error_code() );
+		$this->assertTrue( $result->get_error_data()['retryable'] );
+		$this->assertSame( '2027-01-01', parse_blocks( get_post( $event_id )->post_content )[0]['attrs']['startDate'] );
+		$this->assertSame( $input['expected_fingerprint'], EventUpdateAbilities::fingerprintForEvent( $event_id, 'booking', 'booking-123' ) );
+	}
+
+	public function test_source_update_surfaces_commit_uncertainty_as_retryable(): void {
+		add_filter( 'datamachine_events_update_source_event_permission', '__return_true' );
+		$event_id = $this->makeSourceEvent();
+		$ability  = new class() extends EventUpdateAbilities {
+			protected function transactionQuery( string $sql ) {
+				$result = parent::transactionQuery( $sql );
+				return 'COMMIT' === $sql ? false : $result;
+			}
+		};
+
+		$result = $ability->executeUpdateSourceEvent( $this->sourceInput( $event_id, array( 'startTime' => '23:00' ) ) );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'source_event_commit_uncertain', $result->get_error_code() );
+		$this->assertTrue( $result->get_error_data()['retryable'] );
+		$this->assertTrue( $result->get_error_data()['connection_closed'] );
+		$this->assertTrue( $result->get_error_data()['connection_recovered'] );
+		$this->assertMatchesRegularExpression( '/^[a-f0-9]{64}$/', $result->get_error_data()['fingerprint'] );
+
+		$retry = $this->sourceInput( $event_id, array( 'startTime' => '23:00' ) );
+		$retry['expected_fingerprint'] = $result->get_error_data()['fingerprint'];
+		$converged = $this->ability->executeUpdateSourceEvent( $retry );
+		$this->assertIsArray( $converged );
+		$this->assertSame( 'no_change', $converged['action'] );
+		$this->assertSame( $retry['expected_fingerprint'], $converged['fingerprint'] );
+	}
+
+	public function test_source_update_returns_stable_no_change_result(): void {
+		add_filter( 'datamachine_events_update_source_event_permission', '__return_true' );
+		$event_id = $this->makeSourceEvent();
+		$input    = $this->sourceInput( $event_id, array( 'startTime' => '20:00' ) );
+
+		$result = $this->ability->executeUpdateSourceEvent( $input );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'no_change', $result['action'] );
+		$this->assertSame( array(), $result['updated_fields'] );
+		$this->assertSame( $input['expected_fingerprint'], $result['fingerprint'] );
 	}
 
 	public function test_venue_mutation_success_assigns_term_and_returns_taxonomy_result(): void {
@@ -401,6 +624,28 @@ class EventUpdateAbilitiesTest extends WP_UnitTestCase {
 		$this->assertGreaterThan( 0, $event_id, 'Event fixture creation must return a positive post ID.' );
 
 		return $event_id;
+	}
+
+	private function makeSourceEvent(): int {
+		$event_id = $this->makeEvent();
+		wp_update_post( array( 'ID' => $event_id, 'post_title' => 'Manual title retained' ) );
+		update_post_meta( $event_id, '_datamachine_event_source', 'booking' );
+		update_post_meta( $event_id, '_datamachine_event_source_id', 'booking-123' );
+		update_post_meta( $event_id, '_datamachine_event_source_identity', hash( 'sha256', "booking\0booking-123" ) );
+		return $event_id;
+	}
+
+	private function sourceInput( int $event_id, array $changes ): array {
+		return array_merge(
+			array(
+				'event'                => $event_id,
+				'source'               => 'booking',
+				'source_id'            => 'booking-123',
+				'source_identity'      => hash( 'sha256', "booking\0booking-123" ),
+				'expected_fingerprint' => EventUpdateAbilities::fingerprintForEvent( $event_id, 'booking', 'booking-123' ),
+			),
+			$changes
+		);
 	}
 
 	private function makeVenue( string $name ): int {

--- a/tests/Unit/EventUpsertAbilitiesTest.php
+++ b/tests/Unit/EventUpsertAbilitiesTest.php
@@ -105,6 +105,7 @@ class EventUpsertAbilitiesTest extends WP_UnitTestCase {
 		$this->assertIsArray( $result );
 		$this->assertTrue( $result['success'] );
 		$this->assertSame( 'created', $result['action'] );
+		$this->assertMatchesRegularExpression( '/^[a-f0-9]{64}$/', $result['fingerprint'] );
 		$this->assertGreaterThan( 0, $result['event_id'] );
 		$this->assertSame( 'publish', $result['normalized']['post_status'] );
 		$this->assertSame( '2027-02-20 20:00:00', $result['normalized']['start_datetime'] );


### PR DESCRIPTION
## Summary
- register a narrowly delegated source-owned event update ability with immutable source identity and optimistic fingerprint checks
- persist event details, venue relationships, and derived date rows in one fail-closed MySQL transaction with stable retry and uncertainty errors
- return the initial fingerprint from canonical upsert and cover permission, mismatch, no-op, rollback, lifecycle, and cross-connection atomic visibility

## Tests
- `homeboy review lint ... --changed-only`: PHPCS and PHPStan green (run `56a67b3f-a58f-4d55-89ba-0296095df732`)
- `vendor/bin/phpunit --configuration phpunit.contracts.xml`: 3 tests, 57 assertions green
- `git diff --check`: green
- independent exact review: no named authorization, fingerprint, rollback uncertainty, SQL upsert/delete, no-op, or transaction-isolation blocker remains
- focused real WordPress/MySQL test added at `tests/Integration/EventSourceUpdateMySqlAtomicityTest.php`

Local Homeboy WP Codebox execution is blocked before PHPUnit: runs `23ec7f89-0729-4c4d-851c-e89fb98f8afc`, `ef773d82-e324-446c-8f9d-28b1ed72e534`, `940caa56-9708-4a02-87ad-97fbccc7c650`, and no-prepare run `e7ad29f4-3808-4ed2-a437-5e2dcd47bc66` all exit with zero structured tests and no PHPUnit/bootstrap error. Exact evidence is recorded on #611; hosted MySQL CI is authoritative.

Closes #611
Closes #612