### PR TITLE
fix: recover Tribe events from core REST fallback

### DIFF
--- a/inc/Steps/EventImport/Handlers/WebScraper/Extractors/WordPressExtractor.php
+++ b/inc/Steps/EventImport/Handlers/WebScraper/Extractors/WordPressExtractor.php
@@ -80,11 +80,32 @@ class WordPressExtractor extends BaseExtractor {
 		}
 
 		$json = $this->fetchJson( $api_url );
-		if ( empty( $json ) ) {
+		if ( null === $json ) {
 			return array();
 		}
 
-		return $this->extractFromJson( $json, $source_url );
+		$events = $this->extractFromJson( $json, $source_url );
+		if ( ! empty( $events ) ) {
+			return $events;
+		}
+
+		// Some sites expose current events through the core Tribe CPT route even
+		// when the legacy Tribe collection is valid but empty.
+		if ( false === strpos( $api_url, '/tribe/events/' ) ) {
+			return array();
+		}
+
+		$wp_rest_base = $this->discoverWpRestBase( $html );
+		if ( null === $wp_rest_base ) {
+			return array();
+		}
+
+		$wp_events = $this->fetchJson( $wp_rest_base . 'wp/v2/tribe_events?per_page=100&_embed=1' );
+		if ( null === $wp_events ) {
+			return array();
+		}
+
+		return $this->extractFromJson( $wp_events, $source_url );
 	}
 
 	public function getMethod(): string {
@@ -120,14 +141,20 @@ class WordPressExtractor extends BaseExtractor {
 		$parsed   = wp_parse_url( $source_url );
 		$base_url = ( $parsed['scheme'] ?? 'https' ) . '://' . ( $parsed['host'] ?? '' );
 
-		// Look for Tribe Events REST API link
-		if ( preg_match( '#/wp-json/tribe/events/v1/events#', $html ) ) {
-			return $base_url . '/wp-json/tribe/events/v1/events?per_page=100';
+		// Prefer the versioned Tribe API root advertised by the page. This keeps
+		// discovery aligned with subdirectory and custom REST installations.
+		if ( preg_match( '#https?://[^"\']+/tribe/events/v\d+/#i', $html, $m ) ) {
+			return trailingslashit( html_entity_decode( $m[0], ENT_QUOTES ) ) . 'events?per_page=100';
+		}
+
+		// Retain support for relative direct collection URLs.
+		if ( preg_match( '#/wp-json/tribe/events/v\d+/events#i', $html, $m ) ) {
+			return $base_url . $m[0] . '?per_page=100';
 		}
 
 		// Look for WP REST API discovery link
-		if ( preg_match( '#<link[^>]+rel=["\']https://api\.w\.org/["\'][^>]+href=["\']([^"\']+)["\']#i', $html, $m ) ) {
-			$api_base = $m[1];
+		$api_base = $this->discoverWpRestBase( $html );
+		if ( null !== $api_base ) {
 			// Try Tribe endpoint first
 			$tribe_url  = rtrim( $api_base, '/' ) . '/tribe/events/v1/events?per_page=100';
 			$tribe_json = $this->fetchJson( $tribe_url );
@@ -140,6 +167,29 @@ class WordPressExtractor extends BaseExtractor {
 		if ( preg_match( '/<(div|section|article|main)[^>]+class=["\'][^"\']*tribe-events[^"\']*["\'][^>]*>/i', $html )
 			|| preg_match( '/<(div|section|article|main)[^>]+id=["\'][^"\']*tribe-events[^"\']*["\'][^>]*>/i', $html ) ) {
 			return $base_url . '/wp-json/tribe/events/v1/events?per_page=100';
+		}
+
+		return null;
+	}
+
+	/**
+	 * Read the WordPress REST root advertised by the page.
+	 */
+	private function discoverWpRestBase( string $html ): ?string {
+		if ( ! preg_match_all( '#<link\b[^>]*>#i', $html, $links ) ) {
+			return null;
+		}
+
+		foreach ( $links[0] as $link ) {
+			if ( ! preg_match( '#\brel=["\']https://api\.w\.org/["\']#i', $link )
+				|| ! preg_match( '#\bhref=["\']([^"\']+)["\']#i', $link, $href ) ) {
+				continue;
+			}
+
+			$url = html_entity_decode( $href[1], ENT_QUOTES );
+			if ( wp_http_validate_url( $url ) ) {
+				return trailingslashit( $url );
+			}
 		}
 
 		return null;

--- a/tests/Fixtures/wordpress-tribe/archive.html
+++ b/tests/Fixtures/wordpress-tribe/archive.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en-US">
+<head>
+	<link href="https://example.com/cms/wp-json/" rel="https://api.w.org/" />
+	<link rel="alternate" href="https://example.com/cms/wp-json/tribe/events/v1/" />
+</head>
+<body>
+	<main class="tribe-events-view">Upcoming events</main>
+</body>
+</html>

--- a/tests/Fixtures/wordpress-tribe/core-cpt.json
+++ b/tests/Fixtures/wordpress-tribe/core-cpt.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": 101,
+    "slug": "weekly-show-july-30",
+    "link": "https://example.com/event/weekly-show-july-30/",
+    "title": { "rendered": "Weekly Show" },
+    "content": { "rendered": "<p>First occurrence.</p>" },
+    "meta": {
+      "_EventStartDate": "2026-07-30 21:00:00",
+      "_EventEndDate": "2026-07-31 01:00:00",
+      "_VenueName": "Example Room",
+      "_VenueCity": "Example City",
+      "_VenueState": "CA"
+    }
+  },
+  {
+    "id": 102,
+    "slug": "weekly-show-august-6",
+    "link": "https://example.com/event/weekly-show-august-6/",
+    "title": { "rendered": "Weekly Show" },
+    "content": { "rendered": "<p>Second occurrence.</p>" },
+    "meta": {
+      "_EventStartDate": "2026-08-06 21:00:00",
+      "_EventEndDate": "2026-08-07 01:00:00",
+      "_VenueName": "Example Room",
+      "_VenueCity": "Example City",
+      "_VenueState": "CA"
+    }
+  }
+]

--- a/tests/Fixtures/wordpress-tribe/empty-v1.json
+++ b/tests/Fixtures/wordpress-tribe/empty-v1.json
@@ -1,0 +1,6 @@
+{
+  "events": [],
+  "rest_url": "https://example.com/cms/wp-json/tribe/events/v1/events/",
+  "total": 0,
+  "total_pages": 0
+}

--- a/tests/Unit/WordPressExtractorTest.php
+++ b/tests/Unit/WordPressExtractorTest.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * WordPress Tribe extractor regression tests.
+ *
+ * @package DataMachineEvents\Tests\Unit
+ */
+
+namespace DataMachineEvents\Tests\Unit;
+
+use DataMachineEvents\Steps\EventImport\Handlers\WebScraper\Extractors\WordPressExtractor;
+use WP_UnitTestCase;
+
+class WordPressExtractorTest extends WP_UnitTestCase {
+
+	private WordPressExtractor $extractor;
+	private string $fixtures_dir;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->extractor    = new WordPressExtractor();
+		$this->fixtures_dir = __DIR__ . '/../Fixtures/wordpress-tribe';
+	}
+
+	public function tearDown(): void {
+		remove_all_filters( 'pre_http_request' );
+		parent::tearDown();
+	}
+
+	public function test_uses_advertised_rest_root_and_falls_back_to_core_tribe_cpt(): void {
+		$html     = file_get_contents( $this->fixtures_dir . '/archive.html' );
+		$empty_v1 = file_get_contents( $this->fixtures_dir . '/empty-v1.json' );
+		$core_cpt = file_get_contents( $this->fixtures_dir . '/core-cpt.json' );
+		$requests = array();
+
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) use ( $empty_v1, $core_cpt, &$requests ) {
+				$requests[] = $url;
+				$bodies     = array(
+					'https://example.com/cms/wp-json/tribe/events/v1/events?per_page=100' => $empty_v1,
+					'https://example.com/cms/wp-json/wp/v2/tribe_events?per_page=100&_embed=1' => $core_cpt,
+				);
+
+				if ( ! isset( $bodies[ $url ] ) ) {
+					return new \WP_Error( 'http_request_failed', 'Unmocked URL: ' . $url );
+				}
+
+				return array(
+					'headers'  => array(),
+					'body'     => $bodies[ $url ],
+					'response' => array( 'code' => 200, 'message' => 'OK' ),
+					'cookies'  => array(),
+					'filename' => null,
+				);
+			},
+			10,
+			3
+		);
+
+		$events = $this->extractor->extract( $html, 'https://example.com/calendar/' );
+
+		$this->assertCount( 2, $events );
+		$this->assertSame( '2026-07-30', $events[0]['startDate'] );
+		$this->assertSame( '2026-08-06', $events[1]['startDate'] );
+		$this->assertSame( 'Example Room', $events[0]['venue'] );
+		$this->assertSame(
+			array(
+				'https://example.com/cms/wp-json/tribe/events/v1/events?per_page=100',
+				'https://example.com/cms/wp-json/wp/v2/tribe_events?per_page=100&_embed=1',
+			),
+			$requests
+		);
+	}
+
+	public function test_private_core_fallback_remains_unsupported(): void {
+		$html     = file_get_contents( $this->fixtures_dir . '/archive.html' );
+		$empty_v1 = file_get_contents( $this->fixtures_dir . '/empty-v1.json' );
+
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) use ( $empty_v1 ) {
+				if ( false !== strpos( $url, '/tribe/events/v1/events' ) ) {
+					return array(
+						'headers'  => array(),
+						'body'     => $empty_v1,
+						'response' => array( 'code' => 200, 'message' => 'OK' ),
+						'cookies'  => array(),
+						'filename' => null,
+					);
+				}
+
+				return array(
+					'headers'  => array(),
+					'body'     => wp_json_encode( array( 'code' => 'rest_forbidden' ) ),
+					'response' => array( 'code' => 401, 'message' => 'Unauthorized' ),
+					'cookies'  => array(),
+					'filename' => null,
+				);
+			},
+			10,
+			3
+		);
+
+		$this->assertSame( array(), $this->extractor->extract( $html, 'https://example.com/calendar/' ) );
+	}
+}


