### PR TITLE
fix: serve event map runtime locally

### DIFF
--- a/data-machine-events.php
+++ b/data-machine-events.php
@@ -663,10 +663,21 @@ class DATAMACHINE_Events {
 			(string) filemtime( DATA_MACHINE_EVENTS_PLUGIN_DIR . 'inc/Blocks/root.css' )
 		);
 
-		// Register Leaflet CDN assets for event-details block (single venue maps).
-		// The events-map block bundles Leaflet via webpack and does not need these handles.
-		wp_register_style( 'leaflet', 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css', array(), '1.9.4' );
-		wp_register_script( 'leaflet', 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.js', array(), '1.9.4', true );
+		// Register the Event Details block's locally built Leaflet distribution.
+		// The Events Map block bundles its own module-scoped Leaflet runtime.
+		wp_register_style(
+			'leaflet',
+			DATA_MACHINE_EVENTS_PLUGIN_URL . 'inc/Blocks/EventDetails/build/leaflet.css',
+			array(),
+			'1.9.4'
+		);
+		wp_register_script(
+			'leaflet',
+			DATA_MACHINE_EVENTS_PLUGIN_URL . 'inc/Blocks/EventDetails/build/leaflet.js',
+			array(),
+			'1.9.4',
+			true
+		);
 
 		// Register venue map JS for event-details block.
 		wp_register_script(

--- a/inc/Blocks/EventDetails/package-lock.json
+++ b/inc/Blocks/EventDetails/package-lock.json
@@ -11,7 +11,8 @@
         "@wordpress/block-editor": "^16.0.0",
         "@wordpress/blocks": "^15.24.0",
         "@wordpress/components": "^37.0.0",
-        "@wordpress/i18n": "^6.24.0"
+        "@wordpress/i18n": "^6.24.0",
+        "leaflet": "1.9.4"
       },
       "devDependencies": {
         "@wordpress/eslint-plugin": "^25.7.0",
@@ -17103,6 +17104,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/legacy-javascript": {
       "version": "0.0.1",

--- a/inc/Blocks/EventDetails/package.json
+++ b/inc/Blocks/EventDetails/package.json
@@ -29,6 +29,7 @@
     "@wordpress/block-editor": "^16.0.0",
     "@wordpress/blocks": "^15.24.0",
     "@wordpress/components": "^37.0.0",
-    "@wordpress/i18n": "^6.24.0"
+    "@wordpress/i18n": "^6.24.0",
+    "leaflet": "1.9.4"
   }
 }

--- a/inc/Blocks/EventDetails/render.php
+++ b/inc/Blocks/EventDetails/render.php
@@ -279,6 +279,11 @@ $event_schema     = EventSchemaProvider::generateSchemaOrg( $event_data, $venue_
 				if ( class_exists( 'DataMachineEvents\\Admin\\Settings_Page' ) ) {
 					$map_display_type = \DataMachineEvents\Admin\Settings_Page::get_map_display_type();
 				}
+				$openstreetmap_url = sprintf(
+					'https://www.openstreetmap.org/?mlat=%1$s&mlon=%2$s#map=15/%1$s/%2$s',
+					rawurlencode( $lat ),
+					rawurlencode( $lon )
+				);
 				?>
 				<div class="data-machine-venue-map-section">
 					<h3 class="venue-map-title"><?php echo esc_html__( 'Venue Location', 'data-machine-events' ); ?></h3>
@@ -291,6 +296,15 @@ $event_schema     = EventSchemaProvider::generateSchemaOrg( $event_data, $venue_
 						data-venue-address="<?php echo esc_attr( $address ); ?>"
 						data-map-type="<?php echo esc_attr( $map_display_type ); ?>"
 					></div>
+					<div class="venue-map-fallback">
+						<strong><?php echo esc_html( $venue ); ?></strong>
+						<?php if ( $address ) : ?>
+							<span><?php echo esc_html( $address ); ?></span>
+						<?php endif; ?>
+						<a href="<?php echo esc_url( $openstreetmap_url ); ?>" target="_blank" rel="noopener">
+							<?php esc_html_e( 'View venue on OpenStreetMap', 'data-machine-events' ); ?>
+						</a>
+					</div>
 					<div class="venue-map-attribution">
 						<small>
 							<?php

--- a/inc/Blocks/EventDetails/src/frontend.css
+++ b/inc/Blocks/EventDetails/src/frontend.css
@@ -208,11 +208,42 @@
 }
 
 .data-machine-venue-map {
+    display: none;
     width: 100%;
     height: 400px;
     border-radius: var(--data-machine-border-radius);
     overflow: hidden;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.data-machine-venue-map.map-initialized {
+    display: block;
+}
+
+.venue-map-fallback {
+    display: flex;
+    min-height: 250px;
+    box-sizing: border-box;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 24px;
+    text-align: center;
+    background: var(--data-machine-background-secondary);
+    color: var(--data-machine-text-primary);
+}
+
+.venue-map-fallback span {
+    color: var(--data-machine-text-secondary);
+}
+
+.venue-map-fallback a {
+    color: var(--data-machine-text-accent);
+}
+
+.data-machine-venue-map.map-initialized + .venue-map-fallback {
+    display: none;
 }
 
 /* Custom emoji marker styling */

--- a/inc/Blocks/EventDetails/src/leaflet.js
+++ b/inc/Blocks/EventDetails/src/leaflet.js
@@ -1,0 +1,14 @@
+/**
+ * Leaflet runtime for the Event Details venue map.
+ *
+ * The legacy venue map initializer consumes the global browser API, while
+ * webpack keeps the dependency pinned and served from the plugin build.
+ */
+
+/**
+ * External dependencies
+ */
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+
+window.L = L;

--- a/inc/Blocks/EventDetails/src/leaflet.js
+++ b/inc/Blocks/EventDetails/src/leaflet.js
@@ -8,7 +8,7 @@
 /**
  * External dependencies
  */
-import L from 'leaflet';
-import 'leaflet/dist/leaflet.css';
+import L from 'leaflet'; // eslint-disable-line import/no-unresolved -- Installed by this block package before webpack builds.
+import 'leaflet/dist/leaflet.css'; // eslint-disable-line import/no-unresolved -- Installed by this block package before webpack builds.
 
 window.L = L;

--- a/inc/Blocks/EventDetails/webpack.config.js
+++ b/inc/Blocks/EventDetails/webpack.config.js
@@ -1,16 +1,17 @@
 /**
  * WordPress dependencies
  */
-const defaultConfig = require('@wordpress/scripts/config/webpack.config');
+const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
 
 module.exports = {
-    ...defaultConfig,
-    entry: {
-        index: './src/index.js',
-        frontend: './src/frontend.js'
-    },
-    output: {
-        ...defaultConfig.output,
-        filename: '[name].js'
-    }
-}; 
+	...defaultConfig,
+	entry: {
+		index: './src/index.js',
+		frontend: './src/frontend.js',
+		leaflet: './src/leaflet.js',
+	},
+	output: {
+		...defaultConfig.output,
+		filename: '[name].js',
+	},
+};

--- a/tests/Unit/BlockRegistrationTest.php
+++ b/tests/Unit/BlockRegistrationTest.php
@@ -69,4 +69,22 @@ class BlockRegistrationTest extends WP_UnitTestCase {
 		$this->assertNotNull( $block, 'Event Details block should be registered' );
 		$this->assertSame( 'data-machine-events', $block->category, 'Block should use the plugin category' );
 	}
+
+	public function test_leaflet_assets_are_served_by_the_plugin() {
+		$leaflet_style  = wp_styles()->registered['leaflet'] ?? null;
+		$leaflet_script = wp_scripts()->registered['leaflet'] ?? null;
+
+		$this->assertNotNull( $leaflet_style, 'Leaflet CSS should be registered' );
+		$this->assertNotNull( $leaflet_script, 'Leaflet JavaScript should be registered' );
+		$this->assertSame(
+			DATA_MACHINE_EVENTS_PLUGIN_URL . 'inc/Blocks/EventDetails/build/leaflet.css',
+			$leaflet_style->src
+		);
+		$this->assertSame(
+			DATA_MACHINE_EVENTS_PLUGIN_URL . 'inc/Blocks/EventDetails/build/leaflet.js',
+			$leaflet_script->src
+		);
+		$this->assertStringNotContainsString( 'unpkg.com', $leaflet_style->src );
+		$this->assertStringNotContainsString( 'unpkg.com', $leaflet_script->src );
+	}
 }


### PR DESCRIPTION
## Summary
- build the Event Details map's pinned Leaflet 1.9.4 runtime and stylesheet locally instead of registering unpkg URLs
- keep a server-rendered venue/address/OpenStreetMap fallback visible until Leaflet initializes successfully
- cover the registered asset URLs and verify the blocked-external-network browser path in WP Codebox

## Root Cause And Ownership
The Events Map block already owns a module-scoped Leaflet 1.9.4 dependency bundled by webpack. The Event Details block was a separate legacy consumer of global `window.L`, and its registered `leaflet` handles were the only runtime CDN path. This change fixes that owning Event Details build rather than adding a consumer workaround: the block now pins the same Leaflet version, emits `build/leaflet.js` and `build/leaflet.css`, and registers those plugin-local files.

## Fallback
The venue name, formatted address, and an OpenStreetMap link are server-rendered. The fixed-height map stays out of layout until the existing initializer adds `map-initialized`; successful initialization reveals the map and hides the fallback. Missing JavaScript or initialization failure therefore leaves useful location content instead of a blank panel.

## Verification
- `homeboy review lint --changed-only --summary` (pass, no findings; run `9de26660-a740-4701-b6bc-a0f720f34d03`)
- `npm run lint:js` in `inc/Blocks/EventDetails` (pass)
- `npm run build` in `inc/Blocks/EventDetails` (pass; emits local Leaflet JS/CSS and image assets)
- `vendor/bin/phpunit --configuration phpunit.contracts.xml` (pass, 4 tests / 58 assertions)
- focused WP Codebox PHPUnit: `BlockRegistrationTest` (pass, 5 tests / 15 assertions; artifact bundle `7572dff226d6a96fce80fa86d1d0962b128a1dcf65eb43926eb8576777cc1fe5`)
- WP Codebox Chromium browser probe with `networkPolicy.mode=block` (pass, 3/3 assertions): all 7 external requests blocked, local `build/leaflet.css` and `build/leaflet.js` returned 200, `.leaflet-control-zoom` visible, `.venue-map-fallback` hidden after initialization, and zero page errors
- browser artifact bundle: `7ea11ebefc73a4cc8ddfce23821a176056a432d7c22dc5a0ec8aa4a1f8d83868`
- browser summary: `/mnt/extrachill-workspace/tmp/opencode/dme-692-browser-evidence-final2/runtime-mst1r66h-awvhyx/files/browser/summary.json`

Fixes #692