### PR TITLE
fix: use canonical origins for Wix event APIs

### DIFF
--- a/inc/Steps/EventImport/Handlers/WebScraper/Extractors/WixEventsExtractor.php
+++ b/inc/Steps/EventImport/Handlers/WebScraper/Extractors/WixEventsExtractor.php
@@ -53,7 +53,7 @@ class WixEventsExtractor extends BaseExtractor {
 		}
 
 		// Strategy 2: Wix Events API (handles sites that load events client-side).
-		return $this->extractFromApi( $source_url );
+		return $this->extractFromApi( $source_url, $html );
 	}
 
 	public function getMethod(): string {
@@ -104,11 +104,12 @@ class WixEventsExtractor extends BaseExtractor {
 	 *      instance as the Authorization header.
 	 *   4. Paginate until all events are collected.
 	 *
-	 * @param string $source_url The venue's homepage URL.
+	 * @param string $source_url The configured source URL.
+	 * @param string $html       Fetched Wix page HTML.
 	 * @return array Normalized events.
 	 */
-	private function extractFromApi( string $source_url ): array {
-		$base_url = $this->getBaseUrl( $source_url );
+	private function extractFromApi( string $source_url, string $html ): array {
+		$base_url = $this->getBaseUrl( $source_url, $html );
 		if ( empty( $base_url ) ) {
 			return array();
 		}
@@ -402,17 +403,34 @@ class WixEventsExtractor extends BaseExtractor {
 	// ────────────────────────────────────────────────────────────────────────────
 
 	/**
-	 * Extract scheme + host from a URL.
+	 * Resolve the Wix API origin.
 	 *
-	 * @param string $url Full URL.
+	 * Wix rejects an otherwise valid instance token when an HTTP or non-canonical
+	 * host redirects the API request. Prefer the canonical URL from the fetched
+	 * page so API requests use the same site identity Wix rendered.
+	 *
+	 * @param string $source_url Configured source URL.
+	 * @param string $html       Fetched Wix page HTML.
 	 * @return string Base URL (e.g. https://www.example.com), or empty string.
 	 */
-	private function getBaseUrl( string $url ): string {
+	private function getBaseUrl( string $source_url, string $html ): string {
+		$url = $source_url;
+
+		if ( preg_match( '/<link\b(?=[^>]*\brel=["\'][^"\']*\bcanonical\b[^"\']*["\'])(?=[^>]*\bhref=["\']([^"\']+)["\'])[^>]*>/i', $html, $matches ) ) {
+			$url = html_entity_decode( $matches[1], ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+		}
+
 		$parts = wp_parse_url( $url );
 		if ( empty( $parts['host'] ) ) {
 			return '';
 		}
 
-		return ( $parts['scheme'] ?? 'https' ) . '://' . $parts['host'];
+		$scheme = strtolower( $parts['scheme'] ?? 'https' );
+		if ( ! in_array( $scheme, array( 'http', 'https' ), true ) ) {
+			return '';
+		}
+
+		$port = isset( $parts['port'] ) ? ':' . $parts['port'] : '';
+		return $scheme . '://' . $parts['host'] . $port;
 	}
 }

--- a/tests/Fixtures/wix/access-tokens.json
+++ b/tests/Fixtures/wix/access-tokens.json
@@ -1,0 +1,7 @@
+{
+	"apps": {
+		"140603ad-af8d-84a5-2c80-a0f60cb47351": {
+			"instance": "sanitized-instance-token"
+		}
+	}
+}

--- a/tests/Fixtures/wix/app-state-empty.html
+++ b/tests/Fixtures/wix/app-state-empty.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+<head>
+	<link href="https://www.venue.test/events" rel="canonical">
+</head>
+<body>
+	<script id="wix-warmup-data" type="application/json">{"appsWarmupData":{"140603ad-af8d-84a5-2c80-a0f60cb47351":{"widget-component":{"events":{"events":[],"hasMore":false}}}}}</script>
+</body>
+</html>

--- a/tests/Fixtures/wix/events-page-1.json
+++ b/tests/Fixtures/wix/events-page-1.json
@@ -1,0 +1,22 @@
+{
+	"total": 101,
+	"offset": 0,
+	"limit": 100,
+	"events": [
+		{
+			"id": "event-one",
+			"title": "First Fixture Show",
+			"status": "ACTIVE",
+			"scheduling": {
+				"config": {
+					"startDate": "2099-08-01T00:00:00.000Z",
+					"timeZoneId": "America/New_York"
+				}
+			},
+			"location": {
+				"name": "Fixture Room",
+				"address": "100 Example Street"
+			}
+		}
+	]
+}

--- a/tests/Fixtures/wix/events-page-2.json
+++ b/tests/Fixtures/wix/events-page-2.json
@@ -1,0 +1,22 @@
+{
+	"total": 101,
+	"offset": 100,
+	"limit": 100,
+	"events": [
+		{
+			"id": "event-two",
+			"title": "Second Fixture Show",
+			"status": "SCHEDULED",
+			"scheduling": {
+				"config": {
+					"startDate": "2099-08-02T01:30:00.000Z",
+					"timeZoneId": "America/New_York"
+				}
+			},
+			"location": {
+				"name": "Fixture Room",
+				"address": "100 Example Street"
+			}
+		}
+	]
+}

--- a/tests/Unit/WixEventsExtractorTest.php
+++ b/tests/Unit/WixEventsExtractorTest.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Wix Events extractor tests.
+ *
+ * @package DataMachineEvents\Tests\Unit
+ */
+
+namespace DataMachineEvents\Tests\Unit;
+
+use DataMachineEvents\Steps\EventImport\Handlers\WebScraper\Extractors\WixEventsExtractor;
+use WP_UnitTestCase;
+
+class WixEventsExtractorTest extends WP_UnitTestCase {
+
+	private WixEventsExtractor $extractor;
+	private string $fixtures_dir;
+	private array $requests = array();
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->extractor    = new WixEventsExtractor();
+		$this->fixtures_dir = __DIR__ . '/../Fixtures/wix';
+		$this->requests     = array();
+	}
+
+	public function tearDown(): void {
+		remove_all_filters( 'pre_http_request' );
+		parent::tearDown();
+	}
+
+	public function test_extract_uses_canonical_origin_and_paginates_api_results(): void {
+		$this->mockHttpRoutes(
+			array(
+				'https://www.venue.test/_api/v1/access-tokens' => 'access-tokens.json',
+				'https://www.venue.test/_api/wix-events-web/v1/events?offset=0&limit=100' => 'events-page-1.json',
+				'https://www.venue.test/_api/wix-events-web/v1/events?offset=100&limit=100' => 'events-page-2.json',
+			)
+		);
+
+		$events = $this->extractor->extract(
+			file_get_contents( $this->fixtures_dir . '/app-state-empty.html' ),
+			'http://venue.test/events'
+		);
+
+		$this->assertCount( 2, $events );
+		$this->assertSame( 'First Fixture Show', $events[0]['title'] );
+		$this->assertSame( 'Second Fixture Show', $events[1]['title'] );
+		$this->assertSame(
+			array(
+				'https://www.venue.test/_api/v1/access-tokens',
+				'https://www.venue.test/_api/wix-events-web/v1/events?offset=0&limit=100',
+				'https://www.venue.test/_api/wix-events-web/v1/events?offset=100&limit=100',
+			),
+			array_column( $this->requests, 'url' )
+		);
+		$this->assertSame( 'sanitized-instance-token', $this->requests[1]['headers']['Authorization'] );
+		$this->assertSame( 'sanitized-instance-token', $this->requests[2]['headers']['Authorization'] );
+	}
+
+	public function test_extract_returns_empty_without_wix_events_app_evidence(): void {
+		$this->mockHttpRoutes(
+			array(
+				'https://www.venue.test/_api/v1/access-tokens' => array(
+					'apps' => array(
+						'00000000-0000-0000-0000-000000000000' => array(
+							'instance' => 'unrelated-app-token',
+						),
+					),
+				),
+			)
+		);
+
+		$events = $this->extractor->extract(
+			file_get_contents( $this->fixtures_dir . '/app-state-empty.html' ),
+			'http://venue.test/events'
+		);
+
+		$this->assertSame( array(), $events );
+		$this->assertCount( 1, $this->requests );
+	}
+
+	/**
+	 * Mock Wix API routes with fixture filenames or decoded payloads.
+	 *
+	 * @param array $routes URL-keyed fixture filenames or response arrays.
+	 */
+	private function mockHttpRoutes( array $routes ): void {
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( $routes ) {
+				$this->requests[] = array(
+					'url'     => $url,
+					'headers' => $args['headers'] ?? array(),
+				);
+
+				if ( ! array_key_exists( $url, $routes ) ) {
+					return new \WP_Error( 'http_request_failed', 'Unmocked URL: ' . $url );
+				}
+
+				$payload = $routes[ $url ];
+				$body    = is_string( $payload )
+					? file_get_contents( $this->fixtures_dir . '/' . $payload )
+					: wp_json_encode( $payload );
+
+				return array(
+					'headers'  => array(),
+					'body'     => $body,
+					'response' => array( 'code' => 200, 'message' => 'OK' ),
+					'cookies'  => array(),
+					'filename' => null,
+				);
+			},
+			10,
+			3
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- Resolve Wix Events access-token and events API calls against the canonical origin rendered in fetched Wix HTML.
- Preserve the configured source origin as the fallback when no canonical evidence exists.
- Add sanitized app-state, token, and paginated API fixtures with regression coverage for canonical host selection, authorization, pagination, and no-app outcomes.

## Rationale
The existing Wix primitive is valid: empty warmup state falls back to `/_api/v1/access-tokens`, Wix Events v1 returns the event collection, and offset pagination returns the full cohort. The failure was origin selection. Configured `http://` sources caused Wix to redirect API requests, stripping the instance identity; Quarters additionally requires its canonical `www` host. Wix then returned `428 MISSING_REQUEST_SITE_CONTEXT` despite a valid Events app token.

The fetched pages already provide canonical HTTPS URLs. Reusing that evidence is the smallest general fix and avoids venue-specific logic, browser emulation, anti-bot handling, or a parallel extraction path.

## Before / After
- `http://www.marketonmain.com`: before, redirected API request returned HTTP 428; after, canonical `https://www.marketonmain.com` Wix Events v1 returned 4 events.
- `http://quartersslc.com/the-dlc`: before, redirected API request returned HTTP 428; after, canonical `https://www.quartersslc.com` Wix Events v1 returned 361 records across offsets 0, 100, 200, and 300 (final page: 61).
- `www.birdiesbar.com` and `www.thefootlight.com`: no Wix Events app instance is present in the public access-token inventory. They remain truthful no-evidence outcomes rather than being routed through an unsupported guess.

## Verification
- `php -l inc/Steps/EventImport/Handlers/WebScraper/Extractors/WixEventsExtractor.php` passed.
- `php -l tests/Unit/WixEventsExtractorTest.php` passed.
- `git diff --check origin/main...HEAD` passed.
- Homeboy changed-file lint passed PHPCS and PHPStan with no findings: run `ecacd1de-6ba0-446a-9c42-8bad91cc2cfe`.
- Homeboy test attempts `b8dc5d26-5bb6-4796-ac77-45c3924f41de` (focused) and `0ceacd95-0b86-429a-925e-e7cbe3b5c84b` (changed scope) completed all three configured npm installs/builds, then exited 1 before invoking PHPUnit or emitting test counts/errors. Persisted stdout ends at the successful Events Map webpack build; stderr contains dependency deprecation/peer warnings only. This is a shared validation-harness failure, not a reported test assertion failure.
- Direct local PHPUnit was unavailable because the worktree has no PHPUnit binary and `phpunit` is not installed globally.

## Remaining Gaps
- Wix sites without the Wix Events app remain unsupported unless public structured listing evidence exposes a separate general primitive.
- No venue-specific source selection or custom Wix CMS inference is introduced.

Closes #628