### PR TITLE
fix: prevent early archive map toggle clicks

### DIFF
--- a/inc/Blocks/EventsMap/render.php
+++ b/inc/Blocks/EventsMap/render.php
@@ -166,6 +166,7 @@ $hide_label = __( 'Hide map', 'data-machine-events' );
 			aria-controls="<?php echo esc_attr( $region_id ); ?>"
 			data-label-show="<?php echo esc_attr( $show_label ); ?>"
 			data-label-hide="<?php echo esc_attr( $hide_label ); ?>"
+			disabled
 		><?php echo esc_html( $default_collapsed ? $show_label : $hide_label ); ?></button>
 		<div
 			id="<?php echo esc_attr( $region_id ); ?>"

--- a/inc/Blocks/EventsMap/src/frontend.test.tsx
+++ b/inc/Blocks/EventsMap/src/frontend.test.tsx
@@ -134,7 +134,7 @@ import { act } from 'react';
 /**
  * Internal dependencies
  */
-import { EventsMap } from './frontend';
+import { EventsMap, setupCollapsible } from './frontend';
 
 import type { MapProps } from './types';
 
@@ -192,6 +192,56 @@ function collectBoundsEvents(): {
 			),
 	};
 }
+
+describe( 'EventsMap collapsible disclosure', () => {
+	beforeEach( () => {
+		mockMapInstances.length = 0;
+		document.body.innerHTML = `
+			<div class="data-machine-events-map-collapsible is-collapsed">
+				<button
+					id="map-toggle"
+					aria-expanded="false"
+					data-label-show="Show map"
+					data-label-hide="Hide map"
+					disabled
+				>Show map</button>
+				<div id="map-region" hidden>
+					<div
+						id="map-root"
+						class="data-machine-events-map-root"
+						data-collapsible="1"
+						data-toggle-id="map-toggle"
+						data-region-id="map-region"
+						data-default-collapsed="1"
+					></div>
+				</div>
+			</div>
+		`;
+	} );
+
+	it( 'enables the toggle only after binding and expands on first click', () => {
+		const container = document.getElementById( 'map-root' ) as HTMLElement;
+		const toggle = document.getElementById(
+			'map-toggle'
+		) as HTMLButtonElement;
+		const region = document.getElementById( 'map-region' ) as HTMLElement;
+
+		expect( setupCollapsible( container ) ).toBe( true );
+		expect( toggle.disabled ).toBe( false );
+		expect( mockMapInstances ).toHaveLength( 0 );
+
+		act( () => toggle.click() );
+		expect( toggle.getAttribute( 'aria-expanded' ) ).toBe( 'true' );
+		expect( toggle.textContent ).toBe( 'Hide map' );
+		expect( region.hidden ).toBe( false );
+		expect( mockMapInstances ).toHaveLength( 1 );
+
+		act( () => toggle.click() );
+		expect( toggle.getAttribute( 'aria-expanded' ) ).toBe( 'false' );
+		expect( toggle.textContent ).toBe( 'Show map' );
+		expect( region.hidden ).toBe( true );
+	} );
+} );
 
 describe( 'EventsMap geo authority integration', () => {
 	beforeEach( () => {

--- a/inc/Blocks/EventsMap/src/frontend.tsx
+++ b/inc/Blocks/EventsMap/src/frontend.tsx
@@ -1379,7 +1379,7 @@ function mountMap( container: HTMLElement ): void {
  * @param container Map root container.
  * @return Whether the immediate mount should be skipped (deferred to expand).
  */
-function setupCollapsible( container: HTMLElement ): boolean {
+export function setupCollapsible( container: HTMLElement ): boolean {
 	if ( container.dataset.collapsible !== '1' ) {
 		return false;
 	}
@@ -1439,6 +1439,7 @@ function setupCollapsible( container: HTMLElement ): boolean {
 		const expanded = toggle.getAttribute( 'aria-expanded' ) === 'true';
 		setExpanded( ! expanded );
 	} );
+	toggle.disabled = false;
 
 	// When it starts collapsed, defer the React mount until first expand so
 	// Leaflet never initializes in a zero-height container.


### PR DESCRIPTION
## Summary
- keep collapsible map controls disabled until their interaction handler is bound
- enable the control immediately after binding so the first accepted click always expands the map
- cover first expansion and subsequent collapse with a focused interaction test

Closes #689.

## Verification
- `npm run build`
- `npm test -- --runInBand src/frontend.test.tsx` (16 tests)
- `npm run lint:js`
- `php -l inc/Blocks/EventsMap/render.php`
- `git diff --check`