### PR TITLE
Fix Squarespace calendar block event discovery

### DIFF
--- a/inc/Steps/EventImport/Handlers/WebScraper/Extractors/SquarespaceExtractor.php
+++ b/inc/Steps/EventImport/Handlers/WebScraper/Extractors/SquarespaceExtractor.php
@@ -160,7 +160,7 @@ class SquarespaceExtractor extends BaseExtractor {
 	}
 
 	/**
-	 * Fetch the current month's events for native Squarespace Calendar blocks.
+	 * Fetch upcoming events for native Squarespace Calendar blocks.
 	 *
 	 * Calendar blocks contain only a collection ID in static HTML. The browser
 	 * renderer resolves that ID through Squarespace's public monthly endpoint.
@@ -175,17 +175,35 @@ class SquarespaceExtractor extends BaseExtractor {
 		}
 
 		$parsed   = wp_parse_url( $source_url );
-		$base_url = ( $parsed['scheme'] ?? 'https' ) . '://' . ( $parsed['host'] ?? '' );
+		$port     = isset( $parsed['port'] ) ? ':' . $parsed['port'] : '';
+		$base_url = ( $parsed['scheme'] ?? 'https' ) . '://' . ( $parsed['host'] ?? '' ) . $port;
 		$context  = $this->extractContextData( $html );
 		$timezone = $context['website']['timeZone'] ?? 'UTC';
+		$horizon  = $this->getRecurrenceHorizonDays(
+			array(
+				'source_url' => $source_url,
+				'method'     => $this->getMethod(),
+			)
+		);
 
 		try {
-			$month = ( new \DateTimeImmutable( 'now', new \DateTimeZone( $timezone ) ) )->format( 'm-Y' );
+			$calendar_timezone = new \DateTimeZone( $timezone );
 		} catch ( \Exception $e ) {
-			$month = gmdate( 'm-Y' );
+			$calendar_timezone = new \DateTimeZone( 'UTC' );
 		}
 
-		$seen_ids = array();
+		$now          = $this->getCalendarNow( $calendar_timezone );
+		$cutoff       = $now->modify( '+' . $horizon . ' days' );
+		$month_cursor = $now->modify( 'first day of this month' )->setTime( 0, 0 );
+		$months       = array();
+		while ( $month_cursor <= $cutoff ) {
+			$months[]     = $month_cursor->format( 'm-Y' );
+			$month_cursor = $month_cursor->modify( 'first day of next month' );
+		}
+
+		$seen_ids        = array();
+		$seen_event_keys = array();
+		$events          = array();
 		foreach ( $matches[0] as $tag ) {
 			if ( ! preg_match( '/data-block-json=["\']([^"\']+)["\']/i', $tag, $block_match ) ) {
 				continue;
@@ -202,37 +220,81 @@ class SquarespaceExtractor extends BaseExtractor {
 			}
 			$seen_ids[ $collection_id ] = true;
 
-			$url      = add_query_arg(
-				array(
-					'month'        => $month,
-					'collectionId' => $collection_id,
-				),
-				$base_url . '/api/open/GetItemsByMonth'
-			);
-			$response = \DataMachine\Core\HttpClient::get(
-				$url,
-				array(
-					'timeout' => 15,
-					'context' => 'Squarespace Extractor Calendar Block',
-				)
-			);
+			foreach ( $months as $month ) {
+				$url      = add_query_arg(
+					array(
+						'month'        => $month,
+						'collectionId' => $collection_id,
+					),
+					$base_url . '/api/open/GetItemsByMonth'
+				);
+				$response = \DataMachine\Core\HttpClient::get(
+					$url,
+					array(
+						'timeout' => 15,
+						'context' => 'Squarespace Extractor Calendar Block',
+					)
+				);
 
-			if ( empty( $response['success'] ) || empty( $response['data'] ) ) {
-				continue;
-			}
+				if ( empty( $response['success'] ) || empty( $response['data'] ) ) {
+					continue;
+				}
 
-			$items = json_decode( $response['data'], true );
-			if ( ! is_array( $items ) || JSON_ERROR_NONE !== json_last_error() ) {
-				continue;
-			}
+				$items = json_decode( $response['data'], true );
+				if ( ! is_array( $items ) || JSON_ERROR_NONE !== json_last_error() ) {
+					continue;
+				}
 
-			$items = $this->filterEventItems( $items );
-			if ( ! empty( $items ) ) {
-				return $items;
+				foreach ( $this->filterEventItems( $items ) as $item ) {
+					$start = $item['startDate'] ?? $item['structuredContent']['startDate'] ?? null;
+					if ( is_numeric( $start ) ) {
+						$timestamp = (int) $start;
+						if ( $timestamp > 1000000000000 ) {
+							$timestamp = (int) ( $timestamp / 1000 );
+						}
+						if ( $timestamp > $cutoff->getTimestamp() ) {
+							continue;
+						}
+					}
+
+					$event_keys = array(
+						'event:' . md5( (string) wp_json_encode( array( $item['title'] ?? '', $start, $item['endDate'] ?? '' ) ) ),
+					);
+					if ( ! empty( $item['id'] ) ) {
+						$event_keys[] = 'id:' . $item['id'];
+					}
+					if ( ! empty( $item['fullUrl'] ) ) {
+						$event_keys[] = 'url:' . $item['fullUrl'];
+					}
+
+					if ( array_intersect_key( $seen_event_keys, array_fill_keys( $event_keys, true ) ) ) {
+						continue;
+					}
+					foreach ( $event_keys as $event_key ) {
+						$seen_event_keys[ $event_key ] = true;
+					}
+					$events[] = $item;
+				}
 			}
 		}
 
-		return array();
+		return array_slice(
+			$events,
+			0,
+			$this->getMaxScrapeEvents(
+				array(
+					'source_url' => $source_url,
+					'method'     => $this->getMethod(),
+				)
+			)
+		);
+	}
+
+	/**
+	 * Current instant in the calendar's timezone.
+	 */
+	protected function getCalendarNow( \DateTimeZone $timezone ): \DateTimeImmutable {
+		return new \DateTimeImmutable( 'now', $timezone );
 	}
 
 	/**

--- a/inc/Steps/EventImport/Handlers/WebScraper/Extractors/SquarespaceExtractor.php
+++ b/inc/Steps/EventImport/Handlers/WebScraper/Extractors/SquarespaceExtractor.php
@@ -15,6 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class SquarespaceExtractor extends BaseExtractor {
+	private const MAX_CALENDAR_COLLECTIONS = 10;
 
 	public function canExtract( string $html ): bool {
 		return strpos( $html, 'Static.SQUARESPACE_CONTEXT' ) !== false;
@@ -174,12 +175,18 @@ class SquarespaceExtractor extends BaseExtractor {
 			return array();
 		}
 
-		$parsed   = wp_parse_url( $source_url );
-		$port     = isset( $parsed['port'] ) ? ':' . $parsed['port'] : '';
-		$base_url = ( $parsed['scheme'] ?? 'https' ) . '://' . ( $parsed['host'] ?? '' ) . $port;
-		$context  = $this->extractContextData( $html );
-		$timezone = $context['website']['timeZone'] ?? 'UTC';
-		$horizon  = $this->getRecurrenceHorizonDays(
+		$parsed     = wp_parse_url( $source_url );
+		$port       = isset( $parsed['port'] ) ? ':' . $parsed['port'] : '';
+		$base_url   = ( $parsed['scheme'] ?? 'https' ) . '://' . ( $parsed['host'] ?? '' ) . $port;
+		$context    = $this->extractContextData( $html );
+		$timezone   = $context['website']['timeZone'] ?? 'UTC';
+		$horizon    = $this->getRecurrenceHorizonDays(
+			array(
+				'source_url' => $source_url,
+				'method'     => $this->getMethod(),
+			)
+		);
+		$max_events = $this->getMaxScrapeEvents(
 			array(
 				'source_url' => $source_url,
 				'method'     => $this->getMethod(),
@@ -218,6 +225,9 @@ class SquarespaceExtractor extends BaseExtractor {
 			if ( isset( $seen_ids[ $collection_id ] ) ) {
 				continue;
 			}
+			if ( count( $seen_ids ) >= self::MAX_CALENDAR_COLLECTIONS ) {
+				break;
+			}
 			$seen_ids[ $collection_id ] = true;
 
 			foreach ( $months as $month ) {
@@ -246,15 +256,10 @@ class SquarespaceExtractor extends BaseExtractor {
 				}
 
 				foreach ( $this->filterEventItems( $items ) as $item ) {
-					$start = $item['startDate'] ?? $item['structuredContent']['startDate'] ?? null;
-					if ( is_numeric( $start ) ) {
-						$timestamp = (int) $start;
-						if ( $timestamp > 1000000000000 ) {
-							$timestamp = (int) ( $timestamp / 1000 );
-						}
-						if ( $timestamp > $cutoff->getTimestamp() ) {
-							continue;
-						}
+					$start     = $item['startDate'] ?? $item['structuredContent']['startDate'] ?? null;
+					$timestamp = $this->getCalendarItemStartTimestamp( $start, $calendar_timezone );
+					if ( null === $timestamp || $timestamp < $now->getTimestamp() || $timestamp > $cutoff->getTimestamp() ) {
+						continue;
 					}
 
 					$event_keys = array(
@@ -274,6 +279,9 @@ class SquarespaceExtractor extends BaseExtractor {
 						$seen_event_keys[ $event_key ] = true;
 					}
 					$events[] = $item;
+					if ( count( $events ) >= $max_events ) {
+						return $events;
+					}
 				}
 			}
 		}
@@ -281,13 +289,31 @@ class SquarespaceExtractor extends BaseExtractor {
 		return array_slice(
 			$events,
 			0,
-			$this->getMaxScrapeEvents(
-				array(
-					'source_url' => $source_url,
-					'method'     => $this->getMethod(),
-				)
-			)
+			$max_events
 		);
+	}
+
+	/**
+	 * Resolve a Calendar item start value to a Unix timestamp.
+	 *
+	 * @param mixed         $start    Numeric seconds/milliseconds or a date string.
+	 * @param \DateTimeZone $timezone Calendar timezone for strings without an offset.
+	 */
+	private function getCalendarItemStartTimestamp( $start, \DateTimeZone $timezone ): ?int {
+		if ( is_numeric( $start ) ) {
+			$timestamp = (int) $start;
+			return $timestamp > 1000000000000 ? (int) ( $timestamp / 1000 ) : $timestamp;
+		}
+
+		if ( ! is_string( $start ) || '' === trim( $start ) ) {
+			return null;
+		}
+
+		try {
+			return ( new \DateTimeImmutable( $start, $timezone ) )->getTimestamp();
+		} catch ( \Exception $e ) {
+			return null;
+		}
 	}
 
 	/**

--- a/inc/Steps/EventImport/Handlers/WebScraper/Extractors/SquarespaceExtractor.php
+++ b/inc/Steps/EventImport/Handlers/WebScraper/Extractors/SquarespaceExtractor.php
@@ -90,6 +90,11 @@ class SquarespaceExtractor extends BaseExtractor {
 		}
 
 		if ( empty( $raw_items ) ) {
+			// Native Calendar blocks load their event collection by month at runtime.
+			$raw_items = $this->parseCalendarBlockCollections( $html, $source_url );
+		}
+
+		if ( empty( $raw_items ) ) {
 			return array();
 		}
 
@@ -152,6 +157,82 @@ class SquarespaceExtractor extends BaseExtractor {
 		}
 
 		return $items;
+	}
+
+	/**
+	 * Fetch the current month's events for native Squarespace Calendar blocks.
+	 *
+	 * Calendar blocks contain only a collection ID in static HTML. The browser
+	 * renderer resolves that ID through Squarespace's public monthly endpoint.
+	 *
+	 * @param string $html       Host page HTML.
+	 * @param string $source_url Source URL used to derive the endpoint origin.
+	 * @return array Raw event items, or an empty array on failure.
+	 */
+	private function parseCalendarBlockCollections( string $html, string $source_url ): array {
+		if ( false === strpos( $html, 'calendar-block' ) || ! preg_match_all( '/<div\b[^>]*class=["\'][^"\']*\bcalendar-block\b[^"\']*["\'][^>]*>/i', $html, $matches ) ) {
+			return array();
+		}
+
+		$parsed   = wp_parse_url( $source_url );
+		$base_url = ( $parsed['scheme'] ?? 'https' ) . '://' . ( $parsed['host'] ?? '' );
+		$context  = $this->extractContextData( $html );
+		$timezone = $context['website']['timeZone'] ?? 'UTC';
+
+		try {
+			$month = ( new \DateTimeImmutable( 'now', new \DateTimeZone( $timezone ) ) )->format( 'm-Y' );
+		} catch ( \Exception $e ) {
+			$month = gmdate( 'm-Y' );
+		}
+
+		$seen_ids = array();
+		foreach ( $matches[0] as $tag ) {
+			if ( ! preg_match( '/data-block-json=["\']([^"\']+)["\']/i', $tag, $block_match ) ) {
+				continue;
+			}
+
+			$block = json_decode( html_entity_decode( $block_match[1], ENT_QUOTES, 'UTF-8' ), true );
+			if ( ! is_array( $block ) || empty( $block['collectionId'] ) ) {
+				continue;
+			}
+
+			$collection_id = (string) $block['collectionId'];
+			if ( isset( $seen_ids[ $collection_id ] ) ) {
+				continue;
+			}
+			$seen_ids[ $collection_id ] = true;
+
+			$url      = add_query_arg(
+				array(
+					'month'        => $month,
+					'collectionId' => $collection_id,
+				),
+				$base_url . '/api/open/GetItemsByMonth'
+			);
+			$response = \DataMachine\Core\HttpClient::get(
+				$url,
+				array(
+					'timeout' => 15,
+					'context' => 'Squarespace Extractor Calendar Block',
+				)
+			);
+
+			if ( empty( $response['success'] ) || empty( $response['data'] ) ) {
+				continue;
+			}
+
+			$items = json_decode( $response['data'], true );
+			if ( ! is_array( $items ) || JSON_ERROR_NONE !== json_last_error() ) {
+				continue;
+			}
+
+			$items = $this->filterEventItems( $items );
+			if ( ! empty( $items ) ) {
+				return $items;
+			}
+		}
+
+		return array();
 	}
 
 	/**

--- a/tests/Fixtures/squarespace/womack-calendar-block.html
+++ b/tests/Fixtures/squarespace/womack-calendar-block.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en-US">
+<head>
+<script data-name="static-context">Static = window.Static || {}; Static.SQUARESPACE_CONTEXT = {"website":{"siteTitle":"The Womack","timeZone":"America/Phoenix"},"collection":{"title":"Calendar","id":"6515bd9c9e970435c8c5ac38","fullUrl":"/calendar","type":10}};</script>
+</head>
+<body>
+<div class="sqs-block calendar-block sqs-block-calendar" data-block-json="&#123;&quot;collectionId&quot;:&quot;6515beb3cb46457500c400c9&quot;&#125;" data-block-type="26">
+<div class="sqs-block-content"><!-- The calendar block is initialized by javascript. --></div>
+</div>
+</body>
+</html>

--- a/tests/Fixtures/squarespace/womack-calendar-block.html
+++ b/tests/Fixtures/squarespace/womack-calendar-block.html
@@ -7,5 +7,7 @@
 <div class="sqs-block calendar-block sqs-block-calendar" data-block-json="&#123;&quot;collectionId&quot;:&quot;6515beb3cb46457500c400c9&quot;&#125;" data-block-type="26">
 <div class="sqs-block-content"><!-- The calendar block is initialized by javascript. --></div>
 </div>
+<div class="sqs-block calendar-block sqs-block-calendar" data-block-json="&#123;&quot;collectionId&quot;:&quot;6515beb3cb46457500c400c9&quot;&#125;"></div>
+<div class="sqs-block calendar-block sqs-block-calendar" data-block-json="&#123;&quot;collectionId&quot;:&quot;secondary-calendar&quot;&#125;"></div>
 </body>
 </html>

--- a/tests/Fixtures/squarespace/womack-calendar-items.json
+++ b/tests/Fixtures/squarespace/womack-calendar-items.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "6a799354b462355ff31b8aec",
+    "collectionId": "6515beb3cb46457500c400c9",
+    "recordType": 12,
+    "urlId": "ill-vibe-5",
+    "title": "ill Vibe",
+    "fullUrl": "/womack-events/ill-vibe-5",
+    "structuredContent": {
+      "_type": "CalendarEvent",
+      "startDate": 1788123600243,
+      "endDate": 1788138000243
+    },
+    "startDate": 1788123600243,
+    "endDate": 1788138000243,
+    "recordTypeLabel": "event"
+  },
+  {
+    "id": "6a79931804b60324bea69627",
+    "collectionId": "6515beb3cb46457500c400c9",
+    "recordType": 12,
+    "urlId": "3jtw3a6l6tch7bcfkgrzbw64xtnrx3",
+    "title": "Groove Candy",
+    "fullUrl": "/womack-events/3jtw3a6l6tch7bcfkgrzbw64xtnrx3",
+    "structuredContent": {
+      "_type": "CalendarEvent",
+      "startDate": 1788062400687,
+      "endDate": 1788073140687
+    },
+    "startDate": 1788062400687,
+    "endDate": 1788073140687,
+    "recordTypeLabel": "event"
+  }
+]

--- a/tests/Unit/SquarespaceExtractorTest.php
+++ b/tests/Unit/SquarespaceExtractorTest.php
@@ -34,6 +34,7 @@ class SquarespaceExtractorTest extends WP_UnitTestCase {
 
 	public function tearDown(): void {
 		remove_all_filters( 'pre_http_request' );
+		remove_all_filters( 'data_machine_events_scraper_recurrence_horizon_days' );
 		parent::tearDown();
 	}
 
@@ -351,17 +352,28 @@ class SquarespaceExtractorTest extends WP_UnitTestCase {
 		$this->assertSame( '2099-06-01', $events[0]['startDate'] );
 	}
 
-	public function test_native_calendar_block_fetches_browser_visible_month() {
-		$source_url = 'https://www.thewomack.us/calendar';
+	public function test_native_calendar_blocks_fetch_bounded_months_and_dedupe_events() {
+		$source_url = 'https://www.thewomack.us:8443/calendar';
 		$html       = file_get_contents( $this->fixtures_dir . '/womack-calendar-block.html' );
 		$items      = file_get_contents( $this->fixtures_dir . '/womack-calendar-items.json' );
+		$requests   = array();
+
+		$this->extractor = new class() extends SquarespaceExtractor {
+			protected function getCalendarNow( \DateTimeZone $timezone ): \DateTimeImmutable {
+				return ( new \DateTimeImmutable( '2026-08-01 06:30:00', new \DateTimeZone( 'UTC' ) ) )->setTimezone( $timezone );
+			}
+		};
 
 		add_filter(
 			'pre_http_request',
-			static function ( $preempt, $args, $url ) use ( $items ) {
-				if ( 0 === strpos( $url, 'https://www.thewomack.us/api/open/GetItemsByMonth?' ) ) {
+			static function ( $preempt, $args, $url ) use ( $items, &$requests ) {
+				if ( 0 === strpos( $url, 'https://www.thewomack.us:8443/api/open/GetItemsByMonth?' ) ) {
 					parse_str( (string) wp_parse_url( $url, PHP_URL_QUERY ), $query );
-					if ( '6515beb3cb46457500c400c9' === ( $query['collectionId'] ?? '' ) && preg_match( '/^\d{2}-\d{4}$/', $query['month'] ?? '' ) ) {
+					$collection = $query['collectionId'] ?? '';
+					$month      = $query['month'] ?? '';
+					$requests[] = $collection . '|' . $month;
+
+					if ( '6515beb3cb46457500c400c9' === $collection && '08-2026' === $month ) {
 						return array(
 							'headers'  => array(),
 							'body'     => $items,
@@ -373,9 +385,53 @@ class SquarespaceExtractorTest extends WP_UnitTestCase {
 							'filename' => null,
 						);
 					}
+
+					if ( '6515beb3cb46457500c400c9' === $collection && '09-2026' === $month ) {
+						return array(
+							'headers'  => array(),
+							'body'     => '{malformed',
+							'response' => array( 'code' => 200 ),
+						);
+					}
+
+					if ( 'secondary-calendar' === $collection && '08-2026' === $month ) {
+						$secondary = array(
+							json_decode( $items, true )[0],
+							array(
+								'id'         => 'secondary-event',
+								'recordType' => 12,
+								'title'      => 'Secondary Calendar Show',
+								'fullUrl'    => '/womack-events/secondary-calendar-show',
+								'startDate'  => 1788325200000,
+								'endDate'    => 1788332400000,
+							),
+							array(
+								'id'         => 'beyond-horizon',
+								'recordType' => 12,
+								'title'      => 'Beyond Horizon',
+								'startDate'  => 1793491200000,
+							),
+						);
+
+						return array(
+							'headers'  => array(),
+							'body'     => wp_json_encode( $secondary ),
+							'response' => array( 'code' => 200 ),
+						);
+					}
+
+					if ( 'secondary-calendar' === $collection && '09-2026' === $month ) {
+						return new \WP_Error( 'http_request_failed', 'Calendar unavailable' );
+					}
+
+					return array(
+						'headers'  => array(),
+						'body'     => '[]',
+						'response' => array( 'code' => 200 ),
+					);
 				}
 
-				if ( 'https://www.thewomack.us/calendar?format=json' === $url ) {
+				if ( 'https://www.thewomack.us:8443/calendar?format=json' === $url ) {
 					return array(
 						'headers'  => array(),
 						'body'     => '{"collection":{"type":10,"itemCount":0},"mainContent":""}',
@@ -396,11 +452,26 @@ class SquarespaceExtractorTest extends WP_UnitTestCase {
 
 		$events = $this->extractor->extract( $html, $source_url );
 
-		$this->assertCount( 2, $events );
+		$this->assertCount( 3, $events );
 		$this->assertSame( 'ill Vibe', $events[0]['title'] );
 		$this->assertSame( '2026-08-30', $events[0]['startDate'] );
 		$this->assertSame( 'Groove Candy', $events[1]['title'] );
 		$this->assertSame( '/womack-events/3jtw3a6l6tch7bcfkgrzbw64xtnrx3', $events[1]['source_url'] );
+		$this->assertSame( 'Secondary Calendar Show', $events[2]['title'] );
+		$this->assertSame(
+			array(
+				'6515beb3cb46457500c400c9|07-2026',
+				'6515beb3cb46457500c400c9|08-2026',
+				'6515beb3cb46457500c400c9|09-2026',
+				'6515beb3cb46457500c400c9|10-2026',
+				'secondary-calendar|07-2026',
+				'secondary-calendar|08-2026',
+				'secondary-calendar|09-2026',
+				'secondary-calendar|10-2026',
+			),
+			$requests,
+			'Phoenix is still in July when the UTC clock has crossed into August.'
+		);
 	}
 
 	/* ------------------------------------------------------------------ */

