### PR TITLE
feat: expose canonical venue interval overlaps

### DIFF
--- a/data-machine-events.php
+++ b/data-machine-events.php
@@ -272,6 +272,7 @@ class DATAMACHINE_Events {
 			\DataMachineEvents\Abilities\DuplicateDetectionAbilities::class,
 			\DataMachineEvents\Abilities\UpcomingCountAbilities::class,
 			\DataMachineEvents\Abilities\EventDateQueryAbilities::class,
+			\DataMachineEvents\Abilities\VenueIntervalOverlapAbilities::class,
 			\DataMachineEvents\Abilities\EventsByTermAbilities::class,
 			\DataMachineEvents\Abilities\MergedBillDetectAbilities::class,
 			\DataMachineEvents\Abilities\MergeEventPostsAbilities::class,

--- a/docs/venue-interval-overlap.md
+++ b/docs/venue-interval-overlap.md
@@ -1,0 +1,21 @@
+# Venue Interval Overlap
+
+`data-machine-events/query-venue-interval-overlaps` is the bounded public read
+primitive for canonical event ranges at one venue. Its PHP equivalent is
+`data_machine_events_query_venue_interval_overlaps()`.
+
+## Semantics
+
+- The requested interval is half-open: `[start, end)`. Exact adjacency does not overlap.
+- `start` and `end` are RFC3339 instants with seconds and an explicit offset. They are normalized to the canonical venue's IANA timezone, or the site timezone when the venue has no valid timezone.
+- The event-date index stores one venue-local wall-clock range per canonical event. Only closed ranges with `end > start` participate. An absent, zero-length, or inverted end is not silently assigned a duration.
+- A multi-day event's indexed start/end is one continuous interval.
+- `occurrenceDates` controls calendar display grouping. It does not create separately indexed intervals, so discrete recurring dates are not inferred by this query.
+- The public Ability exposes published events only. Draft, private, pending, future, trashed, and otherwise non-published rows are not public overlap facts.
+- Venue identity is the current site's exact `venue` term ID. The query uses the active multisite site's tables and does not switch sites.
+- Results are ordered by indexed start then event ID. `per_page` is capped at 100, exclusions at 100 IDs, and `has_more` is computed from the same SQL snapshot as the returned page.
+- Date-index repair, source-owned date updates, venue reassignment, and post-status transitions affect the next query immediately because the primitive reads the derived date index, current venue relationship, and synchronized status directly.
+
+The response contains only the venue ID and timezone, normalized requested
+interval, pagination facts, and canonical event ID/start/end/status facts. It
+does not decide whether an overlap is allowed or meaningful to a consumer.

--- a/inc/Abilities/VenueIntervalOverlapAbilities.php
+++ b/inc/Abilities/VenueIntervalOverlapAbilities.php
@@ -1,0 +1,309 @@
+<?php
+/**
+ * Canonical venue interval-overlap query.
+ *
+ * @package DataMachineEvents\Abilities
+ */
+
+namespace DataMachineEvents\Abilities;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Exception;
+use DataMachineEvents\Core\EventDatesTable;
+use DataMachineEvents\Core\Event_Post_Type;
+use DataMachineEvents\Core\Venue_Taxonomy;
+
+defined( 'ABSPATH' ) || exit;
+
+class VenueIntervalOverlapAbilities {
+
+	public const ABILITY_NAME = 'data-machine-events/query-venue-interval-overlaps';
+
+	private const DEFAULT_PER_PAGE = 50;
+	private const MAX_PER_PAGE     = 100;
+	private const MAX_EXCLUSIONS   = 100;
+	private const MAX_PAGE         = 10000;
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( ! self::$registered ) {
+			$this->registerAbility();
+			self::$registered = true;
+		}
+	}
+
+	private function registerAbility(): void {
+		add_action(
+			'wp_abilities_api_init',
+			function (): void {
+				wp_register_ability(
+					self::ABILITY_NAME,
+					array(
+						'label'               => __( 'Query Venue Interval Overlaps', 'data-machine-events' ),
+						'description'         => __( 'Return published canonical events whose indexed closed range overlaps a half-open interval at one venue.', 'data-machine-events' ),
+						'category'            => 'datamachine-events-events',
+						'input_schema'        => self::inputSchema(),
+						'output_schema'       => self::outputSchema(),
+						'execute_callback'    => array( $this, 'execute' ),
+						'permission_callback' => '__return_true',
+						'meta'                => array(
+							'show_in_rest' => true,
+							'annotations'  => array(
+								'readonly'   => true,
+								'idempotent' => true,
+							),
+						),
+					)
+				);
+			}
+		);
+	}
+
+	/**
+	 * Query canonical indexed ranges at one venue.
+	 *
+	 * Input instants must be RFC3339 values with an explicit offset. They are
+	 * normalized to the venue's IANA timezone before comparison with the local
+	 * wall-clock values in the event-date index. Open, zero-length, and inverted
+	 * indexed ranges are not intervals and therefore never overlap.
+	 *
+	 * @param array $input Ability input.
+	 * @return array|\WP_Error
+	 */
+	public function execute( array $input ): array|\WP_Error {
+		global $wpdb;
+
+		$venue_id = absint( $input['venue_id'] ?? 0 );
+		$venue    = $venue_id > 0 ? get_term( $venue_id, 'venue' ) : null;
+		if ( ! $venue || is_wp_error( $venue ) ) {
+			return new \WP_Error( 'venue_overlap_invalid_venue', __( 'venue_id must identify a canonical venue term on the current site.', 'data-machine-events' ), array( 'status' => 400 ) );
+		}
+
+		$timezone = $this->venueTimezone( $venue_id );
+		$start    = $this->parseInstant( $input['start'] ?? null, $timezone );
+		$end      = $this->parseInstant( $input['end'] ?? null, $timezone );
+		if ( is_wp_error( $start ) || is_wp_error( $end ) ) {
+			return is_wp_error( $start ) ? $start : $end;
+		}
+		if ( $start >= $end ) {
+			return new \WP_Error( 'venue_overlap_invalid_interval', __( 'end must be later than start.', 'data-machine-events' ), array( 'status' => 400 ) );
+		}
+
+		$statuses = $input['statuses'] ?? array( 'publish' );
+		if ( ! is_array( $statuses ) || array( 'publish' ) !== array_values( array_unique( $statuses ) ) ) {
+			return new \WP_Error( 'venue_overlap_invalid_statuses', __( 'The public overlap query supports published events only.', 'data-machine-events' ), array( 'status' => 400 ) );
+		}
+
+		$exclude = $input['exclude'] ?? array();
+		if ( ! is_array( $exclude ) || count( $exclude ) > self::MAX_EXCLUSIONS ) {
+			return new \WP_Error( 'venue_overlap_invalid_exclusions', __( 'exclude must contain no more than 100 event IDs.', 'data-machine-events' ), array( 'status' => 400 ) );
+		}
+		$exclude = array_values( array_unique( array_filter( array_map( 'absint', $exclude ) ) ) );
+
+		$page = absint( $input['page'] ?? 1 );
+		if ( $page < 1 || $page > self::MAX_PAGE ) {
+			return new \WP_Error( 'venue_overlap_invalid_page', __( 'page must be between 1 and 10000.', 'data-machine-events' ), array( 'status' => 400 ) );
+		}
+
+		$per_page = min( self::MAX_PER_PAGE, max( 1, absint( $input['per_page'] ?? self::DEFAULT_PER_PAGE ) ) );
+		$offset   = ( $page - 1 ) * $per_page;
+		$table    = EventDatesTable::table_name();
+
+		$sql  = "SELECT ed.post_id, ed.start_datetime, ed.end_datetime, ed.post_status
+			FROM {$table} ed
+			INNER JOIN {$wpdb->posts} p ON p.ID = ed.post_id
+			INNER JOIN {$wpdb->term_relationships} tr ON tr.object_id = ed.post_id
+			INNER JOIN {$wpdb->term_taxonomy} tt ON tt.term_taxonomy_id = tr.term_taxonomy_id
+			WHERE p.post_type = %s
+			AND p.post_status = ed.post_status
+			AND tt.taxonomy = %s
+			AND tt.term_id = %d
+			AND ed.post_status = %s
+			AND ed.end_datetime IS NOT NULL
+			AND ed.end_datetime > ed.start_datetime
+			AND ed.start_datetime < %s
+			AND ed.end_datetime > %s";
+		$args = array(
+			Event_Post_Type::POST_TYPE,
+			'venue',
+			$venue_id,
+			'publish',
+			$end->format( 'Y-m-d H:i:s' ),
+			$start->format( 'Y-m-d H:i:s' ),
+		);
+
+		if ( $exclude ) {
+			$sql .= ' AND ed.post_id NOT IN (' . implode( ', ', array_fill( 0, count( $exclude ), '%d' ) ) . ')';
+			$args = array_merge( $args, $exclude );
+		}
+		$sql   .= ' ORDER BY ed.start_datetime ASC, ed.post_id ASC LIMIT %d OFFSET %d';
+		$args[] = $per_page + 1;
+		$args[] = $offset;
+
+		// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
+		// Identifiers come from the active site connection; every request value is prepared.
+		$rows = $wpdb->get_results( $wpdb->prepare( $sql, $args ), ARRAY_A ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:enable WordPress.DB.PreparedSQL
+		if ( ! is_array( $rows ) ) {
+			return new \WP_Error( 'venue_overlap_query_failed', __( 'The canonical event index could not be queried.', 'data-machine-events' ), array( 'status' => 500 ) );
+		}
+
+		$has_more = count( $rows ) > $per_page;
+		$rows     = array_slice( $rows, 0, $per_page );
+
+		return array(
+			'venue_id' => $venue_id,
+			'timezone' => $timezone->getName(),
+			'interval' => array(
+				'start' => $start->format( DATE_RFC3339 ),
+				'end'   => $end->format( DATE_RFC3339 ),
+			),
+			'events'   => array_map(
+				function ( array $row ) use ( $timezone ): array {
+					return array(
+						'event_id' => (int) $row['post_id'],
+						'start'    => $this->formatIndexedDatetime( $row['start_datetime'], $timezone ),
+						'end'      => $this->formatIndexedDatetime( $row['end_datetime'], $timezone ),
+						'status'   => (string) $row['post_status'],
+					);
+				},
+				$rows
+			),
+			'page'     => $page,
+			'per_page' => $per_page,
+			'has_more' => $has_more,
+		);
+	}
+
+	private function venueTimezone( int $venue_id ): DateTimeZone {
+		$data = Venue_Taxonomy::get_venue_data( $venue_id );
+		try {
+			return new DateTimeZone( (string) ( $data['timezone'] ?? '' ) );
+		} catch ( Exception $exception ) {
+			return wp_timezone();
+		}
+	}
+
+	private function parseInstant( mixed $value, DateTimeZone $timezone ): DateTimeImmutable|\WP_Error {
+		if ( ! is_string( $value ) || ! preg_match( '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:Z|[+-]\d{2}:\d{2})$/', $value ) ) {
+			return new \WP_Error( 'venue_overlap_invalid_datetime', __( 'start and end must be RFC3339 instants with seconds and an explicit offset.', 'data-machine-events' ), array( 'status' => 400 ) );
+		}
+
+		try {
+			return ( new DateTimeImmutable( $value ) )->setTimezone( $timezone );
+		} catch ( Exception $exception ) {
+			return new \WP_Error( 'venue_overlap_invalid_datetime', __( 'start and end must be valid RFC3339 instants.', 'data-machine-events' ), array( 'status' => 400 ) );
+		}
+	}
+
+	private function formatIndexedDatetime( string $value, DateTimeZone $timezone ): string {
+		return ( new DateTimeImmutable( $value, $timezone ) )->format( DATE_RFC3339 );
+	}
+
+	private static function inputSchema(): array {
+		return array(
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'required'             => array( 'venue_id', 'start', 'end' ),
+			'properties'           => array(
+				'venue_id' => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+				),
+				'start'    => array(
+					'type'        => 'string',
+					'format'      => 'date-time',
+					'description' => 'Inclusive RFC3339 interval start with an explicit offset.',
+				),
+				'end'      => array(
+					'type'        => 'string',
+					'format'      => 'date-time',
+					'description' => 'Exclusive RFC3339 interval end with an explicit offset.',
+				),
+				'statuses' => array(
+					'type'        => 'array',
+					'items'       => array(
+						'type' => 'string',
+						'enum' => array( 'publish' ),
+					),
+					'minItems'    => 1,
+					'maxItems'    => 1,
+					'uniqueItems' => true,
+					'description' => 'Bounded public post statuses. Only publish is exposed.',
+				),
+				'exclude'  => array(
+					'type'        => 'array',
+					'items'       => array(
+						'type'    => 'integer',
+						'minimum' => 1,
+					),
+					'maxItems'    => self::MAX_EXCLUSIONS,
+					'uniqueItems' => true,
+				),
+				'page'     => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+				),
+				'per_page' => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+					'maximum' => self::MAX_PER_PAGE,
+				),
+			),
+		);
+	}
+
+	private static function outputSchema(): array {
+		return array(
+			'type'       => 'object',
+			'required'   => array( 'venue_id', 'timezone', 'interval', 'events', 'page', 'per_page', 'has_more' ),
+			'properties' => array(
+				'venue_id' => array( 'type' => 'integer' ),
+				'timezone' => array( 'type' => 'string' ),
+				'interval' => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+					'required'             => array( 'start', 'end' ),
+					'properties'           => array(
+						'start' => array(
+							'type'   => 'string',
+							'format' => 'date-time',
+						),
+						'end'   => array(
+							'type'   => 'string',
+							'format' => 'date-time',
+						),
+					),
+				),
+				'events'   => array(
+					'type'  => 'array',
+					'items' => array(
+						'type'                 => 'object',
+						'additionalProperties' => false,
+						'required'             => array( 'event_id', 'start', 'end', 'status' ),
+						'properties'           => array(
+							'event_id' => array( 'type' => 'integer' ),
+							'start'    => array(
+								'type'   => 'string',
+								'format' => 'date-time',
+							),
+							'end'      => array(
+								'type'   => 'string',
+								'format' => 'date-time',
+							),
+							'status'   => array(
+								'type' => 'string',
+								'enum' => array( 'publish' ),
+							),
+						),
+					),
+				),
+				'page'     => array( 'type' => 'integer' ),
+				'per_page' => array( 'type' => 'integer' ),
+				'has_more' => array( 'type' => 'boolean' ),
+			),
+		);
+	}
+}

