### PR TITLE
fix: bound duplicate candidate date queries

### DIFF
--- a/inc/Abilities/EventDateQueryAbilities.php
+++ b/inc/Abilities/EventDateQueryAbilities.php
@@ -554,9 +554,9 @@ class EventDateQueryAbilities {
 			// Exact date match takes priority (dedup queries). Use a half-open
 			// datetime range so MySQL can use the start_datetime index.
 			if ( ! empty( $date_match ) ) {
-				$start                 = $date_match . ' 00:00:00';
-				$end                   = gmdate( 'Y-m-d H:i:s', strtotime( $start . ' +1 day' ) );
-				$clauses['where']     .= $wpdb->prepare( ' AND ed.start_datetime >= %s AND ed.start_datetime < %s', $start, $end );
+				$start             = $date_match . ' 00:00:00';
+				$end               = gmdate( 'Y-m-d H:i:s', strtotime( $start . ' +1 day' ) );
+				$clauses['where'] .= $wpdb->prepare( ' AND ed.start_datetime >= %s AND ed.start_datetime < %s', $start, $end );
 			} elseif ( ! empty( $date_start ) || ! empty( $date_end ) ) {
 				// Explicit date range — delegates to UpcomingFilter.
 				if ( ! empty( $date_start ) ) {

--- a/inc/Abilities/EventDateQueryAbilities.php
+++ b/inc/Abilities/EventDateQueryAbilities.php
@@ -18,6 +18,7 @@ namespace DataMachineEvents\Abilities;
 use WP_Query;
 use DataMachineEvents\Core\Event_Post_Type;
 use DataMachineEvents\Core\EventDatesTable;
+use DataMachineEvents\Core\DateTimeParser;
 use DataMachineEvents\Blocks\Calendar\Query\ScopeResolver;
 use DataMachineEvents\Blocks\Calendar\Query\UpcomingFilter;
 
@@ -136,6 +137,11 @@ class EventDateQueryAbilities {
 								'minimum'     => 1,
 								'maximum'     => self::MAX_PUBLIC_RESULTS,
 								'description' => 'Events per page. Default: 50. Maximum: 100.',
+							),
+							'page'        => array(
+								'type'        => 'integer',
+								'minimum'     => 1,
+								'description' => 'Results page. Default: 1.',
 							),
 							'fields'      => array(
 								'type'        => 'string',
@@ -269,12 +275,21 @@ class EventDateQueryAbilities {
 		$geo         = is_array( $input['geo'] ?? null ) ? $input['geo'] : array();
 		$exclude     = is_array( $input['exclude'] ?? null ) ? array_map( 'absint', $input['exclude'] ) : array();
 		$per_page    = (int) ( $input['per_page'] ?? -1 );
+		$page        = max( 1, (int) ( $input['page'] ?? 1 ) );
 		$fields      = $input['fields'] ?? 'all';
 		$order       = ! empty( $input[ self::CAPTURE_IDS_QUERY_VAR ] )
 			? ''
 			: ( strtoupper( $input['order'] ?? 'ASC' ) === 'DESC' ? 'DESC' : 'ASC' );
 		$status      = $input['status'] ?? 'publish';
 		$meta_query  = is_array( $input['meta_query'] ?? null ) ? $input['meta_query'] : array();
+
+		if ( '' !== $date_match && ! DateTimeParser::isValidYmd( $date_match ) ) {
+			return array(
+				'posts'      => array(),
+				'total'      => 0,
+				'post_count' => 0,
+			);
+		}
 
 		// #428: resolve a named time scope (today/tonight/this-weekend/
 		// this-week) to concrete date/time boundaries via ScopeResolver —
@@ -303,6 +318,7 @@ class EventDateQueryAbilities {
 			'post_type'      => Event_Post_Type::POST_TYPE,
 			'post_status'    => $status,
 			'posts_per_page' => $per_page,
+			'paged'          => $page,
 			'no_found_rows'  => true, // Avoid deprecated SQL_CALC_FOUND_ROWS; use separate count.
 			'orderby'        => 'none', // Ordering via posts_clauses.
 		);
@@ -535,9 +551,12 @@ class EventDateQueryAbilities {
 
 			$now = current_time( 'mysql' );
 
-			// Exact date match takes priority (dedup queries).
+			// Exact date match takes priority (dedup queries). Use a half-open
+			// datetime range so MySQL can use the start_datetime index.
 			if ( ! empty( $date_match ) ) {
-				$clauses['where'] .= $wpdb->prepare( ' AND DATE(ed.start_datetime) = %s', $date_match );
+				$start                 = $date_match . ' 00:00:00';
+				$end                   = gmdate( 'Y-m-d H:i:s', strtotime( $start . ' +1 day' ) );
+				$clauses['where']     .= $wpdb->prepare( ' AND ed.start_datetime >= %s AND ed.start_datetime < %s', $start, $end );
 			} elseif ( ! empty( $date_start ) || ! empty( $date_end ) ) {
 				// Explicit date range — delegates to UpcomingFilter.
 				if ( ! empty( $date_start ) ) {
@@ -569,9 +588,10 @@ class EventDateQueryAbilities {
 			}
 			// 'all' scope — no date WHERE clause.
 
-			// ORDER BY — always by start_datetime unless date_match (dedup doesn't need ordering).
-			if ( empty( $date_match ) && '' !== $order ) {
-				$clauses['orderby'] = "ed.start_datetime {$order}";
+			// Post ID breaks datetime ties so bounded pages never overlap or skip
+			// candidates because MySQL chose a different equal-value row order.
+			if ( '' !== $order ) {
+				$clauses['orderby'] = "ed.start_datetime {$order}, {$wpdb->posts}.ID {$order}";
 			}
 
 			return $clauses;

--- a/inc/Core/DuplicateDetection/EventDuplicateStrategy.php
+++ b/inc/Core/DuplicateDetection/EventDuplicateStrategy.php
@@ -370,31 +370,31 @@ class EventDuplicateStrategy {
 				// When both sides have venue data, require venue match to avoid
 				// false positives on generic titles at different venues.
 				if ( ! empty( $venue ) || $venue_term ) {
-				// Term-id-aware short-circuit: when the incoming venue resolved
-				// to a term, accept the match if the candidate is tagged with
-				// that same term — regardless of how the venue is spelled in
-				// either post's content.
-				if ( $venue_term ) {
-					$candidate_term_ids = wp_get_post_terms( $post_id, 'venue', array( 'fields' => 'ids' ) );
-					if ( ! is_wp_error( $candidate_term_ids ) && ! empty( $candidate_term_ids )
-						&& in_array( (int) $venue_term->term_id, array_map( 'intval', $candidate_term_ids ), true ) ) {
-						return self::duplicateResult( $post_id, 'date_fuzzy_title_venue_term_id_match' );
+					// Term-id-aware short-circuit: when the incoming venue resolved
+					// to a term, accept the match if the candidate is tagged with
+					// that same term — regardless of how the venue is spelled in
+					// either post's content.
+					if ( $venue_term ) {
+						$candidate_term_ids = wp_get_post_terms( $post_id, 'venue', array( 'fields' => 'ids' ) );
+						if ( ! is_wp_error( $candidate_term_ids ) && ! empty( $candidate_term_ids )
+							&& in_array( (int) $venue_term->term_id, array_map( 'intval', $candidate_term_ids ), true ) ) {
+							return self::duplicateResult( $post_id, 'date_fuzzy_title_venue_term_id_match' );
+						}
 					}
-				}
 
-				if ( '' !== $venue ) {
-					$candidate_venues = wp_get_post_terms( $post_id, 'venue', array( 'fields' => 'names' ) );
-					$candidate_venue  = ( ! is_wp_error( $candidate_venues ) && ! empty( $candidate_venues ) ) ? $candidate_venues[0] : '';
+					if ( '' !== $venue ) {
+						$candidate_venues = wp_get_post_terms( $post_id, 'venue', array( 'fields' => 'names' ) );
+						$candidate_venue  = ( ! is_wp_error( $candidate_venues ) && ! empty( $candidate_venues ) ) ? $candidate_venues[0] : '';
 
-					if ( ! empty( $candidate_venue ) && ! EventIdentifierGenerator::venuesMatch( $venue, $candidate_venue ) ) {
+						if ( ! empty( $candidate_venue ) && ! EventIdentifierGenerator::venuesMatch( $venue, $candidate_venue ) ) {
+							continue;
+						}
+					} elseif ( $venue_term ) {
+						// Incoming side has a resolved term but the candidate
+						// doesn't share it; skip to avoid cross-venue false
+						// positives on generic titles.
 						continue;
 					}
-				} elseif ( $venue_term ) {
-					// Incoming side has a resolved term but the candidate
-					// doesn't share it; skip to avoid cross-venue false
-					// positives on generic titles.
-					continue;
-				}
 				}
 
 				return self::duplicateResult( $post_id, 'date_fuzzy_title' );

--- a/inc/Core/DuplicateDetection/EventDuplicateStrategy.php
+++ b/inc/Core/DuplicateDetection/EventDuplicateStrategy.php
@@ -38,6 +38,7 @@ use function DataMachineEvents\Core\datamachine_extract_ticket_identity;
 defined( 'ABSPATH' ) || exit;
 
 class EventDuplicateStrategy {
+	private const CANDIDATE_PAGE_SIZE = 100;
 
 	/**
 	 * Register this strategy with DM core's duplicate detection system.
@@ -159,21 +160,22 @@ class EventDuplicateStrategy {
 			return null;
 		}
 
-		$candidates         = self::findCandidatesByDate( $date_only, 100 );
 		$canonical_identity = datamachine_extract_ticket_identity( $ticketUrl );
-		foreach ( $candidates as $candidate ) {
-			$post_id              = (int) $candidate->ID;
-			$candidate_ticket_url = (string) get_post_meta( $post_id, EVENT_TICKET_URL_META_KEY, true );
-			if ( '' === $candidate_ticket_url ) {
-				continue;
-			}
+		foreach ( self::candidatePagesByDate( $date_only ) as $candidates ) {
+			foreach ( $candidates as $candidate ) {
+				$post_id              = (int) $candidate->ID;
+				$candidate_ticket_url = (string) get_post_meta( $post_id, EVENT_TICKET_URL_META_KEY, true );
+				if ( '' === $candidate_ticket_url ) {
+					continue;
+				}
 
-			if ( datamachine_normalize_ticket_url( $candidate_ticket_url ) === $normalized_url ) {
-				return self::duplicateResult( $post_id, 'ticket_url_exact' );
-			}
+				if ( datamachine_normalize_ticket_url( $candidate_ticket_url ) === $normalized_url ) {
+					return self::duplicateResult( $post_id, 'ticket_url_exact' );
+				}
 
-			if ( '' !== $canonical_identity && datamachine_extract_ticket_identity( $candidate_ticket_url ) === $canonical_identity ) {
-				return self::duplicateResult( $post_id, 'ticket_url_canonical' );
+				if ( '' !== $canonical_identity && datamachine_extract_ticket_identity( $candidate_ticket_url ) === $canonical_identity ) {
+					return self::duplicateResult( $post_id, 'ticket_url_canonical' );
+				}
 			}
 		}
 
@@ -212,25 +214,25 @@ class EventDuplicateStrategy {
 			return null;
 		}
 
-		$candidates = self::findCandidatesByDate( $date_only, 10, (int) $venue_term->term_id );
+		foreach ( self::candidatePagesByDate( $date_only, (int) $venue_term->term_id ) as $candidates ) {
+			foreach ( $candidates as $candidate ) {
+				$post_id = (int) $candidate->ID;
+				if ( ! self::isValidPost( $post_id ) ) {
+					continue;
+				}
+				if ( ! EventIdentifierGenerator::titlesMatch( $title, $candidate->post_title ) ) {
+					continue;
+				}
 
-		foreach ( $candidates as $candidate ) {
-			$post_id = (int) $candidate->ID;
-			if ( ! self::isValidPost( $post_id ) ) {
-				continue;
-			}
-			if ( ! EventIdentifierGenerator::titlesMatch( $title, $candidate->post_title ) ) {
-				continue;
-			}
+				// Check time window.
+				$candidate_dates   = \DataMachineEvents\Core\EventDatesTable::get( $post_id );
+				$existing_datetime = $candidate_dates ? $candidate_dates->start_datetime : '';
+				if ( ! self::isWithinTimeWindow( $startDate, $existing_datetime ) ) {
+					continue;
+				}
 
-			// Check time window.
-			$candidate_dates   = \DataMachineEvents\Core\EventDatesTable::get( $post_id );
-			$existing_datetime = $candidate_dates ? $candidate_dates->start_datetime : '';
-			if ( ! self::isWithinTimeWindow( $startDate, $existing_datetime ) ) {
-				continue;
+				return self::duplicateResult( $post_id, 'venue_date_fuzzy_title' );
 			}
-
-			return self::duplicateResult( $post_id, 'venue_date_fuzzy_title' );
 		}
 
 		return null;
@@ -271,48 +273,49 @@ class EventDuplicateStrategy {
 		}
 
 		$title_hash = self::computeTitleHash( $title );
-		$candidates = array_filter(
-			self::findCandidatesByDate( $date_only, -1 ),
-			static fn( \WP_Post $candidate ): bool => self::computeTitleHash( $candidate->post_title ) === $title_hash
-		);
-		foreach ( $candidates as $candidate ) {
-			$post_id = (int) $candidate->ID;
-			if ( ! self::isValidPost( $post_id ) ) {
-				continue;
-			}
-
-			$candidate_dates   = \DataMachineEvents\Core\EventDatesTable::get( $post_id );
-			$existing_datetime = $candidate_dates ? $candidate_dates->start_datetime : '';
-			if ( ! self::isWithinTimeWindow( $startDate, $existing_datetime ) ) {
-				continue;
-			}
-
-			if ( empty( $venue ) && ! $venue_term ) {
-				if ( 'low' !== $identity_confidence ) {
-					return self::duplicateResult( $post_id, 'exact_title_no_venue' );
+		foreach ( self::candidatePagesByDate( $date_only ) as $candidates ) {
+			foreach ( $candidates as $candidate ) {
+				if ( self::computeTitleHash( $candidate->post_title ) !== $title_hash ) {
+					continue;
 				}
-				continue;
-			}
-
-			if ( $venue_term ) {
-				$candidate_term_ids = wp_get_post_terms( $post_id, 'venue', array( 'fields' => 'ids' ) );
-				if ( ! is_wp_error( $candidate_term_ids ) && ! empty( $candidate_term_ids )
-					&& in_array( (int) $venue_term->term_id, array_map( 'intval', $candidate_term_ids ), true ) ) {
-					return self::duplicateResult( $post_id, 'exact_title_venue_term_id_match' );
+				$post_id = (int) $candidate->ID;
+				if ( ! self::isValidPost( $post_id ) ) {
+					continue;
 				}
-			}
 
-			$venue_terms = wp_get_post_terms( $post_id, 'venue', array( 'fields' => 'names' ) );
-			if ( empty( $venue_terms ) || is_wp_error( $venue_terms ) ) {
-				if ( 'low' !== $identity_confidence ) {
-					return self::duplicateResult( $post_id, 'exact_title_no_existing_venue' );
+				$candidate_dates   = \DataMachineEvents\Core\EventDatesTable::get( $post_id );
+				$existing_datetime = $candidate_dates ? $candidate_dates->start_datetime : '';
+				if ( ! self::isWithinTimeWindow( $startDate, $existing_datetime ) ) {
+					continue;
 				}
-				continue;
-			}
 
-			foreach ( $venue_terms as $existing_venue ) {
-				if ( $venue === $existing_venue || EventIdentifierGenerator::venuesMatch( $venue, $existing_venue ) ) {
-					return self::duplicateResult( $post_id, 'exact_title_venue_confirmed' );
+				if ( empty( $venue ) && ! $venue_term ) {
+					if ( 'low' !== $identity_confidence ) {
+						return self::duplicateResult( $post_id, 'exact_title_no_venue' );
+					}
+					continue;
+				}
+
+				if ( $venue_term ) {
+					$candidate_term_ids = wp_get_post_terms( $post_id, 'venue', array( 'fields' => 'ids' ) );
+					if ( ! is_wp_error( $candidate_term_ids ) && ! empty( $candidate_term_ids )
+						&& in_array( (int) $venue_term->term_id, array_map( 'intval', $candidate_term_ids ), true ) ) {
+						return self::duplicateResult( $post_id, 'exact_title_venue_term_id_match' );
+					}
+				}
+
+				$venue_terms = wp_get_post_terms( $post_id, 'venue', array( 'fields' => 'names' ) );
+				if ( empty( $venue_terms ) || is_wp_error( $venue_terms ) ) {
+					if ( 'low' !== $identity_confidence ) {
+						return self::duplicateResult( $post_id, 'exact_title_no_existing_venue' );
+					}
+					continue;
+				}
+
+				foreach ( $venue_terms as $existing_venue ) {
+					if ( $venue === $existing_venue || EventIdentifierGenerator::venuesMatch( $venue, $existing_venue ) ) {
+						return self::duplicateResult( $post_id, 'exact_title_venue_confirmed' );
+					}
 				}
 			}
 		}
@@ -348,26 +351,25 @@ class EventDuplicateStrategy {
 			return null;
 		}
 
-		$candidates = self::findCandidatesByDate( $date_only, 20 );
+		foreach ( self::candidatePagesByDate( $date_only ) as $candidates ) {
+			foreach ( $candidates as $candidate ) {
+				$post_id = (int) $candidate->ID;
+				if ( ! self::isValidPost( $post_id ) ) {
+					continue;
+				}
+				if ( ! EventIdentifierGenerator::titlesMatch( $title, $candidate->post_title ) ) {
+					continue;
+				}
 
-		foreach ( $candidates as $candidate ) {
-			$post_id = (int) $candidate->ID;
-			if ( ! self::isValidPost( $post_id ) ) {
-				continue;
-			}
-			if ( ! EventIdentifierGenerator::titlesMatch( $title, $candidate->post_title ) ) {
-				continue;
-			}
+				$candidate_dates   = \DataMachineEvents\Core\EventDatesTable::get( $post_id );
+				$existing_datetime = $candidate_dates ? $candidate_dates->start_datetime : '';
+				if ( ! self::isWithinTimeWindow( $startDate, $existing_datetime ) ) {
+					continue;
+				}
 
-			$candidate_dates   = \DataMachineEvents\Core\EventDatesTable::get( $post_id );
-			$existing_datetime = $candidate_dates ? $candidate_dates->start_datetime : '';
-			if ( ! self::isWithinTimeWindow( $startDate, $existing_datetime ) ) {
-				continue;
-			}
-
-			// When both sides have venue data, require venue match to avoid
-			// false positives on generic titles at different venues.
-			if ( ! empty( $venue ) || $venue_term ) {
+				// When both sides have venue data, require venue match to avoid
+				// false positives on generic titles at different venues.
+				if ( ! empty( $venue ) || $venue_term ) {
 				// Term-id-aware short-circuit: when the incoming venue resolved
 				// to a term, accept the match if the candidate is tagged with
 				// that same term — regardless of how the venue is spelled in
@@ -393,9 +395,10 @@ class EventDuplicateStrategy {
 					// positives on generic titles.
 					continue;
 				}
-			}
+				}
 
-			return self::duplicateResult( $post_id, 'date_fuzzy_title' );
+				return self::duplicateResult( $post_id, 'date_fuzzy_title' );
+			}
 		}
 
 		return null;
@@ -434,30 +437,40 @@ class EventDuplicateStrategy {
 	/**
 	 * Find event candidates through the event-owned date query contract.
 	 *
-	 * @param string   $date_only    Date in YYYY-MM-DD format.
-	 * @param int      $limit        Maximum candidates, or -1 for all.
+	 * Each query is hard-bounded while the generator continues through every
+	 * deterministic page, preserving duplicate detection for crowded dates.
+	 *
+	 * @param string   $date_only     Date in YYYY-MM-DD format.
 	 * @param int|null $venue_term_id Optional venue term constraint.
-	 * @return \WP_Post[]
+	 * @return \Generator<int, \WP_Post[]>
 	 */
-	private static function findCandidatesByDate( string $date_only, int $limit, ?int $venue_term_id = null ): array {
-		$input = array(
-			'date_match' => $date_only,
-			'per_page'   => $limit,
-			'scope'      => 'all',
-			'status'     => array( 'publish', 'future', 'draft', 'pending', 'private' ),
-		);
-		if ( null !== $venue_term_id ) {
-			$input['tax_filters'] = array( 'venue' => array( $venue_term_id ) );
-		}
+	private static function candidatePagesByDate( string $date_only, ?int $venue_term_id = null ): \Generator {
+		$page = 1;
+		do {
+			$input = array(
+				'date_match' => $date_only,
+				'per_page'   => self::CANDIDATE_PAGE_SIZE,
+				'page'       => $page,
+				'order'      => 'ASC',
+				'scope'      => 'all',
+				'status'     => array( 'publish', 'future', 'draft', 'pending', 'private' ),
+			);
+			if ( null !== $venue_term_id ) {
+				$input['tax_filters'] = array( 'venue' => array( $venue_term_id ) );
+			}
 
-		$result = ( new EventDateQueryAbilities() )->executeQueryEvents( $input );
-
-		return array_values(
-			array_filter(
-				$result['posts'] ?? array(),
-				static fn( $post ): bool => $post instanceof \WP_Post && self::isValidPost( (int) $post->ID )
-			)
-		);
+			$result     = ( new EventDateQueryAbilities() )->executeQueryEvents( $input );
+			$candidates = array_values(
+				array_filter(
+					$result['posts'] ?? array(),
+					static fn( $post ): bool => $post instanceof \WP_Post && self::isValidPost( (int) $post->ID )
+				)
+			);
+			if ( ! empty( $candidates ) ) {
+				yield $candidates;
+			}
+			++$page;
+		} while ( (int) ( $result['post_count'] ?? 0 ) === self::CANDIDATE_PAGE_SIZE );
 	}
 
 	/**

--- a/tests/Unit/EventDateQueryAbilitiesTest.php
+++ b/tests/Unit/EventDateQueryAbilitiesTest.php
@@ -217,6 +217,43 @@ class EventDateQueryAbilitiesTest extends WP_UnitTestCase {
 		}
 	}
 
+	public function test_exact_date_pages_are_indexable_bounded_and_deterministic(): void {
+		$date     = '2026-05-24';
+		$post_ids = array();
+		for ( $index = 0; $index < 3; ++$index ) {
+			$post_ids[] = $this->seed_event( 'Paged event ' . $index, 'publish', $date . ' 20:00:00' );
+		}
+
+		$queries  = array();
+		$observer = static function ( string $sql ) use ( &$queries ): string {
+			if ( false !== strpos( $sql, EventDatesTable::table_name() ) ) {
+				$queries[] = $sql;
+			}
+			return $sql;
+		};
+		add_filter( 'query', $observer );
+		try {
+			$result = ( new EventDateQueryAbilities() )->executeQueryEvents(
+				array(
+					'date_match' => $date,
+					'per_page'   => 2,
+					'page'       => 2,
+					'fields'     => 'ids',
+				)
+			);
+		} finally {
+			remove_filter( 'query', $observer );
+		}
+
+		$this->assertSame( array( $post_ids[2] ), array_map( 'intval', $result['posts'] ) );
+		$this->assertCount( 1, $queries );
+		$this->assertMatchesRegularExpression( '/LIMIT\s+2\s*,\s*2\b/i', $queries[0] );
+		$this->assertStringContainsString( 'start_datetime >=', $queries[0] );
+		$this->assertStringContainsString( 'start_datetime <', $queries[0] );
+		$this->assertStringNotContainsString( 'DATE(', $queries[0] );
+		$this->assertMatchesRegularExpression( '/ORDER BY\s+ed\.start_datetime ASC,\s*[^\s]+\.ID ASC/i', $queries[0] );
+	}
+
 	public function test_matching_ids_sql_preserves_consumer_constraints_without_querying(): void {
 		wp_load_alloptions();
 		$filter = static function ( array $query_args, array $input ): array {

--- a/tests/Unit/EventDuplicateStrategyTest.php
+++ b/tests/Unit/EventDuplicateStrategyTest.php
@@ -418,6 +418,71 @@ class EventDuplicateStrategyTest extends WP_UnitTestCase {
 		wp_delete_term( $term_id, 'venue' );
 	}
 
+	public function test_large_same_date_corpus_uses_bounded_pages_and_finds_later_exact_match(): void {
+		$date     = '2026-05-24';
+		$post_ids = array();
+		for ( $index = 0; $index < 105; ++$index ) {
+			$post_id = wp_insert_post(
+				array(
+					'post_title'  => 'Unrelated Same Day Event ' . $index,
+					'post_type'   => Event_Post_Type::POST_TYPE,
+					'post_status' => 'publish',
+				)
+			);
+			$this->assertGreaterThan( 0, $post_id );
+			EventDatesTable::upsert( $post_id, $date . ' 12:00:00' );
+			$post_ids[] = $post_id;
+		}
+
+		$match_id = wp_insert_post(
+			array(
+				'post_title'  => 'Needle Beyond First Page',
+				'post_type'   => Event_Post_Type::POST_TYPE,
+				'post_status' => 'publish',
+			)
+		);
+		EventDatesTable::upsert( $match_id, $date . ' 20:00:00' );
+		$post_ids[] = $match_id;
+
+		$queries  = array();
+		$observer = static function ( string $sql ) use ( &$queries ): string {
+			if ( false !== strpos( $sql, EventDatesTable::table_name() ) && false !== strpos( $sql, 'LIMIT' ) ) {
+				$queries[] = $sql;
+			}
+			return $sql;
+		};
+		add_filter( 'query', $observer );
+		try {
+			$result = EventDuplicateStrategy::check(
+				array(
+					'title'   => 'Needle Beyond First Page',
+					'context' => array(
+						'startDate' => $date . ' 20:30:00',
+					),
+				)
+			);
+		} finally {
+			remove_filter( 'query', $observer );
+		}
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $match_id, $result['match']['post_id'] );
+		$this->assertGreaterThanOrEqual( 2, count( $queries ), 'The match must be retrieved from a later bounded page.' );
+		foreach ( $queries as $query ) {
+			$this->assertMatchesRegularExpression( '/LIMIT\s+(?:\d+\s*,\s*)?100\b/i', $query );
+			$this->assertStringContainsString( 'start_datetime >=', $query );
+			$this->assertStringContainsString( 'start_datetime <', $query );
+			$this->assertStringNotContainsString( 'DATE(', $query );
+			$this->assertMatchesRegularExpression( '/ORDER BY\s+ed\.start_datetime ASC,\s*[^\s]+\.ID ASC/i', $query );
+		}
+
+		global $wpdb;
+		foreach ( $post_ids as $post_id ) {
+			$wpdb->delete( EventDatesTable::table_name(), array( 'post_id' => $post_id ), array( '%d' ) );
+			wp_delete_post( $post_id, true );
+		}
+	}
+
 	// ---------------------------------------------------------------------
 	// check() — date-aware end-to-end cascade tests (#423)
 	// ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- replace duplicate detection's unbounded same-date hydration with deterministic 100-row candidate pages
- make exact-date predicates use the existing indexed `start_datetime` column through a half-open range, with stable datetime/post-ID ordering
- preserve duplicate semantics by scanning subsequent pages until a match or exhaustion, while retaining existing venue taxonomy narrowing
- add large same-date regression coverage proving every query is bounded and a match beyond the first page remains discoverable

## Root cause
`EventDuplicateStrategy::findByExactTitle()` called `findCandidatesByDate()` with `per_page = -1`, causing `EventDateQueryAbilities` to hydrate every event on a busy date for each queued item. Exact-date SQL also wrapped `start_datetime` in `DATE(...)` and omitted deterministic ordering, preventing the existing date index from serving a stable staged scan.

The repository also has Data Machine's identity index with date/title and ticket/date composites. Its current exact methods return one row, which cannot preserve the established early/late-show behavior when several same-title events share a date. This fix therefore uses the Events-owned indexed date table plus existing WordPress taxonomy predicates and bounded deterministic pages rather than adding infrastructure or silently truncating candidates.

## Verification
- PHP syntax checks passed for all four changed files
- WordPress PHPCS passed for all changed files
- contract PHPUnit passed via `phpunit.contracts.xml`
- Composer audit reported no vulnerability advisories
- `git diff --check` passed
- managed CI `review audit` passed
- managed CI `review lint` passed
- managed WordPress suite ran 768 tests, including both added regressions; it retained the same five pre-existing failures as `origin/main`'s 766-test run, with no new failures introduced

The unchanged baseline failures are in the pre-AI gate, legacy source identity transition, taxonomy website assignment, and two Abilities API incorrect-usage assertions. `origin/main` run 31439480725 and this PR run 31598459212 report the identical five-test failure set.

Closes #680.

Implemented with OpenCode assistance.