### PR TITLE
fix: resolve Squarespace summary collection sources

### DIFF
--- a/inc/Steps/EventImport/Handlers/WebScraper/Extractors/SquarespaceExtractor.php
+++ b/inc/Steps/EventImport/Handlers/WebScraper/Extractors/SquarespaceExtractor.php
@@ -45,19 +45,7 @@ class SquarespaceExtractor extends BaseExtractor {
 			$data = array();
 		}
 
-		$raw_items = array();
-
-		// 1. Check for top-level 'upcoming' array (common in Squarespace event collections)
-		if ( isset( $data['upcoming'] ) && is_array( $data['upcoming'] ) && ! empty( $data['upcoming'] ) ) {
-			$raw_items = $data['upcoming'];
-		}
-
-		if ( empty( $raw_items ) ) {
-			// 2. Check for top-level 'past' array if no upcoming events
-			if ( isset( $data['past'] ) && is_array( $data['past'] ) && ! empty( $data['past'] ) ) {
-				$raw_items = $data['past'];
-			}
-		}
+		$raw_items = $this->extractEventsFromCollection( $data );
 
 		if ( empty( $raw_items ) ) {
 			// 3. Try recursive search for items in collection structure
@@ -248,8 +236,8 @@ class SquarespaceExtractor extends BaseExtractor {
 	 * Strategy per block:
 	 *   1. If the block declares an explicit `collectionUrlId` use
 	 *      `/<urlId>?format=json` directly.
-	 *   2. Otherwise probe the `?collectionId=` query against the source
-	 *      origin which Squarespace honors site-wide.
+	 *   2. Otherwise map `collectionId` to the matching collection `fullUrl`
+	 *      in the page's embedded Squarespace context.
 	 *
 	 * Returns an array of raw items (compatible with normalizeItem()) or an
 	 * empty array on failure. Never throws.
@@ -299,7 +287,7 @@ class SquarespaceExtractor extends BaseExtractor {
 			}
 			$seen_ids[ $collection_id ] = true;
 
-			$items = $this->fetchCollectionItemsById( $collection_id, $base_url, $block );
+			$items = $this->fetchCollectionItemsById( $collection_id, $base_url, $html, $block );
 			if ( ! empty( $items ) ) {
 				return $items;
 			}
@@ -344,7 +332,7 @@ class SquarespaceExtractor extends BaseExtractor {
 					continue;
 				}
 				$seen[ $cid ] = true;
-				$items        = $this->fetchCollectionItemsById( $cid, $base_url );
+				$items        = $this->fetchCollectionItemsById( $cid, $base_url, $html );
 				if ( ! empty( $items ) ) {
 					return $items;
 				}
@@ -360,7 +348,7 @@ class SquarespaceExtractor extends BaseExtractor {
 					continue;
 				}
 				$seen[ $cid ] = true;
-				$items        = $this->fetchCollectionItemsById( $cid, $base_url );
+				$items        = $this->fetchCollectionItemsById( $cid, $base_url, $html );
 				if ( ! empty( $items ) ) {
 					return $items;
 				}
@@ -413,29 +401,30 @@ class SquarespaceExtractor extends BaseExtractor {
 	/**
 	 * Fetch a Squarespace collection's events array by collection ID.
 	 *
-	 * Tries (in order):
-	 *   1. The block's own `collectionUrlId` if present (`/<urlId>?format=json`).
-	 *   2. `?collectionId=` query against the source origin — Squarespace
-	 *      resolves this to the collection root regardless of path.
+	 * Resolves the collection path from the block's `collectionUrlId` or from
+	 * the matching collection object in Static.SQUARESPACE_CONTEXT. Squarespace
+	 * does not resolve arbitrary `?collectionId=` requests to collection JSON.
 	 *
 	 * @since 0.15.x
 	 * @param string $collection_id Squarespace collection ID.
 	 * @param string $base_url      Source origin (scheme + host, no trailing slash).
+	 * @param string $html          Host page HTML containing Squarespace context.
 	 * @param array  $block         Optional originating block payload (for urlId hints).
 	 * @return array Raw event items, or empty array on failure.
 	 */
-	private function fetchCollectionItemsById( string $collection_id, string $base_url, array $block = array() ): array {
+	private function fetchCollectionItemsById( string $collection_id, string $base_url, string $html, array $block = array() ): array {
 		$candidates = array();
 
 		if ( ! empty( $block['collectionUrlId'] ) ) {
-			$candidates[] = $base_url . '/' . ltrim( (string) $block['collectionUrlId'], '/' ) . '?format=json';
+			$candidates[] = add_query_arg( 'format', 'json', $base_url . '/' . ltrim( (string) $block['collectionUrlId'], '/' ) );
 		}
 
-		// Squarespace honors `?collectionId=ID` at any path on the same site.
-		// `/?format=json&collectionId=...` resolves to the collection root JSON.
-		$candidates[] = $base_url . '/?format=json&collectionId=' . rawurlencode( $collection_id );
+		$context_path = $this->findCollectionPathById( $html, $collection_id );
+		if ( $context_path ) {
+			$candidates[] = add_query_arg( 'format', 'json', $base_url . '/' . ltrim( $context_path, '/' ) );
+		}
 
-		foreach ( $candidates as $url ) {
+		foreach ( array_unique( $candidates ) as $url ) {
 			$response = \DataMachine\Core\HttpClient::get(
 				$url,
 				array(
@@ -455,11 +444,97 @@ class SquarespaceExtractor extends BaseExtractor {
 
 			$items = $this->extractEventsFromCollection( $data );
 			if ( ! empty( $items ) ) {
+				if ( ! empty( $data['items'] ) ) {
+					$items = $this->fetchPaginatedCollectionItems( $items, $data, $base_url );
+				}
 				return $items;
 			}
 		}
 
 		return array();
+	}
+
+	/**
+	 * Find a collection's same-site path in embedded Squarespace context.
+	 */
+	private function findCollectionPathById( string $html, string $collection_id ): ?string {
+		$context = $this->extractContextData( $html );
+		if ( empty( $context ) ) {
+			return null;
+		}
+
+		$find = static function ( array $value ) use ( &$find, $collection_id ): ?string {
+			if ( isset( $value['id'] ) && $collection_id === (string) $value['id'] ) {
+				$path = $value['fullUrl'] ?? $value['urlId'] ?? '';
+				if ( is_string( $path ) && '' !== trim( $path ) ) {
+					$parsed = wp_parse_url( $path );
+					return $parsed['path'] ?? null;
+				}
+			}
+
+			foreach ( $value as $child ) {
+				if ( ! is_array( $child ) ) {
+					continue;
+				}
+				$path = $find( $child );
+				if ( $path ) {
+					return $path;
+				}
+			}
+
+			return null;
+		};
+
+		return $find( $context );
+	}
+
+	/**
+	 * Follow same-origin pagination for collection payloads using items[].
+	 */
+	private function fetchPaginatedCollectionItems( array $items, array $data, string $base_url ): array {
+		$seen_urls = array();
+
+		for ( $page = 0; $page < 10; ++$page ) {
+			$next_path = $data['pagination']['nextPageUrl'] ?? '';
+			if ( empty( $data['pagination']['nextPage'] ) || ! is_string( $next_path ) || '' === $next_path ) {
+				break;
+			}
+
+			$parsed = wp_parse_url( $next_path );
+			if ( ! empty( $parsed['host'] ) ) {
+				break;
+			}
+
+			$next_url = add_query_arg( 'format', 'json', $base_url . '/' . ltrim( $next_path, '/' ) );
+			if ( isset( $seen_urls[ $next_url ] ) ) {
+				break;
+			}
+			$seen_urls[ $next_url ] = true;
+
+			$response = \DataMachine\Core\HttpClient::get(
+				$next_url,
+				array(
+					'timeout' => 15,
+					'context' => 'Squarespace Extractor Collection Pagination',
+				)
+			);
+			if ( empty( $response['success'] ) || empty( $response['data'] ) ) {
+				break;
+			}
+
+			$data = json_decode( $response['data'], true );
+			if ( ! is_array( $data ) || JSON_ERROR_NONE !== json_last_error() ) {
+				break;
+			}
+
+			$page_items = $this->filterEventItems( $data['items'] ?? array() );
+			if ( empty( $page_items ) ) {
+				break;
+			}
+			$items = array_merge( $items, $page_items );
+		}
+
+		return $items;
 	}
 
 	/**
@@ -484,28 +559,34 @@ class SquarespaceExtractor extends BaseExtractor {
 		}
 
 		if ( ! empty( $data['items'] ) && is_array( $data['items'] ) ) {
-			$events = array();
-			foreach ( $data['items'] as $item ) {
-				if ( ! is_array( $item ) ) {
-					continue;
-				}
-				// recordType 12 = Squarespace event record. When recordType is
-				// absent (older payloads) but the item carries event-ish
-				// fields, accept it too.
-				$is_event = ( isset( $item['recordType'] ) && 12 === (int) $item['recordType'] )
-					|| ! empty( $item['startDate'] )
-					|| ! empty( $item['endDate'] )
-					|| ! empty( $item['eventDates'] );
-				if ( $is_event ) {
-					$events[] = $item;
-				}
-			}
-			if ( ! empty( $events ) ) {
-				return $events;
-			}
+			return $this->filterEventItems( $data['items'] );
 		}
 
 		return array();
+	}
+
+	/**
+	 * Keep only records with explicit event evidence.
+	 */
+	private function filterEventItems( array $items ): array {
+		$events = array();
+		foreach ( $items as $item ) {
+			if ( ! is_array( $item ) ) {
+				continue;
+			}
+			// recordType 12 = Squarespace event record. When recordType is
+			// absent (older payloads) but the item carries event-ish
+			// fields, accept it too.
+			$is_event = ( isset( $item['recordType'] ) && 12 === (int) $item['recordType'] )
+				|| ! empty( $item['startDate'] )
+				|| ! empty( $item['endDate'] )
+				|| ! empty( $item['eventDates'] );
+			if ( $is_event ) {
+				$events[] = $item;
+			}
+		}
+
+		return $events;
 	}
 
 	/**
@@ -586,26 +667,7 @@ class SquarespaceExtractor extends BaseExtractor {
 					return $data;
 				}
 
-				// 2. Check if page has a Summary Block referencing an events collection
-				$events_collection_url = $this->findEventsCollectionUrl( $html, $source_url );
-				if ( $events_collection_url ) {
-					$collection_response = \DataMachine\Core\HttpClient::get(
-						$events_collection_url,
-						array(
-							'timeout' => 30,
-							'context' => 'Squarespace Extractor Events Collection',
-						)
-					);
-
-					if ( $collection_response['success'] && ! empty( $collection_response['data'] ) ) {
-						$collection_data = json_decode( $collection_response['data'], true );
-						if ( json_last_error() === JSON_ERROR_NONE && ! empty( $collection_data ) ) {
-							return $collection_data;
-						}
-					}
-				}
-
-				// 3. Probe common event collection paths via JSON API.
+				// 2. Probe common event collection paths via JSON API.
 				// Squarespace events are often on a separate collection page
 				// (e.g. /events, /shows) that the homepage doesn't reference
 				// via Summary Blocks.
@@ -618,7 +680,14 @@ class SquarespaceExtractor extends BaseExtractor {
 			}
 		}
 
-		// 3. Fallback to extracting from HTML using string search (avoids regex backtracking)
+		// 3. Fallback to the embedded page context.
+		return $this->extractContextData( $html );
+	}
+
+	/**
+	 * Decode Static.SQUARESPACE_CONTEXT from a page.
+	 */
+	private function extractContextData( string $html ): array {
 		$start_token = 'Static.SQUARESPACE_CONTEXT = ';
 		$pos         = strpos( $html, $start_token );
 		if ( false === $pos ) {
@@ -626,79 +695,12 @@ class SquarespaceExtractor extends BaseExtractor {
 		}
 
 		$json_part = substr( $html, $pos + strlen( $start_token ) );
-
-		// Find the first semicolon that isn't inside a string
-		// Simple approach: look for }; or } followed by </script>
-		if ( preg_match( '/^(\{.*?\});\s*(?:<\/script>|window)/s', $json_part, $matches ) ) {
-			$data = json_decode( $matches[1], true );
-			if ( json_last_error() === JSON_ERROR_NONE && ! empty( $data ) ) {
-				return $data;
-			}
+		if ( ! preg_match( '/^(\{.*?\});\s*(?:<\/script>|window)/s', $json_part, $matches ) ) {
+			return array();
 		}
 
-		return array();
-	}
-
-	/**
-	 * Find events collection URL from Summary Block references in HTML.
-	 *
-	 * Summary Blocks on Squarespace pages reference source collections via collectionId.
-	 * This method extracts that ID and constructs the collection's JSON URL.
-	 */
-	private function findEventsCollectionUrl( string $html, string $source_url ): ?string {
-		// Look for Summary Block with showPastOrUpcomingEvents setting (indicates events collection)
-		if ( ! preg_match( '/data-block-json="([^"]*showPastOrUpcomingEvents[^"]*)"/', $html, $matches ) ) {
-			return null;
-		}
-
-		$block_json = html_entity_decode( $matches[1], ENT_QUOTES, 'UTF-8' );
-		$block_data = json_decode( $block_json, true );
-
-		if ( empty( $block_data['collectionId'] ) ) {
-			return null;
-		}
-
-		// Get the collection URL by fetching the site's navigation/collections
-		// For now, try common event collection paths
-		$parsed   = wp_parse_url( $source_url );
-		$base_url = ( $parsed['scheme'] ?? 'https' ) . '://' . ( $parsed['host'] ?? '' );
-
-		// Try common Squarespace event collection paths
-		$common_paths = array(
-			'/events',
-			'/event-listings',
-			'/calendar',
-			'/shows',
-			'/upcoming-events',
-			'/live-events',
-		);
-
-		foreach ( $common_paths as $path ) {
-			// Skip if it's the current URL
-			$current_path = $parsed['path'] ?? '';
-			if ( rtrim( $path, '/' ) === rtrim( $current_path, '/' ) ) {
-				continue;
-			}
-
-			$test_url = $base_url . $path . '?format=json';
-			$response = \DataMachine\Core\HttpClient::get(
-				$test_url,
-				array(
-					'timeout' => 10,
-					'context' => 'Squarespace Extractor Collection Discovery',
-				)
-			);
-
-			if ( $response['success'] && ! empty( $response['data'] ) ) {
-				$test_data = json_decode( $response['data'], true );
-				// Check if this collection has the events we're looking for
-				if ( isset( $test_data['upcoming'] ) && ! empty( $test_data['upcoming'] ) ) {
-					return $test_url;
-				}
-			}
-		}
-
-		return null;
+		$data = json_decode( $matches[1], true );
+		return JSON_ERROR_NONE === json_last_error() && is_array( $data ) ? $data : array();
 	}
 
 	/**
@@ -776,7 +778,10 @@ class SquarespaceExtractor extends BaseExtractor {
 		if ( isset( $data['blocks'] ) && is_array( $data['blocks'] ) ) {
 			foreach ( $data['blocks'] as $block ) {
 				if ( isset( $block['items'] ) && is_array( $block['items'] ) ) {
-					return $block['items'];
+					$events = $this->filterEventItems( $block['items'] );
+					if ( ! empty( $events ) ) {
+						return $events;
+					}
 				}
 			}
 		}
@@ -798,13 +803,20 @@ class SquarespaceExtractor extends BaseExtractor {
 		}
 
 		if ( isset( $data['collection']['items'] ) && is_array( $data['collection']['items'] ) ) {
-			return $data['collection']['items'];
+			return $this->filterEventItems( $data['collection']['items'] );
 		}
 
 		foreach ( $data as $key => $value ) {
 			if ( is_array( $value ) ) {
 				// If we find an array named 'items' or 'userItems' at any level, it might be what we want
-				if ( ( 'items' === $key || 'userItems' === $key ) && ! empty( $value ) && isset( $value[0]['title'] ) ) {
+				if ( 'items' === $key && ! empty( $value ) ) {
+					$events = $this->filterEventItems( $value );
+					if ( ! empty( $events ) ) {
+						return $events;
+					}
+				}
+
+				if ( 'userItems' === $key && ! empty( $value ) && isset( $value[0]['title'] ) ) {
 					return $value;
 				}
 

--- a/tests/Fixtures/squarespace/non-event-items.json
+++ b/tests/Fixtures/squarespace/non-event-items.json
@@ -1,0 +1,18 @@
+{
+  "collection": {
+    "id": "news-collection",
+    "typeName": "blog",
+    "fullUrl": "/news"
+  },
+  "items": [
+    {
+      "id": "post-1",
+      "recordType": 1,
+      "title": "Calendar Announcement",
+      "fullUrl": "/news/calendar-announcement"
+    }
+  ],
+  "pagination": {
+    "nextPage": false
+  }
+}

--- a/tests/Fixtures/squarespace/summary-context.html
+++ b/tests/Fixtures/squarespace/summary-context.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+<head>
+<script>Static.SQUARESPACE_CONTEXT = {"website":{"navigation":[{"id":"events-collection","title":"Live Shows","fullUrl":"/live-shows"}]}};</script>
+</head>
+<body>
+<div class="sqs-block-summary-v2" data-block-json="{&quot;collectionId&quot;:&quot;events-collection&quot;,&quot;design&quot;:&quot;list&quot;,&quot;showPastOrUpcomingEvents&quot;:&quot;upcoming&quot;}"></div>
+</body>
+</html>

--- a/tests/Fixtures/squarespace/summary-events-page-1.json
+++ b/tests/Fixtures/squarespace/summary-events-page-1.json
@@ -1,0 +1,26 @@
+{
+  "collection": {
+    "id": "events-collection",
+    "typeName": "events",
+    "fullUrl": "/live-shows"
+  },
+  "items": [
+    {
+      "id": "event-1",
+      "recordType": 12,
+      "title": "Fixture Show One",
+      "startDate": "2099-07-01T20:00:00+00:00",
+      "fullUrl": "/live-shows/fixture-show-one"
+    },
+    {
+      "id": "blog-1",
+      "recordType": 1,
+      "title": "Venue News",
+      "fullUrl": "/news/venue-news"
+    }
+  ],
+  "pagination": {
+    "nextPage": true,
+    "nextPageUrl": "/live-shows?offset=2"
+  }
+}

--- a/tests/Fixtures/squarespace/summary-events-page-2.json
+++ b/tests/Fixtures/squarespace/summary-events-page-2.json
@@ -1,0 +1,19 @@
+{
+  "collection": {
+    "id": "events-collection",
+    "typeName": "events",
+    "fullUrl": "/live-shows"
+  },
+  "items": [
+    {
+      "id": "event-2",
+      "recordType": 12,
+      "title": "Fixture Show Two",
+      "startDate": "2099-07-08T20:00:00+00:00",
+      "fullUrl": "/live-shows/fixture-show-two"
+    }
+  ],
+  "pagination": {
+    "nextPage": false
+  }
+}

--- a/tests/Unit/SquarespaceExtractorTest.php
+++ b/tests/Unit/SquarespaceExtractorTest.php
@@ -8,8 +8,9 @@
  *   3. Single-event-detail page extraction
  *   4. Fluid Engine deferral (no live fixture content; see PR body)
  *
- * Plus regression coverage for the classic Squarespace Events Collection
- * shape via the Royal American snapshot.
+ * Issue #625 adds context-backed collection URL resolution, paged items, and
+ * strict event evidence. Classic Events Collection behavior remains covered
+ * via the Royal American snapshot.
  *
  * @package DataMachineEvents\Tests\Unit
  * @since   0.15.x
@@ -59,42 +60,36 @@ class SquarespaceExtractorTest extends WP_UnitTestCase {
 	/* ------------------------------------------------------------------ */
 
 	public function test_summary_block_dereferences_collection_id() {
-		$source_url = 'https://example.com/';
+		$source_url = 'https://venue.test/calendar';
+		$html       = file_get_contents( $this->fixtures_dir . '/summary-context.html' );
 
-		$block_json = wp_json_encode(
-			array(
-				'collectionId'             => 'evt-collection-abc',
-				'design'                   => 'list',
-				'showPastOrUpcomingEvents' => 'upcoming',
-			)
-		);
-
-		$html = '<html><script>Static.SQUARESPACE_CONTEXT = {};</script>'
-			. '<div class="sqs-block-summary-v2" data-block-json="' . esc_attr( $block_json ) . '"></div>'
-			. '</html>';
-
-		// The page-level ?format=json returns a non-events payload so the
-		// classic strategies all whiff and we fall through to improvement 1.
-		// Improvement 1 fires `?format=json&collectionId=evt-collection-abc`
-		// which the mock answers with an upcoming[] array.
 		$this->mockHttpRoutes(
 			array(
-				'https://example.com/?format=json' => array( 'website' => array() ),
-				'https://example.com/?format=json&collectionId=evt-collection-abc' => array(
-					'upcoming' => array(
-						$this->makeRawEvent( 'Show One', '2099-01-15T20:00:00+00:00' ),
-						$this->makeRawEvent( 'Show Two', '2099-02-20T20:00:00+00:00' ),
-						$this->makeRawEvent( 'Show Three', '2099-03-05T20:00:00+00:00' ),
-					),
-				),
+				'https://venue.test/calendar?format=json' => array( 'website' => array() ),
+				'https://venue.test/live-shows?format=json' => file_get_contents( $this->fixtures_dir . '/summary-events-page-1.json' ),
+				'https://venue.test/live-shows?offset=2&format=json' => file_get_contents( $this->fixtures_dir . '/summary-events-page-2.json' ),
 			)
 		);
 
 		$events = $this->extractor->extract( $html, $source_url );
 
-		$this->assertCount( 3, $events, 'Summary Block deref should yield 3 events' );
-		$this->assertSame( 'Show One', $events[0]['title'] );
-		$this->assertSame( '2099-01-15', $events[0]['startDate'] );
+		$this->assertCount( 2, $events, 'Summary Block deref should follow paged event items.' );
+		$this->assertSame( 'Fixture Show One', $events[0]['title'] );
+		$this->assertSame( '2099-07-01', $events[0]['startDate'] );
+		$this->assertSame( 'Fixture Show Two', $events[1]['title'] );
+	}
+
+	public function test_non_event_items_are_not_treated_as_events() {
+		$source_url = 'https://venue.test/news';
+		$html       = '<html><script>Static.SQUARESPACE_CONTEXT = {};</script></html>';
+
+		$this->mockHttpRoutes(
+			array(
+				'https://venue.test/news?format=json' => file_get_contents( $this->fixtures_dir . '/non-event-items.json' ),
+			)
+		);
+
+		$this->assertSame( array(), $this->extractor->extract( $html, $source_url ) );
 	}
 
 	public function test_summary_block_gallery_is_skipped() {
@@ -136,7 +131,7 @@ class SquarespaceExtractorTest extends WP_UnitTestCase {
 			)
 		);
 
-		$html = '<html><script>Static.SQUARESPACE_CONTEXT = {};</script>'
+		$html = '<html><script>Static.SQUARESPACE_CONTEXT = {"website":{"navigation":[{"id":"evt-collection-fail","fullUrl":"/events"}]}};</script>'
 			. '<div class="sqs-block-summary-v2" data-block-json="' . esc_attr( $block_json ) . '"></div>'
 			. '</html>';
 
@@ -162,7 +157,7 @@ class SquarespaceExtractorTest extends WP_UnitTestCase {
 	public function test_user_items_list_dereferences_collection_id() {
 		$source_url = 'https://venue.test/';
 
-		$html = '<html><script>Static.SQUARESPACE_CONTEXT = {};</script>'
+		$html = '<html><script>Static.SQUARESPACE_CONTEXT = {"website":{"navigation":[{"id":"evt-uil-xyz","fullUrl":"/events"}]}};</script>'
 			. '<div class="user-items-list" data-collection-id="evt-uil-xyz">'
 			. '<div class="user-items-list-section">skeleton</div>'
 			. '</div>'
@@ -171,7 +166,7 @@ class SquarespaceExtractorTest extends WP_UnitTestCase {
 		$this->mockHttpRoutes(
 			array(
 				'https://venue.test/?format=json' => array( 'website' => array() ),
-				'https://venue.test/?format=json&collectionId=evt-uil-xyz' => array(
+				'https://venue.test/events?format=json' => array(
 					'upcoming' => array(
 						$this->makeRawEvent( 'UIL Show A', '2099-04-01T20:00:00+00:00' ),
 						$this->makeRawEvent( 'UIL Show B', '2099-04-08T20:00:00+00:00' ),


### PR DESCRIPTION
## Summary

- resolve Squarespace Summary Block and collection-backed User Items List IDs through the matching `fullUrl` in `Static.SQUARESPACE_CONTEXT`
- follow same-origin `items[]` pagination while retaining only records with explicit event evidence
- stop treating generic blog/gallery `items[]` as events, preserving truthful empty/stale outcomes
- add sanitized fixtures for context-backed collection discovery, paged event items, and a non-event collection

## Rationale

The previous Summary Block primitive assumed `/?format=json&collectionId=<id>` returned the referenced collection. A public native Events collection disproved that assumption:

- `https://www.theroyalamerican.com/schedule?format=json` returned collection `5a04b27e24a6946807ae890e`, `typeName: events`, 35 upcoming records, 30 past records, and a relative `pagination.nextPageUrl`.
- `https://www.theroyalamerican.com/?format=json&collectionId=5a04b27e24a6946807ae890e` returned the homepage/index collection with zero event arrays.
- The page's embedded `Static.SQUARESPACE_CONTEXT` contained the authoritative mapping `{ id: 5a04..., fullUrl: /schedule }`.

The fix uses that existing Squarespace context evidence instead of guessing domains or adding domain switches. Explicit `collectionUrlId` remains supported. Absolute pagination URLs are refused, repeated URLs are stopped, and pagination is capped at ten pages.

## Before / After

Before, a Summary Block with only `collectionId` probed a non-functional query and returned no collection events. Generic top-level `items[]` could also surface a blog post title as a structured event despite having no event date/type evidence.

After, a context-mapped Summary Block fixture resolves `/live-shows?format=json`, keeps its `recordType: 12` event, rejects the colocated `recordType: 1` blog item, follows `/live-shows?offset=2`, and returns the second event. The non-event collection fixture remains at zero events.

## Representative subcohorts

Public fetches of the five representative sources show that they are not native Squarespace collection fixes and remain intentionally unresolved here:

- Spotted Cat: `/calendar?format=json` reports a page collection with `itemCount: 0`; the page loads Bill's Gigulator.
- Mid City Ballroom: root JSON contains one `recordType: 1` blog item and the page loads Geotix.
- Floyd Miami: current upcoming inventory is a DICE widget; the Squarespace `/event` collection contains stale/past native entries.
- Shaw Center: the Squarespace page links to Manship Theatre and LSU Museum calendars rather than hosting a native event collection.
- Parker Jazz Club: calendar/reservations link to Turntable Tickets.

Those external-source shapes need their owning extractor/source-selection work and are not bypassed or scraped through bot controls by this PR. Truly empty native collections, including the separate #194 case, still return no evidence.

## Tests

- `homeboy review lint --placement local --changed-only --summary` passed PHPCS and PHPStan (run `9a5ef868-634f-433e-8be3-c26b211b676e`).
- Isolated WordPress runtime fixture harness: `{"count":2,"titles":["Fixture Show One","Fixture Show Two"]}`.
- Isolated WordPress runtime non-event harness: `{"count":0}`.
- `php -l inc/Steps/EventImport/Handlers/WebScraper/Extractors/SquarespaceExtractor.php` passed.
- `php -l tests/Unit/SquarespaceExtractorTest.php` passed.
- `git diff --check` passed.
- Homeboy's declared `wp-codebox-phpunit` gate was attempted repeatedly, including focused `SquarespaceExtractorTest`, but failed during sandbox preparation after dependency/build steps and reported 0 tests / 0 PHPUnit failures (runs `a4e5abd2-8119-48c4-b943-8c18f1142b11` and `a655a3d6-973f-4bd5-8cd7-2272da68afe6`). CI should execute the added regression tests in its normal runtime.

## Follow-up

The diagnostic CLI also fatals when its underlying ability returns `WP_Error`; tracked separately in #632 rather than worked around here.

Closes #625