--- a/tests/Unit/SquarespaceExtractorTest.php
+++ b/tests/Unit/SquarespaceExtractorTest.php
@@ -35,6 +35,7 @@ class SquarespaceExtractorTest extends WP_UnitTestCase {
 	public function tearDown(): void {
 		remove_all_filters( 'pre_http_request' );
 		remove_all_filters( 'data_machine_events_scraper_recurrence_horizon_days' );
+		remove_all_filters( 'data_machine_events_scraper_max_events' );
 		parent::tearDown();
 	}
 
@@ -358,11 +359,7 @@ class SquarespaceExtractorTest extends WP_UnitTestCase {
 		$items      = file_get_contents( $this->fixtures_dir . '/womack-calendar-items.json' );
 		$requests   = array();
 
-		$this->extractor = new class() extends SquarespaceExtractor {
-			protected function getCalendarNow( \DateTimeZone $timezone ): \DateTimeImmutable {
-				return ( new \DateTimeImmutable( '2026-08-01 06:30:00', new \DateTimeZone( 'UTC' ) ) )->setTimezone( $timezone );
-			}
-		};
+		$this->extractor = $this->makeFixedCalendarExtractor();
 
 		add_filter(
 			'pre_http_request',
@@ -398,12 +395,36 @@ class SquarespaceExtractorTest extends WP_UnitTestCase {
 						$secondary = array(
 							json_decode( $items, true )[0],
 							array(
+								'id'         => 'past-event',
+								'recordType' => 12,
+								'title'      => 'Past Event',
+								'startDate'  => 1785565799000,
+							),
+							array(
+								'id'         => 'exact-now',
+								'recordType' => 12,
+								'title'      => 'Exact Now',
+								'startDate'  => '2026-08-01T06:30:00Z',
+							),
+							array(
 								'id'         => 'secondary-event',
 								'recordType' => 12,
 								'title'      => 'Secondary Calendar Show',
 								'fullUrl'    => '/womack-events/secondary-calendar-show',
 								'startDate'  => 1788325200000,
 								'endDate'    => 1788332400000,
+							),
+							array(
+								'id'         => 'exact-cutoff',
+								'recordType' => 12,
+								'title'      => 'Exact Cutoff',
+								'startDate'  => '2026-10-30T06:30:00Z',
+							),
+							array(
+								'id'         => 'string-beyond-cutoff',
+								'recordType' => 12,
+								'title'      => 'String Beyond Cutoff',
+								'startDate'  => '2026-10-30T06:30:01Z',
 							),
 							array(
 								'id'         => 'beyond-horizon',
@@ -452,12 +473,15 @@ class SquarespaceExtractorTest extends WP_UnitTestCase {
 
 		$events = $this->extractor->extract( $html, $source_url );
 
-		$this->assertCount( 3, $events );
+		$this->assertCount( 5, $events );
 		$this->assertSame( 'ill Vibe', $events[0]['title'] );
 		$this->assertSame( '2026-08-30', $events[0]['startDate'] );
 		$this->assertSame( 'Groove Candy', $events[1]['title'] );
 		$this->assertSame( '/womack-events/3jtw3a6l6tch7bcfkgrzbw64xtnrx3', $events[1]['source_url'] );
-		$this->assertSame( 'Secondary Calendar Show', $events[2]['title'] );
+		$this->assertSame(
+			array( 'ill Vibe', 'Groove Candy', 'Exact Now', 'Secondary Calendar Show', 'Exact Cutoff' ),
+			array_column( $events, 'title' )
+		);
 		$this->assertSame(
 			array(
 				'6515beb3cb46457500c400c9|07-2026',
@@ -472,6 +496,43 @@ class SquarespaceExtractorTest extends WP_UnitTestCase {
 			$requests,
 			'Phoenix is still in July when the UTC clock has crossed into August.'
 		);
+	}
+
+	public function test_calendar_block_collection_and_event_caps_bound_requests() {
+		$this->extractor = $this->makeFixedCalendarExtractor();
+		$requests        = array();
+		$html            = $this->makeCalendarBlocksHtml(
+			array_map(
+				static fn( int $number ): string => 'collection-' . $number,
+				range( 1, 12 )
+			)
+		);
+
+		$this->mockCalendarBlockRequests( $requests, static fn(): array => array() );
+		$this->assertSame( array(), $this->extractor->extract( $html, 'https://venue.test/calendar' ) );
+		$this->assertCount( 40, $requests, 'Ten collections across four bounded months is the maximum request count.' );
+		$this->assertSame( 'collection-10|10-2026', $requests[39] );
+
+		remove_all_filters( 'pre_http_request' );
+		$requests = array();
+		add_filter( 'data_machine_events_scraper_max_events', static fn(): int => 2 );
+		$this->mockCalendarBlockRequests(
+			$requests,
+			static function ( string $collection, string $month ): array {
+				return array(
+					array(
+						'id'         => $collection . '-' . $month,
+						'recordType' => 12,
+						'title'      => $collection . ' ' . $month,
+						'startDate'  => '07-2026' === $month ? '2026-08-01T06:30:00Z' : '2026-08-02T06:30:00Z',
+					),
+				);
+			}
+		);
+
+		$events = $this->extractor->extract( $html, 'https://venue.test/calendar' );
+		$this->assertCount( 2, $events );
+		$this->assertSame( array( 'collection-1|07-2026', 'collection-1|08-2026' ), $requests );
 	}
 
 	/* ------------------------------------------------------------------ */
@@ -589,6 +650,54 @@ class SquarespaceExtractorTest extends WP_UnitTestCase {
 	/* ------------------------------------------------------------------ */
 	/* Helpers                                                            */
 	/* ------------------------------------------------------------------ */
+
+	private function makeFixedCalendarExtractor(): SquarespaceExtractor {
+		return new class() extends SquarespaceExtractor {
+			protected function getCalendarNow( \DateTimeZone $timezone ): \DateTimeImmutable {
+				return ( new \DateTimeImmutable( '2026-08-01 06:30:00', new \DateTimeZone( 'UTC' ) ) )->setTimezone( $timezone );
+			}
+		};
+	}
+
+	private function makeCalendarBlocksHtml( array $collection_ids ): string {
+		$blocks = '';
+		foreach ( $collection_ids as $collection_id ) {
+			$block   = esc_attr( wp_json_encode( array( 'collectionId' => $collection_id ) ) );
+			$blocks .= '<div class="sqs-block calendar-block" data-block-json="' . $block . '"></div>';
+		}
+
+		return '<html><script>Static.SQUARESPACE_CONTEXT = {"website":{"timeZone":"America/Phoenix"}};</script><body>' . $blocks . '</body></html>';
+	}
+
+	private function mockCalendarBlockRequests( array &$requests, callable $items_for_request ): void {
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) use ( &$requests, $items_for_request ) {
+				if ( false !== strpos( $url, '/api/open/GetItemsByMonth?' ) ) {
+					parse_str( (string) wp_parse_url( $url, PHP_URL_QUERY ), $query );
+					$collection = (string) ( $query['collectionId'] ?? '' );
+					$month      = (string) ( $query['month'] ?? '' );
+					$requests[] = $collection . '|' . $month;
+					$body       = wp_json_encode( $items_for_request( $collection, $month ) );
+				} else {
+					$body = '{"collection":{"type":10,"itemCount":0},"mainContent":""}';
+				}
+
+				return array(
+					'headers'  => array(),
+					'body'     => $body,
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'cookies'  => array(),
+					'filename' => null,
+				);
+			},
+			10,
+			3
+		);
+	}
 
 	/**
 	 * Build a minimal raw Squarespace event item shaped for normalizeItem().

--- a/tests/Unit/SquarespaceExtractorTest.php
+++ b/tests/Unit/SquarespaceExtractorTest.php
@@ -351,6 +351,58 @@ class SquarespaceExtractorTest extends WP_UnitTestCase {
 		$this->assertSame( '2099-06-01', $events[0]['startDate'] );
 	}
 
+	public function test_native_calendar_block_fetches_browser_visible_month() {
+		$source_url = 'https://www.thewomack.us/calendar';
+		$html       = file_get_contents( $this->fixtures_dir . '/womack-calendar-block.html' );
+		$items      = file_get_contents( $this->fixtures_dir . '/womack-calendar-items.json' );
+
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) use ( $items ) {
+				if ( 0 === strpos( $url, 'https://www.thewomack.us/api/open/GetItemsByMonth?' ) ) {
+					parse_str( (string) wp_parse_url( $url, PHP_URL_QUERY ), $query );
+					if ( '6515beb3cb46457500c400c9' === ( $query['collectionId'] ?? '' ) && preg_match( '/^\d{2}-\d{4}$/', $query['month'] ?? '' ) ) {
+						return array(
+							'headers'  => array(),
+							'body'     => $items,
+							'response' => array(
+								'code'    => 200,
+								'message' => 'OK',
+							),
+							'cookies'  => array(),
+							'filename' => null,
+						);
+					}
+				}
+
+				if ( 'https://www.thewomack.us/calendar?format=json' === $url ) {
+					return array(
+						'headers'  => array(),
+						'body'     => '{"collection":{"type":10,"itemCount":0},"mainContent":""}',
+						'response' => array(
+							'code'    => 200,
+							'message' => 'OK',
+						),
+						'cookies'  => array(),
+						'filename' => null,
+					);
+				}
+
+				return new \WP_Error( 'http_request_failed', 'Unmocked URL: ' . $url );
+			},
+			10,
+			3
+		);
+
+		$events = $this->extractor->extract( $html, $source_url );
+
+		$this->assertCount( 2, $events );
+		$this->assertSame( 'ill Vibe', $events[0]['title'] );
+		$this->assertSame( '2026-08-30', $events[0]['startDate'] );
+		$this->assertSame( 'Groove Candy', $events[1]['title'] );
+		$this->assertSame( '/womack-events/3jtw3a6l6tch7bcfkgrzbw64xtnrx3', $events[1]['source_url'] );
+	}
+
 	/* ------------------------------------------------------------------ */
 	/* Live fixtures — integration smoke                                  */
 	/* ------------------------------------------------------------------ */


### PR DESCRIPTION
## Summary
- detect native Squarespace Calendar blocks and read every distinct configured collection ID
- fetch every month intersecting the existing filterable 90-day scraper horizon
- aggregate and deduplicate events across months and collections while preserving source URL ports
- add The Womack block and API response fixtures with deterministic boundary/failure coverage

## Root cause
The Womack's `/calendar?format=json` describes an empty type-10 page collection. The visible calendar is a separate native Calendar block whose HTML-encoded `data-block-json` points to collection `6515beb3cb46457500c400c9`, so the existing page-collection and summary-block strategies never reached its events.

## Actual calendar source
Squarespace's `squarespace-calendar-block-renderer` reads each block collection ID and requests:

`/api/open/GetItemsByMonth?month=MM-YYYY&collectionId=<collection-id>`

That first-party endpoint returns record-type-12 event items with titles, event URLs, and millisecond start/end timestamps. A live browser-user-agent check returned 24 August 2026 events, beginning with `ill Vibe`.

## Behavior change
`SquarespaceExtractor` now falls back to native Calendar block endpoints when all existing collection, HTML, Summary Block, and User Items List strategies return no events. It:

- uses the Squarespace site timezone and a protected clock seam to derive calendar months
- requests all months intersecting the existing `data_machine_events_scraper_recurrence_horizon_days` window, defaulting to 90 days
- filters numeric event timestamps beyond the exact horizon cutoff
- aggregates every distinct Calendar block collection instead of stopping at the first result
- deduplicates by item ID, event URL, or title/start/end identity
- applies the existing per-scrape event cap
- preserves explicit ports when constructing the same-origin API endpoint
- continues past empty, malformed, or failed monthly responses

Existing Squarespace behavior remains intact because this path is attempted only after every existing strategy yields an empty result. Classic `upcoming`/`past`, summary collection dereferencing, inline user items, and HTML extraction keep their existing precedence and code paths.

## Tests
- added real-shape The Womack Calendar block and monthly API fixtures
- added deterministic UTC-to-Phoenix month-boundary coverage asserting exact July through October requests for a 90-day horizon
- covered duplicate blocks, duplicate items, multiple collections, non-default ports, malformed JSON, HTTP failure, beyond-horizon filtering, and continued aggregation
- `homeboy review lint --changed-only` passed PHPCS and PHPStan level 7 with zero findings
- changed PHP files pass `php -l`; `git diff --check` passes
- deterministic live endpoint check returned 24 record-type-12 events

Focused PHPUnit execution was attempted through Homeboy/WP Codebox with an explicit `SquarespaceExtractorTest` filter. PHPUnit did not start because the managed `wordpress-database` MySQL 8.4 Docker service failed provisioning; the run reported 0 executed tests and no assertion failures. This is a test-infrastructure limitation, not a code failure. Normal PR CI remains responsible for executing the fixture regression with its configured MySQL service.

Fixes #685

## Second review hardening
- enforces the inclusive window  for numeric seconds, numeric milliseconds, ISO dates, and timezone-local date strings; unparseable starts are rejected
- adds past, exact-now, exact-cutoff, one-second-beyond-cutoff, and numeric beyond-horizon coverage
- caps native Calendar traversal at 10 distinct collections, bounding the default 90-day window to at most 40 monthly requests
- returns immediately when the existing configurable max-event count is reached, skipping all remaining items, months, and collections
- retains partial successful results when later month requests return malformed JSON or HTTP failures

Follow-up commit: 
## Second review hardening
- enforces the inclusive window `now <= start <= now + horizon` for numeric seconds, numeric milliseconds, ISO dates, and timezone-local date strings; unparseable starts are rejected
- adds past, exact-now, exact-cutoff, one-second-beyond-cutoff, and numeric beyond-horizon coverage
- caps native Calendar traversal at 10 distinct collections, bounding the default 90-day window to at most 40 monthly requests
- returns immediately when the existing configurable max-event count is reached, skipping all remaining items, months, and collections
- retains partial successful results when later month requests return malformed JSON or HTTP failures

Follow-up commit: `f4a8916`