### PR TITLE
feat: add event source cadence tiers

### DIFF
--- a/data-machine-events.php
+++ b/data-machine-events.php
@@ -269,6 +269,7 @@ class DATAMACHINE_Events {
 			\DataMachineEvents\Abilities\FilterAbilities::class,
 			\DataMachineEvents\Abilities\EventQualityAuditAbilities::class,
 			\DataMachineEvents\Abilities\SettingsAbilities::class,
+			\DataMachineEvents\Abilities\SchedulingAbilities::class,
 			\DataMachineEvents\Abilities\DuplicateDetectionAbilities::class,
 			\DataMachineEvents\Abilities\UpcomingCountAbilities::class,
 			\DataMachineEvents\Abilities\EventDateQueryAbilities::class,

--- a/inc/Abilities/SchedulingAbilities.php
+++ b/inc/Abilities/SchedulingAbilities.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Event cadence abilities.
+ *
+ * @package DataMachineEvents\Abilities
+ */
+
+namespace DataMachineEvents\Abilities;
+
+use DataMachineEvents\Core\CadenceReconciler;
+
+defined( 'ABSPATH' ) || exit;
+
+final class SchedulingAbilities {
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( ! self::$registered ) {
+			add_action( 'wp_abilities_api_init', array( $this, 'register' ) );
+			self::$registered = true;
+		}
+	}
+
+	public function register(): void {
+		wp_register_ability(
+			'data-machine-events/get-cadence-status',
+			array(
+				'label'               => __( 'Get Event Cadence Status', 'data-machine-events' ),
+				'description'         => __( 'Project current and policy-resolved event flow cadence without writing.', 'data-machine-events' ),
+				'category'            => AbilityCategories::SETTINGS,
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => new \stdClass(),
+				),
+				'output_schema'       => $this->output_schema(),
+				'execute_callback'    => array( $this, 'execute_status' ),
+				'permission_callback' => AbilityPermissions::canRead(),
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'readonly'   => true,
+						'idempotent' => true,
+					),
+				),
+			)
+		);
+
+		wp_register_ability(
+			'data-machine-events/reconcile-cadence',
+			array(
+				'label'               => __( 'Reconcile Event Cadence', 'data-machine-events' ),
+				'description'         => __( 'Dry-run or apply event flow cadence policy through Data Machine flow abilities.', 'data-machine-events' ),
+				'category'            => AbilityCategories::SETTINGS,
+				'input_schema'        => array(
+					'type'       => 'object',
+					'properties' => array(
+						'apply' => array(
+							'type'    => 'boolean',
+							'default' => false,
+						),
+					),
+				),
+				'output_schema'       => $this->output_schema(),
+				'execute_callback'    => array( $this, 'execute_reconcile' ),
+				'permission_callback' => AbilityPermissions::canWrite(),
+				'meta'                => array(
+					'show_in_rest' => true,
+				),
+			)
+		);
+	}
+
+	public function execute_status( array $input ): array|\WP_Error { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+		return ( new CadenceReconciler() )->reconcile( false, 'status' );
+	}
+
+	public function execute_reconcile( array $input ): array|\WP_Error {
+		return ( new CadenceReconciler() )->reconcile( true === ( $input['apply'] ?? false ) );
+	}
+
+	private function output_schema(): array {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'success'               => array( 'type' => 'boolean' ),
+				'mode'                  => array( 'type' => 'string' ),
+				'flows_total'           => array( 'type' => 'integer' ),
+				'changes_proposed'      => array( 'type' => 'integer' ),
+				'changes_applied'       => array( 'type' => 'integer' ),
+				'failures'              => array( 'type' => 'integer' ),
+				'current_distribution'  => array( 'type' => 'object' ),
+				'resolved_distribution' => array( 'type' => 'object' ),
+				'tier_distribution'     => array( 'type' => 'object' ),
+				'run_budget'            => array( 'type' => 'object' ),
+				'changes'               => array( 'type' => 'array' ),
+				'skipped'               => array( 'type' => 'array' ),
+			),
+		);
+	}
+}

--- a/inc/Cli/CommandRegistry.php
+++ b/inc/Cli/CommandRegistry.php
@@ -57,6 +57,10 @@ class CommandRegistry {
 				'file'  => $cli . 'SettingsCommand.php',
 				'class' => SettingsCommand::class,
 			),