--- a/inc/Abilities/VenueIntervalOverlapAbilities.php
+++ b/inc/Abilities/VenueIntervalOverlapAbilities.php
@@ -28,36 +28,33 @@ class VenueIntervalOverlapAbilities {
 	private static bool $registered = false;
 
 	public function __construct() {
-		if ( ! self::$registered ) {
-			$this->registerAbility();
-			self::$registered = true;
+		if ( self::$registered ) {
+			return;
 		}
+
+		add_action( 'wp_abilities_api_init', array( $this, 'registerAbility' ) );
+		self::$registered = true;
 	}
 
-	private function registerAbility(): void {
-		add_action(
-			'wp_abilities_api_init',
-			function (): void {
-				wp_register_ability(
-					self::ABILITY_NAME,
-					array(
-						'label'               => __( 'Query Venue Interval Overlaps', 'data-machine-events' ),
-						'description'         => __( 'Return published canonical events whose indexed closed range overlaps a half-open interval at one venue.', 'data-machine-events' ),
-						'category'            => 'datamachine-events-events',
-						'input_schema'        => self::inputSchema(),
-						'output_schema'       => self::outputSchema(),
-						'execute_callback'    => array( $this, 'execute' ),
-						'permission_callback' => '__return_true',
-						'meta'                => array(
-							'show_in_rest' => true,
-							'annotations'  => array(
-								'readonly'   => true,
-								'idempotent' => true,
-							),
-						),
-					)
-				);
-			}
+	public function registerAbility(): void {
+		wp_register_ability(
+			self::ABILITY_NAME,
+			array(
+				'label'               => __( 'Query Venue Interval Overlaps', 'data-machine-events' ),
+				'description'         => __( 'Return published canonical events whose indexed closed range overlaps a half-open interval at one venue.', 'data-machine-events' ),
+				'category'            => AbilityCategories::EVENTS,
+				'input_schema'        => self::inputSchema(),
+				'output_schema'       => self::outputSchema(),
+				'execute_callback'    => array( $this, 'execute' ),
+				'permission_callback' => '__return_true',
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'readonly'   => true,
+						'idempotent' => true,
+					),
+				),
+			)
 		);
 	}
 
@@ -267,14 +264,8 @@ class VenueIntervalOverlapAbilities {
 					'additionalProperties' => false,
 					'required'             => array( 'start', 'end' ),
 					'properties'           => array(
-						'start' => array(
-							'type'   => 'string',
-							'format' => 'date-time',
-						),
-						'end'   => array(
-							'type'   => 'string',
-							'format' => 'date-time',
-						),
+						'start' => self::dateTimeSchema(),
+						'end'   => self::dateTimeSchema(),
 					),
 				),
 				'events'   => array(
@@ -285,14 +276,8 @@ class VenueIntervalOverlapAbilities {
 						'required'             => array( 'event_id', 'start', 'end', 'status' ),
 						'properties'           => array(
 							'event_id' => array( 'type' => 'integer' ),
-							'start'    => array(
-								'type'   => 'string',
-								'format' => 'date-time',
-							),
-							'end'      => array(
-								'type'   => 'string',
-								'format' => 'date-time',
-							),
+							'start'    => self::dateTimeSchema(),
+							'end'      => self::dateTimeSchema(),
 							'status'   => array(
 								'type' => 'string',
 								'enum' => array( 'publish' ),
@@ -304,6 +289,13 @@ class VenueIntervalOverlapAbilities {
 				'per_page' => array( 'type' => 'integer' ),
 				'has_more' => array( 'type' => 'boolean' ),
 			),
+		);
+	}
+
+	private static function dateTimeSchema(): array {
+		return array(
+			'type'   => 'string',
+			'format' => 'date-time',
 		);
 	}
 }

--- a/inc/public-api.php
+++ b/inc/public-api.php
@@ -197,6 +197,21 @@ if ( ! function_exists( 'data_machine_events_query_events' ) ) {
 	}
 }
 
+if ( ! function_exists( 'data_machine_events_query_venue_interval_overlaps' ) ) {
+	/**
+	 * Query published canonical event ranges that overlap a venue interval.
+	 *
+	 * This is the PHP boundary for the read-only Ability of the same contract.
+	 * Consumers receive public facts and remain responsible for policy decisions.
+	 *
+	 * @param array $params Venue ID, RFC3339 start/end, and bounded pagination.
+	 * @return array|\WP_Error
+	 */
+	function data_machine_events_query_venue_interval_overlaps( array $params ): array|\WP_Error {
+		return ( new \DataMachineEvents\Abilities\VenueIntervalOverlapAbilities() )->execute( $params );
+	}
+}
+
 if ( ! function_exists( 'data_machine_events_get_venue_data' ) ) {
 	/**
 	 * Get raw venue term metadata.

--- a/tests/Integration/VenueIntervalOverlapMySqlConsistencyTest.php
+++ b/tests/Integration/VenueIntervalOverlapMySqlConsistencyTest.php
@@ -16,7 +16,7 @@ use WP_UnitTestCase;
 class VenueIntervalOverlapMySqlConsistencyTest extends WP_UnitTestCase {
 
 	public function test_overlap_query_observes_only_committed_index_updates(): void {
-		global $wpdb, $table_prefix;
+		global $wpdb;
 		if ( ! $wpdb->dbh instanceof \mysqli ) {
 			$this->markTestSkipped( 'MySQL consistency test requires mysqli.' );
 		}
@@ -26,9 +26,13 @@ class VenueIntervalOverlapMySqlConsistencyTest extends WP_UnitTestCase {
 		if ( ! taxonomy_exists( 'venue' ) ) {
 			Venue_Taxonomy::register();
 		}
-		if ( ! EventDatesTable::table_exists() ) {
-			EventDatesTable::create_table();
-		}
+
+		$table = EventDatesTable::table_name();
+		remove_filter( 'query', array( $this, '_create_temporary_tables' ) );
+		remove_filter( 'query', array( $this, '_drop_temporary_tables' ) );
+		$wpdb->query( "DROP TEMPORARY TABLE IF EXISTS {$table}" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- PHPUnit creates connection-local temporary tables by default.
+		$wpdb->query( "DROP TABLE IF EXISTS {$table}" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Dedicated disposable test database cleanup.
+		EventDatesTable::create_table();
 
 		$venue = wp_insert_term( 'Consistency Venue ' . uniqid(), 'venue' );
 		$this->assertNotWPError( $venue );
@@ -40,6 +44,7 @@ class VenueIntervalOverlapMySqlConsistencyTest extends WP_UnitTestCase {
 		);
 		wp_set_object_terms( $event_id, array( (int) $venue['term_id'] ), 'venue' );
 		EventDatesTable::upsert( $event_id, '2028-01-01 10:00:00', '2028-01-01 11:00:00', 'publish' );
+		$wpdb->query( 'COMMIT' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Make the fixture visible to the independent connection.
 
 		$reader = new VenueIntervalOverlapAbilities();
 		$input  = array(
@@ -50,14 +55,20 @@ class VenueIntervalOverlapMySqlConsistencyTest extends WP_UnitTestCase {
 		$this->assertSame( array( $event_id ), array_column( $reader->execute( $input )['events'], 'event_id' ) );
 
 		$writer = new \wpdb( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST );
-		$writer->set_prefix( $table_prefix );
-		$table = EventDatesTable::table_name();
-		$writer->query( 'START TRANSACTION' );
-		$writer->query( $writer->prepare( "UPDATE {$table} SET start_datetime = %s, end_datetime = %s WHERE post_id = %d", '2028-01-02 10:00:00', '2028-01-02 11:00:00', $event_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Independent transaction proves commit visibility.
+		try {
+			$writer->query( 'START TRANSACTION' );
+			$this->assertSame( 1, $writer->query( $writer->prepare( "UPDATE {$table} SET start_datetime = %s, end_datetime = %s WHERE post_id = %d", '2028-01-02 10:00:00', '2028-01-02 11:00:00', $event_id ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Independent transaction proves commit visibility.
 
-		$this->assertSame( array( $event_id ), array_column( $reader->execute( $input )['events'], 'event_id' ) );
-		$writer->query( 'COMMIT' );
-		$this->assertSame( array(), $reader->execute( $input )['events'] );
-		$writer->close();
+			$this->assertSame( array( $event_id ), array_column( $reader->execute( $input )['events'], 'event_id' ) );
+			$writer->query( 'COMMIT' );
+			$wpdb->query( 'COMMIT' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- End the reader's repeatable-read snapshot after the writer commits.
+			$this->assertSame( array(), $reader->execute( $input )['events'] );
+		} finally {
+			$writer->query( 'ROLLBACK' );
+			$writer->close();
+			wp_delete_post( $event_id, true );
+			wp_delete_term( (int) $venue['term_id'], 'venue' );
+			$wpdb->query( "DROP TABLE IF EXISTS {$table}" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Dedicated disposable test database cleanup.
+		}
 	}
 }

--- a/tests/Integration/VenueIntervalOverlapMySqlConsistencyTest.php
+++ b/tests/Integration/VenueIntervalOverlapMySqlConsistencyTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Real MySQL overlap visibility coverage.
+ *
+ * @package DataMachineEvents\Tests\Integration
+ */
+
+namespace DataMachineEvents\Tests\Integration;
+
+use DataMachineEvents\Abilities\VenueIntervalOverlapAbilities;
+use DataMachineEvents\Core\EventDatesTable;
+use DataMachineEvents\Core\Event_Post_Type;
+use DataMachineEvents\Core\Venue_Taxonomy;
+use WP_UnitTestCase;
+
+class VenueIntervalOverlapMySqlConsistencyTest extends WP_UnitTestCase {
+
+	public function test_overlap_query_observes_only_committed_index_updates(): void {
+		global $wpdb, $table_prefix;
+		if ( ! $wpdb->dbh instanceof \mysqli ) {
+			$this->markTestSkipped( 'MySQL consistency test requires mysqli.' );
+		}
+		if ( ! post_type_exists( Event_Post_Type::POST_TYPE ) ) {
+			Event_Post_Type::register();
+		}
+		if ( ! taxonomy_exists( 'venue' ) ) {
+			Venue_Taxonomy::register();
+		}
+		if ( ! EventDatesTable::table_exists() ) {
+			EventDatesTable::create_table();
+		}
+
+		$venue = wp_insert_term( 'Consistency Venue ' . uniqid(), 'venue' );
+		$this->assertNotWPError( $venue );
+		$event_id = self::factory()->post->create(
+			array(
+				'post_type'   => Event_Post_Type::POST_TYPE,
+				'post_status' => 'publish',
+			)
+		);
+		wp_set_object_terms( $event_id, array( (int) $venue['term_id'] ), 'venue' );
+		EventDatesTable::upsert( $event_id, '2028-01-01 10:00:00', '2028-01-01 11:00:00', 'publish' );
+
+		$reader = new VenueIntervalOverlapAbilities();
+		$input  = array(
+			'venue_id' => (int) $venue['term_id'],
+			'start'    => '2028-01-01T10:00:00+00:00',
+			'end'      => '2028-01-01T12:00:00+00:00',
+		);
+		$this->assertSame( array( $event_id ), array_column( $reader->execute( $input )['events'], 'event_id' ) );
+
+		$writer = new \wpdb( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST );
+		$writer->set_prefix( $table_prefix );
+		$table = EventDatesTable::table_name();
+		$writer->query( 'START TRANSACTION' );
+		$writer->query( $writer->prepare( "UPDATE {$table} SET start_datetime = %s, end_datetime = %s WHERE post_id = %d", '2028-01-02 10:00:00', '2028-01-02 11:00:00', $event_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Independent transaction proves commit visibility.
+
+		$this->assertSame( array( $event_id ), array_column( $reader->execute( $input )['events'], 'event_id' ) );
+		$writer->query( 'COMMIT' );
+		$this->assertSame( array(), $reader->execute( $input )['events'] );
+		$writer->close();
+	}
+}

--- a/tests/Unit/VenueIntervalOverlapAbilitiesTest.php
+++ b/tests/Unit/VenueIntervalOverlapAbilitiesTest.php
@@ -169,7 +169,6 @@ class VenueIntervalOverlapAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function test_registered_ability_schema_and_read_contract_are_bounded(): void {
-		do_action( 'wp_abilities_api_init' );
 		$registered = wp_get_ability( VenueIntervalOverlapAbilities::ABILITY_NAME );
 		$this->assertNotNull( $registered );
 		$this->assertTrue( $registered->get_meta()['show_in_rest'] );

--- a/tests/Unit/VenueIntervalOverlapAbilitiesTest.php
+++ b/tests/Unit/VenueIntervalOverlapAbilitiesTest.php
@@ -1,0 +1,239 @@
+<?php
+/**
+ * Venue interval-overlap Ability tests.
+ *
+ * @package DataMachineEvents\Tests\Unit
+ */
+
+namespace DataMachineEvents\Tests\Unit;
+
+use DataMachineEvents\Abilities\VenueIntervalOverlapAbilities;
+use DataMachineEvents\Core\EventDatesTable;
+use DataMachineEvents\Core\Event_Post_Type;
+use DataMachineEvents\Core\Venue_Taxonomy;
+use WP_UnitTestCase;
+
+class VenueIntervalOverlapAbilitiesTest extends WP_UnitTestCase {
+
+	private VenueIntervalOverlapAbilities $ability;
+	private int $venue_id;
+
+	public function setUp(): void {
+		parent::setUp();
+		if ( ! post_type_exists( Event_Post_Type::POST_TYPE ) ) {
+			Event_Post_Type::register();
+		}
+		if ( ! taxonomy_exists( 'venue' ) ) {
+			Venue_Taxonomy::register();
+		}
+		if ( ! EventDatesTable::table_exists() ) {
+			EventDatesTable::create_table();
+		}
+
+		$venue = wp_insert_term( 'Overlap Venue ' . uniqid(), 'venue' );
+		$this->assertNotWPError( $venue );
+		$this->venue_id = (int) $venue['term_id'];
+		add_term_meta( $this->venue_id, '_venue_timezone', 'America/New_York', true );
+		$this->ability = new VenueIntervalOverlapAbilities();
+	}
+
+	public function test_exact_half_open_overlap_relations_and_venue_isolation(): void {
+		$expected = array(
+			$this->seedEvent( 'Exact', '2027-06-01 10:00:00', '2027-06-01 12:00:00' ),
+			$this->seedEvent( 'Starts inside', '2027-06-01 11:00:00', '2027-06-01 13:00:00' ),
+			$this->seedEvent( 'Ends inside', '2027-06-01 09:00:00', '2027-06-01 11:00:00' ),
+			$this->seedEvent( 'Contains', '2027-06-01 09:00:00', '2027-06-01 13:00:00' ),
+			$this->seedEvent( 'Contained', '2027-06-01 10:30:00', '2027-06-01 11:30:00' ),
+		);
+		$this->seedEvent( 'Adjacent before', '2027-06-01 08:00:00', '2027-06-01 10:00:00' );
+		$this->seedEvent( 'Adjacent after', '2027-06-01 12:00:00', '2027-06-01 14:00:00' );
+		$this->seedEvent( 'Open', '2027-06-01 11:00:00', null );
+		$this->seedEvent( 'Inverted', '2027-06-01 13:00:00', '2027-06-01 11:00:00' );
+
+		$other_venue = wp_insert_term( 'Other Venue ' . uniqid(), 'venue' );
+		$this->assertNotWPError( $other_venue );
+		$this->seedEvent( 'Other venue', '2027-06-01 10:00:00', '2027-06-01 12:00:00', 'publish', (int) $other_venue['term_id'] );
+
+		$result = $this->query( '2027-06-01T10:00:00-04:00', '2027-06-01T12:00:00-04:00' );
+		$this->assertIsArray( $result );
+		$actual = array_column( $result['events'], 'event_id' );
+		sort( $expected );
+		sort( $actual );
+		$this->assertSame( $expected, $actual );
+	}
+
+	public function test_multi_day_range_is_continuous_and_occurrence_dates_do_not_create_indexes(): void {
+		$event_id = $this->seedEvent(
+			'Discrete display dates',
+			'2027-07-01 20:00:00',
+			'2027-07-05 22:00:00',
+			'publish',
+			$this->venue_id,
+			array( '2027-07-01', '2027-07-05' )
+		);
+
+		$result = $this->query( '2027-07-03T12:00:00-04:00', '2027-07-03T13:00:00-04:00' );
+		$this->assertSame( array( $event_id ), array_column( $result['events'], 'event_id' ) );
+	}
+
+	public function test_rfc3339_instants_are_normalized_across_dst(): void {
+		$event_id = $this->seedEvent( 'DST event', '2027-03-14 03:15:00', '2027-03-14 04:00:00' );
+
+		$result = $this->query( '2027-03-14T06:30:00Z', '2027-03-14T07:30:00Z' );
+
+		$this->assertSame( '2027-03-14T01:30:00-05:00', $result['interval']['start'] );
+		$this->assertSame( '2027-03-14T03:30:00-04:00', $result['interval']['end'] );
+		$this->assertSame( array( $event_id ), array_column( $result['events'], 'event_id' ) );
+		$this->assertSame( '2027-03-14T03:15:00-04:00', $result['events'][0]['start'] );
+	}
+
+	public function test_public_status_filter_excludes_non_published_and_tracks_transitions(): void {
+		$published = $this->seedEvent( 'Published', '2027-08-01 10:00:00', '2027-08-01 11:00:00' );
+		$draft     = $this->seedEvent( 'Draft', '2027-08-01 10:00:00', '2027-08-01 11:00:00', 'draft' );
+		$cancelled = $this->seedEvent( 'Cancelled', '2027-08-01 10:00:00', '2027-08-01 11:00:00', 'cancelled' );
+		$trash     = $this->seedEvent( 'Trash', '2027-08-01 10:00:00', '2027-08-01 11:00:00', 'trash' );
+
+		$this->assertSame( array( $published ), array_column( $this->queryDay( '2027-08-01' )['events'], 'event_id' ) );
+
+		wp_update_post( array( 'ID' => $published, 'post_status' => 'draft' ) );
+		wp_update_post( array( 'ID' => $draft, 'post_status' => 'publish' ) );
+		$this->assertSame( array( $draft ), array_column( $this->queryDay( '2027-08-01' )['events'], 'event_id' ) );
+		$this->assertNotContains( $cancelled, array_column( $this->queryDay( '2027-08-01' )['events'], 'event_id' ) );
+		$this->assertNotContains( $trash, array_column( $this->queryDay( '2027-08-01' )['events'], 'event_id' ) );
+	}
+
+	public function test_exclusions_and_bounded_stable_pagination(): void {
+		$ids = array();
+		for ( $hour = 10; $hour < 14; ++$hour ) {
+			$ids[] = $this->seedEvent( 'Page ' . $hour, sprintf( '2027-09-01 %02d:00:00', $hour ), sprintf( '2027-09-01 %02d:30:00', $hour ) );
+		}
+
+		$first = $this->queryDay( '2027-09-01', array( 'per_page' => 2, 'exclude' => array( $ids[0] ) ) );
+		$this->assertSame( array( $ids[1], $ids[2] ), array_column( $first['events'], 'event_id' ) );
+		$this->assertTrue( $first['has_more'] );
+
+		$second = $this->queryDay( '2027-09-01', array( 'per_page' => 2, 'page' => 2, 'exclude' => array( $ids[0] ) ) );
+		$this->assertSame( array( $ids[3] ), array_column( $second['events'], 'event_id' ) );
+		$this->assertFalse( $second['has_more'] );
+	}
+
+	public function test_venue_mutation_and_index_repair_change_the_next_result(): void {
+		$event_id = $this->seedEvent( 'Mutable', '2027-10-01 10:00:00', '2027-10-01 11:00:00' );
+		$this->assertSame( array( $event_id ), array_column( $this->queryDay( '2027-10-01' )['events'], 'event_id' ) );
+
+		$other = wp_insert_term( 'Mutation Target ' . uniqid(), 'venue' );
+		$this->assertNotWPError( $other );
+		wp_set_object_terms( $event_id, array( (int) $other['term_id'] ), 'venue' );
+		$this->assertSame( array(), $this->queryDay( '2027-10-01' )['events'] );
+
+		wp_set_object_terms( $event_id, array( $this->venue_id ), 'venue' );
+		EventDatesTable::upsert( $event_id, '2027-10-02 10:00:00', '2027-10-02 11:00:00', 'publish' );
+		$this->assertSame( array(), $this->queryDay( '2027-10-01' )['events'] );
+		EventDatesTable::upsert( $event_id, '2027-10-01 10:00:00', '2027-10-01 11:00:00', 'publish' );
+		$this->assertSame( array( $event_id ), array_column( $this->queryDay( '2027-10-01' )['events'], 'event_id' ) );
+	}
+
+	public function test_source_owned_date_update_changes_the_next_result(): void {
+		$event_id = $this->seedEvent( 'Source update', '2027-10-03 10:00:00', '2027-10-03 11:00:00' );
+		$this->assertSame( array( $event_id ), array_column( $this->queryDay( '2027-10-03' )['events'], 'event_id' ) );
+
+		wp_update_post(
+			array(
+				'ID'           => $event_id,
+				'post_content' => '<!-- wp:data-machine-events/event-details {"startDate":"2027-10-04","startTime":"10:00","endDate":"2027-10-04","endTime":"11:00"} --><div></div><!-- /wp:data-machine-events/event-details -->',
+			)
+		);
+
+		$this->assertSame( array(), $this->queryDay( '2027-10-03' )['events'] );
+		$this->assertSame( array( $event_id ), array_column( $this->queryDay( '2027-10-04' )['events'], 'event_id' ) );
+	}
+
+	/**
+	 * @dataProvider hostileInputs
+	 */
+	public function test_invalid_and_hostile_inputs_fail_closed( array $changes, string $code ): void {
+		$result = $this->queryDay( '2027-11-01', $changes );
+		$this->assertWPError( $result );
+		$this->assertSame( $code, $result->get_error_code() );
+	}
+
+	public static function hostileInputs(): array {
+		return array(
+			'missing offset' => array( array( 'start' => '2027-11-01T10:00:00' ), 'venue_overlap_invalid_datetime' ),
+			'inverted'       => array( array( 'start' => '2027-11-02T00:00:00-04:00' ), 'venue_overlap_invalid_interval' ),
+			'private status' => array( array( 'statuses' => array( 'private' ) ), 'venue_overlap_invalid_statuses' ),
+			'scalar status'  => array( array( 'statuses' => 'publish' ), 'venue_overlap_invalid_statuses' ),
+			'excess exclude' => array( array( 'exclude' => range( 1, 101 ) ), 'venue_overlap_invalid_exclusions' ),
+			'excess page'    => array( array( 'page' => 10001 ), 'venue_overlap_invalid_page' ),
+		);
+	}
+
+	public function test_registered_ability_schema_and_read_contract_are_bounded(): void {
+		do_action( 'wp_abilities_api_init' );
+		$registered = wp_get_ability( VenueIntervalOverlapAbilities::ABILITY_NAME );
+		$this->assertNotNull( $registered );
+		$this->assertTrue( $registered->get_meta()['show_in_rest'] );
+		$input = $registered->get_input_schema();
+		$this->assertSame( array( 'venue_id', 'start', 'end' ), $input['required'] );
+		$this->assertSame( 100, $input['properties']['per_page']['maximum'] );
+		$this->assertSame( array( 'publish' ), $input['properties']['statuses']['items']['enum'] );
+
+		$this->seedEvent( 'Contract', '2027-12-01 10:00:00', '2027-12-01 11:00:00' );
+		$result = $registered->execute( $this->dayInput( '2027-12-01' ) );
+		$this->assertIsArray( $result );
+		$this->assertSame( array( 'venue_id', 'timezone', 'interval', 'events', 'page', 'per_page', 'has_more' ), array_keys( $result ) );
+		$this->assertSame( array( 'event_id', 'start', 'end', 'status' ), array_keys( $result['events'][0] ) );
+	}
+
+	private function seedEvent( string $title, string $start, ?string $end, string $status = 'publish', ?int $venue_id = null, array $occurrence_dates = array() ): int {
+		$attributes = array(
+			'startDate'       => substr( $start, 0, 10 ),
+			'startTime'       => substr( $start, 11, 5 ),
+			'occurrenceDates' => $occurrence_dates,
+		);
+		if ( null !== $end ) {
+			$attributes['endDate'] = substr( $end, 0, 10 );
+			$attributes['endTime'] = substr( $end, 11, 5 );
+		}
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => $title,
+				'post_type'    => Event_Post_Type::POST_TYPE,
+				'post_status'  => $status,
+				'post_content' => '<!-- wp:data-machine-events/event-details ' . wp_json_encode( $attributes ) . ' --><div></div><!-- /wp:data-machine-events/event-details -->',
+			)
+		);
+		EventDatesTable::upsert( $post_id, $start, $end, $status );
+		wp_set_object_terms( $post_id, array( $venue_id ?? $this->venue_id ), 'venue' );
+		return $post_id;
+	}
+
+	private function query( string $start, string $end, array $changes = array() ): array|\WP_Error {
+		return $this->ability->execute(
+			array_merge(
+				array(
+					'venue_id' => $this->venue_id,
+					'start'    => $start,
+					'end'      => $end,
+				),
+				$changes
+			)
+		);
+	}
+
+	private function queryDay( string $date, array $changes = array() ): array|\WP_Error {
+		return $this->ability->execute( array_merge( $this->dayInput( $date ), $changes ) );
+	}
+
+	private function dayInput( string $date ): array {
+		$timezone = new \DateTimeZone( 'America/New_York' );
+		$start    = new \DateTimeImmutable( $date . ' 00:00:00', $timezone );
+		$end      = new \DateTimeImmutable( $date . ' 23:59:59', $timezone );
+
+		return array(
+			'venue_id' => $this->venue_id,
+			'start'    => $start->format( DATE_RFC3339 ),
+			'end'      => $end->format( DATE_RFC3339 ),
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- add a bounded public Ability and PHP API for exact half-open canonical venue interval overlap facts
- normalize RFC3339 inputs to venue timezones while preserving public status, multisite, exclusion, and pagination boundaries
- document indexed-range versus display-occurrence semantics and cover mutation, repair, DST, hostile input, and real MySQL visibility

## Validation
- PHP syntax and `git diff --check`
- Homeboy PHPCS and PHPStan changed-file lint
- Homeboy PR audit with no introduced findings
- all three nested block builds
- focused and full local managed test attempts reached the WP Codebox adapter, which exited before PHPUnit without diagnostics; CI provides the authoritative managed MySQL run

Closes #636