### PR TITLE
fix: persist canonical event offer fields

### DIFF
--- a/inc/Abilities/EventUpdateAbilities.php
+++ b/inc/Abilities/EventUpdateAbilities.php
@@ -834,6 +834,20 @@ class EventUpdateAbilities {
 				) );
 			}
 		}
+		if ( array_key_exists( 'validFrom', $input )
+			&& ( ! is_string( $input['validFrom'] ) || ( '' !== $input['validFrom'] && ! EventSchemaProvider::isValidValidFrom( $input['validFrom'] ) ) ) ) {
+			return new \WP_Error( 'source_event_update_input_invalid', 'validFrom must be an ISO-8601 date-time.', array(
+				'status'    => 400,
+				'retryable' => false,
+			) );
+		}
+		if ( array_key_exists( 'eventType', $input )
+			&& ( ! is_string( $input['eventType'] ) || ! in_array( $input['eventType'], EventSchemaProvider::EVENT_TYPES, true ) ) ) {
+			return new \WP_Error( 'source_event_update_input_invalid', 'eventType must be a supported Schema.org event type.', array(
+				'status'    => 400,
+				'retryable' => false,
+			) );
+		}
 		if ( ! hash_equals( hash( 'sha256', $source . "\0" . $source_id ), $identity )
 			|| get_post_meta( $event_id, EventUpsert::SOURCE_NAME_META_KEY, true ) !== $source
 			|| get_post_meta( $event_id, EventUpsert::SOURCE_ID_META_KEY, true ) !== $source_id
@@ -1105,7 +1119,10 @@ class EventUpdateAbilities {
 					'format' => 'uri',
 				),
 				'offerAvailability'    => $string,
-				'validFrom'            => $string,
+				'validFrom'            => array(
+					'type'   => 'string',
+					'format' => 'date-time',
+				),
 				'performer'            => $string,
 				'performerType'        => array(
 					'type' => 'string',

--- a/inc/Abilities/EventUpsertAbilities.php
+++ b/inc/Abilities/EventUpsertAbilities.php
@@ -7,6 +7,7 @@
 
 namespace DataMachineEvents\Abilities;
 
+use DataMachineEvents\Core\EventSchemaProvider;
 use DataMachineEvents\Core\VenueParameterProvider;
 use DataMachineEvents\Core\Venue_Taxonomy;
 use DataMachineEvents\Steps\Upsert\Events\EventUpsert;
@@ -253,6 +254,10 @@ class EventUpsertAbilities {
 							'format' => 'uri',
 						),
 						'offerAvailability' => $string,
+						'validFrom'         => array(
+							'type'   => 'string',
+							'format' => 'date-time',
+						),
 						'performer'         => $string,
 						'performerType'     => $string,
 						'organizer'         => $string,
@@ -263,7 +268,10 @@ class EventUpsertAbilities {
 						),
 						'eventStatus'       => $string,
 						'previousStartDate' => $string,
-						'eventType'         => $string,
+						'eventType'         => array(
+							'type' => 'string',
+							'enum' => EventSchemaProvider::EVENT_TYPES,
+						),
 					),
 				),
 			),