+			'data-machine-events scheduling'             => array(
+				'file'  => $cli . 'SchedulingCommand.php',
+				'class' => SchedulingCommand::class,
+			),
 			'data-machine-events get-venue-events'       => array(
 				'file'  => $cli . 'GetVenueEventsCommand.php',
 				'class' => GetVenueEventsCommand::class,

--- a/inc/Cli/SchedulingCommand.php
+++ b/inc/Cli/SchedulingCommand.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Event cadence WP-CLI command.
+ *
+ * @package DataMachineEvents\Cli
+ */
+
+namespace DataMachineEvents\Cli;
+
+use DataMachineEvents\Abilities\SchedulingAbilities;
+use WP_CLI;
+use WP_CLI_Command;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Inspect and reconcile event flow cadence policy.
+ */
+final class SchedulingCommand extends WP_CLI_Command {
+
+	/**
+	 * Emit cadence status when no subcommand is supplied.
+	 */
+	public function __invoke( array $args, array $assoc_args ): void {
+		$this->status( $args, $assoc_args );
+	}
+
+	/**
+	 * Emit current versus resolved cadence and run-budget projection as JSON.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp data-machine-events scheduling status
+	 */
+	public function status( array $args, array $assoc_args ): void {
+		$this->render( ( new SchedulingAbilities() )->execute_status( array() ) );
+	}
+
+	/**
+	 * Reconcile cadence policy. Defaults to a non-mutating dry-run.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--dry-run]
+	 * : Explicitly preview changes without writes (the default).
+	 *
+	 * [--apply]
+	 * : Apply proposed interval changes through datamachine/update-flow.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp data-machine-events scheduling reconcile --dry-run
+	 *     wp data-machine-events scheduling reconcile --apply
+	 */
+	public function reconcile( array $args, array $assoc_args ): void {
+		if ( isset( $assoc_args['apply'], $assoc_args['dry-run'] ) ) {
+			WP_CLI::error( '--apply and --dry-run are mutually exclusive.' );
+		}
+
+		$this->render(
+			( new SchedulingAbilities() )->execute_reconcile(
+				array( 'apply' => isset( $assoc_args['apply'] ) )
+			)
+		);
+	}
+
+	private function render( array|\WP_Error $result ): void {
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+		}
+
+		WP_CLI::log( wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+		if ( false === ( $result['success'] ?? true ) ) {
+			WP_CLI::halt( 1 );
+		}
+	}
+}

--- a/inc/Core/CadencePolicy.php
+++ b/inc/Core/CadencePolicy.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Event source cadence policy.
+ *
+ * @package DataMachineEvents\Core
+ */
+
+namespace DataMachineEvents\Core;
+
+use DataMachineEvents\Steps\EventImport\Handlers\DiceFm\DiceFm;
+use DataMachineEvents\Steps\EventImport\Handlers\SingleRecurring\SingleRecurring;
+use DataMachineEvents\Steps\EventImport\Handlers\Ticketmaster\Ticketmaster;
+use DataMachineEvents\Steps\EventImport\Handlers\WebScraper\UniversalWebScraper;
+
+defined( 'ABSPATH' ) || exit;
+
+final class CadencePolicy {
+
+	public const VENUE_HEAT_META_KEY = '_dme_venue_heat';
+	public const PINNED_INTERVAL_KEY = '_dme_pinned_interval';
+
+	private const VALID_HEAT = array( 'hot', 'warm', 'cold' );
+
+	/** @var array<string, class-string> */
+	private array $handler_classes;
+
+	/** @var callable */
+	private $heat_reader;
+
+	/**
+	 * @param array<string, class-string>|null $handler_classes Registered event-import handler classes.
+	 * @param callable|null                    $heat_reader     Receives a venue term ID and returns its heat.
+	 */
+	public function __construct( ?array $handler_classes = null, ?callable $heat_reader = null ) {
+		$this->handler_classes = $handler_classes ?? $this->registered_handler_classes();
+		$this->heat_reader     = $heat_reader ?? static function ( int $venue_term_id ): string {
+			return (string) get_term_meta( $venue_term_id, self::VENUE_HEAT_META_KEY, true );
+		};
+	}
+
+	/**
+	 * Resolve the cadence owned by an event-import source class.
+	 *
+	 * @return array{interval:string,reason:string,handler:string,source_class:string,venue_term_id:int,heat:string}
+	 */
+	public function resolve( array $flow ): array {
+		$source        = $this->resolve_source( $flow['flow_config'] ?? array() );
+		$handler       = $source['handler'];
+		$source_class  = $source['source_class'];
+		$venue_term_id = 0;
+		$heat          = '';
+
+		if ( Ticketmaster::class === $source_class ) {
+			return $this->result( 'twicedaily', 'ticketmaster_default', $handler, $source_class );
+		}
+
+		if ( DiceFm::class === $source_class ) {
+			return $this->result( 'twicedaily', 'dice_default', $handler, $source_class );
+		}
+
+		if ( SingleRecurring::class === $source_class ) {
+			return $this->result( 'weekly', 'single_recurring_default', $handler, $source_class );
+		}
+
+		if ( UniversalWebScraper::class === $source_class ) {
+			$venue_term_id = $this->extract_venue_term_id( $source['step'], $handler );
+			$heat          = $this->venue_heat( $venue_term_id );
+			$tiers         = array(
+				'hot'  => array( 'twicedaily', 'hot_venue' ),
+				'warm' => array( 'daily', 'warm_venue' ),
+				'cold' => array( 'every_3_days', 'cold_venue' ),
+			);
+
+			return $this->result( $tiers[ $heat ][0], $tiers[ $heat ][1], $handler, $source_class, $venue_term_id, $heat );
+		}
+
+		return $this->result( 'daily', 'unknown_source_fallback', $handler, $source_class );
+	}
+
+	/**
+	 * @return array{handler:string,source_class:string,step:array}
+	 */
+	private function resolve_source( array $flow_config ): array {
+		foreach ( $flow_config as $step ) {
+			if ( ! is_array( $step ) || 'event_import' !== ( $step['step_type'] ?? '' ) || false === ( $step['enabled'] ?? true ) ) {
+				continue;
+			}
+
+			$handler_slugs = (array) ( $step['handler_slugs'] ?? array() );
+			foreach ( $handler_slugs as $handler ) {
+				$handler = (string) $handler;
+				if ( isset( $this->handler_classes[ $handler ] ) ) {
+					return array(
+						'handler'      => $handler,
+						'source_class' => $this->handler_classes[ $handler ],
+						'step'         => $step,
+					);
+				}
+			}
+
+			$first_handler = reset( $handler_slugs );
+			$handler       = false === $first_handler ? '' : (string) $first_handler;
+			return array(
+				'handler'      => $handler,
+				'source_class' => '',
+				'step'         => $step,
+			);
+		}
+
+		return array(
+			'handler'      => '',
+			'source_class' => '',
+			'step'         => array(),
+		);
+	}
+
+	/** @return array<string, class-string> */
+	private function registered_handler_classes(): array {
+		$registered = apply_filters( 'datamachine_handlers', array(), 'event_import' );
+		$classes    = array();
+
+		foreach ( $registered as $handler => $definition ) {
+			if ( is_array( $definition ) && is_string( $definition['class'] ?? null ) ) {
+				$classes[ (string) $handler ] = $definition['class'];
+			}
+		}
+
+		return $classes;
+	}
+
+	private function extract_venue_term_id( array $step, string $handler ): int {
+		$configs = $step['handler_configs'] ?? $step['handler_config'] ?? array();
+		if ( isset( $configs[ $handler ] ) && is_array( $configs[ $handler ] ) ) {
+			$configs = $configs[ $handler ];
+		}
+
+		return absint( $configs['venue'] ?? 0 );
+	}
+
+	private function venue_heat( int $venue_term_id ): string {
+		$heat = $venue_term_id > 0 ? strtolower( trim( (string) call_user_func( $this->heat_reader, $venue_term_id ) ) ) : '';
+		return in_array( $heat, self::VALID_HEAT, true ) ? $heat : 'warm';
+	}
+
+	/**
+	 * @return array{interval:string,reason:string,handler:string,source_class:string,venue_term_id:int,heat:string}
+	 */
+	private function result( string $interval, string $reason, string $handler, string $source_class, int $venue_term_id = 0, string $heat = '' ): array {
+		return array(
+			'interval'      => $interval,
+			'reason'        => $reason,
+			'handler'       => $handler,
+			'source_class'  => $source_class,
+			'venue_term_id' => $venue_term_id,
+			'heat'          => $heat,
+		);
+	}
+}

--- a/inc/Core/CadenceReconciler.php
+++ b/inc/Core/CadenceReconciler.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * Event source cadence reconciliation.
+ *
+ * @package DataMachineEvents\Core
+ */
+
+namespace DataMachineEvents\Core;
+
+defined( 'ABSPATH' ) || exit;
+
+final class CadenceReconciler {
+
+	private const MANAGED_INTERVALS = array( 'qtrdaily', 'twicedaily', 'daily', 'every_3_days', 'weekly' );
+
+	private CadencePolicy $policy;
+
+	/** @var callable */
+	private $flow_loader;
+
+	/** @var callable */
+	private $flow_updater;
+
+	/** @var callable */
+	private $interval_loader;
+
+	public function __construct( ?CadencePolicy $policy = null, ?callable $flow_loader = null, ?callable $flow_updater = null, ?callable $interval_loader = null ) {
+		$this->policy          = $policy ?? new CadencePolicy();
+		$this->flow_loader     = $flow_loader ?? array( $this, 'load_flows' );
+		$this->flow_updater    = $flow_updater ?? array( $this, 'update_flow' );
+		$this->interval_loader = $interval_loader ?? static fn(): array => apply_filters( 'datamachine_scheduler_intervals', array() );
+	}
+
+	/**
+	 * Build a status projection and optionally apply proposed changes.
+	 */
+	public function reconcile( bool $apply = false, string $operation = 'reconcile' ): array|\WP_Error {
+		$flows = call_user_func( $this->flow_loader );
+		if ( is_wp_error( $flows ) ) {
+			return $flows;
+		}
+
+		$intervals             = call_user_func( $this->interval_loader );
+		$current_distribution  = array();
+		$resolved_distribution = array();
+		$tier_distribution     = array();
+		$changes               = array();
+		$skipped               = array();
+		$before_budget         = 0.0;
+		$after_budget          = 0.0;
+		$applied               = 0;
+		$failures              = 0;
+
+		foreach ( $flows as $flow ) {
+			$scheduling        = is_array( $flow['scheduling_config'] ?? null ) ? $flow['scheduling_config'] : array();
+			$current_interval  = (string) ( $scheduling['interval'] ?? 'manual' );
+			$policy            = $this->policy->resolve( $flow );
+			$resolved_interval = $policy['interval'];
+			$skip_reason       = $this->skip_reason( $scheduling, $current_interval );
+
+			if ( '' !== $skip_reason ) {
+				$resolved_interval = $current_interval;
+				$skipped[]         = array(
+					'flow_id'  => (int) ( $flow['flow_id'] ?? 0 ),
+					'interval' => $current_interval,
+					'reason'   => $skip_reason,
+				);
+			}
+
+			$this->increment( $current_distribution, $current_interval );
+			$this->increment( $resolved_distribution, $resolved_interval );
+			$this->increment(
+				$tier_distribution,
+				implode(
+					'|',
+					array(
+						'' !== $policy['handler'] ? $policy['handler'] : 'unknown',
+						'' !== $policy['heat'] ? $policy['heat'] : 'n/a',
+						$current_interval,
+						$resolved_interval,
+					)
+				)
+			);
+
+			$is_enabled     = false !== ( $scheduling['enabled'] ?? true );
+			$before_budget += $is_enabled ? $this->runs_per_day( $current_interval, $intervals ) : 0.0;
+			$after_budget  += $is_enabled ? $this->runs_per_day( $resolved_interval, $intervals ) : 0.0;
+
+			if ( '' !== $skip_reason || $current_interval === $resolved_interval ) {
+				continue;
+			}
+
+			$change = array(
+				'flow_id'           => (int) ( $flow['flow_id'] ?? 0 ),
+				'flow_name'         => (string) ( $flow['flow_name'] ?? '' ),
+				'handler'           => $policy['handler'],
+				'source_class'      => $policy['source_class'],
+				'venue_term_id'     => $policy['venue_term_id'],
+				'heat'              => $policy['heat'],
+				'current_interval'  => $current_interval,
+				'resolved_interval' => $resolved_interval,
+				'reason'            => $policy['reason'],
+				'applied'           => false,
+			);
+
+			if ( $apply ) {
+				$result = call_user_func( $this->flow_updater, $flow, $resolved_interval );
+				if ( is_wp_error( $result ) || false === $result ) {
+					++$failures;
+					$change['error'] = is_wp_error( $result ) ? $result->get_error_message() : 'Flow update failed.';
+				} else {
+					++$applied;
+					$change['applied'] = true;
+					do_action( 'datamachine_log', 'info', 'Event cadence reconciled', $change );
+				}
+			}
+
+			$changes[] = $change;
+		}
+
+		ksort( $current_distribution );
+		ksort( $resolved_distribution );
+		ksort( $tier_distribution );
+		$mode = 'status' === $operation ? 'status' : 'dry-run';
+		if ( $apply ) {
+			$mode = 'apply';
+		}
+
+		return array(
+			'success'               => 0 === $failures,
+			'mode'                  => $mode,
+			'flows_total'           => count( $flows ),
+			'changes_proposed'      => count( $changes ),
+			'changes_applied'       => $applied,
+			'failures'              => $failures,
+			'current_distribution'  => $current_distribution,
+			'resolved_distribution' => $resolved_distribution,
+			'tier_distribution'     => $tier_distribution,
+			'run_budget'            => array(
+				'before_per_day' => round( $before_budget, 3 ),
+				'after_per_day'  => round( $after_budget, 3 ),
+				'delta_per_day'  => round( $after_budget - $before_budget, 3 ),
+			),
+			'changes'               => $changes,
+			'skipped'               => $skipped,
+		);
+	}
+
+	private function skip_reason( array $scheduling, string $interval ): string {
+		if ( false === ( $scheduling['enabled'] ?? true ) ) {
+			return 'inactive_flow_preserved';
+		}
+		if ( true === ( $scheduling[ CadencePolicy::PINNED_INTERVAL_KEY ] ?? false ) ) {
+			return 'pinned_interval_preserved';
+		}
+		if ( 'manual' === $interval || '' === $interval ) {
+			return 'manual_flow_preserved';
+		}
+		if ( in_array( $interval, array( 'one_time', 'cron' ), true ) || ! in_array( $interval, self::MANAGED_INTERVALS, true ) ) {
+			return 'custom_interval_preserved';
+		}
+		return '';
+	}
+
+	private function runs_per_day( string $interval, array $intervals ): float {
+		$seconds = (int) ( $intervals[ $interval ]['seconds'] ?? 0 );
+		return $seconds > 0 ? DAY_IN_SECONDS / $seconds : 0.0;
+	}
+
+	private function increment( array &$distribution, string $key ): void {
+		$key                  = '' !== $key ? $key : 'manual';
+		$distribution[ $key ] = ( $distribution[ $key ] ?? 0 ) + 1;
+	}
+
+	private function load_flows(): array|\WP_Error {
+		$ability = wp_get_ability( 'datamachine/get-flows' );
+		if ( ! $ability ) {
+			return new \WP_Error( 'cadence_flow_reader_missing', 'The datamachine/get-flows ability is unavailable.' );
+		}
+
+		$result = $ability->execute(
+			array(
+				'per_page'    => 0,
+				'output_mode' => 'list',
+			)
+		);
+
+		if ( is_wp_error( $result ) || false === ( $result['success'] ?? false ) ) {
+			return is_wp_error( $result ) ? $result : new \WP_Error( 'cadence_flow_read_failed', $result['error'] ?? 'Unable to read flows.' );
+		}
+
+		return $result['flows'] ?? array();
+	}
+
+	private function update_flow( array $flow, string $resolved_interval ): bool|\WP_Error {
+		$get_ability    = wp_get_ability( 'datamachine/get-flows' );
+		$update_ability = wp_get_ability( 'datamachine/update-flow' );
+		if ( ! $get_ability || ! $update_ability ) {
+			return new \WP_Error( 'cadence_flow_writer_missing', 'Data Machine flow abilities are unavailable.' );
+		}
+
+		$current = $get_ability->execute(
+			array(
+				'flow_id'     => (int) $flow['flow_id'],
+				'output_mode' => 'list',
+			)
+		);
+		$latest  = $current['flows'][0] ?? null;
+		if ( ! is_array( $latest ) ) {
+			return new \WP_Error( 'cadence_flow_missing', 'Flow disappeared before cadence reconciliation.' );
+		}
+
+		$expected_interval = (string) ( $flow['scheduling_config']['interval'] ?? 'manual' );
+		$latest_interval   = (string) ( $latest['scheduling_config']['interval'] ?? 'manual' );
+		if ( $expected_interval !== $latest_interval ) {
+			return new \WP_Error( 'cadence_schedule_changed', 'Flow schedule changed after status resolution; rerun reconciliation.' );
+		}
+
+		$scheduling             = $latest['scheduling_config'];
+		$scheduling['interval'] = $resolved_interval;
+		foreach ( array( 'interval_seconds', 'first_run', 'scheduled_time', 'action_id' ) as $derived_key ) {
+			unset( $scheduling[ $derived_key ] );
+		}
+
+		$result = $update_ability->execute(
+			array(
+				'flow_id'           => (int) $flow['flow_id'],
+				'scheduling_config' => $scheduling,
+			)
+		);
+
+		return true === ( $result['success'] ?? false ) ? true : new \WP_Error( 'cadence_update_failed', $result['error'] ?? 'Flow update failed.' );
+	}
+}

--- a/tests/Unit/CadencePolicyTest.php
+++ b/tests/Unit/CadencePolicyTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Event cadence policy tests.
+ *
+ * @package DataMachineEvents\Tests\Unit
+ */
+
+namespace DataMachineEvents\Tests\Unit;
+
+use DataMachineEvents\Core\CadencePolicy;
+use DataMachineEvents\Steps\EventImport\Handlers\DiceFm\DiceFm;
+use DataMachineEvents\Steps\EventImport\Handlers\SingleRecurring\SingleRecurring;
+use DataMachineEvents\Steps\EventImport\Handlers\Ticketmaster\Ticketmaster;
+use DataMachineEvents\Steps\EventImport\Handlers\WebScraper\UniversalWebScraper;
+use WP_UnitTestCase;
+
+class CadencePolicyTest extends WP_UnitTestCase {
+
+	private const HANDLER_CLASSES = array(
+		'ticketmaster'          => Ticketmaster::class,
+		'dice_fm'               => DiceFm::class,
+		'universal_web_scraper' => UniversalWebScraper::class,
+		'single_recurring'      => SingleRecurring::class,
+	);
+
+	/**
+	 * @dataProvider source_default_provider
+	 */
+	public function test_source_class_defaults( string $handler, string $expected_interval, string $expected_reason ): void {
+		$policy = new CadencePolicy( self::HANDLER_CLASSES, static fn(): string => '' );
+		$result = $policy->resolve( $this->flow( $handler ) );
+
+		$this->assertSame( self::HANDLER_CLASSES[ $handler ], $result['source_class'] );
+		$this->assertSame( $expected_interval, $result['interval'] );
+		$this->assertSame( $expected_reason, $result['reason'] );
+	}
+
+	public function source_default_provider(): array {
+		return array(
+			'ticketmaster'     => array( 'ticketmaster', 'twicedaily', 'ticketmaster_default' ),
+			'dice'             => array( 'dice_fm', 'twicedaily', 'dice_default' ),
+			'single recurring' => array( 'single_recurring', 'weekly', 'single_recurring_default' ),
+		);
+	}
+
+	/**
+	 * @dataProvider venue_heat_provider
+	 */
+	public function test_scraper_venue_heat_tiers( string $stored_heat, string $expected_heat, string $interval, string $reason ): void {
+		$policy = new CadencePolicy( self::HANDLER_CLASSES, static fn( int $venue_id ): string => $stored_heat );
+		$result = $policy->resolve( $this->flow( 'universal_web_scraper', 42 ) );
+
+		$this->assertSame( 42, $result['venue_term_id'] );
+		$this->assertSame( $expected_heat, $result['heat'] );
+		$this->assertSame( $interval, $result['interval'] );
+		$this->assertSame( $reason, $result['reason'] );
+	}
+
+	public function venue_heat_provider(): array {
+		return array(
+			'hot'             => array( 'hot', 'hot', 'twicedaily', 'hot_venue' ),
+			'warm'            => array( 'warm', 'warm', 'daily', 'warm_venue' ),
+			'cold'            => array( 'cold', 'cold', 'every_3_days', 'cold_venue' ),
+			'missing default' => array( '', 'warm', 'daily', 'warm_venue' ),
+			'invalid default' => array( 'boiling', 'warm', 'daily', 'warm_venue' ),
+		);
+	}
+
+	public function test_unknown_source_uses_daily_fallback(): void {
+		$policy = new CadencePolicy( array(), static fn(): string => '' );
+		$result = $policy->resolve( $this->flow( 'future_event_source' ) );
+
+		$this->assertSame( '', $result['source_class'] );
+		$this->assertSame( 'daily', $result['interval'] );
+		$this->assertSame( 'unknown_source_fallback', $result['reason'] );
+	}
+
+	private function flow( string $handler, int $venue_id = 0 ): array {
+		$config = array();
+		if ( $venue_id > 0 ) {
+			$config['venue'] = (string) $venue_id;
+		}
+
+		return array(
+			'flow_config' => array(
+				'event_import_step' => array(
+					'step_type'       => 'event_import',
+					'enabled'         => true,
+					'handler_slugs'   => array( $handler ),
+					'handler_configs' => array( $handler => $config ),
+				),
+			),
+		);
+	}
+}

--- a/tests/Unit/CadenceReconcilerTest.php
+++ b/tests/Unit/CadenceReconcilerTest.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Event cadence reconciler tests.
+ *
+ * @package DataMachineEvents\Tests\Unit
+ */
+
+namespace DataMachineEvents\Tests\Unit;
+
+use DataMachineEvents\Core\CadencePolicy;
+use DataMachineEvents\Core\CadenceReconciler;
+use DataMachineEvents\Steps\EventImport\Handlers\DiceFm\DiceFm;
+use DataMachineEvents\Steps\EventImport\Handlers\Ticketmaster\Ticketmaster;
+use DataMachineEvents\Steps\EventImport\Handlers\WebScraper\UniversalWebScraper;
+use WP_UnitTestCase;
+
+class CadenceReconcilerTest extends WP_UnitTestCase {
+
+	private const HANDLER_CLASSES = array(
+		'ticketmaster'          => Ticketmaster::class,
+		'dice_fm'               => DiceFm::class,
+		'universal_web_scraper' => UniversalWebScraper::class,
+	);
+
+	private function intervals(): array {
+		return array(
+			'hourly'       => array( 'seconds' => HOUR_IN_SECONDS ),
+			'twicedaily'   => array( 'seconds' => 12 * HOUR_IN_SECONDS ),
+			'daily'        => array( 'seconds' => DAY_IN_SECONDS ),
+			'every_3_days' => array( 'seconds' => 3 * DAY_IN_SECONDS ),
+			'weekly'       => array( 'seconds' => WEEK_IN_SECONDS ),
+		);
+	}
+
+	public function test_dry_run_projects_changes_without_mutating(): void {
+		$updates = array();
+		$flows   = $this->safety_fixture();
+		$policy  = new CadencePolicy( self::HANDLER_CLASSES, static fn( int $venue_id ): string => 20 === $venue_id ? 'cold' : 'warm' );
+		$service = new CadenceReconciler(
+			$policy,
+			static fn(): array => $flows,
+			static function ( array $flow, string $interval ) use ( &$updates ): bool {
+				$updates[ $flow['flow_id'] ] = $interval;
+				return true;
+			},
+			fn(): array => $this->intervals()
+		);
+
+		$result = $service->reconcile( false );
+
+		$this->assertSame( array(), $updates, 'Dry-run must never call the flow updater.' );
+		$this->assertSame( 'dry-run', $result['mode'] );
+		$this->assertSame( 2, $result['changes_proposed'] );
+		$this->assertSame( 0, $result['changes_applied'] );
+		$this->assertSame( 27.0, $result['run_budget']['before_per_day'] );
+		$this->assertSame( 27.333, $result['run_budget']['after_per_day'] );
+		$this->assertSame( 0.333, $result['run_budget']['delta_per_day'] );
+		$this->assertSame( 'ticketmaster_default', $result['changes'][0]['reason'] );
+		$this->assertSame( 'cold_venue', $result['changes'][1]['reason'] );
+		$this->assertSame( 2, $result['resolved_distribution']['daily'] );
+		$this->assertSame( 1, $result['resolved_distribution']['every_3_days'] );
+		$this->assertSame( 1, $result['resolved_distribution']['twicedaily'] );
+		$this->assertSame(
+			array( 'pinned_interval_preserved', 'manual_flow_preserved', 'inactive_flow_preserved', 'custom_interval_preserved' ),
+			array_column( $result['skipped'], 'reason' )
+		);
+	}
+
+	public function test_apply_updates_only_proposed_changes(): void {
+		$updates = array();
+		$flows   = array(
+			$this->flow( 1, 'Ticketmaster', 'ticketmaster', 'daily' ),
+			$this->flow( 2, 'Dice', 'dice_fm', 'daily', array( CadencePolicy::PINNED_INTERVAL_KEY => true ) ),
+		);
+		$policy  = new CadencePolicy( self::HANDLER_CLASSES, static fn(): string => 'warm' );
+		$service = new CadenceReconciler(
+			$policy,
+			static fn(): array => $flows,
+			static function ( array $flow, string $interval ) use ( &$updates ): bool {
+				$updates[ $flow['flow_id'] ] = $interval;
+				return true;
+			},
+			fn(): array => $this->intervals()
+		);
+
+		$result = $service->reconcile( true );
+
+		$this->assertSame( array( 1 => 'twicedaily' ), $updates );
+		$this->assertSame( 'apply', $result['mode'] );
+		$this->assertSame( 1, $result['changes_applied'] );
+		$this->assertTrue( $result['changes'][0]['applied'] );
+		$this->assertSame( 'pinned_interval_preserved', $result['skipped'][0]['reason'] );
+	}
+
+	public function test_matching_schedule_is_idempotent_no_op(): void {
+		$updates = 0;
+		$flows   = array( $this->flow( 1, 'Ticketmaster', 'ticketmaster', 'twicedaily' ) );
+		$service = new CadenceReconciler(
+			new CadencePolicy( self::HANDLER_CLASSES, static fn(): string => 'warm' ),
+			static fn(): array => $flows,
+			static function () use ( &$updates ): bool {
+				++$updates;
+				return true;
+			},
+			fn(): array => $this->intervals()
+		);
+
+		$result = $service->reconcile( true );
+
+		$this->assertSame( 0, $updates );
+		$this->assertSame( 0, $result['changes_proposed'] );
+		$this->assertSame( 0, $result['changes_applied'] );
+	}
+
+	public function test_apply_failure_is_reported_without_hiding_other_projection_data(): void {
+		$flows   = array( $this->flow( 1, 'Ticketmaster', 'ticketmaster', 'daily' ) );
+		$service = new CadenceReconciler(
+			new CadencePolicy( self::HANDLER_CLASSES, static fn(): string => 'warm' ),
+			static fn(): array => $flows,
+			static fn(): \WP_Error => new \WP_Error( 'write_failed', 'No write.' ),
+			fn(): array => $this->intervals()
+		);
+
+		$result = $service->reconcile( true );
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 1, $result['failures'] );
+		$this->assertSame( 'No write.', $result['changes'][0]['error'] );
+		$this->assertSame( 1.0, $result['run_budget']['before_per_day'] );
+		$this->assertSame( 2.0, $result['run_budget']['after_per_day'] );
+	}
+
+	private function safety_fixture(): array {
+		return array(
+			$this->flow( 1, 'Ticketmaster', 'ticketmaster', 'daily' ),
+			$this->flow( 2, 'Cold scraper', 'universal_web_scraper', 'daily', array(), 20 ),
+			$this->flow( 3, 'Pinned Dice', 'dice_fm', 'daily', array( CadencePolicy::PINNED_INTERVAL_KEY => true ) ),
+			$this->flow( 4, 'Manual source', 'ticketmaster', 'manual' ),
+			$this->flow( 5, 'Inactive source', 'ticketmaster', 'daily', array( 'enabled' => false ) ),
+			$this->flow( 6, 'Custom source', 'future_source', 'hourly' ),
+		);
+	}
+
+	private function flow( int $id, string $name, string $handler, string $interval, array $scheduling = array(), int $venue_id = 0 ): array {
+		$config = $venue_id > 0 ? array( 'venue' => (string) $venue_id ) : array();
+
+		return array(
+			'flow_id'           => $id,
+			'flow_name'         => $name,
+			'scheduling_config' => array_merge( array( 'interval' => $interval ), $scheduling ),
+			'flow_config'       => array(
+				'event_import_step' => array(
+					'step_type'       => 'event_import',
+					'enabled'         => true,
+					'handler_slugs'   => array( $handler ),
+					'handler_configs' => array( $handler => $config ),
+				),
+			),
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- Resolve event flow cadence from the registered event-import source class and persisted flow context.
- Add JSON abilities and `wp data-machine-events scheduling status|reconcile` for status, dry-run, and explicit apply.
- Project current versus resolved interval distributions and before/after runs-per-day, with deterministic reasons for every proposal.
- Preserve pinned, inactive, manual, one-time, cron, and non-tier custom schedules.

## Existing primitives reused
- Reads decoded flow context through `datamachine/get-flows` with `output_mode=list`.
- Applies intervals through `datamachine/update-flow`, which owns validation, persistence, and Action Scheduler reconciliation.
- Uses the existing `datamachine_scheduler_intervals` registry for run-budget math.
- Stores venue heat in existing venue term meta (`_dme_venue_heat`) and the pin flag in existing `scheduling_config` (`_dme_pinned_interval`); no new table, option, REST client, or flow updater was added.

## Policy choices
- Ticketmaster: `twicedaily` (`ticketmaster_default`).
- Dice: `twicedaily` (`dice_default`).
- Universal web scraper: hot `twicedaily`, warm/default `daily`, cold `every_3_days`.
- Single recurring: `weekly`.
- Unknown event-import source: `daily` fallback when the current interval is policy-managed.
- Friday-only Ticketmaster switching and nightly automation are intentionally deferred. Without guaranteed follow-up reconciliation, a transient on-sale interval could remain stuck; operator-triggered stable reconciliation is the minimal safe first rollout.

## CLI examples
```bash
wp data-machine-events scheduling status
wp data-machine-events scheduling reconcile --dry-run
wp data-machine-events scheduling reconcile --apply
wp term meta update venue <term-id> _dme_venue_heat hot
```

## Test evidence
- Added unit coverage for source-class defaults, hot/warm/cold tiers, unknown fallback, pinned intervals, inactive/manual/custom preservation, dry-run nonmutation, apply, no-op idempotency, update failure reporting, and run-budget projection.
- `homeboy review lint --changed-only`: pass, including PHPCS and PHPStan (run `df78d28a-0285-451c-93f8-548c29dd55f1`).
- `homeboy review audit --changed-since=origin/main`: pass with no introduced findings (run `629f9770-f576-42ee-9c87-4591978e1d36`).
- Read-only WordPress smoke assertions: pass for two proposed changes, dry-run nonmutation, apply callback execution, and budget projection.
- `git diff --check`: pass.
- Homeboy selected the two new PHPUnit files but its Codebox test runner exited during frontend prepare after successful builds, before PHPUnit started (`0` tests, no PHP/bootstrap error; runs `d7af2c2d-b3ed-412a-bd12-57a05e9a2739` and `e28c6e11-7a49-47a6-bd0b-392ad256265b`). CI should execute the committed tests in the repository workflow.

## Rollout safety
- Status and reconcile default to non-mutating output; writes require `--apply` or ability input `apply=true`.
- Apply re-reads each flow and refuses to overwrite a schedule changed after projection.
- Existing scheduling metadata is preserved while derived scheduler fields are regenerated by Data Machine.
- No live flow schedule, release, deployment, or automation was changed while developing this PR.

Closes #260