### PR TITLE
fix: qualify server-rendered event listings

### DIFF
--- a/inc/Steps/EventImport/Handlers/WebScraper/Extractors/GenericHtmlEventsExtractor.php
+++ b/inc/Steps/EventImport/Handlers/WebScraper/Extractors/GenericHtmlEventsExtractor.php
@@ -45,6 +45,8 @@ class GenericHtmlEventsExtractor extends BaseExtractor {
 	 */
 	private const FIELD_PATTERNS = array(
 		'title' => array(
+			'/<h[1-6][^>]+class=["\'][^"\']*image-with-text__heading[^"\']*["\'][^>]*>(.*?)<\/h[1-6]>/is',
+			'/<[^>]+class=["\'][^"\']*resentitem-title[^"\']*["\'][^>]*>.*?<a[^>]*>(.*?)<\/a>/is',
 			'/<(?:div|span|h[1-6])[^>]+class="[^"]*eventTitle[^"]*"[^>]*>.*?<a[^>]+title="([^"]+)"/is',
 			'/<(?:div|span|p|h[1-6])[^>]+class="[^"]*eventTitle[^"]*"[^>]*>.*?<a[^>]*>(.*?)<\/a>/is',
 			'/<(?:div|span|p|h[1-6])[^>]+class="[^"]*event-title[^"]*"[^>]*>(.*?)<\/(?:div|span|p|h[1-6])>/is',
@@ -52,27 +54,33 @@ class GenericHtmlEventsExtractor extends BaseExtractor {
 			'/<h[1-6][^>]*>\s*<a[^>]+href="[^"]*event[^"]*"[^>]*>(.*?)<\/a>/is',
 		),
 		'date'  => array(
+			'/<[^>]+class=["\'][^"\']*date-event[^"\']*["\'][^>]*>(.*?)<\/[^>]+>/is',
+			'/Date:\s*([^<]+)/iu',
 			'/<(?:div|span|p|time)[^>]+class="[^"]*eventDate[^"]*"[^>]*>(.*?)<\/(?:div|span|p|time)>/is',
 			'/<(?:div|span|p|time)[^>]+class="[^"]*event-date[^"]*"[^>]*>(.*?)<\/(?:div|span|p|time)>/is',
 			'/<[^>]+class="[^"]*when[^"]*"[^>]*>(.*?)<\/[^>]+>/is',
 			'/<time[^>]+datetime="([^"]+)"/i',
 		),
 		'time'  => array(
+			'/<[^>]+class=["\'][^"\']*time-event[^"\']*["\'][^>]*>(.*?)<\/[^>]+>/is',
+			'/Time:\s*([^<]+)/iu',
 			'/<span[^>]+class="[^"]*event-time[^"]*"[^>]*>(.*?)<\/span>/is',
 			'/<(?:div|span|p)[^>]+class="[^"]*eventTime[^"]*"[^>]*>(.*?)<\/(?:div|span|p)>/is',
 		),
 		'price' => array(
+			'/Entry Fee:\s*([^<]+)/iu',
 			'/<(?:div|span)[^>]+class="[^"]*eventPrice[^"]*"[^>]*>(.*?)<\/(?:div|span)>/is',
 			'/<(?:div|span)[^>]+class="[^"]*event-price[^"]*"[^>]*>(.*?)<\/(?:div|span)>/is',
 		),
 		'link'  => array(
+			'/<[^>]+class=["\'][^"\']*resentitem-title[^"\']*["\'][^>]*>.*?<a[^>]+href=["\']([^"\']+)["\']/is',
 			'/<[^>]+class="[^"]*(?:event-title|event-link)[^"]*"[^>]*>.*?<a[^>]+href="([^"]+)"/is',
 			'/<a[^>]+href="(https?:\/\/[^"]*\/events?\/[^"]+)"/i',
 			'/<a[^>]+href="(\/events?\/[^"]+)"/i',
 		),
 		'image' => array(
 			'/background-image:\s*url\(([^)]+)\)/i',
-			'/<img[^>]+src="([^"]+)"/i',
+			'/<img[^>]+src=["\']([^"\']+)["\']/i',
 		),
 	);
 
@@ -154,7 +162,13 @@ class GenericHtmlEventsExtractor extends BaseExtractor {
 		$loaded = $this->loadDom( $html );
 		$dom    = $loaded['dom'];
 		$xpath  = $loaded['xpath'];
-		$pairs  = array(
+
+		$explicit_containers = $this->findExplicitContainers( $dom, $xpath );
+		if ( count( $explicit_containers ) >= self::MIN_CONTAINERS ) {
+			return $explicit_containers;
+		}
+
+		$pairs = array(
 			array( 'event-title', 'event-date' ),
 			array( 'event-link', 'when' ),
 		);
@@ -199,6 +213,52 @@ class GenericHtmlEventsExtractor extends BaseExtractor {
 		}
 
 		return array();
+	}
+
+	/**
+	 * Find repeated server-rendered cards whose container classes do not use
+	 * generic event names but whose internal fields are unambiguous.
+	 *
+	 * @return string[] Serialized event container HTML.
+	 */
+	private function findExplicitContainers( \DOMDocument $dom, \DOMXPath $xpath ): array {
+		$containers = array();
+		$queries    = array(
+			"//*[contains(concat(' ', normalize-space(@class), ' '), ' resentitem ')]",
+			"//*[contains(concat(' ', normalize-space(@class), ' '), ' image-with-text ')]",
+		);
+
+		foreach ( $queries as $query ) {
+			$nodes = $xpath->query( $query );
+			if ( false === $nodes ) {
+				continue;
+			}
+
+			foreach ( $nodes as $node ) {
+				$html = $dom->saveHTML( $node );
+				if ( ! is_string( $html ) || ! $this->hasExplicitEventFields( $html ) ) {
+					continue;
+				}
+				$containers[] = $html;
+			}
+
+			if ( count( $containers ) >= self::MIN_CONTAINERS ) {
+				return $containers;
+			}
+			$containers = array();
+		}
+
+		return array();
+	}
+
+	private function hasExplicitEventFields( string $html ): bool {
+		$is_events_manager_row = false !== strpos( $html, 'resentitem-title' )
+			&& false !== strpos( $html, 'date-event' );
+		$is_shopify_event_card = false !== strpos( $html, 'image-with-text__heading' )
+			&& false !== strpos( $html, 'Time:' )
+			&& false !== strpos( $html, 'Date:' );
+
+		return $is_events_manager_row || $is_shopify_event_card;
 	}
 
 	public function getMethod(): string {
@@ -248,7 +308,7 @@ class GenericHtmlEventsExtractor extends BaseExtractor {
 							break 2;
 
 						case 'time':
-							$event['startTime'] = $this->parseTimeString( $value );
+							$event['startTime'] = $this->parseExplicitTime( $value, $block );
 							break 2;
 
 						case 'price':
@@ -265,7 +325,11 @@ class GenericHtmlEventsExtractor extends BaseExtractor {
 
 						case 'image':
 							$url = $value;
-							if ( strpos( $url, '/' ) === 0 ) {
+							if ( str_starts_with( $url, '//' ) ) {
+								$parsed_scheme = wp_parse_url( $base_url, PHP_URL_SCHEME );
+								$scheme        = $parsed_scheme ? $parsed_scheme : 'https';
+								$url           = $scheme . ':' . $url;
+							} elseif ( strpos( $url, '/' ) === 0 ) {
 								$url = $base_url . $url;
 							}
 							$event['imageUrl'] = esc_url_raw( $url );
@@ -276,6 +340,24 @@ class GenericHtmlEventsExtractor extends BaseExtractor {
 		}
 
 		return $event;
+	}
+
+	/**
+	 * Parse the first time in a listing field without changing global handling
+	 * of ambiguous clock values. Events Manager rows omit meridiem but represent
+	 * evening entertainment, while Shopify cards include it explicitly.
+	 */
+	private function parseExplicitTime( string $value, string $block ): string {
+		if ( ! preg_match( '/\b(\d{1,2}(?::\d{2})?\s*(?:am|pm)?)/i', $value, $matches ) ) {
+			return '';
+		}
+
+		$time = trim( $matches[1] );
+		if ( false !== strpos( $block, 'resentitem-title' ) && ! preg_match( '/\b(?:am|pm)\b/i', $time ) ) {
+			$time .= ' pm';
+		}
+
+		return $this->parseTimeString( $time );
 	}
 
 	/**
@@ -307,14 +389,16 @@ class GenericHtmlEventsExtractor extends BaseExtractor {
 		// Strip day name prefix (Mon, Tue, etc.).
 		$date_str = preg_replace( '/^[A-Za-z]{2,3}\s+/', '', $date_str );
 
-		// Try parsing.
-		$ts = strtotime( $date_str );
+		$has_year = (bool) preg_match( '/\b(?:19|20)\d{2}\b|\b\d{1,2}\/\d{1,2}\/\d{2,4}\b/', $date_str );
+		$ts       = strtotime( $date_str );
 		if ( $ts ) {
-			$year = (int) gmdate( 'Y', $ts );
+			$now_year = (int) gmdate( 'Y' );
+			$year     = $has_year
+				? (int) gmdate( 'Y', $ts )
+				: $this->inferYearForMonth( (int) gmdate( 'n', $ts ), (int) gmdate( 'n' ), $now_year );
 
 			// Two-digit year fix: strtotime('03/28/26') → 2026 on most systems,
 			// but verify it's reasonable (within 2 years of now).
-			$now_year = (int) gmdate( 'Y' );
 			if ( $year < 100 ) {
 				$year += 2000;
 			}
@@ -324,5 +408,13 @@ class GenericHtmlEventsExtractor extends BaseExtractor {
 
 			$event['startDate'] = sprintf( '%04d-%02d-%02d', $year, (int) gmdate( 'm', $ts ), (int) gmdate( 'd', $ts ) );
 		}
+	}
+
+	/**
+	 * Treat January-March listings viewed in October-December as the next year.
+	 * All other omitted-year dates remain in the current calendar year.
+	 */
+	private function inferYearForMonth( int $month, int $current_month, int $current_year ): int {
+		return $current_month >= 10 && $month <= 3 ? $current_year + 1 : $current_year;
 	}
 }

--- a/tests/Fixtures/wp-generic/events-manager-resentitem-list.html
+++ b/tests/Fixtures/wp-generic/events-manager-resentitem-list.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+<body>
+<div class="em-events-list"><div class="resentitem"><div class="event-date-area"><span class="date-event">08/14/2099</span><span class="time-event">8:30</span></div><div class="resentitem-title"><h2><a href="https://venue.example.com/events/illuman-80s/">The Illuman 80's</a></h2></div><img src='https://venue.example.com/illuman.jpg'></div>
+<div class="resentitem"><div class="event-date-area"><span class="date-event">08/21/2099</span><span class="time-event">8:30</span></div><div class="resentitem-title"><h2><a href="https://venue.example.com/events/the-stilettos/">The Stilettos</a></h2></div><img src='https://venue.example.com/stilettos.jpg'></div>
+<div class="resentitem"><div class="event-date-area"><span class="date-event">09/11/2099</span><span class="time-event">11:30</span></div><div class="resentitem-title"><h2><a href="https://venue.example.com/events/thomas-james-band/">The Thomas James Band</a></h2></div><img src='https://venue.example.com/thomas-james.jpg'></div></div>
+</body>
+</html>

--- a/tests/Fixtures/wp-generic/image-only-flyers.html
+++ b/tests/Fixtures/wp-generic/image-only-flyers.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+<body>
+<main class="flyer-gallery">
+<img src="https://venue.example.com/flyer-one.jpg" width="1200" height="1500" alt="Event flyer">
+<img src="https://venue.example.com/flyer-two.jpg" width="1200" height="1500" alt="Event flyer">
+<img src="https://venue.example.com/flyer-three.jpg" width="1200" height="1500" alt="Event flyer">
+</main>
+</body>
+</html>

--- a/tests/Fixtures/wp-generic/shopify-image-with-text-events.html
+++ b/tests/Fixtures/wp-generic/shopify-image-with-text-events.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+<body>
+<div class="image-with-text"><div class="image-with-text__media"><img src="//cdn.example.com/nitra.jpg"></div><div class="image-with-text__content"><h2 class="image-with-text__heading">Nitra Nicole 08/14</h2><div class="image-with-text__text"><p>Time: 8:30 pm through 1:00 am</p><p>Date: Friday, August 14th</p><p>Entry Fee: $10.00</p><p>Location: 4747 E. Elliot Rd, Phoenix, AZ</p></div></div></div>
+<div class="image-with-text"><div class="image-with-text__media"><img src="//cdn.example.com/zeppapotapuss.jpg"></div><div class="image-with-text__content"><h2 class="image-with-text__heading">Zeppapotapuss 08/15</h2><div class="image-with-text__text"><p>Time: 7:00 pm</p><p>Date: Saturday, August 15th</p><p>Entry Fee: $15.00</p><p>Location: 4747 E. Elliot Rd, Phoenix, AZ</p></div></div></div>
+<div class="image-with-text"><div class="image-with-text__media"><img src="//cdn.example.com/good-medicine.jpg"></div><div class="image-with-text__content"><h2 class="image-with-text__heading">The Good Medicine Band 08/21</h2><div class="image-with-text__text"><p>Time: 8:00 pm</p><p>Date: Friday, August 21st</p><p>Entry Fee: $10.00</p><p>Location: 4747 E. Elliot Rd, Phoenix, AZ</p></div></div></div>
+</body>
+</html>

--- a/tests/Unit/EventScraperTestAbilityTest.php
+++ b/tests/Unit/EventScraperTestAbilityTest.php
@@ -32,6 +32,7 @@ use ReflectionClass;
 use DataMachineEvents\Abilities\EventScraperTest;
 use DataMachineEvents\Steps\EventImport\Handlers\WebScraper\Extractors\BandzoogleExtractor;
 use DataMachineEvents\Steps\EventImport\Handlers\WebScraper\Extractors\EventbriteExtractor;
+use DataMachineEvents\Steps\EventImport\Handlers\WebScraper\Extractors\GenericHtmlEventsExtractor;
 use DataMachineEvents\Steps\EventImport\Handlers\WebScraper\Extractors\JsonLdExtractor;
 
 class EventScraperTestAbilityTest extends WP_UnitTestCase {
@@ -423,6 +424,48 @@ class EventScraperTestAbilityTest extends WP_UnitTestCase {
 			$direct_count,
 			count( $result['event_data']['items'] ?? array() ),
 			'event_data.items[] length must match JsonLdExtractor::extract() count exactly.'
+		);
+	}
+
+	/**
+	 * @dataProvider generic_server_rendered_listing_provider
+	 */
+	public function test_server_rendered_listing_wins_before_fallback( string $fixture, string $target_url ): void {
+		$html   = (string) file_get_contents( $this->fixtures_dir . '/wp-generic/' . $fixture );
+		$direct = ( new GenericHtmlEventsExtractor() )->extract( $html, $target_url );
+		$this->mockHttpResponse( $html );
+
+		$result = ( new EventScraperTest() )->test( $target_url );
+
+		$this->assertTrue( $result['success'] ?? false, wp_json_encode( $result ) );
+		$this->assertCount( 3, $direct );
+		$this->assertSame( 'event', $result['extraction_info']['payload_type'] );
+		$this->assertSame( 'generic_html_events', $result['extraction_info']['extraction_method'] );
+		$this->assertSame( $target_url, $result['target_url'] );
+		$this->assertSame( 3, $result['event_data']['event_count'] );
+		$this->assertSame( 3, $result['extraction_info']['unique_source_event_count'] );
+	}
+
+	public function test_image_only_listing_still_reaches_vision_fallback(): void {
+		$html       = (string) file_get_contents( $this->fixtures_dir . '/wp-generic/image-only-flyers.html' );
+		$target_url = 'https://venue.example.com/flyers/';
+		$this->mockHttpResponse( $html );
+
+		$result = ( new EventScraperTest() )->test( $target_url );
+
+		$this->assertTrue( $result['success'] ?? false, wp_json_encode( $result ) );
+		$this->assertSame( 'vision_flyer', $result['extraction_info']['payload_type'] );
+		$this->assertSame( 'vision', $result['extraction_info']['extraction_method'] );
+		$this->assertSame( 0, $result['extraction_info']['unique_source_event_count'] );
+		$this->assertSame( 1, $result['extraction_info']['flyer_candidate_count'] );
+		$this->assertSame( $target_url, $result['event_data']['page_url'] );
+		$this->assertSame( 'https://venue.example.com/flyer-one.jpg', $result['event_data']['image_url'] );
+	}
+
+	public function generic_server_rendered_listing_provider(): array {
+		return array(
+			'cactus shopify cards' => array( 'shopify-image-with-text-events.html', 'https://cactus.example.com/pages/calendar' ),
+			'roosters event rows'  => array( 'events-manager-resentitem-list.html', 'https://venue.example.com/live-music/' ),
 		);
 	}
 

--- a/tests/Unit/GenericHtmlEventsExtractorTest.php
+++ b/tests/Unit/GenericHtmlEventsExtractorTest.php
@@ -8,6 +8,7 @@
 namespace DataMachineEvents\Tests\Unit;
 
 use DataMachineEvents\Steps\EventImport\Handlers\WebScraper\Extractors\GenericHtmlEventsExtractor;
+use ReflectionClass;
 use WP_UnitTestCase;
 
 class GenericHtmlEventsExtractorTest extends WP_UnitTestCase {
@@ -49,6 +50,49 @@ class GenericHtmlEventsExtractorTest extends WP_UnitTestCase {
 		$this->assertSame( 'First Event', $events[0]['title'] );
 		$this->assertSame( '2099-07-28', $events[0]['startDate'] );
 		$this->assertSame( 'https://venue.example.com/events/first-event/', $events[0]['source_url'] );
+	}
+
+	public function test_extracts_shopify_image_with_text_event_cards(): void {
+		$html = file_get_contents( $this->fixture_dir . '/shopify-image-with-text-events.html' );
+
+		$this->assertTrue( $this->extractor->canExtract( $html ) );
+		$events = $this->extractor->extract( $html, 'https://cactus.example.com/pages/calendar' );
+
+		$this->assertCount( 3, $events );
+		$this->assertSame( 'Nitra Nicole 08/14', $events[0]['title'] );
+		$this->assertSame( gmdate( 'Y' ) . '-08-14', $events[0]['startDate'] );
+		$this->assertSame( '20:30', $events[0]['startTime'] );
+		$this->assertSame( '$10.00', $events[0]['ticketPrice'] );
+		$this->assertSame( 'https://cdn.example.com/nitra.jpg', $events[0]['imageUrl'] );
+	}
+
+	public function test_extracts_events_manager_resentitem_rows(): void {
+		$html = file_get_contents( $this->fixture_dir . '/events-manager-resentitem-list.html' );
+
+		$this->assertTrue( $this->extractor->canExtract( $html ) );
+		$events = $this->extractor->extract( $html, 'https://venue.example.com/live-music/' );
+
+		$this->assertCount( 3, $events );
+		$this->assertSame( "The Illuman 80's", $events[0]['title'] );
+		$this->assertSame( '2099-08-14', $events[0]['startDate'] );
+		$this->assertSame( '20:30', $events[0]['startTime'] );
+		$this->assertSame( 'https://venue.example.com/events/illuman-80s/', $events[0]['source_url'] );
+	}
+
+	public function test_omitted_year_rolls_january_into_next_year_from_december(): void {
+		$method = ( new ReflectionClass( $this->extractor ) )->getMethod( 'inferYearForMonth' );
+		$method->setAccessible( true );
+
+		$this->assertSame( 2027, $method->invoke( $this->extractor, 1, 12, 2026 ) );
+		$this->assertSame( 2026, $method->invoke( $this->extractor, 12, 1, 2026 ) );
+		$this->assertSame( 2026, $method->invoke( $this->extractor, 8, 8, 2026 ) );
+	}
+
+	public function test_rejects_image_only_flyer_page(): void {
+		$html = file_get_contents( $this->fixture_dir . '/image-only-flyers.html' );
+
+		$this->assertFalse( $this->extractor->canExtract( $html ) );
+		$this->assertSame( array(), $this->extractor->extract( $html, 'https://venue.example.com/flyers/' ) );
 	}
 
 	public function test_rejects_insufficient_semantic_event_evidence(): void {


### PR DESCRIPTION
## Summary
- recognize Cactus Jack's Shopify image-with-text cards and Roosters Events Manager rows as structured event listings before raw HTML or vision fallback
- preserve listing-specific time semantics, omitted-year rollover, detail links, prices, and sibling flyer images without changing generic ambiguous-time parsing
- add source-shaped regression fixtures plus ability-level coverage proving structured listings win while genuine image-only pages still reach vision

## Root Cause
`GenericHtmlEventsExtractor` only recognized generic event container and field class names. Cactus Jack's exposes repeated Shopify `image-with-text` cards with labeled textual fields, so no structured extractor matched and UniversalWebScraper fell through to `VisionExtractor`. Roosters exposes repeated Events Manager `resentitem` rows with `date-event`, `time-event`, and `resentitem-title`; those rows were returned as one raw HTML packet, while qualification evaluated each discovered detail URL independently and never accumulated enough listing evidence.

## Behavior Change
- Cactus cards now produce structured `generic_html_events` packets from the direct calendar URL, including the first time in overnight ranges, inferred current/rollover year, price, and protocol-relative sibling image URL.
- Roosters rows now produce structured packets from `/live-music/`; PM is inferred only for this exact Events Manager row shape, so global ambiguous clock parsing is unchanged.
- Diagnostic output reports `payload_type: event`, `extraction_method: generic_html_events`, the direct target URL, and the full unique event count.
- Image-only pages do not satisfy the text-card gates and continue to the existing vision pathway.

## Reproduction Evidence
Before this change, live diagnostics returned `vision_flyer` for Cactus and one `raw_html` packet for Roosters. Running the updated extractor against the live pages on August 14, 2026 produced:

- Cactus Jack's: `canExtract=true`, 14 structured events, first time `20:30`, sibling image retained
- Roosters: `canExtract=true`, 14 structured events, first time `19:00`; fixture verifies `8:30` resolves to `20:30`
- Image-only fixture: `canExtract=false`, zero generic events

Because both listing pages now exceed the structured qualification threshold directly, qualification uses the production-safe listing URL rather than flyer fallback or isolated detail-page attempts.

## Tests
- `composer test:contracts` (4 tests, 58 assertions)
- focused Homeboy PHPCS and PHPStan gate for `GenericHtmlEventsExtractor.php` (clean)
- PHP syntax checks for all modified PHP files
- fixture/live extraction check for Cactus, Roosters, and image-only HTML
- added `GenericHtmlEventsExtractorTest` coverage for both source shapes, PM inference, overnight range starts, omitted-year rollover, sibling images, and flyer rejection
- added `EventScraperTestAbilityTest` coverage for truthful structured evidence and end-to-end vision fallback

The local managed WordPress PHPUnit route initialized its sandbox but reported zero executed tests; the committed WordPress cases are left for CI's managed bootstrap.

Closes #684