### PR TITLE
fix: stack single-day calendar events vertically

### DIFF
--- a/inc/Blocks/Calendar/render.php
+++ b/inc/Blocks/Calendar/render.php
@@ -256,10 +256,13 @@ if ( ! empty( $archive_context['taxonomy'] ) && ! empty( $archive_context['term_
 
 \DataMachineEvents\Blocks\Calendar\Template_Loader::init();
 
-$instance_id        = wp_unique_id( 'data-machine-calendar-' );
-$wrapper_class      = $is_month_grid_mode
-	? 'data-machine-events-calendar data-machine-events-date-grouped data-machine-events-month-grid-mode'
-	: 'data-machine-events-calendar data-machine-events-date-grouped';
+$instance_id   = wp_unique_id( 'data-machine-calendar-' );
+$wrapper_class = 'data-machine-events-calendar data-machine-events-date-grouped';
+if ( $is_month_grid_mode ) {
+	$wrapper_class .= ' data-machine-events-month-grid-mode';
+} elseif ( in_array( $scope, array( 'today', 'tonight' ), true ) ) {
+	$wrapper_class .= ' data-machine-events-single-day-list';
+}
 $wrapper_attributes = get_block_wrapper_attributes(
 	array(
 		'class' => $wrapper_class,
@@ -273,7 +276,7 @@ if ( ! empty( $archive_context['taxonomy'] ) ) {
 	$archive_data_attrs = sprintf(
 		' data-archive-taxonomy="%s" data-archive-term-id="%d" data-archive-term-name="%s"',
 		esc_attr( $archive_context['taxonomy'] ),
-		esc_attr( $archive_context['term_id'] ),
+		absint( $archive_context['term_id'] ),
 		esc_attr( $archive_context['term_name'] )
 	);
 }
@@ -284,7 +287,7 @@ if ( ! empty( $geo_lat ) && ! empty( $geo_lng ) ) {
 		' data-geo-lat="%s" data-geo-lng="%s" data-geo-radius="%s" data-geo-radius-unit="%s"',
 		esc_attr( $geo_lat ),
 		esc_attr( $geo_lng ),
-		esc_attr( $geo_radius ),
+		esc_attr( (string) $geo_radius ),
 		esc_attr( $geo_radius_unit )
 	);
 }
@@ -347,7 +350,7 @@ $map_sync_attr              = '' !== $map_sync_id
 	?>
 
 	<?php
-	if ( $is_month_grid_mode && is_array( $grid_payload ) ) :
+	if ( $is_month_grid_mode ) :
 		// Build the base URL for prev/next/today nav. `add_query_arg`
 		// with null/null returns the current request URL (with all
 		// existing query args); `remove_query_arg` strips `month` so

--- a/inc/Blocks/Calendar/src/frontend.test.ts
+++ b/inc/Blocks/Calendar/src/frontend.test.ts
@@ -59,6 +59,7 @@ jest.mock( './modules/month-grid-response-renderer', () => ( {
  */
 import { renderMonthGridResponse } from './modules/month-grid-response-renderer';
 import { initCalendarInstance } from './frontend';
+import { initCarousel, destroyCarousel } from './modules/carousel';
 
 import type { FlatpickrInstance } from './types';
 
@@ -72,6 +73,8 @@ const mockPicker: FlatpickrInstance = {
 };
 const mockFetch = jest.fn();
 const mockRenderMonthGridResponse = renderMonthGridResponse as jest.Mock;
+const mockInitCarousel = initCarousel as jest.Mock;
+const mockDestroyCarousel = destroyCarousel as jest.Mock;
 
 function successfulResponse(): Promise< Response > {
 	return Promise.resolve( {
@@ -103,7 +106,11 @@ function deferredResponse(): {
 	};
 }
 
-function calendarMarkup( withMap = false, mode = 'month-grid' ): string {
+function calendarMarkup(
+	withMap = false,
+	mode = 'month-grid',
+	scope = 'tonight'
+): string {
 	return `
 		${
 			withMap
@@ -111,7 +118,7 @@ function calendarMarkup( withMap = false, mode = 'month-grid' ): string {
 				: ''
 		}
 		<div class="data-machine-events-calendar" data-display-mode="${ mode }"
-			data-scope="tonight" data-scope-token="opaque-token"
+			data-scope="${ scope }" data-scope-token="opaque-token"
 			data-archive-taxonomy="location" data-archive-term-id="12">
 			<div class="data-machine-events-filter-bar">
 				<input class="data-machine-events-search-input" value="new search">
@@ -138,10 +145,81 @@ describe( 'calendar frontend month-grid integration', () => {
 		mockFetch.mockImplementation( successfulResponse );
 		global.fetch = mockFetch;
 		mockRenderMonthGridResponse.mockClear();
+		mockInitCarousel.mockClear();
+		mockDestroyCarousel.mockClear();
 		mockPicker.selectedDates = [
 			new Date( 2026, 7, 10 ),
 			new Date( 2026, 7, 12 ),
 		];
+	} );
+
+	it( 'marks single-day scopes as vertical lists without carousel controls', () => {
+		document.body.innerHTML = calendarMarkup(
+			false,
+			'date-groups',
+			'tonight'
+		);
+		const calendar = document.querySelector< HTMLElement >(
+			'.data-machine-events-calendar'
+		)!;
+
+		initCalendarInstance( calendar );
+
+		expect(
+			calendar.classList.contains( 'data-machine-events-single-day-list' )
+		).toBe( true );
+		expect( mockInitCarousel ).not.toHaveBeenCalled();
+	} );
+
+	it( 'keeps multi-day date groups in carousel layout', () => {
+		document.body.innerHTML = calendarMarkup(
+			false,
+			'date-groups',
+			'this-week'
+		);
+		const calendar = document.querySelector< HTMLElement >(
+			'.data-machine-events-calendar'
+		)!;
+
+		initCalendarInstance( calendar );
+
+		expect(
+			calendar.classList.contains( 'data-machine-events-single-day-list' )
+		).toBe( false );
+		expect( mockInitCarousel ).toHaveBeenCalledWith( calendar );
+	} );
+
+	it( 'resynchronizes layout when dynamic scope content changes', () => {
+		document.body.innerHTML = calendarMarkup(
+			false,
+			'date-groups',
+			'this-week'
+		);
+		const calendar = document.querySelector< HTMLElement >(
+			'.data-machine-events-calendar'
+		)!;
+		initCalendarInstance( calendar );
+
+		calendar.dataset.scope = 'tonight';
+		calendar.dispatchEvent(
+			new CustomEvent( 'data-machine-calendar-content-updated' )
+		);
+
+		expect( mockDestroyCarousel ).toHaveBeenCalledWith( calendar );
+		expect(
+			calendar.classList.contains( 'data-machine-events-single-day-list' )
+		).toBe( true );
+		expect( mockInitCarousel ).toHaveBeenCalledTimes( 1 );
+
+		calendar.dataset.scope = 'this-week';
+		calendar.dispatchEvent(
+			new CustomEvent( 'data-machine-calendar-content-updated' )
+		);
+
+		expect(
+			calendar.classList.contains( 'data-machine-events-single-day-list' )
+		).toBe( false );
+		expect( mockInitCarousel ).toHaveBeenCalledTimes( 2 );
 	} );
 
 	afterEach( () => {

--- a/inc/Blocks/Calendar/src/frontend.ts
+++ b/inc/Blocks/Calendar/src/frontend.ts
@@ -55,8 +55,29 @@ function isMonthGridMode( calendar: HTMLElement ): boolean {
  * @param calendar
  */
 function isSingleDayScope( calendar: HTMLElement ): boolean {
-	const scope = calendar.getAttribute( 'data-scope' );
+	const activeScope = calendar.querySelector< HTMLElement >(
+		'.data-machine-events-scope-chip-active[data-scope]'
+	);
+	const scope = activeScope?.dataset.scope ?? calendar.dataset.scope;
 	return scope === 'tonight' || scope === 'today';
+}
+
+/**
+ * Keep the visual layout aligned with the active time scope.
+ *
+ * The server emits this class for first paint. Scope preset changes replace
+ * only the content region, so the frontend must update the root class too.
+ *
+ * @param calendar
+ */
+function syncSingleDayListLayout( calendar: HTMLElement ): boolean {
+	const useSingleDayList =
+		! isMonthGridMode( calendar ) && isSingleDayScope( calendar );
+	calendar.classList.toggle(
+		'data-machine-events-single-day-list',
+		useSingleDayList
+	);
+	return useSingleDayList;
 }
 
 const calendarInstances = new WeakMap< HTMLElement, true >();
@@ -83,9 +104,9 @@ export function initCalendarInstance( calendar: HTMLElement ): void {
 
 	// #428: skip the horizontal carousel for single-day scopes (tonight/
 	// today) and render a flat vertical list instead. Mirrors the month-grid
-	// skip — `useCarousel` is the single gate for carousel init/destroy so
-	// both the initial mount and the content-updated re-init stay in sync.
-	const useCarousel = ! gridMode && ! isSingleDayScope( calendar );
+	// skip. The root layout class owns CSS while carousel initialization owns
+	// controls; both are recalculated after dynamic content updates.
+	const useCarousel = ! gridMode && ! syncSingleDayListLayout( calendar );
 
 	if ( gridMode ) {
 		// In grid mode the list view is the mobile fallback and the
@@ -206,12 +227,10 @@ export function initCalendarInstance( calendar: HTMLElement ): void {
 		function () {
 			destroyLazyRender( calendar );
 			destroyDayLoader( calendar );
-			if ( useCarousel ) {
-				destroyCarousel( calendar );
-			}
+			destroyCarousel( calendar );
 			initLazyRender( calendar );
 			initDayLoader( calendar );
-			if ( useCarousel ) {
+			if ( ! gridMode && ! syncSingleDayListLayout( calendar ) ) {
 				initCarousel( calendar );
 			}
 

--- a/inc/Blocks/Calendar/style.css
+++ b/inc/Blocks/Calendar/style.css
@@ -1091,6 +1091,28 @@
     }
 }
 
+/* Today and Tonight show one chronological, vertically stacked event list. */
+.data-machine-events-calendar.data-machine-events-single-day-list .data-machine-date-group .data-machine-events-wrapper {
+    flex-direction: column;
+    flex-wrap: nowrap;
+    overflow-x: visible;
+}
+
+.data-machine-events-calendar.data-machine-events-single-day-list .data-machine-date-group .data-machine-event-item {
+    width: 100%;
+    min-width: 0;
+    height: auto;
+    flex: 1 1 auto;
+}
+
+.data-machine-events-calendar.data-machine-events-single-day-list .data-machine-date-group .data-machine-event-link {
+    height: auto;
+}
+
+.data-machine-events-calendar.data-machine-events-single-day-list .data-machine-date-group::after {
+    display: none;
+}
+
 /* Day-specific backgrounds */
 .data-machine-events-calendar .data-machine-day-sunday .data-machine-event-item { background: var(--data-machine-day-sunday-rgba); }
 .data-machine-events-calendar .data-machine-day-monday .data-machine-event-item { background: var(--data-machine-day-monday-rgba); }

--- a/tests/Unit/CalendarBlockTest.php
+++ b/tests/Unit/CalendarBlockTest.php
@@ -126,6 +126,19 @@ class CalendarBlockTest extends WP_UnitTestCase {
 		$_GET = $original_get;
 	}
 
+	public function test_single_day_scope_renders_vertical_list_layout_class(): void {
+		$original_get = $_GET;
+		$_GET         = array( 'scope' => 'tonight' );
+
+		try {
+			$html = $this->render_calendar( array( 'displayMode' => 'date-groups' ) );
+		} finally {
+			$_GET = $original_get;
+		}
+
+		$this->assertStringContainsString( 'data-machine-events-single-day-list', $html );
+	}
+
 	public function test_calendar_request_defaults_preserve_explicit_values_and_reject_invalid_state() {
 		$original_get = $_GET;
 		$_GET        = array(


### PR DESCRIPTION
## Summary
- render Today and Tonight scopes as full-width vertically stacked event cards
- keep the root layout class and carousel lifecycle synchronized after dynamic scope updates
- preserve horizontal carousel behavior for multi-day date groups
- clean up static-analysis findings surfaced in the changed renderer

## Testing
- `npm test -- --runInBand src/frontend.test.ts` (8 passed)
- `npm run lint:js`
- `npm run build`
- `git diff --check`
- `homeboy review lint data-machine-events --path /var/lib/datamachine/workspace/data-machine-events@fix-668-single-day-vertical-list --changed-only --placement local --errors-only`

Fixes #668