--- a/inc/Core/EventSchemaProvider.php
+++ b/inc/Core/EventSchemaProvider.php
@@ -317,6 +317,24 @@ class EventSchemaProvider {
 	}
 
 	/**
+	 * Check a validFrom value without changing the caller-provided timestamp.
+	 *
+	 * WordPress's RFC3339 parser accepts timezone-less ISO-8601 timestamps, so
+	 * this follows the core date-time contract while rejecting impossible dates.
+	 */
+	public static function isValidValidFrom( string $value ): bool {
+		if ( false === rest_parse_date( $value ) ) {
+			return false;
+		}
+
+		if ( ! preg_match( '/^(\d{4})-(\d{2})-(\d{2})[Tt ](?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:\.\d+)?(?:Z|[+-](?:[01]\d|2[0-3])(?::?[0-5]\d)?)?$/', $value, $matches ) ) {
+			return false;
+		}
+
+		return checkdate( (int) $matches[2], (int) $matches[3], (int) $matches[1] );
+	}
+
+	/**
 	 * Convert a field definition map into a canonical JSON Schema fragment.
 	 *
 	 * Returns `{ properties: {...}, required: [...] }`. The `required` key is
@@ -419,7 +437,7 @@ class EventSchemaProvider {
 			$schema['image'] = $images;
 		}
 
-		if ( ! empty( $event_data['ticketUrl'] ) || ! empty( $event_data['price'] ) ) {
+		if ( ! empty( $event_data['ticketUrl'] ) || ! empty( $event_data['price'] ) || ! empty( $event_data['validFrom'] ) ) {
 			$schema['offers'] = self::buildOffersSchema( $event_data );
 		}
 

--- a/inc/Steps/Upsert/Events/EventBlockContentBuilder.php
+++ b/inc/Steps/Upsert/Events/EventBlockContentBuilder.php
@@ -46,6 +46,8 @@ class EventBlockContentBuilder {
 			'previousStartDate' => $event_data['previousStartDate'] ?? '',
 			'priceCurrency'     => $event_data['priceCurrency'] ?? 'USD',
 			'offerAvailability' => $event_data['offerAvailability'] ?? 'InStock',
+			'validFrom'         => $event_data['validFrom'] ?? '',
+			'eventType'         => $event_data['eventType'] ?? '',
 
 			'showVenue'         => true,
 			'showPrice'         => true,

--- a/inc/Steps/Upsert/Events/EventUpsertValidator.php
+++ b/inc/Steps/Upsert/Events/EventUpsertValidator.php
@@ -16,6 +16,7 @@
 namespace DataMachineEvents\Steps\Upsert\Events;
 
 use DataMachine\Core\EngineData;
+use DataMachineEvents\Core\EventSchemaProvider;
 use DataMachineEvents\Steps\EventImport\JunkPayloadFilter;
 
 defined( 'ABSPATH' ) || exit;
@@ -159,6 +160,34 @@ class EventUpsertValidator {
 				),
 				'invalid_start_date'
 			);
+		}
+
+		$valid_from = $engine->get( 'validFrom' );
+		if ( ( null === $valid_from || '' === $valid_from ) && array_key_exists( 'validFrom', $parameters ) ) {
+			$valid_from = $parameters['validFrom'];
+		}
+		if ( ( null !== $valid_from && '' !== $valid_from ) || array_key_exists( 'validFrom', $parameters ) ) {
+			if ( ! is_string( $valid_from ) || ( '' !== $valid_from && ! EventSchemaProvider::isValidValidFrom( $valid_from ) ) ) {
+				return $this->gateRejection(
+					'validFrom must be an ISO-8601 date-time.',
+					array( 'validFrom' => $valid_from ),
+					'invalid_valid_from'
+				);
+			}
+		}
+
+		$event_type = $engine->get( 'eventType' );
+		if ( ( null === $event_type || '' === $event_type ) && array_key_exists( 'eventType', $parameters ) ) {
+			$event_type = $parameters['eventType'];
+		}
+		if ( ( null !== $event_type && '' !== $event_type ) || array_key_exists( 'eventType', $parameters ) ) {
+			if ( ! is_string( $event_type ) || ! in_array( $event_type, EventSchemaProvider::EVENT_TYPES, true ) ) {
+				return $this->gateRejection(
+					'eventType must be a supported Schema.org event type.',
+					array( 'eventType' => $event_type ),
+					'invalid_event_type'
+				);
+			}
 		}
 
 		// 5. Junk / test payload — reuse the filterable JunkPayloadFilter

--- a/tests/Unit/EventBlockContentBuilderTest.php
+++ b/tests/Unit/EventBlockContentBuilderTest.php
@@ -11,6 +11,7 @@
 namespace DataMachineEvents\Tests\Unit;
 
 use WP_UnitTestCase;
+use DataMachineEvents\Core\EventSchemaProvider;
 use DataMachineEvents\Steps\Upsert\Events\EventBlockContentBuilder;
 
 class EventBlockContentBuilderTest extends WP_UnitTestCase {
@@ -60,6 +61,57 @@ class EventBlockContentBuilderTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( '"showVenue":true', $content );
 		$this->assertStringContainsString( '"showPrice":true', $content );
 		$this->assertStringContainsString( '"showTicketLink":true', $content );
+	}
+
+	public function test_build_round_trips_canonical_offer_and_type_attributes() {
+		$content = $this->builder->generate_event_block_content(
+			array(
+				'startDate'         => '2026-08-01',
+				'price'             => '$25',
+				'priceCurrency'     => 'USD',
+				'ticketUrl'         => 'https://example.com/tickets',
+				'offerAvailability' => 'InStock',
+				'validFrom'         => '2026-07-01T10:30:00-04:00',
+				'eventType'         => 'MusicEvent',
+			)
+		);
+
+		$block = parse_blocks( $content )[0];
+		$this->assertSame( '2026-07-01T10:30:00-04:00', $block['attrs']['validFrom'] );
+		$this->assertSame( 'MusicEvent', $block['attrs']['eventType'] );
+		$this->assertSame( '$25', $block['attrs']['price'] );
+		$this->assertSame( 'USD', $block['attrs']['priceCurrency'] );
+		$this->assertSame( 'https://example.com/tickets', $block['attrs']['ticketUrl'] );
+		$this->assertSame( 'InStock', $block['attrs']['offerAvailability'] );
+
+		$serialized = serialize_blocks( parse_blocks( $content ) );
+		$round_trip = parse_blocks( $serialized )[0]['attrs'];
+		$this->assertSame( $block['attrs'], $round_trip );
+
+		$schema = EventSchemaProvider::generateSchemaOrg( $round_trip, array() );
+		$this->assertSame( 'MusicEvent', $schema['@type'] );
+		$this->assertSame( 'https://example.com/tickets', $schema['offers']['url'] );
+		$this->assertSame( 25.0, $schema['offers']['price'] );
+		$this->assertSame( 'USD', $schema['offers']['priceCurrency'] );
+		$this->assertSame( 'https://schema.org/InStock', $schema['offers']['availability'] );
+		$this->assertSame( '2026-07-01T10:30:00-04:00', $schema['offers']['validFrom'] );
+	}
+
+	public function test_build_preserves_legacy_omission_of_optional_fields() {
+		$content = $this->builder->generate_event_block_content( array( 'startDate' => '2026-08-01' ) );
+		$attrs   = parse_blocks( $content )[0]['attrs'];
+
+		$this->assertArrayNotHasKey( 'validFrom', $attrs );
+		$this->assertArrayNotHasKey( 'eventType', $attrs );
+	}
+
+	public function test_valid_from_alone_is_exposed_in_canonical_schema_output() {
+		$schema = EventSchemaProvider::generateSchemaOrg(
+			array( 'validFrom' => '2026-07-01T10:30:00Z' ),
+			array()
+		);
+
+		$this->assertSame( '2026-07-01T10:30:00Z', $schema['offers']['validFrom'] );
 	}
 
 	public function test_build_omits_empty_attributes() {

--- a/tests/Unit/EventUpdateAbilitiesTest.php
+++ b/tests/Unit/EventUpdateAbilitiesTest.php
@@ -257,6 +257,57 @@ class EventUpdateAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( $input['expected_fingerprint'], $result['fingerprint'] );
 	}
 
+	public function test_source_update_round_trips_schema_fields_with_cas_and_exact_retry(): void {
+		add_filter( 'datamachine_events_update_source_event_permission', '__return_true' );
+		$event_id = $this->makeSourceEvent();
+		$input    = $this->sourceInput(
+			$event_id,
+			array(
+				'validFrom' => '2026-12-01T09:00:00-05:00',
+				'eventType' => 'MusicEvent',
+			)
+		);
+
+		$updated = $this->ability->executeUpdateSourceEvent( $input );
+		$this->assertIsArray( $updated );
+		$this->assertSame( 'updated', $updated['action'] );
+		$this->assertSame( array( 'validFrom', 'eventType' ), $updated['updated_fields'] );
+		$this->assertNotSame( $input['expected_fingerprint'], $updated['fingerprint'] );
+		$attrs = parse_blocks( get_post_field( 'post_content', $event_id ) )[0]['attrs'];
+		$this->assertSame( '2026-12-01T09:00:00-05:00', $attrs['validFrom'] );
+		$this->assertSame( 'MusicEvent', $attrs['eventType'] );
+
+		$stale = $this->ability->executeUpdateSourceEvent( $input );
+		$this->assertWPError( $stale );
+		$this->assertSame( 'source_event_fingerprint_conflict', $stale->get_error_code() );
+
+		$input['expected_fingerprint'] = $updated['fingerprint'];
+		$retry                         = $this->ability->executeUpdateSourceEvent( $input );
+		$this->assertIsArray( $retry );
+		$this->assertSame( 'no_change', $retry['action'] );
+		$this->assertSame( $updated['fingerprint'], $retry['fingerprint'] );
+	}
+
+	public function test_source_update_rejects_malformed_schema_fields_without_rewriting(): void {
+		add_filter( 'datamachine_events_update_source_event_permission', '__return_true' );
+		$event_id = $this->makeSourceEvent();
+		$before   = get_post_field( 'post_content', $event_id );
+
+		foreach ( array(
+			array( 'validFrom' => '2026-02-30T09:00:00Z' ),
+			array( 'validFrom' => 'tomorrow' ),
+			array( 'validFrom' => '2026-12-01T09:00:00+24:00' ),
+			array( 'validFrom' => array( '2026-12-01T09:00:00Z' ) ),
+			array( 'eventType' => 'Concert' ),
+			array( 'eventType' => array( 'MusicEvent' ) ),
+		) as $changes ) {
+			$result = $this->ability->executeUpdateSourceEvent( $this->sourceInput( $event_id, $changes ) );
+			$this->assertWPError( $result );
+			$this->assertSame( 'source_event_update_input_invalid', $result->get_error_code() );
+			$this->assertSame( $before, get_post_field( 'post_content', $event_id ) );
+		}
+	}
+
 	public function test_venue_mutation_success_assigns_term_and_returns_taxonomy_result(): void {
 		$event_id = $this->makeEvent();
 		$venue    = $this->makeVenue( 'Success Venue' );

--- a/tests/Unit/EventUpsertAbilitiesTest.php
+++ b/tests/Unit/EventUpsertAbilitiesTest.php
@@ -119,6 +119,11 @@ class EventUpsertAbilitiesTest extends WP_UnitTestCase {
 
 	public function test_replay_of_source_identity_returns_same_event(): void {
 		$input  = $this->validInput();
+		$input['event']['price']             = '$25';
+		$input['event']['priceCurrency']     = 'USD';
+		$input['event']['offerAvailability'] = 'InStock';
+		$input['event']['validFrom']         = '2027-01-20T10:30:00-05:00';
+		$input['event']['eventType']         = 'MusicEvent';
 		$first  = $this->ability->executeUpsertEvent( $input );
 		$second = $this->ability->executeUpsertEvent( $input );
 
@@ -126,6 +131,57 @@ class EventUpsertAbilitiesTest extends WP_UnitTestCase {
 		$this->assertIsArray( $second );
 		$this->assertSame( $first['event_id'], $second['event_id'] );
 		$this->assertSame( 'no_change', $second['action'] );
+		$this->assertSame( $first['fingerprint'], $second['fingerprint'] );
+		$attrs = parse_blocks( get_post_field( 'post_content', $first['event_id'] ) )[0]['attrs'];
+		$this->assertSame( '2027-01-20T10:30:00-05:00', $attrs['validFrom'] );
+		$this->assertSame( 'MusicEvent', $attrs['eventType'] );
+		$this->assertSame( '$25', $attrs['price'] );
+		$this->assertSame( 'USD', $attrs['priceCurrency'] );
+		$this->assertSame( 'InStock', $attrs['offerAvailability'] );
+	}
+
+	public function test_schema_fields_update_same_source_event_without_changing_duplicate_identity(): void {
+		$input = $this->validInput();
+		$first = $this->ability->executeUpsertEvent( $input );
+
+		$input['event']['validFrom'] = '2027-01-20T10:30:00Z';
+		$input['event']['eventType'] = 'Festival';
+		$second                      = $this->ability->executeUpsertEvent( $input );
+
+		$this->assertSame( $first['event_id'], $second['event_id'] );
+		$this->assertSame( 'updated', $second['action'] );
+		$this->assertNotSame( $first['fingerprint'], $second['fingerprint'] );
+		$this->assertSame( 1, $this->countEventsWithTitle( $input['event']['title'] ) );
+	}
+
+	public function test_omitted_legacy_fields_remain_omitted_and_idempotent(): void {
+		$input  = $this->validInput();
+		$first  = $this->ability->executeUpsertEvent( $input );
+		$second = $this->ability->executeUpsertEvent( $input );
+		$attrs  = parse_blocks( get_post_field( 'post_content', $first['event_id'] ) )[0]['attrs'];
+
+		$this->assertSame( 'no_change', $second['action'] );
+		$this->assertArrayNotHasKey( 'validFrom', $attrs );
+		$this->assertArrayNotHasKey( 'eventType', $attrs );
+	}
+
+	public function test_malformed_canonical_schema_fields_fail_before_write(): void {
+		foreach ( array(
+			array( 'validFrom', '2027-02-30T10:30:00Z', 'invalid_valid_from' ),
+			array( 'validFrom', 'next Tuesday', 'invalid_valid_from' ),
+			array( 'validFrom', '2027-01-20T10:30:00+24:00', 'invalid_valid_from' ),
+			array( 'validFrom', array( '2027-01-20T10:30:00Z' ), 'invalid_valid_from' ),
+			array( 'eventType', 'Concert', 'invalid_event_type' ),
+			array( 'eventType', array( 'MusicEvent' ), 'invalid_event_type' ),
+		) as [$field, $value, $error_code] ) {
+			$input                    = $this->validInput();
+			$input['event'][ $field ] = $value;
+			$result                   = $this->ability->executeUpsertEvent( $input );
+
+			$this->assertWPError( $result );
+			$this->assertSame( $error_code, $result->get_error_code() );
+			$this->assertSame( 0, $this->countEventsWithTitle( $input['event']['title'] ) );
+		}
 	}
 
 	public function test_validation_failure_returns_machine_readable_error_without_write(): void {

--- a/tests/Unit/EventUpsertValidatorTest.php
+++ b/tests/Unit/EventUpsertValidatorTest.php
@@ -94,6 +94,45 @@ class EventUpsertValidatorTest extends WP_UnitTestCase {
 		$this->assertNull( $result, 'A valid event must pass the validation gate.' );
 	}
 
+	public function test_gate_uses_parameter_schema_fields_when_engine_placeholders_are_empty() {
+		$engine   = new \DataMachine\Core\EngineData(
+			array(
+				'validFrom' => '',
+				'eventType' => '',
+			),
+			0
+		);
+		$evidence = array(
+			'title'       => 'Schema Field Event',
+			'venue'       => 'Some Venue',
+			'startDate'   => '2026-08-01',
+			'startTime'   => '20:00',
+			'source_type' => '',
+			'artist'      => '',
+		);
+
+		$valid = $this->validator->validateForPublish(
+			$evidence,
+			array(
+				'startDate' => '2026-08-01',
+				'validFrom' => '2026-07-01T10:30:00Z',
+				'eventType' => 'MusicEvent',
+			),
+			$engine
+		);
+		$this->assertNull( $valid );
+
+		$invalid = $this->validator->validateForPublish(
+			$evidence,
+			array(
+				'startDate' => '2026-08-01',
+				'validFrom' => 'tomorrow',
+			),
+			$engine
+		);
+		$this->assertSame( 'invalid_valid_from', $invalid['rule'] ?? '' );
+	}
+
 	public function test_gate_rejects_missing_title() {
 		$engine = new \DataMachine\Core\EngineData( array(), 0 );
 


### PR DESCRIPTION
## Summary
- persist `validFrom` and `eventType` through canonical event block creation and upsert
- validate canonical/source-owned values without rewriting caller-provided timestamps or unsupported event types
- preserve omitted legacy attributes while covering CAS fingerprints, idempotent retries, duplicate identity, serialization, and Schema.org offer output

## Semantics
- both fields participate in content hashes and source CAS fingerprints because they are canonical block content
- neither field participates in duplicate identity; sale timing and Schema.org classification update the same physical/source event

## Validation
- PHP syntax and `git diff --check`
- Homeboy PHPCS and PHPStan lint
- Homeboy PR architecture audit
- Homeboy production build, including all three block builds and package validation
- independent exact-diff review: no findings after fixes
- focused and full Homeboy test runs were attempted, but the managed Codebox harness exited before producing PHPUnit results; GitHub CI is the executable test authority for this PR

Closes #635