### PR TITLE
fix: parse localized Webflow event listings

### DIFF
--- a/inc/Steps/EventImport/Handlers/WebScraper/Extractors/WebflowExtractor.php
+++ b/inc/Steps/EventImport/Handlers/WebScraper/Extractors/WebflowExtractor.php
@@ -24,7 +24,17 @@ class WebflowExtractor extends BaseExtractor {
 	/**
 	 * Date pattern: month + day (e.g., "May 16", "Jun 24", "March 5").
 	 */
-	private const DATE_PATTERN = '/\b(Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s+(\d{1,2})\b/i';
+	private const DATE_PATTERN = '/\b(Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?|Enero|Febrero|Marzo|Abril|Mayo|Junio|Julio|Agosto|Septiembre|Octubre|Noviembre|Diciembre)\s+(\d{1,2})\b/iu';
+
+	/**
+	 * Date pattern: day + month (e.g., "07 agosto", "11 September").
+	 */
+	private const DAY_MONTH_PATTERN = '/\b(\d{1,2})\s+(Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?|Enero|Febrero|Marzo|Abril|Mayo|Junio|Julio|Agosto|Septiembre|Octubre|Noviembre|Diciembre)\b/iu';
+
+	/**
+	 * Numeric US date pattern used by Webflow CMS text fields.
+	 */
+	private const NUMERIC_DATE_PATTERN = '#\b(\d{1,2})/(\d{1,2})/(\d{2}|\d{4})\b#';
 
 	/**
 	 * Time pattern: 12-hour time (e.g., "7:00 pm", "8:30 PM", "9pm").
@@ -78,23 +88,27 @@ class WebflowExtractor extends BaseExtractor {
 	 * @return array Array of HTML strings, one per dynamic item.
 	 */
 	private function extractDynItems( string $html ): array {
+		$dom = new \DOMDocument();
+		libxml_use_internal_errors( true );
+		$loaded = $dom->loadHTML( $html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
+		libxml_clear_errors();
+
+		if ( ! $loaded ) {
+			return array();
+		}
+
+		$xpath = new \DOMXPath( $dom );
+		$nodes = $xpath->query( '//*[contains(concat(" ", normalize-space(@class), " "), " w-dyn-item ")]' );
 		$items = array();
 
-		// Split by w-dyn-item occurrences and extract each block.
-		// Webflow dynamic items are typically: <div role="listitem" class="... w-dyn-item">...</div>
-		$pattern = '/<div[^>]*\bw-dyn-item\b[^>]*>(.*?)(?=<div[^>]*\bw-dyn-item\b|<\/div>\s*<\/div>\s*<\/div>\s*<\/div>)/si';
-
-		if ( preg_match_all( $pattern, $html, $matches ) ) {
-			return $matches[1];
+		foreach ( $nodes as $node ) {
+			$item_html = $dom->saveHTML( $node );
+			if ( false !== $item_html ) {
+				$items[] = $item_html;
+			}
 		}
 
-		// Fallback: simpler split on role="listitem"
-		$pattern2 = '/<div[^>]*role="listitem"[^>]*class="[^"]*w-dyn-item[^"]*"[^>]*>(.*?)(?=<div[^>]*role="listitem"|$)/si';
-		if ( preg_match_all( $pattern2, $html, $matches ) ) {
-			return $matches[1];
-		}
-
-		return array();
+		return $items;
 	}
 
 	/**
@@ -136,10 +150,18 @@ class WebflowExtractor extends BaseExtractor {
 	 */
 	private function findTitle( string $html ): string {
 		// Try headings first.
-		if ( preg_match( '/<h[1-4][^>]*>(.*?)<\/h[1-4]>/si', $html, $m ) ) {
-			$text = wp_strip_all_tags( $m[1] );
-			if ( strlen( trim( $text ) ) >= 2 ) {
-				return trim( $text );
+		if ( preg_match_all( '/<h[1-4][^>]*>(.*?)<\/h[1-4]>/si', $html, $headings ) ) {
+			foreach ( $headings[1] as $heading ) {
+				$text = trim( wp_strip_all_tags( $heading ) );
+				if (
+					strlen( $text ) >= 2
+					&& ! preg_match( self::DATE_PATTERN, $text )
+					&& ! preg_match( self::DAY_MONTH_PATTERN, $text )
+					&& ! preg_match( self::NUMERIC_DATE_PATTERN, $text )
+					&& ! preg_match( self::TIME_PATTERN, $text )
+				) {
+					return $text;
+				}
 			}
 		}
 
@@ -198,11 +220,33 @@ class WebflowExtractor extends BaseExtractor {
 	private function findDate( string $html, int $current_year ): array {
 		$month_str = '';
 		$day       = 0;
+		$year      = $current_year;
+		$has_year  = false;
+
+		if ( preg_match( self::NUMERIC_DATE_PATTERN, $html, $numeric ) ) {
+			$month    = (int) $numeric[1];
+			$day      = (int) $numeric[2];
+			$year     = (int) $numeric[3];
+			$year     = $year < 100 ? 2000 + $year : $year;
+			$has_year = true;
+
+			if ( ! checkdate( $month, $day, $year ) ) {
+				return array( 'date' => '' );
+			}
+
+			return array( 'date' => sprintf( '%04d-%02d-%02d', $year, $month, $day ) );
+		}
 
 		// First try: month + day in a single text node (e.g., "May 16").
 		if ( preg_match( self::DATE_PATTERN, $html, $m ) ) {
 			$month_str = $m[1];
 			$day       = (int) $m[2];
+		}
+
+		// Webflow text fields also commonly render day-first localized dates.
+		if ( empty( $month_str ) && preg_match( self::DAY_MONTH_PATTERN, $html, $m ) ) {
+			$day       = (int) $m[1];
+			$month_str = $m[2];
 		}
 
 		// Second try: multi-element date pattern where month and day are in
@@ -221,45 +265,57 @@ class WebflowExtractor extends BaseExtractor {
 		}
 
 		// Check if a year is present.
-		$year = $current_year;
 		if ( preg_match( self::YEAR_PATTERN, $html, $ym ) ) {
-			$year = (int) $ym[1];
+			$year     = (int) $ym[1];
+			$has_year = true;
 		}
 
 		$month_map = array(
-			'jan'       => 1,
-			'january'   => 1,
-			'feb'       => 2,
-			'february'  => 2,
-			'mar'       => 3,
-			'march'     => 3,
-			'apr'       => 4,
-			'april'     => 4,
-			'may'       => 5,
-			'jun'       => 6,
-			'june'      => 6,
-			'jul'       => 7,
-			'july'      => 7,
-			'aug'       => 8,
-			'august'    => 8,
-			'sep'       => 9,
-			'september' => 9,
-			'oct'       => 10,
-			'october'   => 10,
-			'nov'       => 11,
-			'november'  => 11,
-			'dec'       => 12,
-			'december'  => 12,
+			'jan'        => 1,
+			'january'    => 1,
+			'feb'        => 2,
+			'february'   => 2,
+			'mar'        => 3,
+			'march'      => 3,
+			'apr'        => 4,
+			'april'      => 4,
+			'may'        => 5,
+			'jun'        => 6,
+			'june'       => 6,
+			'jul'        => 7,
+			'july'       => 7,
+			'aug'        => 8,
+			'august'     => 8,
+			'sep'        => 9,
+			'september'  => 9,
+			'oct'        => 10,
+			'october'    => 10,
+			'nov'        => 11,
+			'november'   => 11,
+			'dec'        => 12,
+			'december'   => 12,
+			'enero'      => 1,
+			'febrero'    => 2,
+			'marzo'      => 3,
+			'abril'      => 4,
+			'mayo'       => 5,
+			'junio'      => 6,
+			'julio'      => 7,
+			'agosto'     => 8,
+			'septiembre' => 9,
+			'octubre'    => 10,
+			'noviembre'  => 11,
+			'diciembre'  => 12,
 		);
 
 		$month = $month_map[ strtolower( $month_str ) ] ?? 0;
-		if ( 0 === $month || $day < 1 || $day > 31 ) {
+		if ( 0 === $month || ! checkdate( $month, $day, $year ) ) {
 			return array( 'date' => '' );
 		}
 
 		// If the date is in the past (e.g., Jan event viewed in Nov), assume next year.
 		$date_str = sprintf( '%04d-%02d-%02d', $year, $month, $day );
-		if ( strtotime( $date_str ) < strtotime( '-7 days' ) && $year === $current_year ) {
+		if ( ! $has_year && strtotime( $date_str ) < strtotime( '-7 days' ) ) {
 			$date_str = sprintf( '%04d-%02d-%02d', $year + 1, $month, $day );
 		}
 

--- a/tests/Fixtures/webflow/localized-listing.html
+++ b/tests/Fixtures/webflow/localized-listing.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html data-wf-site="fixture-site">
+<body>
+<div class="promo-list w-dyn-list">
+  <div role="list" class="w-dyn-items">
+    <div role="listitem" class="promo w-dyn-item"><img src="https://cdn.example.test/promo.jpg" alt="Sponsor banner"></div>
+  </div>
+</div>
+<div class="event-list w-dyn-list">
+  <div role="list" class="w-dyn-items">
+    <div role="listitem" class="event-card w-dyn-item">
+      <img src="https://cdn.example.test/show-one.jpg" alt="Show One">
+      <div class="event-copy"><div class="event-name">Show One</div><div class="event-date">07 agosto</div></div>
+      <a href="/events/show-one">More info</a><a href="https://tickets.example.test/show-one">Tickets</a>
+    </div>
+    <div role="listitem" class="event-card w-dyn-item">
+      <img src="https://cdn.example.test/show-two.jpg" alt="Show Two">
+      <div class="event-copy"><div class="event-name">Show Two</div><div class="event-date">11 septiembre</div></div>
+      <a href="/events/show-two">More info</a><a href="https://tickets.example.test/show-two">Tickets</a>
+    </div>
+  </div>
+</div>
+<a href="?events_page=2" aria-label="Next Page" class="w-pagination-next">Next</a>
+</body>
+</html>

--- a/tests/Fixtures/webflow/numeric-nested-listing.html
+++ b/tests/Fixtures/webflow/numeric-nested-listing.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html data-wf-site="fixture-site">
+<body>
+<div class="event-list w-dyn-list">
+  <div role="list" class="w-dyn-items">
+    <div role="listitem" class="event-card w-dyn-item">
+      <a href="/event/first-show"><div style="background-image:url('https://cdn.example.test/first.jpg')"></div></a>
+      <div class="event-time"><h3>7/30/26</h3></div>
+      <h3>First Show</h3>
+      <div class="locations w-dyn-list"><div role="list" class="w-dyn-items"><div role="listitem" class="location w-dyn-item">Main Hall</div></div></div>
+    </div>
+    <div role="listitem" class="event-card w-dyn-item">
+      <a href="/event/second-show"><img src="/images/second.jpg" alt="Second Show"></a>
+      <div class="event-time"><h3>8/1/2026</h3></div>
+      <h3>Second Show</h3>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/tests/Fixtures/webflow/unsupported-availability.html
+++ b/tests/Fixtures/webflow/unsupported-availability.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html data-wf-site="fixture-site">
+<body>
+<div class="calendar w-embed w-iframe">
+  <iframe src="https://reservations.example.test/events/rooftop" title="Calendar of availability"></iframe>
+</div>
+<div class="other-venues w-dyn-list">
+  <div role="list" class="w-dyn-items">
+    <div role="listitem" class="venue-card w-dyn-item"><h3>Another Venue</h3><p>Friday and Saturday, 10 p.m. to close.</p></div>
+  </div>
+</div>
+</body>
+</html>

--- a/tests/Unit/WebflowExtractorTest.php
+++ b/tests/Unit/WebflowExtractorTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Webflow Extractor Tests
+ *
+ * @package DataMachineEvents\Tests\Unit
+ */
+
+namespace DataMachineEvents\Tests\Unit;
+
+use DataMachineEvents\Steps\EventImport\Handlers\WebScraper\Extractors\WebflowExtractor;
+use WP_UnitTestCase;
+
+class WebflowExtractorTest extends WP_UnitTestCase {
+
+	private WebflowExtractor $extractor;
+	private string $fixtures_dir;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->extractor    = new WebflowExtractor();
+		$this->fixtures_dir = dirname( __DIR__ ) . '/Fixtures/webflow';
+	}
+
+	public function test_extracts_localized_day_first_dates_from_event_collection() {
+		$html   = file_get_contents( $this->fixtures_dir . '/localized-listing.html' );
+		$events = $this->extractor->extract( $html, 'https://venue.example.test/' );
+
+		$this->assertCount( 2, $events );
+		$this->assertSame( 'Show One', $events[0]['title'] );
+		$this->assertSame( $this->expectedInferredDate( '08-07' ), $events[0]['startDate'] );
+		$this->assertSame( 'https://tickets.example.test/show-one', $events[0]['ticketUrl'] );
+		$this->assertSame( 'Show Two', $events[1]['title'] );
+		$this->assertSame( $this->expectedInferredDate( '09-11' ), $events[1]['startDate'] );
+	}
+
+	public function test_extracts_numeric_dates_without_promoting_nested_collection_items() {
+		$html   = file_get_contents( $this->fixtures_dir . '/numeric-nested-listing.html' );
+		$events = $this->extractor->extract( $html, 'https://venue.example.test/event' );
+
+		$this->assertCount( 2, $events );
+		$this->assertSame( 'First Show', $events[0]['title'] );
+		$this->assertSame( '2026-07-30', $events[0]['startDate'] );
+		$this->assertSame( 'https://cdn.example.test/first.jpg', $events[0]['imageUrl'] );
+		$this->assertSame( 'Second Show', $events[1]['title'] );
+		$this->assertSame( '2026-08-01', $events[1]['startDate'] );
+		$this->assertSame( 'https://venue.example.test/images/second.jpg', $events[1]['imageUrl'] );
+	}
+
+	public function test_availability_embed_without_dated_events_remains_unsupported() {
+		$html = file_get_contents( $this->fixtures_dir . '/unsupported-availability.html' );
+
+		$this->assertTrue( $this->extractor->canExtract( $html ) );
+		$this->assertSame( array(), $this->extractor->extract( $html, 'https://venue.example.test/rooftop' ) );
+	}
+
+	public function test_rejects_invalid_numeric_dates() {
+		$html = '<html data-wf-site="fixture"><body><div class="w-dyn-item"><h3>Not An Event</h3><p>13/40/26</p></div></body></html>';
+
+		$this->assertSame( array(), $this->extractor->extract( $html, 'https://venue.example.test/' ) );
+	}
+
+	private function expectedInferredDate( string $month_day ): string {
+		$year = (int) gmdate( 'Y' );
+		if ( strtotime( $year . '-' . $month_day ) < strtotime( '-7 days' ) ) {
+			++$year;
+		}
+
+		return $year . '-' . $month_day;
+	}
+}


### PR DESCRIPTION
## Summary
- replace regex-based Webflow CMS item slicing with DOM-backed `w-dyn-item` boundaries so nested collections do not corrupt event cards
- parse Webflow's numeric `M/D/YY` dates and day-first English/Spanish month dates while retaining explicit-year validation and inferred-year rollover
- add sanitized fixtures for localized listings, numeric listings with nested CMS items, and reservation-only availability that must remain unsupported

## Investigation and rationale
The existing generic primitives cover part, but not all, of the representative shapes:

- `JsonLdExtractor` already recursively walks `event[]`, so Pepsi Center's `EventVenue.event[]` JSON-LD shape does not need a new JSON-LD primitive. Its authorized response currently contains stale February/March records while the visible Webflow CMS lists current August/September events, so JSON-LD alone does not qualify the current source.
- `HtmlLinkPaginator` already recognizes Webflow's `w-pagination-next` links and same-host query pagination. No new paginator is needed.
- The existing Webflow extractor only accepted English month-first dates and split nested HTML with a regex. POST Houston uses `M/D/YY`; Pepsi Center uses day-first Spanish month names. Those listing shapes therefore yielded no current Webflow events before this change.
- Existing embedded-provider extractors do not turn arbitrary cross-domain calendar links or SevenRooms reservation availability into trustworthy event records. Following those sources or inventing dates would broaden scope and create false positives.

The smallest general fix is therefore confined to Webflow CMS item boundaries and date normalization. There are no domain branches or bot-control bypasses.

## Representative evidence
Authorized responses inspected on July 28, 2026:

- `pepsicenterwtc.com`: current CMS cards use values such as `07 agosto` and expose Webflow query pagination; before, the Webflow extractor returned no dated cards and stale JSON-LD was the only structured candidate. The sanitized equivalent now extracts both localized cards with ticket/image data.
- `posthtx.com`: homepage and `/event` CMS cards use values such as `7/30/26`, including nested location collections; before, the date parser rejected them and regex boundaries could mix nested items. The sanitized equivalent now extracts two outer events and does not promote the nested location item.
- `orbitalmusicpark.com`: links to a separate Reveler calendar and contains no local dated CMS events; remains unsupported.
- `hardrocknightlife.com/venues/rooftop-live`: embeds SevenRooms availability/reservation UI, not trustworthy dated event records; the negative fixture remains empty.
- `prohibitioncharleston.com`: static recurring schedule copy and manually written month lists do not provide durable CMS event objects; remains unsupported rather than guessing occurrences.

Sanitized fixture execution changed the supported shapes from zero to two localized events and zero to two numeric events, while the availability fixture remains zero.

## Tests
- `php -l inc/Steps/EventImport/Handlers/WebScraper/Extractors/WebflowExtractor.php`
- `php -l tests/Unit/WebflowExtractorTest.php`
- `git diff --check`
- standalone fixture execution against all three sanitized fixtures: 2 localized events, 2 numeric events, 0 unsupported availability events
- `homeboy review lint data-machine-events --changed-only`: passed PHPCS and PHPStan with no findings (run `e491d5e7-436a-4940-9e1e-aaef0f71add0`)

### Shared Homeboy test harness limitation
Focused PHPUnit could not complete through the shared local Homeboy harness. Run `63e70e6f-fe17-446c-8cc8-94209a78ca52` spent its command window hydrating and successfully building three unrelated block packages, then timed out before PHPUnit emitted any output. A retry with prepare steps disabled (`21f626be-a262-4552-b57e-fd6e335dc66e`) exited before producing test output or structured counts. Neither run reported a branch assertion failure; the lightweight extractor execution, syntax checks, PHPCS, PHPStan, and diff checks pass.

## Remaining gaps
- Cross-domain calendars require an explicitly supported provider/source rather than generic link following.
- Reservation availability without event objects remains unsupported.
- Static recurring prose without reliable occurrence dates remains unsupported.

Closes #629