### PR TITLE
fix(calendar): wait for complete date ranges

### DIFF
--- a/inc/Blocks/Calendar/src/frontend.test.ts
+++ b/inc/Blocks/Calendar/src/frontend.test.ts
@@ -3,7 +3,12 @@ jest.mock( './modules/carousel', () => ( {
 	destroyCarousel: jest.fn(),
 } ) );
 jest.mock( './modules/date-picker', () => ( {
-	initDatePicker: jest.fn(),
+	initDatePicker: jest.fn(
+		( _calendar: HTMLElement, onChange: () => void ) => {
+			mockDateChangeCallback = onChange;
+			return mockPicker;
+		}
+	),
 	destroyDatePicker: jest.fn(),
 	getDatePicker: jest.fn( () => mockPicker ),
 } ) );
@@ -58,6 +63,7 @@ import { initCalendarInstance } from './frontend';
 import type { FlatpickrInstance } from './types';
 
 let mockResetCallback: ( params: URLSearchParams ) => void;
+let mockDateChangeCallback: () => void;
 const mockPicker: FlatpickrInstance = {
 	selectedDates: [ new Date( 2026, 7, 10 ), new Date( 2026, 7, 12 ) ],
 	clear: jest.fn(),
@@ -168,6 +174,21 @@ describe( 'calendar frontend month-grid integration', () => {
 			calendar.querySelector( '.data-machine-events-content' )!
 				.textContent
 		).toBe( 'mobile:2026-08' );
+	} );
+
+	it( 'applies one completed picker range through the month-grid controller', async () => {
+		const calendar = document.querySelector< HTMLElement >(
+			'.data-machine-events-calendar'
+		)!;
+		initCalendarInstance( calendar );
+
+		mockDateChangeCallback();
+		await flush();
+
+		expect( mockFetch ).toHaveBeenCalledTimes( 1 );
+		const request = requestedParams( 0 );
+		expect( request.get( 'date_start' ) ).toBe( '2026-08-10' );
+		expect( request.get( 'date_end' ) ).toBe( '2026-08-12' );
 	} );
 
 	it( 'keeps reset, month navigation, and popstate on the controller path', async () => {

--- a/inc/Blocks/Calendar/src/modules/date-picker.integration.test.ts
+++ b/inc/Blocks/Calendar/src/modules/date-picker.integration.test.ts
@@ -107,4 +107,26 @@ describe( 'real Flatpickr navigation lifecycle', () => {
 			remainingMonth + 1
 		);
 	} );
+
+	it( 'emits only complete ranges and explicit clears through the real picker', () => {
+		const calendar = document.querySelector< HTMLElement >( '#first' )!;
+		const apply = jest.fn();
+		const picker = initDatePicker( calendar, apply ) as Instance;
+
+		expect( apply ).not.toHaveBeenCalled();
+
+		picker.setDate( '2026-08-10', true );
+		expect( apply ).not.toHaveBeenCalled();
+
+		picker.setDate( [ '2026-08-10', '2026-08-12' ], true );
+		expect( apply ).toHaveBeenCalledTimes( 1 );
+		expect( apply.mock.calls[ 0 ][ 0 ] ).toEqual( [
+			new Date( 2026, 7, 10 ),
+			new Date( 2026, 7, 12 ),
+		] );
+
+		picker.clear();
+		expect( apply ).toHaveBeenCalledTimes( 2 );
+		expect( apply ).toHaveBeenLastCalledWith( [] );
+	} );
 } );

--- a/inc/Blocks/Calendar/src/modules/date-picker.test.ts
+++ b/inc/Blocks/Calendar/src/modules/date-picker.test.ts
@@ -25,11 +25,14 @@ import { __ } from '@wordpress/i18n';
 import { destroyDatePicker, initDatePicker } from './date-picker';
 
 interface FlatpickrOptions {
+	mode: string;
+	defaultDate?: string | string[];
 	onReady: (
 		selectedDates: Date[],
 		dateStr: string,
 		instance: MockFlatpickrInstance
 	) => void;
+	onChange: ( selectedDates: Date[] ) => void;
 }
 
 interface MockFlatpickrInstance {
@@ -134,5 +137,94 @@ describe( 'Flatpickr month navigation accessibility', () => {
 
 		expect( click ).not.toHaveBeenCalled();
 		expect( picker!.destroy ).toHaveBeenCalledTimes( 1 );
+	} );
+} );
+
+describe( 'Flatpickr range application', () => {
+	let calendar: HTMLElement;
+	let clearButton: HTMLButtonElement;
+	let picker: MockFlatpickrInstance;
+	let options: FlatpickrOptions;
+	let apply: jest.Mock;
+
+	beforeEach( () => {
+		document.body.innerHTML = calendarMarkup( 'range' );
+		calendar = document.querySelector< HTMLElement >( '#range' )!;
+		clearButton = calendar.querySelector< HTMLButtonElement >(
+			'.data-machine-events-date-clear-btn'
+		)!;
+		apply = jest.fn();
+		mockFlatpickr.mockReset();
+		mockFlatpickr.mockImplementation(
+			( _input: HTMLInputElement, config: FlatpickrOptions ) => {
+				options = config;
+				picker = {
+					selectedDates: [],
+					prevMonthNav: document.createElement( 'span' ),
+					nextMonthNav: document.createElement( 'span' ),
+					clear: jest.fn( () => {
+						picker.selectedDates = [];
+						options.onChange( [] );
+					} ),
+					setDate: jest.fn(),
+					destroy: jest.fn(),
+				};
+				config.onReady( [], '', picker );
+				return picker;
+			}
+		);
+	} );
+
+	afterEach( () => {
+		destroyDatePicker( calendar );
+	} );
+
+	it( 'waits for both dates before applying the range', () => {
+		initDatePicker( calendar, apply );
+		const start = new Date( 2026, 7, 10 );
+		const end = new Date( 2026, 7, 12 );
+
+		options.onChange( [ start ] );
+		expect( apply ).not.toHaveBeenCalled();
+		expect( clearButton.classList.contains( 'visible' ) ).toBe( true );
+
+		options.onChange( [ start, end ] );
+		expect( apply ).toHaveBeenCalledTimes( 1 );
+		expect( apply ).toHaveBeenCalledWith( [ start, end ] );
+	} );
+
+	it( 'applies a single day only when the day is selected twice', () => {
+		initDatePicker( calendar, apply );
+		const day = new Date( 2026, 7, 10 );
+
+		options.onChange( [ day ] );
+		options.onChange( [ day, day ] );
+
+		expect( apply ).toHaveBeenCalledTimes( 1 );
+		expect( apply ).toHaveBeenCalledWith( [ day, day ] );
+	} );
+
+	it( 'uses Flatpickr clear as the one intentional reset path', () => {
+		initDatePicker( calendar, apply );
+		clearButton.classList.add( 'visible' );
+
+		clearButton.click();
+
+		expect( picker.clear ).toHaveBeenCalledTimes( 1 );
+		expect( apply ).toHaveBeenCalledTimes( 1 );
+		expect( apply ).toHaveBeenCalledWith( [] );
+		expect( clearButton.classList.contains( 'visible' ) ).toBe( false );
+	} );
+
+	it( 'hydrates initial dates without applying filters', () => {
+		const input = calendar.querySelector< HTMLInputElement >( 'input' )!;
+		input.dataset.dateStart = '2026-08-10';
+		input.dataset.dateEnd = '2026-08-12';
+
+		initDatePicker( calendar, apply );
+
+		expect( options.mode ).toBe( 'range' );
+		expect( options.defaultDate ).toEqual( [ '2026-08-10', '2026-08-12' ] );
+		expect( apply ).not.toHaveBeenCalled();
 	} );
 } );