### PR DESCRIPTION
## Summary
- honor the versioned Tribe API root and WordPress REST root advertised by the source page, including subdirectory installs and attribute-order differences
- when a valid Tribe v1 collection contains no usable events, reuse the existing `tribe_wp` mapper against the public core `wp/v2/tribe_events` route
- keep failed, private, empty, and date-less REST responses unsupported rather than manufacturing a successful extraction
- add sanitized archive, empty Tribe v1, and recurring-occurrence CPT fixtures with regression coverage

## Before / after evidence
Before, `WordPressExtractor` stopped after a valid empty `/tribe/events/v1/events` response. Its existing `mapTribeWpEvent()` path was effectively unreachable because discovery only probed `/wp/v2/events`, not The Events Calendar's registered `/wp/v2/tribe_events` REST base.

After, a sanitized source advertising `https://example.com/cms/wp-json/` produces these requests in order:
1. `/cms/wp-json/tribe/events/v1/events?per_page=100` -> valid empty Tribe response
2. `/cms/wp-json/wp/v2/tribe_events?per_page=100&_embed=1` -> two recurring occurrences normalized with distinct dates

A 401 response from the core CPT fallback still returns no events.

## Live cohort investigation
Public REST discovery on 2026-07-28 confirmed all four sites register `tribe/events/v1` and `wp/v2/tribe_events`; no alternate Tribe API version is currently advertised. Tribe v1 pagination remains the existing `total_pages` flow (Bedlam returned 362 bounded historical results over 8 pages with the server capping `per_page` at 50).

