### PR TITLE
fix: support Eventbrite venue discovery

### DIFF
--- a/inc/Steps/EventImport/Handlers/WebScraper/Extractors/EventbriteExtractor.php
+++ b/inc/Steps/EventImport/Handlers/WebScraper/Extractors/EventbriteExtractor.php
@@ -31,6 +31,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class EventbriteExtractor extends BaseExtractor {
 
+	private const MAX_DISCOVERED_SOURCES = 25;
+
 	/**
 	 * Check if this extractor can handle the given HTML content.
 	 *
@@ -38,14 +40,9 @@ class EventbriteExtractor extends BaseExtractor {
 	 * in JSON-LD data or canonical link tags.
 	 */
 	public function canExtract( string $html ): bool {
-		if ( strpos( $html, 'application/ld+json' ) === false ) {
-			return false;
-		}
-
-		// Eventbrite organizer or event page markers.
-		return strpos( $html, 'eventbrite.com/o/' ) !== false
-			|| strpos( $html, 'eventbrite.com/e/' ) !== false
-			|| strpos( $html, 'evbuc.com' ) !== false;
+		return ( false !== strpos( $html, 'id="__NEXT_DATA__"' ) && false !== strpos( $html, 'organizer-profile' ) )
+			|| ( false !== strpos( $html, 'application/ld+json' ) && $this->containsEventbriteEventUrl( $html ) )
+			|| ! empty( $this->discoverEventbriteSources( $html ) );
 	}
 
 	/**
@@ -57,6 +54,41 @@ class EventbriteExtractor extends BaseExtractor {
 	 * 3. Series/recurring events: detects isSeries flag and uses nextAvailableSession
 	 */
 	public function extract( string $html, string $source_url ): array {
+		$events = array_merge(
+			$this->extractJsonLdEvents( $html ),
+			$this->extractOrganizerListingEvents( $html )
+		);
+
+		if ( empty( $events ) && ! $this->isEventbriteUrl( $source_url ) ) {
+			foreach ( $this->discoverEventbriteSources( $html ) as $eventbrite_url ) {
+				$eventbrite_html = $this->fetchUrl(
+					$eventbrite_url,
+					array(
+						'timeout' => 30,
+						'headers' => array( 'Accept' => 'text/html,application/xhtml+xml' ),
+					),
+					'Eventbrite public page'
+				);
+
+				if ( empty( $eventbrite_html ) ) {
+					continue;
+				}
+
+				$events = array_merge(
+					$events,
+					$this->extractJsonLdEvents( $eventbrite_html ),
+					$this->extractOrganizerListingEvents( $eventbrite_html )
+				);
+			}
+		}
+
+		return $this->deduplicateEvents( $events );
+	}
+
+	/**
+	 * Extract Eventbrite Event objects from public JSON-LD.
+	 */
+	private function extractJsonLdEvents( string $html ): array {
 		if ( ! preg_match_all( '/<script[^>]*type=["\']application\/ld\+json["\'][^>]*>(.*?)<\/script>/is', $html, $matches ) ) {
 			return array();
 		}
@@ -112,6 +144,167 @@ class EventbriteExtractor extends BaseExtractor {
 		}
 
 		return $events;
+	}
+
+	/**
+	 * Extract events from the public server-rendered organizer profile payload.
+	 */
+	private function extractOrganizerListingEvents( string $html ): array {
+		if ( ! preg_match( '/<script[^>]*id=["\']__NEXT_DATA__["\'][^>]*>(.*?)<\/script>/is', $html, $match ) ) {
+			return array();
+		}
+
+		$data = json_decode( trim( $match[1] ), true );
+		if ( JSON_ERROR_NONE !== json_last_error() || ! is_array( $data ) ) {
+			return array();
+		}
+
+		$page_props = $data['props']['pageProps'] ?? array();
+		$organizer  = $page_props['organizer'] ?? array();
+		$raw_events = $page_props['upcomingEvents'] ?? array();
+
+		if ( empty( $organizer['id'] ) || ! is_array( $raw_events ) ) {
+			return array();
+		}
+
+		$events = array();
+		foreach ( $raw_events as $raw_event ) {
+			if ( ! is_array( $raw_event ) || ! empty( $raw_event['is_cancelled'] ) || ! empty( $raw_event['is_protected_event'] ) ) {
+				continue;
+			}
+
+			$event = $this->parseOrganizerListingEvent( $raw_event, $organizer );
+			if ( null !== $event ) {
+				$events[] = $event;
+			}
+		}
+
+		return $events;
+	}
+
+	/**
+	 * Map an organizer profile event card to the standard event shape.
+	 */
+	private function parseOrganizerListingEvent( array $raw_event, array $organizer ): ?array {
+		$title      = html_entity_decode( (string) ( $raw_event['name'] ?? '' ) );
+		$start_date = (string) ( $raw_event['start_date'] ?? '' );
+
+		if ( '' === $title || ! preg_match( '/^\d{4}-\d{2}-\d{2}$/', $start_date ) ) {
+			return null;
+		}
+
+		$venue   = $raw_event['primary_venue'] ?? array();
+		$address = is_array( $venue['address'] ?? null ) ? $venue['address'] : array();
+		$image   = is_array( $raw_event['image'] ?? null ) ? $raw_event['image'] : array();
+		$event   = array(
+			'title'         => $title,
+			'description'   => $raw_event['summary'] ?? '',
+			'startDate'     => $start_date,
+			'startTime'     => $this->normalizeListingTime( $raw_event['start_time'] ?? '' ),
+			'endDate'       => $raw_event['end_date'] ?? '',
+			'endTime'       => $this->normalizeListingTime( $raw_event['end_time'] ?? '' ),
+			'venueTimezone' => $raw_event['timezone'] ?? '',
+			'organizer'     => $organizer['name'] ?? '',
+			'organizerUrl'  => $this->canonicalizeEventbriteUrl( $organizer['profilePageUrl'] ?? '' ),
+			'ticketUrl'     => $this->canonicalizeEventbriteUrl( $raw_event['url'] ?? '' ),
+			'imageUrl'      => $image['url'] ?? '',
+			'venue'         => html_entity_decode( (string) ( $venue['name'] ?? '' ) ),
+			'venueAddress'  => html_entity_decode( (string) ( $address['address_1'] ?? '' ) ),
+			'venueCity'     => html_entity_decode( (string) ( $address['city'] ?? '' ) ),
+			'venueState'    => html_entity_decode( (string) ( $address['region'] ?? '' ) ),
+			'venueZip'      => $address['postal_code'] ?? '',
+			'venueCountry'  => $address['country'] ?? '',
+		);
+
+		if ( ! empty( $address['latitude'] ) && ! empty( $address['longitude'] ) ) {
+			$event['venueCoordinates'] = $address['latitude'] . ',' . $address['longitude'];
+		}
+
+		$availability   = $raw_event['ticket_availability'] ?? array();
+		$minimum        = $availability['minimum_ticket_price']['major_value'] ?? null;
+		$maximum        = $availability['maximum_ticket_price']['major_value'] ?? null;
+		$currency       = $availability['minimum_ticket_price']['currency'] ?? 'USD';
+		$is_free        = isset( $availability['is_free'] ) ? (bool) $availability['is_free'] : null;
+		$event['price'] = $this->formatStructuredPrice(
+			null !== $minimum ? (float) $minimum : null,
+			null !== $maximum ? (float) $maximum : null,
+			(string) $currency,
+			$is_free
+		);
+
+		return $event;
+	}
+
+	/**
+	 * Discover canonical organizer/event pages and documented checkout widgets.
+	 */
+	private function discoverEventbriteSources( string $html ): array {
+		$sources = array();
+
+		if ( preg_match_all( '/\bhref\s*=\s*(["\'])(.*?)\1/is', $html, $matches ) ) {
+			foreach ( $matches[2] as $href ) {
+				$url = $this->canonicalizeEventbriteUrl( html_entity_decode( $href ) );
+				if ( '' !== $url ) {
+					$sources[ $url ] = true;
+				}
+			}
+		}
+
+		if ( preg_match_all( '/EBWidgets\.createWidget\s*\(\s*\{.*?\beventId\s*:\s*(["\']?)(\d{6,})\1.*?\}\s*\)/is', $html, $matches ) ) {
+			foreach ( $matches[2] as $event_id ) {
+				$sources[ 'https://www.eventbrite.com/e/' . $event_id ] = true;
+			}
+		}
+
+		return array_slice( array_keys( $sources ), 0, self::MAX_DISCOVERED_SOURCES );
+	}
+
+	/**
+	 * Normalize a public Eventbrite organizer/event URL and remove tracking data.
+	 */
+	private function canonicalizeEventbriteUrl( string $url ): string {
+		$url   = esc_url_raw( trim( $url ) );
+		$parts = wp_parse_url( $url );
+
+		if ( empty( $parts['host'] ) || empty( $parts['path'] ) ) {
+			return '';
+		}
+
+		$host = strtolower( $parts['host'] );
+		if ( 'eventbrite.com' !== $host && ! str_ends_with( $host, '.eventbrite.com' ) ) {
+			return '';
+		}
+
+		if ( ! preg_match( '#^/(?:o|e)/[^/]+(?:/)?$#i', $parts['path'] ) ) {
+			return '';
+		}
+
+		return 'https://www.eventbrite.com' . rtrim( $parts['path'], '/' );
+	}
+
+	private function isEventbriteUrl( string $url ): bool {
+		$host = strtolower( (string) wp_parse_url( $url, PHP_URL_HOST ) );
+		return 'eventbrite.com' === $host || str_ends_with( $host, '.eventbrite.com' );
+	}
+
+	private function containsEventbriteEventUrl( string $html ): bool {
+		return (bool) preg_match( '#https?://(?:[^/]+\.)?eventbrite\.com/(?:o|e)/#i', $html );
+	}
+
+	private function normalizeListingTime( string $time ): string {
+		return preg_match( '/^(\d{2}:\d{2})(?::\d{2})?$/', $time, $match ) ? $match[1] : '';
+	}
+
+	private function deduplicateEvents( array $events ): array {
+		$deduplicated = array();
+		foreach ( $events as $event ) {
+			$key = $event['ticketUrl'] ?? ( ( $event['title'] ?? '' ) . '|' . ( $event['startDate'] ?? '' ) );
+			if ( '' !== $key ) {
+				$deduplicated[ $key ] = $event;
+			}
+		}
+
+		return array_values( $deduplicated );
 	}
 
 	public function getMethod(): string {

--- a/tests/Fixtures/eventbrite/event.html
+++ b/tests/Fixtures/eventbrite/event.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html>
+<head>
+<link rel="canonical" href="https://www.eventbrite.com/e/direct-listing-tickets-123456789">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Event",
+  "name": "Direct Listing",
+  "description": "A sanitized direct Eventbrite event.",
+  "startDate": "2099-09-12T20:00:00-04:00",
+  "endDate": "2099-09-12T22:00:00-04:00",
+  "url": "https://www.eventbrite.com/e/direct-listing-tickets-123456789?aff=venue",
+  "location": {
+    "@type": "Place",
+    "name": "Example Hall",
+    "address": {
+      "@type": "PostalAddress",
+      "streetAddress": "456 Fixture Avenue",
+      "addressLocality": "Sample City",
+      "addressRegion": "NC",
+      "postalCode": "20000",
+      "addressCountry": "US"
+    }
+  }
+}
+</script>
+</head>
+<body></body>
+</html>

--- a/tests/Fixtures/eventbrite/organizer.html
+++ b/tests/Fixtures/eventbrite/organizer.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html>
+<head>
+<script src="/organizer-profile/_next/static/chunks/app.js"></script>
+<script id="__NEXT_DATA__" type="application/json">
+{
+  "props": {
+    "pageProps": {
+      "organizer": {
+        "id": "123456789",
+        "name": "Example Room",
+        "profilePageUrl": "https://www.eventbrite.com/o/example-room-123456789?aff=profile"
+      },
+      "upcomingEvents": [
+        {
+          "id": "987654321",
+          "name": "Example Room Presents",
+          "url": "https://www.eventbrite.com/e/example-room-presents-tickets-987654321?aff=profile",
+          "start_date": "2099-08-02",
+          "start_time": "19:30:00",
+          "end_date": "2099-08-02",
+          "end_time": "22:00:00",
+          "timezone": "America/New_York",
+          "summary": "A sanitized organizer listing event.",
+          "image": {"url": "https://images.example.test/event.jpg"},
+          "primary_venue": {
+            "name": "Example Room",
+            "address": {
+              "address_1": "123 Example Street",
+              "city": "Exampleville",
+              "region": "GA",
+              "postal_code": "30000",
+              "country": "US",
+              "latitude": 33.1,
+              "longitude": -83.2
+            }
+          },
+          "ticket_availability": {
+            "is_free": false,
+            "minimum_ticket_price": {"major_value": 15, "currency": "USD"},
+            "maximum_ticket_price": {"major_value": 25, "currency": "USD"}
+          }
+        },
+        {
+          "id": "987654322",
+          "name": "Protected Listing",
+          "url": "https://www.eventbrite.com/e/protected-listing-tickets-987654322",
+          "start_date": "2099-08-03",
+          "start_time": "20:00:00",
+          "is_protected_event": true
+        }
+      ]
+    }
+  }
+}
+</script>
+</head>
+<body></body>
+</html>

--- a/tests/Fixtures/eventbrite/venue-links.html
+++ b/tests/Fixtures/eventbrite/venue-links.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+<body>
+<section class="events">
+  <a href="https://www.eventbrite.com/o/example-room-123456789?aff=venue">All venue tickets</a>
+  <a href="https://www.eventbrite.com/e/direct-listing-tickets-123456789?aff=venue">Direct event tickets</a>
+</section>
+<footer>
+  <a href="https://www.eventbrite.com/about/">About Eventbrite</a>
+  <script src="https://www.eventbrite.com/static/widgets/eb_widgets.js"></script>
+</footer>
+</body>
+</html>

--- a/tests/Unit/EventbriteExtractorTest.php
+++ b/tests/Unit/EventbriteExtractorTest.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Eventbrite extractor regression tests.
+ *
+ * @package DataMachineEvents\Tests\Unit
+ */
+
+namespace DataMachineEvents\Tests\Unit;
+
+use DataMachineEvents\Steps\EventImport\Handlers\WebScraper\Extractors\EventbriteExtractor;
+use WP_UnitTestCase;
+
+class EventbriteExtractorTest extends WP_UnitTestCase {
+
+	private EventbriteExtractor $extractor;
+	private string $fixtures_dir;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->extractor    = new EventbriteExtractor();
+		$this->fixtures_dir = __DIR__ . '/../Fixtures/eventbrite';
+	}
+
+	public function tearDown(): void {
+		remove_all_filters( 'pre_http_request' );
+		parent::tearDown();
+	}
+
+	public function test_extracts_public_organizer_next_data(): void {
+		$html   = $this->fixture( 'organizer.html' );
+		$events = $this->extractor->extract( $html, 'https://www.eventbrite.com/o/example-room-123456789' );
+
+		$this->assertTrue( $this->extractor->canExtract( $html ) );
+		$this->assertCount( 1, $events, 'Protected organizer events must remain unresolved.' );
+		$this->assertSame( 'Example Room Presents', $events[0]['title'] );
+		$this->assertSame( '2099-08-02', $events[0]['startDate'] );
+		$this->assertSame( '19:30', $events[0]['startTime'] );
+		$this->assertSame( 'America/New_York', $events[0]['venueTimezone'] );
+		$this->assertSame( 'https://www.eventbrite.com/e/example-room-presents-tickets-987654321', $events[0]['ticketUrl'] );
+		$this->assertSame( '$15.00 - $25.00', $events[0]['price'] );
+		$this->assertSame( '33.1,-83.2', $events[0]['venueCoordinates'] );
+	}
+
+	public function test_discovers_canonical_organizer_and_event_links(): void {
+		$routes = array(
+			'https://www.eventbrite.com/o/example-room-123456789'             => $this->fixture( 'organizer.html' ),
+			'https://www.eventbrite.com/e/direct-listing-tickets-123456789' => $this->fixture( 'event.html' ),
+		);
+		$requested = array();
+		$this->mockHttpRoutes( $routes, $requested );
+
+		$html   = $this->fixture( 'venue-links.html' );
+		$events = $this->extractor->extract( $html, 'https://venue.example.test/events' );
+
+		$this->assertCount( 2, $events );
+		$this->assertSame( array_keys( $routes ), $requested );
+		$this->assertSame( array( 'Example Room Presents', 'Direct Listing' ), array_column( $events, 'title' ) );
+	}
+
+	public function test_documented_checkout_widget_event_id_is_actionable(): void {
+		$html = '<script src="https://www.eventbrite.com/static/widgets/eb_widgets.js"></script>'
+			. '<script>EBWidgets.createWidget({widgetType: "checkout", eventId: "123456789"});</script>';
+		$requested = array();
+		$this->mockHttpRoutes(
+			array( 'https://www.eventbrite.com/e/123456789' => $this->fixture( 'event.html' ) ),
+			$requested
+		);
+
+		$this->assertTrue( $this->extractor->canExtract( $html ) );
+		$this->assertCount( 1, $this->extractor->extract( $html, 'https://venue.example.test/events' ) );
+		$this->assertSame( array( 'https://www.eventbrite.com/e/123456789' ), $requested );
+	}
+
+	public function test_incidental_eventbrite_references_are_not_actionable(): void {
+		$html = '<a href="https://www.eventbrite.com/about/">About Eventbrite</a>'
+			. '<script src="https://www.eventbrite.com/static/widgets/eb_widgets.js"></script>';
+
+		$this->assertFalse( $this->extractor->canExtract( $html ) );
+		$this->assertSame( array(), $this->extractor->extract( $html, 'https://venue.example.test/events' ) );
+	}
+
+	private function fixture( string $name ): string {
+		return (string) file_get_contents( $this->fixtures_dir . '/' . $name );
+	}
+
+	private function mockHttpRoutes( array $routes, array &$requested ): void {
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) use ( $routes, &$requested ) {
+				$requested[] = $url;
+				if ( ! isset( $routes[ $url ] ) ) {
+					return new \WP_Error( 'http_request_failed', 'Unexpected URL: ' . $url );
+				}
+
+				return array(
+					'headers'  => array(),
+					'body'     => $routes[ $url ],
+					'response' => array( 'code' => 200, 'message' => 'OK' ),
+					'cookies'  => array(),
+					'filename' => null,
+				);
+			},
+			10,
+			3
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- parse modern Eventbrite organizer `upcomingEvents` from the public server-rendered `__NEXT_DATA__` payload
- discover canonical organizer/event anchors and documented checkout-widget event IDs from venue pages
- reject generic Eventbrite references, bare widget loaders, cancelled listings, and protected listings
- add sanitized organizer, direct-event, and venue-link fixtures with regression coverage

## Rationale
The removed Eventbrite handler and current extractor only consume public page JSON-LD. Eventbrite's documented API requires authentication and does not provide an existing unauthenticated feed primitive for this venue-source shape. Modern organizer profiles instead expose their public listing in server-rendered Next.js data, while direct event pages continue to expose Schema.org JSON-LD. This change extends the existing extractor only across those public, authorized surfaces and canonicalizes discovered URLs to remove tracking parameters.

## Evidence
Before:
- modern organizer pages contain no `application/ld+json`, so the extractor returns no events
- venue pages containing `/o/` or `/e/` links are detected inconsistently but never dereferenced
- a bare Eventbrite widget loader can look Eventbrite-related without identifying any event

After:
- the current Eagle's Dare organizer payload exposes 6 public upcoming events and matches the new organizer shape
- Macon Arts Center and Sea of Glass expose canonical direct `/e/` ticket links that can now be resolved through their public event JSON-LD
- Eagle's Dare exposes a canonical `/o/` organizer link that can now be resolved through public organizer data
- generic Eventbrite pages and Sultan Room's bare `eb_widgets.js` loader remain non-actionable

## Tests
- `php -l inc/Steps/EventImport/Handlers/WebScraper/Extractors/EventbriteExtractor.php`
- `php -l tests/Unit/EventbriteExtractorTest.php`
- `git diff --check`
- `homeboy --placement local review lint --changed-only --summary` (PHPCS and PHPStan pass with zero findings)

Homeboy's local test harness failed before PHPUnit emitted any test results after all configured JavaScript prepare/build steps completed. This is a shared harness/bootstrap failure rather than a reported assertion failure; runs: `e1c4d035-d771-45f9-b155-52176ec75f10` and `e86094ed-c894-4d84-8e7a-d32e559d673b`. The focused regression suite is included for CI's managed WordPress bootstrap.

## Unresolved surfaces
- The Foundry organizer currently reports zero public upcoming events, so there is no authorized listing data to import.
- Protected Eventbrite listings are deliberately skipped; this implementation does not probe or bypass protected surfaces.
- Sultan Room loads Eventbrite's widget library without an organizer URL, event URL, or checkout `eventId`; that insufficient reference remains non-actionable.
- Direct links to past or unrelated Eventbrite events remain subject to the existing downstream date and eligibility filters.

Closes #627