### PR TITLE
fix: make REST coordinate sanitizers callback-safe

### DIFF
--- a/inc/Api/Routes.php
+++ b/inc/Api/Routes.php
@@ -150,11 +150,15 @@ function register_routes() {
 			'args'                => array(
 				'lat'         => array(
 					'type'              => 'number',
-					'sanitize_callback' => 'floatval',
+					'sanitize_callback' => function ( $value ) {
+						return (float) $value;
+					},
 				),
 				'lng'         => array(
 					'type'              => 'number',
-					'sanitize_callback' => 'floatval',
+					'sanitize_callback' => function ( $value ) {
+						return (float) $value;
+					},
 				),
 				'radius'      => array(
 					'type'              => 'integer',
@@ -264,11 +268,15 @@ function register_routes() {
 				),
 				'lat'              => array(
 					'type'              => 'number',
-					'sanitize_callback' => 'floatval',
+					'sanitize_callback' => function ( $value ) {
+						return (float) $value;
+					},
 				),
 				'lng'              => array(
 					'type'              => 'number',
-					'sanitize_callback' => 'floatval',
+					'sanitize_callback' => function ( $value ) {
+						return (float) $value;
+					},
 				),
 				'radius'           => array(
 					'type'              => 'integer',

--- a/tests/rest-route-coordinate-sanitizer-smoke.php
+++ b/tests/rest-route-coordinate-sanitizer-smoke.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * REST coordinate sanitizer contract smoke test.
+ *
+ * Verifies that all coordinate route sanitizers accept the three arguments
+ * supplied by WP_REST_Request::sanitize_params() while preserving float casts.
+ *
+ * Run directly:
+ *   php tests/rest-route-coordinate-sanitizer-smoke.php
+ *
+ * @package DataMachineEvents\Tests
+ */
+
+namespace {
+	define( 'ABSPATH', __DIR__ . '/' );
+
+	$GLOBALS['dme_registered_routes'] = array();
+
+	function register_rest_route( string $namespace, string $route, array $args ): void {
+		$GLOBALS['dme_registered_routes'][ $namespace . $route ] = $args;
+	}
+
+	function add_action(): void {}
+
+	function sanitize_text_field( $value ) {
+		return $value;
+	}
+
+	function sanitize_key( $value ) {
+		return $value;
+	}
+
+	function absint( $value ): int {
+		return abs( (int) $value );
+	}
+
+	function rest_sanitize_boolean( $value ): bool {
+		return (bool) $value;
+	}
+}
+
+namespace DataMachineEvents\Api\Controllers {
+	final class Calendar {}
+	final class Venues {}
+	final class EventIcs {}
+	final class Filters {}
+	final class Geocoding {}
+	final class VenueMap {}
+}
+
+namespace {
+	require_once dirname( __DIR__ ) . '/inc/Api/Routes.php';
+
+	\DataMachineEvents\Api\register_routes();
+
+	$pass = 0;
+	$fail = 0;
+
+	function check( string $label, bool $condition ): void {
+		global $pass, $fail;
+		if ( $condition ) {
+			++$pass;
+		} else {
+			++$fail;
+			echo "FAIL: {$label}\n";
+		}
+	}
+
+	$expected = array(
+		'/events/venues'  => array( 'lat', 'lng' ),
+		'/events/filters' => array( 'lat', 'lng' ),
+	);
+
+	foreach ( $expected as $route => $fields ) {
+		$args = $GLOBALS['dme_registered_routes'][ 'datamachine/v1' . $route ]['args'] ?? array();
+		foreach ( $fields as $field ) {
+			$callback = $args[ $field ]['sanitize_callback'] ?? null;
+			check( "{$route}.{$field} has callable sanitizer", is_callable( $callback ) );
+			if ( is_callable( $callback ) ) {
+				$result = $callback( '12.3456', new \stdClass(), $field );
+				check( "{$route}.{$field} preserves float conversion", is_float( $result ) && 12.3456 === $result );
+			}
+		}
+	}
+
+	printf( "\n%d passed, %d failed\n", $pass, $fail );
+	exit( $fail > 0 ? 1 : 0 );
+}


### PR DESCRIPTION
## Summary
Prevent PHP 8 REST fatals when coordinate query parameters are sanitized.

## What changed
- Replaced four direct floatval REST callbacks with callback-safe closures and added route-level three-argument sanitizer coverage.

## How to test
1. Run `php tests/rest-route-coordinate-sanitizer-smoke.php`; expect Reports 8 passed, 0 failed.
2. Run `php -l inc/Api/Routes.php`; expect Reports no syntax errors.
3. Run `php -l tests/rest-route-coordinate-sanitizer-smoke.php`; expect Reports no syntax errors.

## Compatibility
Preserves float conversion for lat/lng while accepting WordPress REST's three callback arguments.

## Evidence
- Base unchanged since verification: main remains at 7b2a8204f158b4efd6b3f2f8d1b92999ea05ac78.
- Reviewer-resolvable evidence from source\_refs\[0\]: https://github.com/Extra-Chill/data-machine-events/issues/683
- Verified finalization base: main at 7b2a8204f158b4efd6b3f2f8d1b92999ea05ac78
- coordinate-smoke: passed (8 passed, 0 failed) (Passed)
- routes-syntax: passed (no syntax errors) (Passed)
- test-syntax: passed (no syntax errors) (Passed)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Homeboy (OpenCode)
- **Model:** openai/gpt-5.6-sol
- **Used for:** Traced the REST callback contract, implemented the four route-owner fixes, and authored focused regression coverage; deterministic gates independently verified the result.

## Source relationships
- Closes #683