Current public outcomes that remain truthful gaps:
- `bedlamlive.com`: healthy REST surface, but no upcoming events; bounded data ends July 11, 2026
- `thevalenciaroom.com`: public event pages show future occurrences, but both collection routes return empty and individual Tribe/core REST lookups reject those cached page IDs/slugs; no REST bypass added
- `savannahmusicfestival.org`: valid public Tribe and core CPT collections, both empty
- `hubdowntown.com/playground-rooftop`: valid Tribe collection with one upcoming site-wide restaurant event, insufficient and not specific to the selected Playground page

The code change therefore unlocks supported sites where the already-public core Tribe CPT collection contains events, without relabeling this cohort's currently unavailable/private/insufficient surfaces as successful.

## Tests
- `php -l inc/Steps/EventImport/Handlers/WebScraper/Extractors/WordPressExtractor.php`
- `php -l tests/Unit/WordPressExtractorTest.php`
- `vendor/bin/phpunit --configuration phpunit.contracts.xml` (3 tests, 57 assertions)
- `git diff --check`
- managed WordPress PHPUnit regression tests added; raw PHPUnit cannot load `WP_UnitTestCase` without the managed bootstrap
- Homeboy lint/test attempted but refused by the warm-machine resource policy with no Lab runner available

Closes #626