--- a/inc/Blocks/Calendar/src/modules/date-picker.ts
+++ b/inc/Blocks/Calendar/src/modules/date-picker.ts
@@ -103,7 +103,7 @@ export function initDatePicker(
 			];
 		},
 		onChange( selectedDates: Date[] ) {
-			if ( onChange ) {
+			if ( selectedDates.length === 0 || selectedDates.length === 2 ) {
 				onChange( selectedDates );
 			}
 
@@ -113,14 +113,6 @@ export function initDatePicker(
 				} else {
 					clearBtn.classList.remove( 'visible' );
 				}
-			}
-		},
-		onClear() {
-			if ( onChange ) {
-				onChange( [] );
-			}
-			if ( clearBtn ) {
-				clearBtn.classList.remove( 'visible' );
 			}
 		},
 	} ) as unknown as FlatpickrInstance;


### PR DESCRIPTION
## Summary
- defer Calendar filter application until Flatpickr reports a complete two-date range
- route explicit clears through Flatpickr's supported `onChange([])` callback exactly once instead of the unsupported `onClear` option
- define single-day filtering as intentionally selecting the same day twice, yielding a complete `[day, day]` range
- preserve initial hydration and the shared callback path used by list/date-groups, month-grid, pointer, keyboard, and touch interactions

Closes #615

## Callback semantics
Flatpickr's range-mode `onChange` hook reports zero dates for clear, one date for a partial range, and two dates for a complete range. The integration now forwards only zero or two dates. A first date therefore leaves the picker open; the second applies once with exact start/end values. Initial `defaultDate` hydration remains silent.

## Tests
- `npm test -- --runInBand`: 10 suites, 58 tests passed
- `npm run lint:js`: passed
- `npm run build`: passed
- `homeboy review --changed-since origin/main --summary`: audit passed with zero findings; lint passed across PHPCS, ESLint, and PHPStan; all block preparation builds passed, but the test harness exited after about 6m42s with zero tests/results and no reported error
- `npx tsc --noEmit`: attempted; the repository's standalone TypeScript configuration lacks Jest and editor-package type wiring and reports the existing broad baseline, so the configured build and Homeboy lint gates are authoritative here
- PHP contract suite was not locally runnable because the worktree has no dev `phpunit` binary; this change is frontend-only

Focused coverage proves partial ranges do not apply, complete ranges apply exactly once with exact dates, same-day ranges require a deliberate second selection, clear resets once, initial values do not apply, real Flatpickr behavior matches the mock contract, and month-grid receives one completed range request.

## Browser evidence
The original failure reproduced identically at desktop `1280x900` and authentic mobile/touch `390x844` in:

`/mnt/extrachill-workspace/tmp/opencode/events-ui-fuzz-20260726/browser-matrices/extrachill-events-calendar-date/events-calendar-date-20260727-01/`

Replay seeds from #615:
- desktop: `993d2e5df3ffbdb857a57779eb1ed814c2b816d0d42bda26ebf1968bc16ffaed`
- mobile/touch: `458176bbd4cd0e7b497fd50c24b71ca5d6d8dcaab02268eaa55fb121334274f1`

## Residual risks
- The disposable browser matrix captured the deployed failure but was not replayed against this branch; the real Flatpickr integration test encodes the callback regression contract instead.
- Homeboy's repository test stage produced no result after successful dependency preparation and block builds, so CI should provide the full WordPress test result.

## AI assistance
OpenAI GPT-5.6 Sol via OpenCode inspected the existing picker, filter-state, list/month-grid flow, and Flatpickr source; implemented the fix and tests; and ran the validation described above. Chris Huber owns review and merge decisions.