### PR TITLE
Fix semantic WordPress event listing extraction

### DIFF
--- a/inc/Steps/EventImport/Handlers/WebScraper/Extractors/GenericHtmlEventsExtractor.php
+++ b/inc/Steps/EventImport/Handlers/WebScraper/Extractors/GenericHtmlEventsExtractor.php
@@ -46,24 +46,27 @@ class GenericHtmlEventsExtractor extends BaseExtractor {
 	private const FIELD_PATTERNS = array(
 		'title' => array(
 			'/<(?:div|span|h[1-6])[^>]+class="[^"]*eventTitle[^"]*"[^>]*>.*?<a[^>]+title="([^"]+)"/is',
-			'/<(?:div|span|h[1-6])[^>]+class="[^"]*eventTitle[^"]*"[^>]*>.*?<a[^>]*>(.*?)<\/a>/is',
-			'/<(?:div|span|h[1-6])[^>]+class="[^"]*event-title[^"]*"[^>]*>(.*?)<\/(?:div|span|h[1-6])>/is',
+			'/<(?:div|span|p|h[1-6])[^>]+class="[^"]*eventTitle[^"]*"[^>]*>.*?<a[^>]*>(.*?)<\/a>/is',
+			'/<(?:div|span|p|h[1-6])[^>]+class="[^"]*event-title[^"]*"[^>]*>(.*?)<\/(?:div|span|p|h[1-6])>/is',
+			'/<[^>]+class="[^"]*event-link[^"]*"[^>]*>.*?<a[^>]*>(.*?)<\/a>/is',
 			'/<h[1-6][^>]*>\s*<a[^>]+href="[^"]*event[^"]*"[^>]*>(.*?)<\/a>/is',
 		),
 		'date'  => array(
-			'/<(?:div|span|time)[^>]+class="[^"]*eventDate[^"]*"[^>]*>(.*?)<\/(?:div|span|time)>/is',
-			'/<(?:div|span|time)[^>]+class="[^"]*event-date[^"]*"[^>]*>(.*?)<\/(?:div|span|time)>/is',
+			'/<(?:div|span|p|time)[^>]+class="[^"]*eventDate[^"]*"[^>]*>(.*?)<\/(?:div|span|p|time)>/is',
+			'/<(?:div|span|p|time)[^>]+class="[^"]*event-date[^"]*"[^>]*>(.*?)<\/(?:div|span|p|time)>/is',
+			'/<[^>]+class="[^"]*when[^"]*"[^>]*>(.*?)<\/[^>]+>/is',
 			'/<time[^>]+datetime="([^"]+)"/i',
 		),
 		'time'  => array(
-			'/<(?:div|span)[^>]+class="[^"]*eventTime[^"]*"[^>]*>(.*?)<\/(?:div|span)>/is',
-			'/<(?:div|span)[^>]+class="[^"]*event-time[^"]*"[^>]*>(.*?)<\/(?:div|span)>/is',
+			'/<span[^>]+class="[^"]*event-time[^"]*"[^>]*>(.*?)<\/span>/is',
+			'/<(?:div|span|p)[^>]+class="[^"]*eventTime[^"]*"[^>]*>(.*?)<\/(?:div|span|p)>/is',
 		),
 		'price' => array(
 			'/<(?:div|span)[^>]+class="[^"]*eventPrice[^"]*"[^>]*>(.*?)<\/(?:div|span)>/is',
 			'/<(?:div|span)[^>]+class="[^"]*event-price[^"]*"[^>]*>(.*?)<\/(?:div|span)>/is',
 		),
 		'link'  => array(
+			'/<[^>]+class="[^"]*(?:event-title|event-link)[^"]*"[^>]*>.*?<a[^>]+href="([^"]+)"/is',
 			'/<a[^>]+href="(https?:\/\/[^"]*\/events?\/[^"]+)"/i',
 			'/<a[^>]+href="(\/events?\/[^"]+)"/i',
 		),
@@ -88,18 +91,16 @@ class GenericHtmlEventsExtractor extends BaseExtractor {
 			|| substr_count( $html, 'event-listing' ) >= self::MIN_CONTAINERS
 		);
 
-		if ( ! $has_event_classes ) {
-			return false;
-		}
-
-		// Confirm at least one container pattern actually matches.
-		foreach ( self::CONTAINER_PATTERNS as $pattern ) {
-			if ( preg_match( $pattern, $html ) ) {
-				return true;
+		if ( $has_event_classes ) {
+			// Confirm at least one container pattern actually matches.
+			foreach ( self::CONTAINER_PATTERNS as $pattern ) {
+				if ( preg_match( $pattern, $html ) ) {
+					return true;
+				}
 			}
 		}
 
-		return false;
+		return count( $this->findSemanticContainers( $html ) ) >= self::MIN_CONTAINERS;
 	}
 
 	public function extract( string $html, string $source_url ): array {
@@ -112,6 +113,9 @@ class GenericHtmlEventsExtractor extends BaseExtractor {
 				$containers = $matches[1];
 				break;
 			}
+		}
+		if ( empty( $containers ) ) {
+			$containers = $this->findSemanticContainers( $html );
 		}
 
 		if ( empty( $containers ) ) {
@@ -131,6 +135,70 @@ class GenericHtmlEventsExtractor extends BaseExtractor {
 		}
 
 		return $events;
+	}
+
+	/**
+	 * Find repeated event containers by paired semantic field classes.
+	 *
+	 * Some WordPress plugins and themes do not name the card itself, but do
+	 * consistently expose title/date fields. The nearest ancestor containing
+	 * both fields is the event boundary.
+	 *
+	 * @return string[] Serialized event container HTML.
+	 */
+	private function findSemanticContainers( string $html ): array {
+		if ( '' === $html ) {
+			return array();
+		}
+
+		$loaded = $this->loadDom( $html );
+		$dom    = $loaded['dom'];
+		$xpath  = $loaded['xpath'];
+		$pairs  = array(
+			array( 'event-title', 'event-date' ),
+			array( 'event-link', 'when' ),
+		);
+
+		foreach ( $pairs as [ $title_class, $date_class ] ) {
+			$title_query = sprintf(
+				"//*[contains(concat(' ', normalize-space(@class), ' '), ' %s ')]",
+				$title_class
+			);
+			$title_nodes = $xpath->query( $title_query );
+			$containers  = array();
+
+			if ( false === $title_nodes ) {
+				continue;
+			}
+
+			foreach ( $title_nodes as $title_node ) {
+				$container = $title_node->parentNode;
+
+				for ( $depth = 0; $depth < 4 && $container instanceof \DOMElement; ++$depth ) {
+					$date_query = sprintf(
+						".//*[contains(concat(' ', normalize-space(@class), ' '), ' %s ')]",
+						$date_class
+					);
+					$date_nodes = $xpath->query( $date_query, $container );
+
+					if ( false !== $date_nodes && $date_nodes->length > 0 ) {
+						$path = $container->getNodePath();
+						if ( is_string( $path ) ) {
+							$containers[ $path ] = $dom->saveHTML( $container );
+						}
+						break;
+					}
+
+					$container = $container->parentNode;
+				}
+			}
+
+			if ( count( $containers ) >= self::MIN_CONTAINERS ) {
+				return array_values( $containers );
+			}
+		}
+
+		return array();
 	}
 
 	public function getMethod(): string {

--- a/tests/Fixtures/wp-generic/events-manager-list.html
+++ b/tests/Fixtures/wp-generic/events-manager-list.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html>
+<head><title>Calendar - Example Venue</title></head>
+<body>
+<div class="css-events-list">
+<ul>
+<li>
+<div class="event-link"><p><a href="/events/first-event/">First Event</a></p></div>
+<div class="when"><p>07/28/2099</p></div>
+</li>
+<li>
+<div class="event-link"><p><a href="/events/second-event/">Second Event</a></p></div>
+<div class="when"><p>07/29/2099</p></div>
+</li>
+<li>
+<div class="event-link"><p><a href="/events/third-event/">Third Event</a></p></div>
+<div class="when"><p>07/30/2099</p></div>
+</li>
+</ul>
+</div>
+</body>
+</html>

--- a/tests/Fixtures/wp-generic/semantic-event-cards.html
+++ b/tests/Fixtures/wp-generic/semantic-event-cards.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html>
+<head><title>Upcoming Shows</title></head>
+<body>
+<ul class="calendar-list">
+<li class="listing-card">
+<img src="https://example.com/uploads/show-one.jpg" alt="Show One">
+<div class="event-info-block">
+<p class="event-header">Local Promoter Presents</p>
+<p class="event-title"><a href="https://tickets.example.net/show-one">Show One</a></p>
+<p class="venue">at Example Room</p>
+<p class="event-date">Tue Jul 28</p>
+<p class="doortime-showtime"><span class="door-time">Doors: 7:00 PM</span> / <span class="event-time">Show: 8:00 PM</span></p>
+</div>
+</li>
+<li class="listing-card">
+<div class="event-info-block">
+<p class="event-title"><a href="https://tickets.example.net/show-two">Show Two</a></p>
+<p class="event-date">Wed Jul 29</p>
+<p><span class="event-time">9:30 PM</span></p>
+</div>
+</li>
+<li class="listing-card">
+<div class="event-info-block">
+<p class="event-title"><a href="/tickets/show-three">Show Three</a></p>
+<p class="event-date">Thursday July 30, 2099</p>
+</div>
+</li>
+</ul>
+</body>
+</html>

--- a/tests/Unit/GenericHtmlEventsExtractorTest.php
+++ b/tests/Unit/GenericHtmlEventsExtractorTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Generic HTML Events Extractor Tests.
+ *
+ * @package DataMachineEvents\Tests\Unit
+ */
+
+namespace DataMachineEvents\Tests\Unit;
+
+use DataMachineEvents\Steps\EventImport\Handlers\WebScraper\Extractors\GenericHtmlEventsExtractor;
+use WP_UnitTestCase;
+
+class GenericHtmlEventsExtractorTest extends WP_UnitTestCase {
+
+	private GenericHtmlEventsExtractor $extractor;
+	private string $fixture_dir;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->extractor   = new GenericHtmlEventsExtractor();
+		$this->fixture_dir = __DIR__ . '/../Fixtures/wp-generic';
+	}
+
+	public function test_extracts_repeated_semantic_event_cards(): void {
+		$html = file_get_contents( $this->fixture_dir . '/semantic-event-cards.html' );
+
+		$this->assertTrue( $this->extractor->canExtract( $html ) );
+
+		$events = $this->extractor->extract( $html, 'https://venue.example.com/' );
+
+		$this->assertCount( 3, $events );
+		$this->assertSame( 'Show One', $events[0]['title'] );
+		$this->assertSame( gmdate( 'Y' ) . '-07-28', $events[0]['startDate'] );
+		$this->assertSame( '20:00', $events[0]['startTime'] );
+		$this->assertSame( 'https://tickets.example.net/show-one', $events[0]['source_url'] );
+		$this->assertSame( 'Show Three', $events[2]['title'] );
+		$this->assertSame( '2099-07-30', $events[2]['startDate'] );
+		$this->assertSame( 'https://venue.example.com/tickets/show-three', $events[2]['source_url'] );
+	}
+
+	public function test_extracts_repeated_event_link_and_when_rows(): void {
+		$html = file_get_contents( $this->fixture_dir . '/events-manager-list.html' );
+
+		$this->assertTrue( $this->extractor->canExtract( $html ) );
+
+		$events = $this->extractor->extract( $html, 'https://venue.example.com/calendar/' );
+
+		$this->assertCount( 3, $events );
+		$this->assertSame( 'First Event', $events[0]['title'] );
+		$this->assertSame( '2099-07-28', $events[0]['startDate'] );
+		$this->assertSame( 'https://venue.example.com/events/first-event/', $events[0]['source_url'] );
+	}
+
+	public function test_rejects_insufficient_semantic_event_evidence(): void {
+		$html = '<div><p class="event-title">Only One</p><p class="event-date">Jul 28</p></div>';
+
+		$this->assertFalse( $this->extractor->canExtract( $html ) );
+		$this->assertSame( array(), $this->extractor->extract( $html, 'https://venue.example.com/' ) );
+	}
+}


### PR DESCRIPTION
## Summary
- Extend the existing generic HTML extractor to discover unnamed event containers from repeated `event-title` + `event-date` or `event-link` + `when` field pairs.
- Parse paragraph-based title/date fields, show-time spans, and arbitrary title links without domain-specific branches.
- Add sanitized fixtures and regression coverage for semantic event cards, Events Manager rows, and the minimum-evidence rejection threshold.

## Rationale
`GenericHtmlEventsExtractor` already owns repeating semantic HTML and runs before `WordPressGenericExtractor`. Extending that primitive closes the observed WordPress gaps without adding a parallel WordPress client or duplicating REST, JSON-LD, Tribe, Showtime, or AI fallback behavior. Detection still requires at least three independently bounded title/date pairs, preserving truthful rejection when a page has insufficient event evidence.

## Evidence
Representative behavior before this change:
- Harvard & Stone `/calendar/`: one `Raw HTML Event Section` packet from AI fallback.
- Beat Kitchen homepage: one `Raw HTML Event Section` packet from AI fallback.
- Pilot Light: one prose-heavy `Raw HTML Event Section` packet.
- Last Concert calendar: no actionable repeated event evidence during verification.
- Wilson Center: non-WordPress Hybrid Framework markup already owned by `ShowtimeExtractor`; no new path needed.

Representative behavior with this branch loaded against authorized public fetches:
- Harvard & Stone: 10 normalized events via `event-link` + `when` rows.
- Beat Kitchen: 101 normalized events via repeated `event-title` + `event-date` cards, including show times and external ticket URLs.
- Pilot Light remains unchanged because its calendar is unstructured prose in one post.
- Last Concert remains non-actionable because the fetched surface did not meet the three-container evidence threshold.

## Tests
- `php -l inc/Steps/EventImport/Handlers/WebScraper/Extractors/GenericHtmlEventsExtractor.php`
- `php -l tests/Unit/GenericHtmlEventsExtractorTest.php`
- `git diff --check`
- `homeboy review lint --changed-only --summary --placement local` passed PHPCS and PHPStan (run `35c22e27-6972-4f26-89eb-a5e3d028434e`).
- Worktree extractor executed through WordPress against both sanitized fixtures: 3/3 events extracted from each fixture with expected titles, dates, times, and URLs; insufficient one-card input rejected.

Homeboy's PHPUnit profile was attempted twice, including `--ci-job wp-codebox-phpunit`, but both runs exited after dependency hydration and successful block builds without invoking PHPUnit or emitting PHPUnit results (runs `96591531-212e-44fc-8416-9f8f3a89c05f` and `16548ead-1b1f-4041-aae5-92bc92cf1c4b`). The generated ignored `node_modules` directories were removed afterward.

## Remaining Gaps
- Prose calendars with many events inside one post, such as Pilot Light, still require a separately scoped text-list parser or AI fan-out improvement.
- Pages with fewer than three repeated title/date containers remain intentionally rejected.
- REST-hidden custom post types remain unavailable to the existing WordPress REST CPT discovery path.
- SPA-only and login/anti-bot surfaces remain unsupported.

Closes #624