### PR TITLE
fix: omit invalid Eventbrite end times

### DIFF
--- a/inc/Steps/EventImport/Handlers/WebScraper/Extractors/EventbriteExtractor.php
+++ b/inc/Steps/EventImport/Handlers/WebScraper/Extractors/EventbriteExtractor.php
@@ -23,6 +23,7 @@
 
 namespace DataMachineEvents\Steps\EventImport\Handlers\WebScraper\Extractors;
 
+use DataMachineEvents\Core\DateTimeParser;
 use DataMachineEvents\Core\VenueService;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -201,7 +202,7 @@ class EventbriteExtractor extends BaseExtractor {
 			'description'   => $raw_event['summary'] ?? '',
 			'startDate'     => $start_date,
 			'startTime'     => $this->normalizeListingTime( $raw_event['start_time'] ?? '' ),
-			'endDate'       => $raw_event['end_date'] ?? '',
+			'endDate'       => (string) ( $raw_event['end_date'] ?? '' ),
 			'endTime'       => $this->normalizeListingTime( $raw_event['end_time'] ?? '' ),
 			'venueTimezone' => $raw_event['timezone'] ?? '',
 			'organizer'     => $organizer['name'] ?? '',
@@ -231,6 +232,7 @@ class EventbriteExtractor extends BaseExtractor {
 			(string) $currency,
 			$is_free
 		);
+		$this->normalizeEnd( $event );
 
 		return $event;
 	}
@@ -383,6 +385,33 @@ class EventbriteExtractor extends BaseExtractor {
 			if ( ! empty( $parsed['timezone'] ) ) {
 				$event['venueTimezone'] = $parsed['timezone'];
 			}
+		}
+
+		$this->normalizeEnd( $event );
+	}
+
+	/**
+	 * Omit unusable Eventbrite ends so canonical storage can represent unknown duration.
+	 */
+	private function normalizeEnd( array &$event ): void {
+		$start_date = trim( (string) ( $event['startDate'] ?? '' ) );
+		$start_time = trim( (string) ( $event['startTime'] ?? '' ) );
+		$end_date   = trim( (string) ( $event['endDate'] ?? '' ) );
+		$end_time   = trim( (string) ( $event['endTime'] ?? '' ) );
+		$time_regex = '/^(?:[01]\d|2[0-3]):[0-5]\d$/';
+
+		$valid_date = DateTimeParser::isValidYmd( $start_date ) && DateTimeParser::isValidYmd( $end_date );
+		$valid_time = ( '' === $start_time || preg_match( $time_regex, $start_time ) )
+			&& preg_match( $time_regex, $end_time );
+		$positive   = $valid_date && $valid_time;
+		if ( $positive ) {
+			$start_datetime = $start_date . ' ' . ( '' !== $start_time ? $start_time : '00:00' );
+			$end_datetime   = $end_date . ' ' . $end_time;
+			$positive       = $end_datetime > $start_datetime;
+		}
+
+		if ( ! $positive ) {
+			unset( $event['endDate'], $event['endTime'] );
 		}
 	}
 

