### PR TITLE
fix: add bounded batch action recovery

### DIFF
--- a/data-machine-events.php
+++ b/data-machine-events.php
@@ -262,6 +262,7 @@ class DATAMACHINE_Events {
 			\DataMachineEvents\Abilities\VenueMapAbilities::class,
 			\DataMachineEvents\Abilities\CalendarAbilities::class,
 			\DataMachineEvents\Abilities\TicketUrlResyncAbilities::class,
+			\DataMachineEvents\Abilities\BatchActionRecoveryAbilities::class,
 			\DataMachineEvents\Abilities\TicketmasterTest::class,
 			\DataMachineEvents\Abilities\DiceFmTest::class,
 			\DataMachineEvents\Abilities\GeocodingAbilities::class,
@@ -414,6 +415,11 @@ class DATAMACHINE_Events {
 		if ( file_exists( DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Abilities/TicketUrlResyncAbilities.php' ) ) {
 			require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Abilities/TicketUrlResyncAbilities.php';
 			new \DataMachineEvents\Abilities\TicketUrlResyncAbilities();
+		}
+
+		if ( file_exists( DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Abilities/BatchActionRecoveryAbilities.php' ) ) {
+			require_once DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Abilities/BatchActionRecoveryAbilities.php';
+			new \DataMachineEvents\Abilities\BatchActionRecoveryAbilities();
 		}
 
 		if ( file_exists( DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Abilities/TicketmasterTest.php' ) ) {

--- a/inc/Abilities/BatchActionRecoveryAbilities.php
+++ b/inc/Abilities/BatchActionRecoveryAbilities.php
@@ -32,32 +32,52 @@ class BatchActionRecoveryAbilities {
 	}
 
 	private function registerAbility(): void {
-		add_action(
-			'wp_abilities_api_init',
-			function (): void {
-				wp_register_ability(
+		$register_callback = function (): void {
+			wp_register_ability(
 					'data-machine-events/recover-batch-actions',
 					array(
 						'label'               => __( 'Recover Pipeline Batch Actions', 'data-machine-events' ),
 						'description'         => __( 'Classify and remove exact obsolete pipeline batch action paths in bounded batches.', 'data-machine-events' ),
-						'category'            => 'datamachine-events-events',
+						'category'            => AbilityCategories::EVENTS,
 						'input_schema'        => array(
 							'type'       => 'object',
 							'properties' => array(
-								'apply'          => array( 'type' => 'boolean', 'default' => false ),
-								'cursor'         => array( 'type' => 'integer', 'minimum' => 0, 'default' => 0 ),
-								'review_through' => array( 'type' => 'integer', 'minimum' => 0, 'default' => 0 ),
-								'scan_limit'     => array( 'type' => 'integer', 'minimum' => 1, 'maximum' => self::MAX_SCAN_LIMIT, 'default' => self::DEFAULT_SCAN_LIMIT ),
-								'mutation_limit' => array( 'type' => 'integer', 'minimum' => 1, 'maximum' => self::MAX_MUTATIONS, 'default' => self::DEFAULT_MUTATIONS ),
+								'apply'          => array(
+									'type'    => 'boolean',
+									'default' => false,
+								),
+								'cursor'         => array(
+									'type'    => 'integer',
+									'minimum' => 0,
+									'default' => 0,
+								),
+								'review_through' => array(
+									'type'    => 'integer',
+									'minimum' => 0,
+									'default' => 0,
+								),
+								'scan_limit'     => array(
+									'type'    => 'integer',
+									'minimum' => 1,
+									'maximum' => self::MAX_SCAN_LIMIT,
+									'default' => self::DEFAULT_SCAN_LIMIT,
+								),
+								'mutation_limit' => array(
+									'type'    => 'integer',
+									'minimum' => 1,
+									'maximum' => self::MAX_MUTATIONS,
+									'default' => self::DEFAULT_MUTATIONS,
+								),
 							),
 						),
 						'output_schema'       => array( 'type' => 'object' ),
 						'execute_callback'    => array( $this, 'execute' ),
 						'permission_callback' => AbilityPermissions::canWrite(),
 					)
-				);
-			}
-		);
+			);
+		};
+
+		add_action( 'wp_abilities_api_init', $register_callback );
 	}
 
 	/**
@@ -87,7 +107,7 @@ class BatchActionRecoveryAbilities {
 		}
 
 		// The primary-key window bounds rows examined even when hook/status indexes are unhealthy.
-		$sql     = $apply
+		$sql = $apply
 			? $wpdb->prepare(
 				'SELECT action_id, hook, status, claim_id, args FROM %i WHERE action_id > %d AND action_id <= %d ORDER BY action_id ASC LIMIT %d',
 				$actions_table,
@@ -101,12 +121,13 @@ class BatchActionRecoveryAbilities {
 				$cursor,
 				$scan_limit
 			);
-		$wpdb->last_error = '';
-		$actions          = $wpdb->get_results(
+		$wpdb->flush();
+		$actions = $wpdb->get_results(
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Both query shapes are prepared directly above.
 			$sql,
 			ARRAY_A
 		);
-		if ( '' !== $wpdb->last_error || ! is_array( $actions ) ) {
+		if ( ! empty( $wpdb->last_error ) || ! is_array( $actions ) ) {
 			return array( 'error' => 'Unable to read the Action Scheduler recovery window.' );
 		}
 
@@ -122,9 +143,9 @@ class BatchActionRecoveryAbilities {
 			}
 			$parent_job_id = (int) $args['parent_job_id'];
 			if ( ! array_key_exists( $parent_job_id, $parent_cache ) ) {
-				$wpdb->last_error               = '';
+				$wpdb->flush();
 				$parent_cache[ $parent_job_id ] = $jobs->get_job( $parent_job_id );
-				if ( '' !== $wpdb->last_error ) {
+				if ( ! empty( $wpdb->last_error ) ) {
 					return array( 'error' => 'Unable to verify a batch parent; no actions were changed.' );
 				}
 			}
@@ -133,23 +154,23 @@ class BatchActionRecoveryAbilities {
 			if ( ! is_array( $parent ) || JobStatus::PROCESSING !== (string) ( $parent['status'] ?? '' ) ) {
 				continue;
 			}
-			$wpdb->last_error              = '';
+			$wpdb->flush();
 			$outstanding[ $parent_job_id ] = $batch_items->first_outstanding_index( (int) $parent_job_id );
-			if ( '' !== $wpdb->last_error ) {
+			if ( ! empty( $wpdb->last_error ) ) {
 				return array( 'error' => 'Unable to verify a batch worklist; no actions were changed.' );
 			}
 		}
 
-		$details        = array();
-		$counts         = array(
-			'rows_scanned'       => count( $actions ),
-			'chunk_actions'      => 0,
-			'claimed_preserved'  => 0,
-			'eligible'           => 0,
-			'deleted'            => 0,
-			'preserved'          => 0,
-			'race_skipped'       => 0,
-			'malformed'          => 0,
+		$details       = array();
+		$counts        = array(
+			'rows_scanned'      => count( $actions ),
+			'chunk_actions'     => 0,
+			'claimed_preserved' => 0,
+			'eligible'          => 0,
+			'deleted'           => 0,
+			'preserved'         => 0,
+			'race_skipped'      => 0,
+			'malformed'         => 0,
 		);
 		$next_cursor   = $apply && empty( $actions ) ? $review_through : $cursor;
 		$limit_reached = false;
@@ -165,7 +186,11 @@ class BatchActionRecoveryAbilities {
 			if ( 0 !== (int) $action['claim_id'] ) {
 				++$counts['claimed_preserved'];
 				++$counts['preserved'];
-				$details[] = array( 'action_id' => $action_id, 'disposition' => 'preserved', 'reason' => 'action_claimed' );
+				$details[] = array(
+					'action_id'   => $action_id,
+					'disposition' => 'preserved',
+					'reason'      => 'action_claimed',
+				);
 				continue;
 			}
 
@@ -173,19 +198,23 @@ class BatchActionRecoveryAbilities {
 			if ( null === $args ) {
 				++$counts['malformed'];
 				++$counts['preserved'];
-				$details[] = array( 'action_id' => $action_id, 'disposition' => 'preserved', 'reason' => 'malformed_args' );
+				$details[] = array(
+					'action_id'   => $action_id,
+					'disposition' => 'preserved',
+					'reason'      => 'malformed_args',
+				);
 				continue;
 			}
 
 			$parent_job_id = (int) $args['parent_job_id'];
-			$parent = $parent_cache[ $parent_job_id ];
+			$parent_job    = $parent_cache[ $parent_job_id ];
 
 			$classification = self::classifyPendingAction(
 				$args,
-				is_array( $parent ) ? $parent : null,
+				is_array( $parent_job ) ? $parent_job : null,
 				$outstanding[ $parent_job_id ] ?? null
 			);
-			$detail = array(
+			$detail         = array(
 				'action_id'     => $action_id,
 				'parent_job_id' => $parent_job_id,
 				'offset'        => (int) $args['offset'],
@@ -276,30 +305,48 @@ class BatchActionRecoveryAbilities {
 	 * Select only paths proven obsolete from durable parent/worklist state.
 	 *
 	 * @param array{parent_job_id:int,offset:int} $args Action arguments.
-	 * @param array<string,mixed>|null            $parent Parent job row.
+	 * @param array<string,mixed>|null            $parent_job Parent job row.
 	 * @return array{eligible:bool,reason:string}
 	 */
-	private static function classifyPendingAction( array $args, ?array $parent, ?int $first_outstanding ): array {
-		if ( null === $parent ) {
-			return array( 'eligible' => true, 'reason' => 'parent_missing' );
+	private static function classifyPendingAction( array $args, ?array $parent_job, ?int $first_outstanding ): array {
+		if ( null === $parent_job ) {
+			return array(
+				'eligible' => true,
+				'reason'   => 'parent_missing',
+			);
 		}
-		$status = (string) ( $parent['status'] ?? '' );
+		$status = (string) ( $parent_job['status'] ?? '' );
 		if ( JobStatus::isStatusFinal( $status ) ) {
-			return array( 'eligible' => true, 'reason' => 'parent_terminal' );
+			return array(
+				'eligible' => true,
+				'reason'   => 'parent_terminal',
+			);
 		}
 		if ( JobStatus::PROCESSING !== $status ) {
-			return array( 'eligible' => false, 'reason' => 'parent_not_processing' );
+			return array(
+				'eligible' => false,
+				'reason'   => 'parent_not_processing',
+			);
 		}
 
-		$engine_data = is_array( $parent['engine_data'] ?? null ) ? $parent['engine_data'] : array();
+		$engine_data = is_array( $parent_job['engine_data'] ?? null ) ? $parent_job['engine_data'] : array();
 		if ( ! empty( $engine_data['batch_state']['worklist_complete'] ) ) {
-			return array( 'eligible' => true, 'reason' => 'worklist_complete' );
+			return array(
+				'eligible' => true,
+				'reason'   => 'worklist_complete',
+			);
 		}
-		$chunk_size = max( 1, (int) ( $parent['engine_data']['batch_chunk_size'] ?? 10 ) );
+		$chunk_size = max( 1, (int) ( $parent_job['engine_data']['batch_chunk_size'] ?? 10 ) );
 		if ( null !== $first_outstanding && $args['offset'] + $chunk_size <= $first_outstanding ) {
-			return array( 'eligible' => true, 'reason' => 'offset_superseded' );
+			return array(
+				'eligible' => true,
+				'reason'   => 'offset_superseded',
+			);
 		}
 
-		return array( 'eligible' => false, 'reason' => null === $first_outstanding ? 'worklist_state_ambiguous' : 'active_or_future_path' );
+		return array(
+			'eligible' => false,
+			'reason'   => null === $first_outstanding ? 'worklist_state_ambiguous' : 'active_or_future_path',
+		);
 	}
 }

--- a/inc/Abilities/BatchActionRecoveryAbilities.php
+++ b/inc/Abilities/BatchActionRecoveryAbilities.php
@@ -1,0 +1,305 @@
+<?php
+// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Incident recovery requires fresh, cursor-bounded scheduler evidence.
+/**
+ * Bounded recovery for obsolete pipeline batch actions.
+ *
+ * @package DataMachineEvents\Abilities
+ */
+
+namespace DataMachineEvents\Abilities;
+
+use DataMachine\Core\Database\BatchItems\BatchItems;
+use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\JobStatus;
+
+defined( 'ABSPATH' ) || exit;
+
+class BatchActionRecoveryAbilities {
+
+	private const HOOK               = 'datamachine_pipeline_batch_chunk';
+	private const DEFAULT_SCAN_LIMIT = 250;
+	private const MAX_SCAN_LIMIT     = 1000;
+	private const DEFAULT_MUTATIONS  = 25;
+	private const MAX_MUTATIONS      = 100;
+
+	private static bool $registered = false;
+
+	public function __construct() {
+		if ( ! self::$registered ) {
+			$this->registerAbility();
+			self::$registered = true;
+		}
+	}
+
+	private function registerAbility(): void {
+		add_action(
+			'wp_abilities_api_init',
+			function (): void {
+				wp_register_ability(
+					'data-machine-events/recover-batch-actions',
+					array(
+						'label'               => __( 'Recover Pipeline Batch Actions', 'data-machine-events' ),
+						'description'         => __( 'Classify and remove exact obsolete pipeline batch action paths in bounded batches.', 'data-machine-events' ),
+						'category'            => 'datamachine-events-events',
+						'input_schema'        => array(
+							'type'       => 'object',
+							'properties' => array(
+								'apply'          => array( 'type' => 'boolean', 'default' => false ),
+								'cursor'         => array( 'type' => 'integer', 'minimum' => 0, 'default' => 0 ),
+								'review_through' => array( 'type' => 'integer', 'minimum' => 0, 'default' => 0 ),
+								'scan_limit'     => array( 'type' => 'integer', 'minimum' => 1, 'maximum' => self::MAX_SCAN_LIMIT, 'default' => self::DEFAULT_SCAN_LIMIT ),
+								'mutation_limit' => array( 'type' => 'integer', 'minimum' => 1, 'maximum' => self::MAX_MUTATIONS, 'default' => self::DEFAULT_MUTATIONS ),
+							),
+						),
+						'output_schema'       => array( 'type' => 'object' ),
+						'execute_callback'    => array( $this, 'execute' ),
+						'permission_callback' => AbilityPermissions::canWrite(),
+					)
+				);
+			}
+		);
+	}
+
+	/**
+	 * Classify and optionally remove one bounded scheduler page.
+	 *
+	 * @param array<string,mixed> $input Ability input.
+	 * @return array<string,mixed>
+	 */
+	public function execute( array $input ): array {
+		if ( ! class_exists( Jobs::class ) || ! class_exists( BatchItems::class ) ) {
+			return array( 'error' => 'Data Machine batch recovery primitives are unavailable.' );
+		}
+
+		global $wpdb;
+		$apply          = ! empty( $input['apply'] );
+		$cursor         = max( 0, (int) ( $input['cursor'] ?? 0 ) );
+		$review_through = max( 0, (int) ( $input['review_through'] ?? 0 ) );
+		$scan_limit     = max( 1, min( self::MAX_SCAN_LIMIT, (int) ( $input['scan_limit'] ?? self::DEFAULT_SCAN_LIMIT ) ) );
+		$mutation_limit = max( 1, min( self::MAX_MUTATIONS, (int) ( $input['mutation_limit'] ?? self::DEFAULT_MUTATIONS ) ) );
+		$actions_table  = $wpdb->prefix . 'actionscheduler_actions';
+		$jobs           = new Jobs();
+		$batch_items    = new BatchItems();
+		$mutations      = 0;
+
+		if ( $apply && $review_through <= $cursor ) {
+			return array( 'error' => 'Apply requires --review-through greater than --cursor from a reviewed dry-run window.' );
+		}
+
+		// The primary-key window bounds rows examined even when hook/status indexes are unhealthy.
+		$sql     = $apply
+			? $wpdb->prepare(
+				'SELECT action_id, hook, status, claim_id, args FROM %i WHERE action_id > %d AND action_id <= %d ORDER BY action_id ASC LIMIT %d',
+				$actions_table,
+				$cursor,
+				$review_through,
+				$scan_limit
+			)
+			: $wpdb->prepare(
+				'SELECT action_id, hook, status, claim_id, args FROM %i WHERE action_id > %d ORDER BY action_id ASC LIMIT %d',
+				$actions_table,
+				$cursor,
+				$scan_limit
+			);
+		$wpdb->last_error = '';
+		$actions          = $wpdb->get_results(
+			$sql,
+			ARRAY_A
+		);
+		if ( '' !== $wpdb->last_error || ! is_array( $actions ) ) {
+			return array( 'error' => 'Unable to read the Action Scheduler recovery window.' );
+		}
+
+		$parent_cache = array();
+		$outstanding  = array();
+		foreach ( $actions as $action ) {
+			if ( self::HOOK !== $action['hook'] || 'pending' !== $action['status'] || 0 !== (int) $action['claim_id'] ) {
+				continue;
+			}
+			$args = self::decodeActionArgs( (string) $action['args'] );
+			if ( null === $args ) {
+				continue;
+			}
+			$parent_job_id = (int) $args['parent_job_id'];
+			if ( ! array_key_exists( $parent_job_id, $parent_cache ) ) {
+				$wpdb->last_error               = '';
+				$parent_cache[ $parent_job_id ] = $jobs->get_job( $parent_job_id );
+				if ( '' !== $wpdb->last_error ) {
+					return array( 'error' => 'Unable to verify a batch parent; no actions were changed.' );
+				}
+			}
+		}
+		foreach ( $parent_cache as $parent_job_id => $parent ) {
+			if ( ! is_array( $parent ) || JobStatus::PROCESSING !== (string) ( $parent['status'] ?? '' ) ) {
+				continue;
+			}
+			$wpdb->last_error              = '';
+			$outstanding[ $parent_job_id ] = $batch_items->first_outstanding_index( (int) $parent_job_id );
+			if ( '' !== $wpdb->last_error ) {
+				return array( 'error' => 'Unable to verify a batch worklist; no actions were changed.' );
+			}
+		}
+
+		$details        = array();
+		$counts         = array(
+			'rows_scanned'       => count( $actions ),
+			'chunk_actions'      => 0,
+			'claimed_preserved'  => 0,
+			'eligible'           => 0,
+			'deleted'            => 0,
+			'preserved'          => 0,
+			'race_skipped'       => 0,
+			'malformed'          => 0,
+		);
+		$next_cursor   = $apply && empty( $actions ) ? $review_through : $cursor;
+		$limit_reached = false;
+
+		foreach ( $actions as $action ) {
+			$action_id   = (int) $action['action_id'];
+			$last_cursor = $next_cursor;
+			$next_cursor = $action_id;
+			if ( self::HOOK !== $action['hook'] || 'pending' !== $action['status'] ) {
+				continue;
+			}
+			++$counts['chunk_actions'];
+			if ( 0 !== (int) $action['claim_id'] ) {
+				++$counts['claimed_preserved'];
+				++$counts['preserved'];
+				$details[] = array( 'action_id' => $action_id, 'disposition' => 'preserved', 'reason' => 'action_claimed' );
+				continue;
+			}
+
+			$args = self::decodeActionArgs( (string) $action['args'] );
+			if ( null === $args ) {
+				++$counts['malformed'];
+				++$counts['preserved'];
+				$details[] = array( 'action_id' => $action_id, 'disposition' => 'preserved', 'reason' => 'malformed_args' );
+				continue;
+			}
+
+			$parent_job_id = (int) $args['parent_job_id'];
+			$parent = $parent_cache[ $parent_job_id ];
+
+			$classification = self::classifyPendingAction(
+				$args,
+				is_array( $parent ) ? $parent : null,
+				$outstanding[ $parent_job_id ] ?? null
+			);
+			$detail = array(
+				'action_id'     => $action_id,
+				'parent_job_id' => $parent_job_id,
+				'offset'        => (int) $args['offset'],
+				'disposition'   => $classification['eligible'] ? ( $apply ? 'delete' : 'would_delete' ) : 'preserved',
+				'reason'        => $classification['reason'],
+			);
+
+			if ( ! $classification['eligible'] ) {
+				++$counts['preserved'];
+				$details[] = $detail;
+				continue;
+			}
+			if ( $apply && $mutations >= $mutation_limit ) {
+				$limit_reached = true;
+				$next_cursor   = $last_cursor;
+				break;
+			}
+			++$counts['eligible'];
+
+			if ( $apply ) {
+				$deleted = $wpdb->delete(
+					$actions_table,
+					array(
+						'action_id' => $action_id,
+						'hook'      => self::HOOK,
+						'status'    => 'pending',
+						'claim_id'  => 0,
+						'args'      => (string) $action['args'],
+					),
+					array( '%d', '%s', '%s', '%d', '%s' )
+				);
+				if ( 1 === $deleted ) {
+					++$mutations;
+					++$counts['deleted'];
+					$detail['disposition'] = 'deleted';
+					do_action( 'action_scheduler_deleted_action', $action_id );
+				} else {
+					++$counts['race_skipped'];
+					$detail['disposition'] = 'race_skipped';
+				}
+			}
+			$details[] = $detail;
+		}
+
+		return array(
+			'success'        => true,
+			'dry_run'        => ! $apply,
+			'cursor'         => $cursor,
+			'next_cursor'    => $next_cursor,
+			'review_through' => $apply ? $review_through : $next_cursor,
+			'has_more'       => $limit_reached || ( $apply ? $next_cursor < $review_through : count( $actions ) === $scan_limit ),
+			'limit_reached'  => $limit_reached,
+			'mutation_limit' => $mutation_limit,
+			'mutations'      => $mutations,
+			'counts'         => $counts,
+			'actions'        => $details,
+		);
+	}
+
+	/** @return array{parent_job_id:int,offset:int}|null */
+	private static function decodeActionArgs( string $raw ): ?array {
+		$args = json_decode( $raw, true );
+		if ( ! is_array( $args ) ) {
+			$args = maybe_unserialize( $raw );
+		}
+		if ( ! is_array( $args ) ) {
+			return null;
+		}
+		if ( ! isset( $args['parent_job_id'], $args['offset'] ) && isset( $args[0] ) && is_array( $args[0] ) ) {
+			$args = $args[0];
+		}
+		if ( ! isset( $args['parent_job_id'], $args['offset'] ) || ! is_numeric( $args['parent_job_id'] ) || ! is_numeric( $args['offset'] ) ) {
+			return null;
+		}
+		$parent_job_id = (int) $args['parent_job_id'];
+		$offset        = (int) $args['offset'];
+		if ( $parent_job_id <= 0 || $offset < 0 ) {
+			return null;
+		}
+
+		return array(
+			'parent_job_id' => $parent_job_id,
+			'offset'        => $offset,
+		);
+	}
+
+	/**
+	 * Select only paths proven obsolete from durable parent/worklist state.
+	 *
+	 * @param array{parent_job_id:int,offset:int} $args Action arguments.
+	 * @param array<string,mixed>|null            $parent Parent job row.
+	 * @return array{eligible:bool,reason:string}
+	 */
+	private static function classifyPendingAction( array $args, ?array $parent, ?int $first_outstanding ): array {
+		if ( null === $parent ) {
+			return array( 'eligible' => true, 'reason' => 'parent_missing' );
+		}
+		$status = (string) ( $parent['status'] ?? '' );
+		if ( JobStatus::isStatusFinal( $status ) ) {
+			return array( 'eligible' => true, 'reason' => 'parent_terminal' );
+		}
+		if ( JobStatus::PROCESSING !== $status ) {
+			return array( 'eligible' => false, 'reason' => 'parent_not_processing' );
+		}
+
+		$engine_data = is_array( $parent['engine_data'] ?? null ) ? $parent['engine_data'] : array();
+		if ( ! empty( $engine_data['batch_state']['worklist_complete'] ) ) {
+			return array( 'eligible' => true, 'reason' => 'worklist_complete' );
+		}
+		$chunk_size = max( 1, (int) ( $parent['engine_data']['batch_chunk_size'] ?? 10 ) );
+		if ( null !== $first_outstanding && $args['offset'] + $chunk_size <= $first_outstanding ) {
+			return array( 'eligible' => true, 'reason' => 'offset_superseded' );
+		}
+
+		return array( 'eligible' => false, 'reason' => null === $first_outstanding ? 'worklist_state_ambiguous' : 'active_or_future_path' );
+	}
+}

--- a/inc/Cli/BatchActionRecoveryCommand.php
+++ b/inc/Cli/BatchActionRecoveryCommand.php
@@ -60,7 +60,12 @@ class BatchActionRecoveryCommand {
 			return;
 		}
 		if ( 'json' === $format ) {
-			\WP_CLI::log( wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			$json = wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+			if ( false === $json ) {
+				\WP_CLI::error( 'Unable to encode recovery output.' );
+				return;
+			}
+			\WP_CLI::log( $json );
 			return;
 		}
 

--- a/inc/Cli/BatchActionRecoveryCommand.php
+++ b/inc/Cli/BatchActionRecoveryCommand.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * WP-CLI wrapper for bounded pipeline batch action recovery.
+ *
+ * @package DataMachineEvents\Cli
+ */
+
+namespace DataMachineEvents\Cli;
+
+use DataMachineEvents\Abilities\BatchActionRecoveryAbilities;
+
+defined( 'ABSPATH' ) || exit;
+
+class BatchActionRecoveryCommand {
+
+	/**
+	 * Review or apply one bounded recovery window.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--cursor=<action-id>]
+	 * : Resume after this Action Scheduler action ID. Default: 0.
+	 *
+	 * [--scan-limit=<number>]
+	 * : Maximum physical action rows to inspect. Default: 250; maximum: 1000.
+	 *
+	 * [--mutation-limit=<number>]
+	 * : Hard deletion ceiling. Default: 25; maximum: 100.
+	 *
+	 * [--review-through=<action-id>]
+	 * : Dry-run upper action ID. Required with --apply so later rows cannot enter the reviewed window.
+	 *
+	 * [--apply]
+	 * : Apply exact reviewed mutations. Without this flag the command is a dry run.
+	 *
+	 * [--format=<format>]
+	 * : Output format: table or json. Default: table.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp data-machine-events recover-batch-actions --scan-limit=250
+	 *     wp data-machine-events recover-batch-actions --cursor=100000 --format=json
+	 *     wp data-machine-events recover-batch-actions --cursor=100000 --review-through=100250 --mutation-limit=10 --apply
+	 */
+	public function __invoke( array $args, array $assoc_args ): void {
+		$apply  = isset( $assoc_args['apply'] );
+		$format = (string) ( $assoc_args['format'] ?? 'table' );
+		$result = ( new BatchActionRecoveryAbilities() )->execute(
+			array(
+				'apply'          => $apply,
+				'cursor'         => (int) ( $assoc_args['cursor'] ?? 0 ),
+				'review_through' => (int) ( $assoc_args['review-through'] ?? 0 ),
+				'scan_limit'     => (int) ( $assoc_args['scan-limit'] ?? 250 ),
+				'mutation_limit' => (int) ( $assoc_args['mutation-limit'] ?? 25 ),
+			)
+		);
+
+		if ( isset( $result['error'] ) ) {
+			\WP_CLI::error( (string) $result['error'] );
+			return;
+		}
+		if ( 'json' === $format ) {
+			\WP_CLI::log( wp_json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+			return;
+		}
+
+		\WP_CLI::log( 'Mode: ' . ( $apply ? 'APPLY' : 'DRY RUN' ) );
+		\WP_CLI::log( sprintf( 'Cursor: %d -> %d; scanned: %d', $result['cursor'], $result['next_cursor'], $result['counts']['rows_scanned'] ) );
+		if ( ! empty( $result['actions'] ) ) {
+			\WP_CLI\Utils\format_items( 'table', $result['actions'], array( 'action_id', 'parent_job_id', 'offset', 'disposition', 'reason' ) );
+		}
+		\WP_CLI::log( sprintf( 'Eligible: %d; deleted: %d; preserved: %d; races: %d; mutations: %d/%d', $result['counts']['eligible'], $result['counts']['deleted'], $result['counts']['preserved'], $result['counts']['race_skipped'], $result['mutations'], $result['mutation_limit'] ) );
+		$resume = 'Recovery window complete. Resume with --cursor=' . $result['next_cursor'];
+		if ( $apply ) {
+			$resume .= ' --review-through=' . $result['review_through'] . ' --apply';
+		}
+		\WP_CLI::success( $result['has_more'] ? $resume . '.' : 'Recovery scan complete.' );
+		if ( ! $apply && $result['counts']['eligible'] > 0 ) {
+			\WP_CLI::warning( 'Dry run only. Review the exact IDs above, then add --review-through=' . $result['review_through'] . ' --apply to mutate only this window.' );
+		}
+	}
+}

--- a/inc/Cli/CommandRegistry.php
+++ b/inc/Cli/CommandRegistry.php
@@ -149,6 +149,10 @@ class CommandRegistry {
 				'file'  => $cli . 'BackfillEventDatesCommand.php',
 				'class' => BackfillEventDatesCommand::class,
 			),
+			'data-machine-events recover-batch-actions'  => array(
+				'file'  => $cli . 'BatchActionRecoveryCommand.php',
+				'class' => BatchActionRecoveryCommand::class,
+			),
 		);
 	}
 }

--- a/tests/Unit/BatchActionRecoveryAbilitiesTest.php
+++ b/tests/Unit/BatchActionRecoveryAbilitiesTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Batch action recovery selection tests.
+ *
+ * @package DataMachineEvents\Tests\Unit
+ */
+
+namespace DataMachineEvents\Tests\Unit;
+
+use DataMachineEvents\Abilities\BatchActionRecoveryAbilities;
+use WP_UnitTestCase;
+
+class BatchActionRecoveryAbilitiesTest extends WP_UnitTestCase {
+
+	/** @dataProvider classificationProvider */
+	public function test_only_proven_obsolete_paths_are_eligible( ?array $parent, ?int $outstanding, int $offset, bool $eligible, string $reason ): void {
+		$method = new \ReflectionMethod( BatchActionRecoveryAbilities::class, 'classifyPendingAction' );
+		$method->setAccessible( true );
+		$result = $method->invoke( null, array( 'parent_job_id' => 9, 'offset' => $offset ), $parent, $outstanding );
+
+		$this->assertSame( $eligible, $result['eligible'] );
+		$this->assertSame( $reason, $result['reason'] );
+	}
+
+	public function classificationProvider(): array {
+		return array(
+			'missing parent'       => array( null, null, 0, true, 'parent_missing' ),
+			'terminal parent'      => array( array( 'status' => 'completed', 'engine_data' => array() ), null, 0, true, 'parent_terminal' ),
+			'completed worklist'   => array( array( 'status' => 'processing', 'engine_data' => array( 'batch_state' => array( 'worklist_complete' => true ) ) ), null, 0, true, 'worklist_complete' ),
+			'superseded offset'    => array( array( 'status' => 'processing', 'engine_data' => array() ), 20, 10, true, 'offset_superseded' ),
+			'partially outstanding chunk' => array( array( 'status' => 'processing', 'engine_data' => array() ), 15, 10, false, 'active_or_future_path' ),
+			'current active path'  => array( array( 'status' => 'processing', 'engine_data' => array() ), 20, 20, false, 'active_or_future_path' ),
+			'future active path'   => array( array( 'status' => 'processing', 'engine_data' => array() ), 20, 30, false, 'active_or_future_path' ),
+			'ambiguous worklist'   => array( array( 'status' => 'processing', 'engine_data' => array() ), null, 10, false, 'worklist_state_ambiguous' ),
+			'non-processing parent' => array( array( 'status' => 'pending', 'engine_data' => array() ), null, 0, false, 'parent_not_processing' ),
+		);
+	}
+
+	/** @dataProvider argumentProvider */
+	public function test_action_arguments_require_exact_parent_and_offset( string $raw, ?array $expected ): void {
+		$method = new \ReflectionMethod( BatchActionRecoveryAbilities::class, 'decodeActionArgs' );
+		$method->setAccessible( true );
+		$this->assertSame( $expected, $method->invoke( null, $raw ) );
+	}
+
+	public function argumentProvider(): array {
+		return array(
+			'json'       => array( '{"parent_job_id":12,"offset":30}', array( 'parent_job_id' => 12, 'offset' => 30 ) ),
+			'nested json' => array( '[[{"parent_job_id":12,"offset":30}]]', null ),
+			'missing offset' => array( '{"parent_job_id":12}', null ),
+			'invalid parent' => array( '{"parent_job_id":0,"offset":30}', null ),
+			'invalid offset' => array( '{"parent_job_id":12,"offset":-1}', null ),
+			'invalid'    => array( 'not-an-action-payload', null ),
+		);
+	}
+}


### PR DESCRIPTION
## Summary

- add a dry-run-first ability and WP-CLI command for reviewing the existing pipeline chunk backlog through bounded Action Scheduler primary-key windows
- classify only exact obsolete or fully superseded `(parent_job_id, offset)` paths and preserve claimed, malformed, ambiguous, active, and partially outstanding paths
- require an operator-reviewed upper action ID for apply, cap each invocation at 100 mutations, and make every delete conditional on the row remaining exact, pending, and unclaimed

Fixes #676.

## Root Cause Ownership

The crash crossed three owner layers:

- WooCommerce Action Scheduler owns the claim query and canonical table schema. Data Machine PR #3070 (`e768c6bf`) added a guarded operator path for the missing claim-order index while preserving upstream schema ownership.
- Data Machine owned the self-perpetuating producer/recovery chain. PR #3063 (`f7aaf955`) made non-owning deliveries terminal, established recovery only for claimed work, and added durable pathless batch requeueing. PR #3065 (`0647debc`) preserved exact argument decoding and recovery semantics.
- Data Machine PR #3075 (`fed93ed1`) restored native retention as a bounded backstop for completed/canceled history.

This Events PR does not build another scheduler, change fan-out, alter Action Scheduler schema, or perform hook-wide deletion. It fills only the Events incident-recovery gap left after those upstream fixes: operator-reviewed classification and removal of the already-created pending chunk backlog.

## Exact Selection And Safety Model

Each invocation reads at most 1,000 physical Action Scheduler rows through `action_id > cursor ORDER BY action_id LIMIT n`, avoiding a hook/status scan on the bloated table. Only exact `datamachine_pipeline_batch_chunk` rows that are still `pending` and `claim_id = 0` are considered.

A row is eligible only when durable owner evidence proves one of these cases:

- the exact parent no longer exists
- the parent is terminal
- the durable worklist is complete
- the action's entire chunk range ends at or before the first outstanding worklist index

Active/future paths, partially outstanding chunks, non-processing parents, malformed arguments, claimed actions, and failed/ambiguous reads are preserved. All parent and worklist reads complete and fail closed before any mutation starts. Apply repeats the exact action ID/hook/status/claim/args predicate so a claim or row change racing the review becomes a no-op.

Pathless active-parent reconciliation remains in Data Machine's `jobs recover-stuck` owner surface rather than being wrapped here. While auditing it, this work found its active-action lookup is not bounded on incident-scale tables; that owner-layer follow-up is tracked in Extra-Chill/data-machine#3077.

## Dry Run And Apply

`wp data-machine-events recover-batch-actions` is a dry run by default. It returns exact action IDs, classifications, `next_cursor`, and `review_through`.

Apply requires both `--apply` and the dry run's `--review-through=<action-id>`. The upper bound prevents later rows from entering the reviewed window if earlier rows disappear between review and apply. `--mutation-limit` defaults to 25 and is hard-capped at 100; resumptions preserve both cursor and review boundary.

## Tests

- `composer test:contracts` - 4 tests, 58 assertions passed
- PHP syntax checks for all changed PHP files
- `git diff --check`
- focused selection/argument checks passed in the WordPress runtime
- added `BatchActionRecoveryAbilitiesTest` for terminal/missing/complete/superseded/partial/active/ambiguous selection and malformed identifier handling

The unmanaged local `phpunit.xml` invocation cannot bootstrap the existing `WP_UnitTestCase` suite; managed CI owns that WordPress bootstrap per `homeboy.json`.

## Production Safety

No production cleanup command, apply flag, DDL, database mutation, release, deployment, or plugin/theme edit was performed during investigation, implementation, or verification.