### PR TITLE
test: restore managed PHPUnit baseline

### DIFF
--- a/tests/Integration/EventSourceUpdateMySqlAtomicityTest.php
+++ b/tests/Integration/EventSourceUpdateMySqlAtomicityTest.php
@@ -9,12 +9,18 @@ namespace DataMachineEvents\Tests\Integration;
 
 use DataMachineEvents\Abilities\EventUpdateAbilities;
 use DataMachineEvents\Core\Event_Post_Type;
+use DataMachineEvents\Core\EventDatesTable;
 use DataMachineEvents\Core\Venue_Taxonomy;
 use WP_UnitTestCase;
 
 class EventSourceUpdateMySqlAtomicityTest extends WP_UnitTestCase {
 
 	public function setUp(): void {
+		// Create the table before WP_UnitTestCase rewrites CREATE TABLE as temporary.
+		if ( ! EventDatesTable::table_exists() ) {
+			EventDatesTable::create_table();
+		}
+
 		parent::setUp();
 		global $wpdb;
 		if ( ! $wpdb->dbh instanceof \mysqli ) {
@@ -35,7 +41,7 @@ class EventSourceUpdateMySqlAtomicityTest extends WP_UnitTestCase {
 	}
 
 	public function test_second_connection_never_observes_combined_update_half_applied(): void {
-		global $table_prefix;
+		global $wpdb;
 		add_filter( 'datamachine_events_update_source_event_permission', '__return_true' );
 		$previous = wp_insert_term( 'Atomic Previous ' . uniqid(), 'venue' );
 		$next     = wp_insert_term( 'Atomic Next ' . uniqid(), 'venue' );
@@ -55,15 +61,17 @@ class EventSourceUpdateMySqlAtomicityTest extends WP_UnitTestCase {
 		update_post_meta( $event_id, '_datamachine_event_source_identity', $identity );
 		$observed = null;
 
+		$posts_table             = $wpdb->posts;
+		$term_relationships_table = $wpdb->term_relationships;
+		$term_taxonomy_table      = $wpdb->term_taxonomy;
 		add_action(
 			'datamachine_events_after_event_venue_mutation',
-			static function () use ( &$observed, $event_id, $table_prefix ): void {
+			static function () use ( &$observed, $event_id, $posts_table, $term_relationships_table, $term_taxonomy_table ): void {
 				$reader = new \wpdb( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST );
-				$reader->set_prefix( $table_prefix );
-				$content = $reader->get_var( $reader->prepare( "SELECT post_content FROM {$reader->posts} WHERE ID = %d", $event_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Independent connection proves transaction isolation.
+				$content = $reader->get_var( $reader->prepare( "SELECT post_content FROM {$posts_table} WHERE ID = %d", $event_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Independent connection proves transaction isolation.
 				$terms = $reader->get_col(
 					$reader->prepare(
-						"SELECT tt.term_id FROM {$reader->term_relationships} tr INNER JOIN {$reader->term_taxonomy} tt ON tt.term_taxonomy_id = tr.term_taxonomy_id WHERE tr.object_id = %d AND tt.taxonomy = 'venue'",
+						"SELECT tt.term_id FROM {$term_relationships_table} tr INNER JOIN {$term_taxonomy_table} tt ON tt.term_taxonomy_id = tr.term_taxonomy_id WHERE tr.object_id = %d AND tt.taxonomy = 'venue'",
 						$event_id
 					)
 				); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Independent connection proves transaction isolation.

--- a/tests/Unit/CalendarAbilitiesTest.php
+++ b/tests/Unit/CalendarAbilitiesTest.php
@@ -12,6 +12,7 @@ use DataMachineEvents\Abilities\CalendarAbilities;
 use DataMachineEvents\Core\Event_Post_Type;
 use DataMachineEvents\Core\EventDatesTable;
 use DataMachineEvents\Core\Venue_Taxonomy;
+use DataMachineEvents\Blocks\Calendar\Query\ScopeResolver;
 
 class CalendarAbilitiesTest extends WP_UnitTestCase {
 
@@ -202,30 +203,33 @@ class CalendarAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	public function test_month_intersects_resolved_scope_and_can_be_empty(): void {
-		$today         = current_datetime()->setTime( 12, 0 );
-		$tomorrow      = $today->modify( '+1 day' );
-		$today_id      = $this->seed_event( 'Today scoped event', $today->format( 'Y-m-d 12:00:00' ), $today->format( 'Y-m-d 14:00:00' ) );
-		$future_id     = $this->seed_event( 'Tomorrow unscoped event', $tomorrow->format( 'Y-m-d 12:00:00' ), $tomorrow->format( 'Y-m-d 14:00:00' ) );
-		$current_month = $today->format( 'Y-m' );
+		$scope_bounds  = ScopeResolver::resolve( 'today' );
+		$this->assertIsArray( $scope_bounds );
+		$scope_date    = new \DateTimeImmutable( $scope_bounds['date_start'], wp_timezone() );
+		$outside_date  = new \DateTimeImmutable( $scope_bounds['date_end'], wp_timezone() );
+		$outside_date  = $outside_date->modify( '+1 day' );
+		$today_id      = $this->seed_event( 'Today scoped event', $scope_date->format( 'Y-m-d 12:00:00' ), $scope_date->format( 'Y-m-d 14:00:00' ) );
+		$future_id     = $this->seed_event( 'Tomorrow unscoped event', $outside_date->format( 'Y-m-d 12:00:00' ), $outside_date->format( 'Y-m-d 14:00:00' ) );
+		$current_month = $scope_date->format( 'Y-m' );
 
 		$scoped = $this->abilities->executeGetCalendarPage(
 			array(
 				'month'        => $current_month,
 				'scope'        => 'today',
-				'date_start'   => $today->format( 'Y-m-d' ),
-				'date_end'     => $today->format( 'Y-m-d' ),
+				'date_start'   => $scope_date->format( 'Y-m-d' ),
+				'date_end'     => $scope_date->format( 'Y-m-d' ),
 				'include_html' => false,
 			)
 		);
 		$scoped_ids = array_column( $scoped['paged_date_groups'][0]['events'], 'post_id' );
-		$this->assertSame( $today->format( 'Y-m-d' ), $scoped['date_boundaries']['start_date'] );
-		$this->assertSame( $today->format( 'Y-m-d' ), $scoped['date_boundaries']['end_date'] );
+		$this->assertSame( $scope_date->format( 'Y-m-d' ), $scoped['date_boundaries']['start_date'] );
+		$this->assertSame( $scope_date->format( 'Y-m-d' ), $scoped['date_boundaries']['end_date'] );
 		$this->assertContains( $today_id, $scoped_ids );
 		$this->assertNotContains( $future_id, $scoped_ids );
 
 		$empty = $this->abilities->executeGetCalendarPage(
 			array(
-				'month'        => $today->modify( '+2 months' )->format( 'Y-m' ),
+				'month'        => $scope_date->modify( '+2 months' )->format( 'Y-m' ),
 				'scope'        => 'today',
 				'include_html' => false,
 			)

--- a/tests/Unit/EventRestControllerTest.php
+++ b/tests/Unit/EventRestControllerTest.php
@@ -16,6 +16,7 @@ use WP_REST_Server;
 use DataMachineEvents\Core\Event_Post_Type;
 use DataMachineEvents\Core\EventDatesTable;
 use DataMachineEvents\Core\Venue_Taxonomy;
+use DataMachineEvents\Blocks\Calendar\Cache\CalendarCache;
 use const DataMachineEvents\Api\API_NAMESPACE;
 
 class EventRestControllerTest extends WP_UnitTestCase {
@@ -105,7 +106,8 @@ class EventRestControllerTest extends WP_UnitTestCase {
 
 		// Set event datetime in the future (table is the query source of truth).
 		$future_datetime = current_datetime()->modify( '+1 week' )->format( 'Y-m-d H:i:s' );
-		EventDatesTable::upsert( $post_id, $future_datetime );
+		$this->assertTrue( EventDatesTable::upsert( $post_id, $future_datetime ) );
+		CalendarCache::invalidate();
 
 		$request  = $this->calendar_request();
 		$request->set_param( 'format', 'data' );
@@ -132,7 +134,8 @@ class EventRestControllerTest extends WP_UnitTestCase {
 		);
 
 		$future_datetime = current_datetime()->modify( '+1 week' )->format( 'Y-m-d H:i:s' );
-		EventDatesTable::upsert( $post_id, $future_datetime );
+		$this->assertTrue( EventDatesTable::upsert( $post_id, $future_datetime ) );
+		CalendarCache::invalidate();
 
 		$request = $this->calendar_request();
 		$request->set_param( 'event_search', $unique_term );

--- a/tests/Unit/EventTaxonomyAssignerTest.php
+++ b/tests/Unit/EventTaxonomyAssignerTest.php
@@ -22,6 +22,9 @@ class EventTaxonomyAssignerTest extends WP_UnitTestCase {
 
 	public function setUp(): void {
 		parent::setUp();
+		global $wpdb;
+		$wpdb->query( 'COMMIT' );
+		$wpdb->query( 'SET autocommit = 1' );
 
 		if ( ! post_type_exists( 'data_machine_events' ) ) {
 			Event_Post_Type::register();
@@ -48,6 +51,13 @@ class EventTaxonomyAssignerTest extends WP_UnitTestCase {
 		}
 
 		$this->assigner = new EventTaxonomyAssigner();
+	}
+
+	public function tearDown(): void {
+		global $wpdb;
+		$wpdb->query( 'SET autocommit = 0' );
+		$wpdb->query( 'START TRANSACTION' );
+		parent::tearDown();
 	}
 
 	public function test_assigner_instantiation() {

--- a/tests/Unit/EventUpdateAbilitiesTest.php
+++ b/tests/Unit/EventUpdateAbilitiesTest.php
@@ -51,7 +51,7 @@ class EventUpdateAbilitiesTest extends WP_UnitTestCase {
 		$result = $registered->execute( $this->sourceInput( $this->makeSourceEvent(), array( 'startTime' => '21:00' ) ) );
 
 		$this->assertWPError( $result );
-		$this->assertSame( 'source_event_update_forbidden', $result->get_error_code() );
+		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code() );
 	}
 
 	public function test_source_update_rejects_wrong_identity_event_and_stale_fingerprint(): void {

--- a/tests/Unit/VenueMergeHelperTest.php
+++ b/tests/Unit/VenueMergeHelperTest.php
@@ -587,7 +587,7 @@ class VenueMergeHelperTest extends WP_UnitTestCase {
 			)
 		);
 		$loser  = $this->make_venue(
-			'HI-FI Indianapolis Suite 4',
+			'HI-FI Indianapolis',
 			array(
 				'_venue_address' => '1043 Virginia Ave',
 				'_venue_city'    => 'Indianapolis',


### PR DESCRIPTION
## Summary
- align calendar fixtures with late-night scope semantics and invalidate cache state after direct date-table writes
- run venue metadata fixtures outside the transaction intentionally rejected by canonical venue mutations, and align native Abilities/venue-alias expectations with current contracts
- provision the event dates table for the MySQL atomicity test and query exact multisite table names from its independent connection

## Root causes
- `CalendarAbilitiesTest`: the fixture used literal noon/current-calendar-day assumptions even though `today` resolves to a nightlife display day; around the late-night cutoff this left the expected date group empty.
- `EventRestControllerTest`: tests wrote directly to `EventDatesTable`, bypassing the normal event-save cache-generation rotation after the canonical datetime write.
- `EventTaxonomyAssignerTest`: canonical venue mutations correctly reject pre-existing SQL transactions, but these metadata assertions were running inside `WP_UnitTestCase`'s transaction and silently observing no ticketing metadata write.
- `EventUpdateAbilitiesTest`: registered `WP_Ability::execute()` now rejects at its permission boundary with the native `ability_invalid_permissions` code before the execute callback's defense-in-depth check.
- `VenueMergeHelperTest`: the fixture called an added `Suite 4` token a case-only alias even though the production contract intentionally requires exact normalized token sets.
- `EventSourceUpdateMySqlAtomicityTest`: the fixture omitted the custom dates table and initialized a second multisite `wpdb` without usable blog table properties, producing both `event_dates_write_failed` and malformed independent-reader SQL.

## Changes
This is a test-only baseline repair. Production behavior is unchanged. Fixtures now exercise the current production contracts rather than weakening them with skips, retries, suppressions, or compatibility branches.

## Baseline comparison
Current `main` at `2fb1839a241c798bff0271f0de0f7412abcd5193` failed 8 of 746 tests in Homeboy run `30679169927`. The branch was rebased onto `350803a` after PR #669 merged; that commit only changes Calendar renderer/frontend files and `CalendarBlockTest`, not these six repaired test files.

## Verification
- `homeboy review lint data-machine-events --path /var/lib/datamachine/workspace/data-machine-events@fix-600-homeboy-tests --placement local --changed-only`: passed, 6 changed files, no findings.
- `php -l` on all six changed PHP files: passed.
- `git diff --check`: passed.
- `homeboy review test data-machine-events --path /var/lib/datamachine/workspace/data-machine-events@fix-600-homeboy-tests --placement local`: attempted twice. The first run hit the known unavailable-artifact/zero-tests adapter path; final run `22ac72e1-468d-41c9-a275-cde07c569269` retained artifacts and identified local managed MySQL provisioning as blocked because `docker` is unavailable (`provider-unavailable`, `ENOENT`).
- Calendar, EventDetails, and EventsMap `npm ci` plus `npm run build`: all passed as Homeboy prepare steps.
- `composer test:contracts`: unavailable locally because the worktree has no local PHPUnit binary; the managed Homeboy runtime owns dependency installation.
- The GitHub Homeboy test job is the authoritative MySQL-backed verification for this PR.

Fixes #600