--- a/tests/Fixtures/eventbrite/lofi-missing-end.html
+++ b/tests/Fixtures/eventbrite/lofi-missing-end.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html>
+<head>
+<script src="/organizer-profile/_next/static/chunks/app.js"></script>
+<script id="__NEXT_DATA__" type="application/json">
+{
+  "props": {
+    "pageProps": {
+      "organizer": {
+        "id": "14959647606",
+        "name": "Lo-Fi Brewing",
+        "profilePageUrl": "https://www.eventbrite.com/o/lo-fi-brewing-14959647606"
+      },
+      "upcomingEvents": [
+        {
+          "id": "1992991575452",
+          "name": "CHARLESTON MINI FOLK FEST",
+          "url": "https://www.eventbrite.com/e/charleston-mini-folk-fest-tickets-1992991575452",
+          "start_date": "2099-08-08",
+          "start_time": "19:00:00",
+          "end_date": "2099-08-08",
+          "end_time": "19:00:00",
+          "timezone": "America/New_York",
+          "summary": "Eventbrite supplied no usable duration.",
+          "primary_venue": {
+            "name": "Lo-Fi Brewing",
+            "address": {
+              "address_1": "2038 Meeting Street Road",
+              "city": "Charleston",
+              "region": "SC",
+              "postal_code": "29405",
+              "country": "US"
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+</script>
+</head>
+<body></body>
+</html>

--- a/tests/Unit/EventScraperTestAbilityTest.php
+++ b/tests/Unit/EventScraperTestAbilityTest.php
@@ -31,6 +31,7 @@ use WP_UnitTestCase;
 use ReflectionClass;
 use DataMachineEvents\Abilities\EventScraperTest;
 use DataMachineEvents\Steps\EventImport\Handlers\WebScraper\Extractors\BandzoogleExtractor;
+use DataMachineEvents\Steps\EventImport\Handlers\WebScraper\Extractors\EventbriteExtractor;
 use DataMachineEvents\Steps\EventImport\Handlers\WebScraper\Extractors\JsonLdExtractor;
 
 class EventScraperTestAbilityTest extends WP_UnitTestCase {
@@ -359,6 +360,25 @@ class EventScraperTestAbilityTest extends WP_UnitTestCase {
 			$result['extraction_info']['event_count'] ?? null,
 			'extraction_info.event_count must mirror event_data.event_count.'
 		);
+	}
+
+	public function test_eventbrite_diagnostic_matches_direct_missing_end_payload(): void {
+		$html       = (string) file_get_contents( $this->fixtures_dir . '/eventbrite/lofi-missing-end.html' );
+		$target_url = 'https://www.eventbrite.com/o/lo-fi-brewing-14959647606';
+		$direct     = ( new EventbriteExtractor() )->extract( $html, $target_url );
+		$this->mockHttpResponse( $html );
+
+		$ability = new EventScraperTest();
+		$result  = $ability->test( $target_url, array( 'venue_name' => 'Lo-Fi Brewing' ) );
+
+		$this->assertTrue( $result['success'] ?? false, wp_json_encode( $result ) );
+		$this->assertCount( 1, $direct );
+		$diagnostic = $result['event_data']['items'][0];
+		$this->assertSame( $direct[0]['title'], $diagnostic['title'] );
+		$this->assertSame( $direct[0]['startDate'], $diagnostic['startDate'] );
+		$this->assertSame( $direct[0]['startTime'], $diagnostic['startTime'] );
+		$this->assertArrayNotHasKey( 'endDate', $diagnostic );
+		$this->assertArrayNotHasKey( 'endTime', $diagnostic );
 	}
 
 	/**

--- a/tests/Unit/EventUpsertTest.php
+++ b/tests/Unit/EventUpsertTest.php
@@ -14,6 +14,8 @@ use DataMachine\Core\Database\PostIdentityIndex\PostIdentityIndex;
 use DataMachine\Core\EngineData;
 use WP_UnitTestCase;
 use DataMachineEvents\Steps\Upsert\Events\EventUpsert;
+use DataMachineEvents\Steps\EventImport\EventEngineData;
+use DataMachineEvents\Steps\EventImport\Handlers\WebScraper\Extractors\EventbriteExtractor;
 use DataMachineEvents\Core\Event_Post_Type;
 use DataMachineEvents\Core\EventDatesTable;
 use DataMachineEvents\Core\Venue_Taxonomy;
@@ -979,6 +981,34 @@ class EventUpsertTest extends WP_UnitTestCase {
 
 		$this->assertFalse( $result['success'] ?? null, 'Upsert with an unparseable startDate must not succeed.' );
 		$this->assertStringContainsString( 'startDate', $result['error'] ?? '' );
+	}
+
+	public function test_lofi_eventbrite_missing_end_reaches_canonical_upsert(): void {
+		$html  = (string) file_get_contents( dirname( __DIR__ ) . '/Fixtures/eventbrite/lofi-missing-end.html' );
+		$event = ( new EventbriteExtractor() )->extract(
+			$html,
+			'https://www.eventbrite.com/o/lo-fi-brewing-14959647606'
+		)[0];
+		$engine = new EngineData( EventEngineData::buildEngineData( $event, array() ), 0 );
+		$method = new \ReflectionMethod( $this->handler, 'executeUpsert' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke(
+			$this->handler,
+			array(
+				'title'           => $event['title'],
+				'description'     => $event['description'],
+				'source_identity' => 'eventbrite:1992991575452-' . uniqid(),
+				'engine'          => $engine,
+				'job_id'          => 0,
+			),
+			array()
+		);
+
+		$this->assertTrue( $result['success'] ?? false, wp_json_encode( $result ) );
+		$dates = EventDatesTable::get( (int) $result['data']['post_id'] );
+		$this->assertSame( '2099-08-08 19:00:00', $dates->start_datetime );
+		$this->assertNull( $dates->end_datetime );
 	}
 
 	/**

--- a/tests/Unit/EventbriteExtractorTest.php
+++ b/tests/Unit/EventbriteExtractorTest.php
@@ -41,6 +41,78 @@ class EventbriteExtractorTest extends WP_UnitTestCase {
 		$this->assertSame( '33.1,-83.2', $events[0]['venueCoordinates'] );
 	}
 
+	public function test_omits_equal_organizer_listing_end(): void {
+		$events = $this->extractor->extract(
+			$this->fixture( 'lofi-missing-end.html' ),
+			'https://www.eventbrite.com/o/lo-fi-brewing-14959647606'
+		);
+
+		$this->assertCount( 1, $events );
+		$this->assertSame( 'CHARLESTON MINI FOLK FEST', $events[0]['title'] );
+		$this->assertSame( '2099-08-08', $events[0]['startDate'] );
+		$this->assertSame( '19:00', $events[0]['startTime'] );
+		$this->assertArrayNotHasKey( 'endDate', $events[0] );
+		$this->assertArrayNotHasKey( 'endTime', $events[0] );
+	}
+
+	public function test_omits_missing_empty_invalid_and_equal_json_ld_ends(): void {
+		$ends = array( null, '', 'not-a-date', '2099-08-08T19:00:00-04:00' );
+
+		foreach ( $ends as $index => $end ) {
+			$event = array(
+				'@context'  => 'https://schema.org',
+				'@type'     => 'Event',
+				'name'      => 'Unknown Duration ' . $index,
+				'startDate' => '2099-08-08T19:00:00-04:00',
+				'url'       => 'https://www.eventbrite.com/e/unknown-duration-' . $index,
+			);
+			if ( null !== $end ) {
+				$event['endDate'] = $end;
+			}
+
+			$html      = '<script type="application/ld+json">' . wp_json_encode( $event ) . '</script>';
+			$extracted = $this->extractor->extract( $html, $event['url'] );
+
+			$this->assertCount( 1, $extracted );
+			$this->assertArrayNotHasKey( 'endDate', $extracted[0] );
+			$this->assertArrayNotHasKey( 'endTime', $extracted[0] );
+		}
+	}
+
+	public function test_preserves_positive_and_overnight_json_ld_ends(): void {
+		$events = array(
+			array(
+				'@context'  => 'https://schema.org',
+				'@type'     => 'Event',
+				'name'      => 'Positive Duration',
+				'startDate' => '2099-08-08T19:00:00-04:00',
+				'endDate'   => '2099-08-08T22:00:00-04:00',
+				'url'       => 'https://www.eventbrite.com/e/positive-duration',
+			),
+			array(
+				'@context'  => 'https://schema.org',
+				'@type'     => 'Event',
+				'name'      => 'Overnight Duration',
+				'startDate' => '2099-08-08T23:00:00-04:00',
+				'endDate'   => '2099-08-09T02:00:00-04:00',
+				'url'       => 'https://www.eventbrite.com/e/overnight-duration',
+			),
+		);
+		$html   = '<script type="application/ld+json">' . wp_json_encode(
+			array(
+				'@type'           => 'ItemList',
+				'itemListElement' => $events,
+			)
+		) . '</script>';
+
+		$extracted = $this->extractor->extract( $html, 'https://www.eventbrite.com/o/example-123' );
+
+		$this->assertSame( '2099-08-08', $extracted[0]['endDate'] );
+		$this->assertSame( '22:00', $extracted[0]['endTime'] );
+		$this->assertSame( '2099-08-09', $extracted[1]['endDate'] );
+		$this->assertSame( '02:00', $extracted[1]['endTime'] );
+	}
+
 	public function test_discovers_canonical_organizer_and_event_links(): void {
 		$routes = array(
 			'https://www.eventbrite.com/o/example-room-123456789'             => $this->fixture( 'organizer.html' ),


### PR DESCRIPTION
## Summary
- normalize Eventbrite JSON-LD and organizer-listing ends at extraction so missing, empty, invalid, and non-positive values are omitted
- preserve authoritative starts plus genuine positive-duration and overnight ends
- add a committed Lo-Fi fixture covering direct diagnostics, normal processor payloads, and canonical upsert

## Canonical Missing-End Contract
`EventDatesTable::upsert()` accepts a nullable `end_datetime`, and `EventEngineData` omits empty end fields. This change uses that existing unknown-duration contract directly. Canonical upsert's strict `end > start` invariant is unchanged.

## Normalization Matrix
| Eventbrite end | Normalized result |
| --- | --- |
| Missing | Omit `endDate` and `endTime` |
| Empty | Omit `endDate` and `endTime` |
| Invalid date/time | Omit `endDate` and `endTime` |
| Equal to start | Omit `endDate` and `endTime` |
| Earlier than start | Omit `endDate` and `endTime` |
| Positive same-day duration | Preserve supplied end |
| Positive overnight duration | Preserve supplied end |

## Lo-Fi Reproduction
The committed Eventbrite organizer fixture reproduces `CHARLESTON MINI FOLK FEST` with a `19:00` start and equal `19:00` end. Direct extraction and the diagnostic/normal processor path now retain the start while omitting the unusable end. The resulting engine data reaches canonical upsert and stores a null end instead of deferring the item.

## Tests And Results
- `php -l` on all changed PHP files: passed
- `git diff --check`: passed
- Homeboy changed-file PHPCS: passed
- Homeboy changed-file PHPStan (level 7, PHP 8.2 target): passed
- Homeboy PR audit against `origin/main`: passed with zero introduced findings
- Homeboy WP Codebox PHPUnit job: infrastructure failure before PHPUnit started; dependency hydration and all block builds passed, but the runner exited with zero tests/results (runs `52c83a6d-3971-4b39-b94a-e66bc056599d`, `bf5d5fb1-fea5-468f-a4d9-758772e7d4f1`, and umbrella run `0176502d-5481-4a0f-b052-49335b5254df`)

Closes #642