### PR TITLE
fix: attach Ticketmaster claim descriptors

### DIFF
--- a/inc/Steps/EventImport/Handlers/Ticketmaster/Ticketmaster.php
+++ b/inc/Steps/EventImport/Handlers/Ticketmaster/Ticketmaster.php
@@ -7,6 +7,8 @@
 
 namespace DataMachineEvents\Steps\EventImport\Handlers\Ticketmaster;
 
+use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
+use DataMachine\Core\Database\TrackedItems\TrackedItems;
 use DataMachine\Core\ExecutionContext;
 use DataMachineEvents\Steps\EventImport\Handlers\EventImportHandler;
 use DataMachineEvents\Steps\EventImport\JunkPayloadFilter;
@@ -74,7 +76,6 @@ class Ticketmaster extends EventImportHandler {
 
 	public function __construct() {
 		parent::__construct( 'ticketmaster' );
-		TicketmasterSourceIdentity::register();
 
 		self::registerHandler(
 			'ticketmaster',
@@ -291,11 +292,6 @@ class Ticketmaster extends EventImportHandler {
 				$engine_data                    = $this->buildEventEngineData( $standardized_event, $venue_metadata );
 				$engine_data['item_identifier'] = $item_identifier;
 				$engine_data['source_type']     = 'ticketmaster';
-				$engine_data[ TicketmasterSourceIdentity::ENGINE_KEY ] = array(
-					'item_id'    => $item_identifier,
-					'revision'   => $source_revision,
-					'source_ref' => $standardized_event['ticketUrl'] ?? '',
-				);
 				$this->stripVenueMetadataFromEvent( $standardized_event );
 
 				$eligible_items[] = array(
@@ -338,21 +334,56 @@ class Ticketmaster extends EventImportHandler {
 		$claimed_items  = array();
 
 		foreach ( $eligible_items as $item ) {
-			$item_id  = (string) ( $item['metadata']['source_item_id'] ?? '' );
-			$revision = (string) ( $item['metadata']['source_revision'] ?? '' );
-			$claim    = TicketmasterSourceIdentity::claim( $item_id, $revision, $context );
+			$item_id    = (string) ( $item['metadata']['source_item_id'] ?? '' );
+			$revision   = (string) ( $item['metadata']['source_revision'] ?? '' );
+			$source_ref = (string) ( $item['metadata']['_engine_data']['ticketUrl'] ?? '' );
+			$claim      = $context->claimItemOwnership(
+				TicketmasterSourceIdentity::CLAIM_SCOPE,
+				$item_id,
+				TicketmasterSourceIdentity::CLAIM_TTL,
+				array(
+					'handler'          => 'tracked_item',
+					'retain_processed' => false,
+					'payload'          => array(
+						'item' => array(
+							'namespace'       => TicketmasterSourceIdentity::TRACK_NAMESPACE,
+							'item_id'         => $item_id,
+							'item_type'       => 'event',
+							'state'           => TrackedItems::STATE_GENERATED,
+							'source_ref'      => $source_ref,
+							'source_revision' => $revision,
+						),
+					),
+				)
+			);
 
-			if ( 'claimed' === $claim || 'direct' === $claim ) {
-				$claimed_items[] = $item;
+			if ( false === $claim ) {
+				++$pre_fanout_deduped;
+				++$contended_count;
 				continue;
 			}
 
-			++$pre_fanout_deduped;
-			if ( 'unchanged' === $claim ) {
+			// Recheck under ownership because another city may have committed the
+			// revision after the pre-cap check but before this claim was acquired.
+			if ( TicketmasterSourceIdentity::shouldSkip( $item_id, $revision, $context ) ) {
+				if ( false !== ( $claim['persisted'] ?? true ) ) {
+					( new ProcessedItems() )->release_owned_claim(
+						$claim['identity_scope'],
+						$claim['source_type'],
+						$claim['item_identifier'],
+						$claim['ownership_token']
+					);
+				}
+				++$pre_fanout_deduped;
 				++$unchanged_count;
-			} else {
-				++$contended_count;
+				continue;
 			}
+
+			$item['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ] = $claim;
+			if ( isset( $claim['disposition_id'] ) ) {
+				$item['metadata'][ ProcessedItems::DISPOSITION_ID_METADATA_KEY ] = $claim['disposition_id'];
+			}
+			$claimed_items[] = $item;
 		}
 
 		$eligible_items = $claimed_items;

--- a/inc/Steps/EventImport/Handlers/Ticketmaster/Ticketmaster.php
+++ b/inc/Steps/EventImport/Handlers/Ticketmaster/Ticketmaster.php
@@ -367,12 +367,23 @@ class Ticketmaster extends EventImportHandler {
 			// revision after the pre-cap check but before this claim was acquired.
 			if ( TicketmasterSourceIdentity::shouldSkip( $item_id, $revision, $context ) ) {
 				if ( false !== ( $claim['persisted'] ?? true ) ) {
-					( new ProcessedItems() )->release_owned_claim(
+					$released = ( new ProcessedItems() )->release_owned_claim(
 						$claim['identity_scope'],
 						$claim['source_type'],
 						$claim['item_identifier'],
 						$claim['ownership_token']
 					);
+					if ( 1 !== $released ) {
+						$context->log(
+							'error',
+							'Ticketmaster: Exact unchanged-revision claim release failed',
+							array(
+								'item_identifier' => $claim['item_identifier'],
+								'disposition_id'  => $claim['disposition_id'],
+							)
+						);
+						throw new \RuntimeException( 'Ticketmaster could not release the exact unchanged-revision claim.' );
+					}
 				}
 				++$pre_fanout_deduped;
 				++$unchanged_count;

--- a/inc/Steps/EventImport/Handlers/Ticketmaster/TicketmasterSourceIdentity.php
+++ b/inc/Steps/EventImport/Handlers/Ticketmaster/TicketmasterSourceIdentity.php
@@ -7,7 +7,6 @@
 
 namespace DataMachineEvents\Steps\EventImport\Handlers\Ticketmaster;
 
-use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 use DataMachine\Core\Database\TrackedItems\TrackedItems;
 use DataMachine\Core\ExecutionContext;
 
@@ -20,21 +19,12 @@ class TicketmasterSourceIdentity {
 
 	public const CLAIM_SCOPE     = 'event_import:ticketmaster';
 	public const TRACK_NAMESPACE = 'event_import:ticketmaster';
-	public const ENGINE_KEY      = 'ticketmaster_source_identity';
 	public const CLAIM_TTL       = 3 * DAY_IN_SECONDS;
 
 	/**
 	 * Static lifecycle service.
 	 */
 	private function __construct() {
-	}
-
-	/**
-	 * Register terminal lifecycle handlers for source claims and revisions.
-	 */
-	public static function register(): void {
-		add_action( 'datamachine_step_lifecycle_completed', array( static::class, 'handleCompleted' ), 20, 2 );
-		add_action( 'datamachine_step_lifecycle_failed', array( static::class, 'handleFailed' ), 20, 2 );
 	}
 
 	/**
@@ -75,108 +65,6 @@ class TicketmasterSourceIdentity {
 				'job_id'          => (int) $context->getJobId(),
 				'source_revision' => $revision,
 			)
-		);
-	}
-
-	/**
-	 * Atomically select an item after the handler's fan-out cap is applied.
-	 *
-	 * @return string claimed, direct, unchanged, or contended.
-	 */
-	public static function claim( string $item_id, string $revision, ExecutionContext $context ): string {
-		if ( $context->isDirect() || $context->isStandalone() ) {
-			return 'direct';
-		}
-
-		$job_id = (int) $context->getJobId();
-		if ( $job_id < 1 ) {
-			return 'contended';
-		}
-
-		$processed_items = new ProcessedItems();
-		if ( ! $processed_items->claim_item( self::CLAIM_SCOPE, 'ticketmaster', $item_id, $job_id, self::CLAIM_TTL ) ) {
-			return 'contended';
-		}
-
-		// Recheck inside the lock because another city may have completed after
-		// the pre-cap revision check but before this claim was acquired.
-		if ( self::shouldSkip( $item_id, $revision, $context ) ) {
-			$processed_items->release_claim( self::CLAIM_SCOPE, 'ticketmaster', $item_id );
-			return 'unchanged';
-		}
-
-		return 'claimed';
-	}
-
-	/**
-	 * Persist the source revision only after the downstream pipeline succeeds.
-	 *
-	 * @param int        $job_id      Completed child job ID.
-	 * @param array|null $engine_data Child engine data.
-	 */
-	public static function handleCompleted( int $job_id, ?array $engine_data = null ): void {
-		$identity = self::identityFromEngine( $engine_data );
-		if ( null === $identity ) {
-			return;
-		}
-
-		( new TrackedItems() )->upsert(
-			array(
-				'namespace'       => self::TRACK_NAMESPACE,
-				'item_id'         => $identity['item_id'],
-				'item_type'       => 'event',
-				'state'           => TrackedItems::STATE_GENERATED,
-				'source_ref'      => $identity['source_ref'],
-				'source_revision' => $identity['revision'],
-				'last_job_id'     => $job_id,
-			)
-		);
-
-		self::release( $identity['item_id'] );
-	}
-
-	/**
-	 * Release the cross-flow claim after terminal failure without tracking the revision.
-	 *
-	 * @param int        $job_id      Failed child job ID.
-	 * @param array|null $engine_data Child engine data.
-	 */
-	public static function handleFailed( int $job_id, ?array $engine_data = null ): void {
-		$job_id;
-		$identity = self::identityFromEngine( $engine_data );
-		if ( null !== $identity ) {
-			self::release( $identity['item_id'] );
-		}
-	}
-
-	/**
-	 * Release a source claim explicitly.
-	 */
-	public static function release( string $item_id ): void {
-		( new ProcessedItems() )->release_claim( self::CLAIM_SCOPE, 'ticketmaster', $item_id );
-	}
-
-	/**
-	 * Read validated Ticketmaster identity data from a child engine snapshot.
-	 *
-	 * @param array|null $engine_data Engine data.
-	 * @return array{item_id:string,revision:string,source_ref:string}|null
-	 */
-	private static function identityFromEngine( ?array $engine_data ): ?array {
-		$identity = is_array( $engine_data[ self::ENGINE_KEY ] ?? null )
-			? $engine_data[ self::ENGINE_KEY ]
-			: array();
-
-		$item_id  = trim( (string) ( $identity['item_id'] ?? '' ) );
-		$revision = trim( (string) ( $identity['revision'] ?? '' ) );
-		if ( '' === $item_id || '' === $revision ) {
-			return null;
-		}
-
-		return array(
-			'item_id'    => $item_id,
-			'revision'   => $revision,
-			'source_ref' => (string) ( $identity['source_ref'] ?? '' ),
 		);
 	}
 }

--- a/tests/Unit/TicketmasterHandlerTest.php
+++ b/tests/Unit/TicketmasterHandlerTest.php
@@ -237,14 +237,19 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 			$this->assertSame( $claim, $after_first[ ProcessedItems::CLAIMS_METADATA_KEY ][0] );
 			$this->assertGreaterThan( time() + 3000, strtotime( (string) $wpdb->get_var( $wpdb->prepare( 'SELECT claim_expires_at FROM %i WHERE claim_token = %s', $wpdb->prefix . ProcessedItems::TABLE_NAME, $claim['ownership_token'] ) ) ) );
 
-			\DataMachine\Engine\Actions\datamachine_resume_ai_step_action( $job_id, 'ai-step', 0, '', 1 );
+			$this->assertTrue( AIConcurrencyBackpressure::beginGeneration( $job_id, 'ai-step', 1, time() ) );
+			$second = $executor->execute( array( 'job_id' => $job_id, 'flow_step_id' => 'ai-step', 'ai_resume_generation' => 1 ) );
+			$this->assertSame( 'blocked', $second['outcome'] );
+			$this->assertFalse( AIConcurrencyBackpressure::beginGeneration( $job_id, 'ai-step', 1, time() ) );
 			$after_second = datamachine_get_engine_data( $job_id );
 			$this->assertSame( 2, $after_second['ai_concurrency_throttle']['resume_generation'] );
 			$this->assertSame( $claim, $after_second[ ProcessedItems::CLAIMS_METADATA_KEY ][0] );
 			$this->assertSame( $claim['disposition_id'], $packet['metadata'][ ProcessedItems::DISPOSITION_ID_METADATA_KEY ] );
 
 			$blocker['lease']->release();
-			\DataMachine\Engine\Actions\datamachine_resume_ai_step_action( $job_id, 'ai-step', 0, '', 2 );
+			$this->assertTrue( AIConcurrencyBackpressure::beginGeneration( $job_id, 'ai-step', 2, time() ) );
+			$resumed = $executor->execute( array( 'job_id' => $job_id, 'flow_step_id' => 'ai-step', 'ai_resume_generation' => 2 ) );
+			$this->assertSame( 'inline_continuation', $resumed['outcome'] );
 			$this->assertCount( 1, $scheduled_packets );
 			$this->assertSame( $claim, $scheduled_packets[0]['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ] );
 			$this->assertSame( $claim['disposition_id'], $scheduled_packets[0]['metadata'][ ProcessedItems::DISPOSITION_ID_METADATA_KEY ] );

--- a/tests/Unit/TicketmasterHandlerTest.php
+++ b/tests/Unit/TicketmasterHandlerTest.php
@@ -14,6 +14,7 @@ use WP_UnitTestCase;
 use DataMachine\Abilities\Engine\ExecuteStepAbility;
 use DataMachine\Abilities\Engine\PipelineBatchScheduler;
 use DataMachine\Abilities\HandlerAbilities;
+use DataMachine\Abilities\AbilityRegistration;
 use DataMachine\Core\Database\Agents\Agents;
 use DataMachine\Core\Database\BatchItems\BatchItems;
 use DataMachine\Core\Database\Flows\Flows;
@@ -268,6 +269,14 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 
 		try {
 			$executor = new ExecuteStepAbility();
+			if ( ! wp_get_ability( 'datamachine/execute-step' ) ) {
+				$owners          = new \ReflectionProperty( AbilityRegistration::class, 'registration_owners' );
+				$original_owners = $owners->getValue();
+				$owners->setValue( null, array() );
+				( new \ReflectionMethod( $executor, 'registerAbility' ) )->invoke( $executor );
+				$owners->setValue( null, $original_owners );
+			}
+			$this->assertNotNull( wp_get_ability( 'datamachine/execute-step' ) );
 			$first    = $executor->execute( array( 'job_id' => $job_id, 'flow_step_id' => 'ai-step' ) );
 			$this->assertSame( 'blocked', $first['outcome'] );
 			$after_first = datamachine_get_engine_data( $job_id );

--- a/tests/Unit/TicketmasterHandlerTest.php
+++ b/tests/Unit/TicketmasterHandlerTest.php
@@ -11,10 +11,16 @@
 namespace DataMachineEvents\Tests\Unit;
 
 use WP_UnitTestCase;
+use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\Database\ProcessedItems\FanoutClaimOwnership;
 use DataMachine\Core\Database\TrackedItems\TrackedItems;
 use DataMachine\Core\EngineData;
 use DataMachine\Core\ExecutionContext;
 use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
+use DataMachine\Core\JobStatus;
+use DataMachine\Core\RunMetrics;
+use DataMachine\Core\Steps\Fetch\Tools\FetchItemDispositionTool;
+use DataMachine\Engine\Actions\Handlers\StepLifecycleHandler;
 use DataMachineEvents\Core\DuplicateDetection\PreAIEventDedupGate;
 use DataMachineEvents\Core\EventDatesTable;
 use DataMachineEvents\Core\Event_Post_Type;
@@ -27,18 +33,23 @@ use ReflectionClass;
 class TicketmasterHandlerTest extends WP_UnitTestCase {
 
 	private Ticketmaster $handler;
+	private \Closure $tracked_completion_filter;
 
 	public function setUp(): void {
 		parent::setUp();
 		$this->ensureEventIdentityTables();
+		Jobs::create_table();
 		( new ProcessedItems() )->create_table();
 		( new TrackedItems() )->create_table();
+		$this->tracked_completion_filter = static fn( array $handlers ): array => TrackedItems::registerClaimCompletionHandler( $handlers );
+		add_filter( 'datamachine_item_claim_completion_handlers', $this->tracked_completion_filter );
 		$this->handler = new Ticketmaster();
 		set_transient( 'data_machine_events_ticketmaster_classifications', array( 'music' => 'Music' ) );
 	}
 
 	public function tearDown(): void {
 		remove_filter( 'data_machine_events_junk_payload_patterns', array( $this->handler, 'register_junk_patterns' ), 10 );
+		remove_filter( 'datamachine_item_claim_completion_handlers', $this->tracked_completion_filter );
 		delete_transient( 'data_machine_events_ticketmaster_classifications' );
 		parent::tearDown();
 	}
@@ -114,7 +125,152 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 		$this->assertSame( 'TM-new-event', $packet['metadata']['source_item_id'] );
 		$this->assertArrayNotHasKey( 'item_identifier', $packet['metadata'] );
 		$this->assertSame( 'TM-new-event', $packet['metadata']['_engine_data']['item_identifier'] );
+		$claim = $packet['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ];
+		$this->assertSame( TicketmasterSourceIdentity::CLAIM_SCOPE, $claim['identity_scope'] );
+		$this->assertSame( 'ticketmaster', $claim['source_type'] );
+		$this->assertSame( 'TM-new-event', $claim['item_identifier'] );
+		$this->assertSame( 'tracked_item', $claim['completion']['handler'] );
+		$this->assertFalse( $claim['completion']['retain_processed'] );
+		$this->assertSame( $claim['disposition_id'], $packet['metadata'][ ProcessedItems::DISPOSITION_ID_METADATA_KEY ] );
 		$this->failPacket( $packet, 1001 );
+	}
+
+	public function test_single_packet_inline_ai_resume_and_upsert_commit_canonical_claim(): void {
+		$item_id = 'TM-inline-' . uniqid();
+		$job_id  = $this->createJob( 'Ticketmaster inline lifecycle' );
+		$packets = ( new TicketmasterHandlerTestDouble( array( 0 => $this->ticketmasterPage( array( $this->ticketmasterEvent( $item_id, 'Inline Event' ) ) ) ) ) )
+			->get_fetch_data( 1, $this->handlerConfig( '32.7765,-79.9311', 'inline-fetch' ), (string) $job_id );
+		$packet = $packets[0]->addTo( array() )[0];
+
+		$this->assertTrue( StepLifecycleHandler::handleInlineContinuation( $job_id, array( 'step_type' => 'event_import' ), array( $packet ) ) );
+		$claim = datamachine_get_engine_data( $job_id )[ ProcessedItems::CLAIMS_METADATA_KEY ][0];
+		datamachine_merge_engine_data( $job_id, array( 'ai_resume_generation' => 2 ) );
+		$this->assertSame( $claim, datamachine_get_engine_data( $job_id )[ ProcessedItems::CLAIMS_METADATA_KEY ][0] );
+		$this->assertTrue( StepLifecycleHandler::reconcileStepOutput( $job_id, array( 'step_type' => 'ai' ), array( $packet ), true )['success'] );
+		$this->assertTrue( StepLifecycleHandler::reconcileStepOutput( $job_id, array( 'step_type' => 'upsert' ), array( $packet ), true )['success'] );
+		$this->assertTrue( ( new Jobs() )->complete_job( $job_id, JobStatus::COMPLETED ) );
+
+		$tracked = ( new TrackedItems() )->get( TicketmasterSourceIdentity::TRACK_NAMESPACE, $item_id );
+		$this->assertSame( $packet['metadata']['source_revision'], $tracked['source_revision'] );
+		$this->assertFalse( ( new ProcessedItems() )->has_active_claim( TicketmasterSourceIdentity::CLAIM_SCOPE, 'ticketmaster', $item_id ) );
+		$this->assertSame( 1, RunMetrics::fromJob( ( new Jobs() )->get_job( $job_id ) )['counts']['processed'] );
+	}
+
+	public function test_reject_and_defer_resolve_exact_ticketmaster_disposition(): void {
+		foreach ( array( 'reject_source', 'defer_item' ) as $disposition ) {
+			$item_id = 'TM-' . $disposition . '-' . uniqid();
+			$job_id  = $this->createJob( 'Ticketmaster ' . $disposition );
+			$packets = ( new TicketmasterHandlerTestDouble( array( 0 => $this->ticketmasterPage( array( $this->ticketmasterEvent( $item_id, 'Disposition Event' ) ) ) ) ) )
+				->get_fetch_data( 1, $this->handlerConfig( '32.7765,-79.9311', $disposition . '-fetch' ), (string) $job_id );
+			$packet = $packets[0]->addTo( array() )[0];
+			$this->assertTrue( StepLifecycleHandler::handleInlineContinuation( $job_id, array( 'step_type' => 'event_import' ), array( $packet ) ) );
+			$disposition_id = $packet['metadata'][ ProcessedItems::DISPOSITION_ID_METADATA_KEY ];
+			$tool           = new FetchItemDispositionTool();
+			$wrong          = $tool->handle_tool_call(
+				array(
+					'reason'         => 'Wrong packet identity',
+					'job_id'         => $job_id,
+					'disposition_id' => str_repeat( '0', 64 ),
+					'engine'         => EngineData::forJob( $job_id ),
+				),
+				array( 'disposition' => $disposition )
+			);
+			$this->assertFalse( $wrong['success'] );
+			$parameters = array(
+				'reason'         => 'Canonical disposition test',
+				'job_id'         => $job_id,
+				'disposition_id' => $disposition_id,
+				'engine'         => EngineData::forJob( $job_id ),
+			);
+			$result     = $tool->handle_tool_call( $parameters, array( 'disposition' => $disposition ) );
+			$this->assertTrue( $result['success'] );
+			$this->assertSame( $disposition_id, $result['disposition_id'] );
+			$parameters['reason'] = 'Replay';
+			$replay               = $tool->handle_tool_call( $parameters, array( 'disposition' => $disposition ) );
+			$this->assertTrue( $replay['already_dispositioned'] );
+
+			$packet['metadata']['packet_disposition'] = $disposition;
+			$this->assertTrue( StepLifecycleHandler::reconcileStepOutput( $job_id, array( 'step_type' => 'ai' ), array( $packet ), true )['success'] );
+			$tracked = ( new TrackedItems() )->get( TicketmasterSourceIdentity::TRACK_NAMESPACE, $item_id );
+			if ( 'reject_source' === $disposition ) {
+				$this->assertNotNull( $tracked );
+			} else {
+				$this->assertNull( $tracked );
+			}
+			$this->assertFalse( ( new ProcessedItems() )->has_active_claim( TicketmasterSourceIdentity::CLAIM_SCOPE, 'ticketmaster', $item_id ) );
+		}
+	}
+
+	public function test_failed_ai_and_upsert_release_claim_without_revision(): void {
+		foreach ( array( 'ai', 'upsert' ) as $step_type ) {
+			$item_id = 'TM-failed-' . $step_type . '-' . uniqid();
+			$job_id  = $this->createJob( 'Ticketmaster failed ' . $step_type );
+			$packets = ( new TicketmasterHandlerTestDouble( array( 0 => $this->ticketmasterPage( array( $this->ticketmasterEvent( $item_id, 'Failed Event' ) ) ) ) ) )
+				->get_fetch_data( 1, $this->handlerConfig( '32.7765,-79.9311', $step_type . '-failure-fetch' ), (string) $job_id );
+			$packet = $packets[0]->addTo( array() )[0];
+			$this->assertTrue( StepLifecycleHandler::handleInlineContinuation( $job_id, array( 'step_type' => 'event_import' ), array( $packet ) ) );
+			$this->assertTrue( StepLifecycleHandler::reconcileStepOutput( $job_id, array( 'step_type' => $step_type ), array(), false )['success'] );
+			$this->assertFalse( ( new ProcessedItems() )->has_active_claim( TicketmasterSourceIdentity::CLAIM_SCOPE, 'ticketmaster', $item_id ) );
+			$this->assertNull( ( new TrackedItems() )->get( TicketmasterSourceIdentity::TRACK_NAMESPACE, $item_id ) );
+		}
+	}
+
+	public function test_two_packet_scheduled_fanout_settles_without_parent_claims(): void {
+		$parent_id = $this->createJob( 'Ticketmaster fanout parent' );
+		$events    = array(
+			$this->ticketmasterEvent( 'TM-fanout-a-' . uniqid(), 'Fanout A' ),
+			$this->ticketmasterEvent( 'TM-fanout-b-' . uniqid(), 'Fanout B' ),
+		);
+		$packets = ( new TicketmasterHandlerTestDouble( array( 0 => $this->ticketmasterPage( $events ) ) ) )
+			->get_fetch_data( 1, $this->handlerConfig( '32.7765,-79.9311', 'fanout-fetch' ), (string) $parent_id );
+		$this->assertCount( 2, $packets );
+		$ownership = new FanoutClaimOwnership();
+		$child_ids = array();
+
+		foreach ( $packets as $index => $data_packet ) {
+			$packet      = $data_packet->addTo( array() )[0];
+			$claim       = $packet['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ];
+			$child_id    = $this->createJob( 'Ticketmaster fanout child ' . $index, $parent_id );
+			$child_ids[] = $child_id;
+			$this->assertTrue( $ownership->adopt_owned_claims( array( $claim ), $parent_id, $child_id ) );
+			$this->assertTrue( StepLifecycleHandler::handleCompleted( $child_id, array( ProcessedItems::CLAIM_METADATA_KEY => $claim ) ) );
+		}
+
+		$this->assertCount( 0, $ownership->active_claims_for_job( $parent_id ) );
+		foreach ( $child_ids as $child_id ) {
+			$this->assertCount( 0, $ownership->active_claims_for_job( $child_id ) );
+		}
+	}
+
+	public function test_case_variant_sql_row_uses_acquisition_descriptor_authoritatively(): void {
+		$lowercase = 'tm-case-' . uniqid();
+		$uppercase = strtoupper( $lowercase );
+		$processed = new ProcessedItems();
+		$this->assertTrue( $processed->claim_item( TicketmasterSourceIdentity::CLAIM_SCOPE, 'ticketmaster', $lowercase, 1701 ) );
+		$this->assertSame( 1, $processed->complete_claim_for_job( TicketmasterSourceIdentity::CLAIM_SCOPE, 'ticketmaster', $lowercase, 1701 ) );
+
+		$packets = ( new TicketmasterHandlerTestDouble( array( 0 => $this->ticketmasterPage( array( $this->ticketmasterEvent( $uppercase, 'Case Variant Event' ) ) ) ) ) )
+			->get_fetch_data( 1, $this->handlerConfig( '32.7765,-79.9311', 'case-variant-fetch' ), '1702' );
+		$this->assertCount( 1, $packets );
+		$packet = $packets[0]->addTo( array() )[0];
+		$claim  = $packet['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ];
+		$this->assertSame( $uppercase, $claim['item_identifier'] );
+		$this->assertSame( ProcessedItems::disposition_identity( TicketmasterSourceIdentity::CLAIM_SCOPE, 'ticketmaster', $uppercase ), $claim['disposition_id'] );
+		$this->completePacket( $packet, 1702 );
+		$this->assertNotNull( ( new TrackedItems() )->get( TicketmasterSourceIdentity::TRACK_NAMESPACE, $uppercase ) );
+	}
+
+	public function test_terminal_replay_is_idempotent_for_ticketmaster_descriptor(): void {
+		$item_id = 'TM-terminal-replay-' . uniqid();
+		$packets = ( new TicketmasterHandlerTestDouble( array( 0 => $this->ticketmasterPage( array( $this->ticketmasterEvent( $item_id, 'Replay Event' ) ) ) ) ) )
+			->get_fetch_data( 1, $this->handlerConfig( '32.7765,-79.9311', 'terminal-replay-fetch' ), '1801' );
+		$packet = $packets[0]->addTo( array() )[0];
+		$this->completePacket( $packet, 1801 );
+		StepLifecycleHandler::handleCompleted( 1801, array( ProcessedItems::CLAIM_METADATA_KEY => $packet['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ] ) );
+
+		$tracked = ( new TrackedItems() )->get( TicketmasterSourceIdentity::TRACK_NAMESPACE, $item_id );
+		$this->assertSame( $packet['metadata']['source_revision'], $tracked['source_revision'] );
+		$this->assertFalse( ( new ProcessedItems() )->has_active_claim( TicketmasterSourceIdentity::CLAIM_SCOPE, 'ticketmaster', $item_id ) );
 	}
 
 	public function test_repeated_ticketmaster_ids_across_pages_only_schedule_once(): void {
@@ -589,11 +745,24 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 	}
 
 	private function completePacket( array $packet, int $job_id ): void {
-		TicketmasterSourceIdentity::handleCompleted( $job_id, $packet['metadata']['_engine_data'] );
+		$this->assertTrue( StepLifecycleHandler::handleCompleted( $job_id, array( ProcessedItems::CLAIM_METADATA_KEY => $packet['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ] ) ) );
 	}
 
 	private function failPacket( array $packet, int $job_id ): void {
-		TicketmasterSourceIdentity::handleFailed( $job_id, $packet['metadata']['_engine_data'] );
+		$this->assertTrue( StepLifecycleHandler::handleFailed( $job_id, array( ProcessedItems::CLAIM_METADATA_KEY => $packet['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ] ) ) );
+	}
+
+	private function createJob( string $label, int $parent_job_id = 0 ): int {
+		$job_id = ( new Jobs() )->create_job(
+			array(
+				'pipeline_id'   => 1,
+				'flow_id'       => 1,
+				'label'         => $label,
+				'parent_job_id' => $parent_job_id,
+			)
+		);
+		$this->assertIsInt( $job_id );
+		return $job_id;
 	}
 
 	private function ticketmasterEvent( string $id, string $title, string $ticket_url = '' ): array {

--- a/tests/Unit/TicketmasterHandlerTest.php
+++ b/tests/Unit/TicketmasterHandlerTest.php
@@ -161,7 +161,45 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 	}
 
 	public function test_single_packet_survives_real_ai_parking_resumes_and_upsert(): void {
-		$fixture  = $this->createExecutionFixture();
+		$handler_filter = static function ( array $handlers, ?string $step_type = null ): array {
+			if ( null === $step_type || 'upsert' === $step_type ) {
+				$handlers['ticketmaster_test_upsert'] = array(
+					'label' => 'Ticketmaster Test Upsert',
+					'type'  => 'upsert',
+					'class' => TicketmasterClaimTestUpsertHandler::class,
+				);
+			}
+			return $handlers;
+		};
+		$tools_filter = static function ( array $tools ): array {
+			$tools['__handler_tools_ticketmaster_test_upsert'] = array(
+				'_handler_callable' => static fn( string $slug, array $config ): array => array(
+					'ticketmaster_test_upsert' => array(
+						'description'             => 'Complete the Ticketmaster test upsert.',
+						'class'                   => TicketmasterClaimTestUpsertTool::class,
+						'client_context_bindings' => array( 'job_id' ),
+						'method'                  => 'handle',
+						'handler'                 => $slug,
+						'handler_config'          => $config,
+						'parameters'              => array(
+							'description' => array(
+								'type'     => 'string',
+								'required' => true,
+							),
+						),
+					),
+				),
+				'handler'           => 'ticketmaster_test_upsert',
+				'modes'             => array( 'pipeline' ),
+				'access_level'      => 'admin',
+			);
+			return $tools;
+		};
+		add_filter( 'datamachine_handlers', $handler_filter, 10, 2 );
+		add_filter( 'datamachine_tools', $tools_filter );
+		HandlerAbilities::clearCache();
+		ToolManager::clearCache();
+		$fixture  = $this->createExecutionFixture( 'ticketmaster_test_upsert' );
 		$item_id  = 'TM-inline-' . uniqid();
 		$job_id   = $this->createJob( 'Ticketmaster inline lifecycle', 0, $fixture );
 		$engine   = $this->executionEngine( $job_id, $fixture );
@@ -219,7 +257,7 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 					'content'    => '',
 					'tool_calls' => array(
 						array(
-							'name'       => 'upsert_event',
+							'name'       => 'ticketmaster_test_upsert',
 							'parameters' => array( 'description' => 'Production-shaped AI resume coverage.' ),
 						),
 					),
@@ -237,9 +275,10 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 			$this->assertSame( $claim, $after_first[ ProcessedItems::CLAIMS_METADATA_KEY ][0] );
 			$this->assertGreaterThan( time() + 3000, strtotime( (string) $wpdb->get_var( $wpdb->prepare( 'SELECT claim_expires_at FROM %i WHERE claim_token = %s', $wpdb->prefix . ProcessedItems::TABLE_NAME, $claim['ownership_token'] ) ) ) );
 
-			$this->assertTrue( AIConcurrencyBackpressure::beginGeneration( $job_id, 'ai-step', 1, time() ) );
-			$second = $executor->execute( array( 'job_id' => $job_id, 'flow_step_id' => 'ai-step', 'ai_resume_generation' => 1 ) );
-			$this->assertSame( 'blocked', $second['outcome'] );
+			if ( ! function_exists( 'datamachine_resume_ai_step_action' ) ) {
+				require_once DATAMACHINE_PATH . 'inc/Engine/Actions/Engine.php';
+			}
+			\datamachine_resume_ai_step_action( $job_id, 'ai-step', 0, '', 1 );
 			$this->assertFalse( AIConcurrencyBackpressure::beginGeneration( $job_id, 'ai-step', 1, time() ) );
 			$after_second = datamachine_get_engine_data( $job_id );
 			$this->assertSame( 2, $after_second['ai_concurrency_throttle']['resume_generation'] );
@@ -247,9 +286,7 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 			$this->assertSame( $claim['disposition_id'], $packet['metadata'][ ProcessedItems::DISPOSITION_ID_METADATA_KEY ] );
 
 			$blocker['lease']->release();
-			$this->assertTrue( AIConcurrencyBackpressure::beginGeneration( $job_id, 'ai-step', 2, time() ) );
-			$resumed = $executor->execute( array( 'job_id' => $job_id, 'flow_step_id' => 'ai-step', 'ai_resume_generation' => 2 ) );
-			$this->assertSame( 'inline_continuation', $resumed['outcome'] );
+			\datamachine_resume_ai_step_action( $job_id, 'ai-step', 0, '', 2 );
 			$this->assertCount( 1, $scheduled_packets );
 			$this->assertSame( $claim, $scheduled_packets[0]['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ] );
 			$this->assertSame( $claim['disposition_id'], $scheduled_packets[0]['metadata'][ ProcessedItems::DISPOSITION_ID_METADATA_KEY ] );
@@ -258,8 +295,12 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 			$blocker['lease']->release();
 			remove_action( 'datamachine_schedule_next_step', $schedule_capture, 1 );
 			remove_filter( 'datamachine_pipeline_ai_concurrency_limit', $limit_filter );
+			remove_filter( 'datamachine_handlers', $handler_filter, 10 );
+			remove_filter( 'datamachine_tools', $tools_filter );
 			update_option( 'datamachine_settings', $original_settings );
 			PluginSettings::clearCache();
+			HandlerAbilities::clearCache();
+			ToolManager::clearCache();
 			WpAiClientTestDouble::reset();
 		}
 
@@ -968,7 +1009,7 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 		return $job_id;
 	}
 
-	private function createExecutionFixture(): array {
+	private function createExecutionFixture( string $upsert_handler = 'upsert_event' ): array {
 		datamachine_register_capabilities();
 		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $user_id );
@@ -1032,8 +1073,8 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 					'execution_order'  => 2,
 					'pipeline_id'      => $pipeline_id,
 					'flow_id'          => $flow_id,
-					'handler_slugs'    => array( 'upsert_event' ),
-					'handler_configs'  => array( 'upsert_event' => array( 'post_status' => 'draft' ) ),
+					'handler_slugs'    => array( $upsert_handler ),
+					'handler_configs'  => array( $upsert_handler => array() ),
 				)
 			),
 		);
@@ -1179,6 +1220,22 @@ class TicketmasterHandlerTestDouble extends Ticketmaster {
 			'page'   => array(
 				'number'     => (int) ( $params['page'] ?? 0 ),
 				'totalPages' => 0,
+			),
+		);
+	}
+}
+
+class TicketmasterClaimTestUpsertHandler {
+}
+
+class TicketmasterClaimTestUpsertTool {
+
+	public function handle( array $parameters, array $tool_def ): array {
+		$tool_def;
+		return array(
+			'success' => true,
+			'data'    => array(
+				'description' => (string) ( $parameters['description'] ?? '' ),
 			),
 		);
 	}

--- a/tests/Unit/TicketmasterHandlerTest.php
+++ b/tests/Unit/TicketmasterHandlerTest.php
@@ -11,16 +11,29 @@
 namespace DataMachineEvents\Tests\Unit;
 
 use WP_UnitTestCase;
+use DataMachine\Abilities\Engine\ExecuteStepAbility;
+use DataMachine\Abilities\Engine\PipelineBatchScheduler;
+use DataMachine\Abilities\HandlerAbilities;
+use DataMachine\Core\Database\Agents\Agents;
+use DataMachine\Core\Database\BatchItems\BatchItems;
+use DataMachine\Core\Database\Flows\Flows;
 use DataMachine\Core\Database\Jobs\Jobs;
+use DataMachine\Core\Database\Pipelines\Pipelines;
 use DataMachine\Core\Database\ProcessedItems\FanoutClaimOwnership;
 use DataMachine\Core\Database\TrackedItems\TrackedItems;
 use DataMachine\Core\EngineData;
 use DataMachine\Core\ExecutionContext;
 use DataMachine\Core\Database\ProcessedItems\ProcessedItems;
 use DataMachine\Core\JobStatus;
+use DataMachine\Core\PluginSettings;
 use DataMachine\Core\RunMetrics;
+use DataMachine\Core\Steps\FlowStepConfigFactory;
 use DataMachine\Core\Steps\Fetch\Tools\FetchItemDispositionTool;
 use DataMachine\Engine\Actions\Handlers\StepLifecycleHandler;
+use DataMachine\Engine\AI\AIConcurrencyBackpressure;
+use DataMachine\Engine\AI\PipelineAIConcurrencyLimiter;
+use DataMachine\Engine\AI\Tools\ToolManager;
+use DataMachine\Tests\Unit\Support\WpAiClientTestDouble;
 use DataMachineEvents\Core\DuplicateDetection\PreAIEventDedupGate;
 use DataMachineEvents\Core\EventDatesTable;
 use DataMachineEvents\Core\Event_Post_Type;
@@ -30,6 +43,8 @@ use DataMachineEvents\Steps\EventImport\Handlers\Ticketmaster\TicketmasterSettin
 use DataMachineEvents\Steps\EventImport\Handlers\Ticketmaster\TicketmasterSourceIdentity;
 use ReflectionClass;
 
+require_once DATAMACHINE_PATH . 'tests/Unit/Support/WpAiClientTestDoubles.php';
+
 class TicketmasterHandlerTest extends WP_UnitTestCase {
 
 	private Ticketmaster $handler;
@@ -38,7 +53,11 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 	public function setUp(): void {
 		parent::setUp();
 		$this->ensureEventIdentityTables();
+		Agents::create_table();
+		BatchItems::create_table();
+		Flows::create_table();
 		Jobs::create_table();
+		Pipelines::create_table();
 		( new ProcessedItems() )->create_table();
 		( new TrackedItems() )->create_table();
 		$this->tracked_completion_filter = static fn( array $handlers ): array => TrackedItems::registerClaimCompletionHandler( $handlers );
@@ -50,7 +69,13 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 	public function tearDown(): void {
 		remove_filter( 'data_machine_events_junk_payload_patterns', array( $this->handler, 'register_junk_patterns' ), 10 );
 		remove_filter( 'datamachine_item_claim_completion_handlers', $this->tracked_completion_filter );
+		WpAiClientTestDouble::reset();
+		if ( function_exists( 'as_unschedule_all_actions' ) ) {
+			as_unschedule_all_actions( AIConcurrencyBackpressure::RESUME_HOOK );
+			as_unschedule_all_actions( PipelineBatchScheduler::BATCH_HOOK );
+		}
 		delete_transient( 'data_machine_events_ticketmaster_classifications' );
+		wp_set_current_user( 0 );
 		parent::tearDown();
 	}
 
@@ -135,20 +160,103 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 		$this->failPacket( $packet, 1001 );
 	}
 
-	public function test_single_packet_inline_ai_resume_and_upsert_commit_canonical_claim(): void {
-		$item_id = 'TM-inline-' . uniqid();
-		$job_id  = $this->createJob( 'Ticketmaster inline lifecycle' );
-		$packets = ( new TicketmasterHandlerTestDouble( array( 0 => $this->ticketmasterPage( array( $this->ticketmasterEvent( $item_id, 'Inline Event' ) ) ) ) ) )
-			->get_fetch_data( 1, $this->handlerConfig( '32.7765,-79.9311', 'inline-fetch' ), (string) $job_id );
+	public function test_single_packet_survives_real_ai_parking_resumes_and_upsert(): void {
+		$fixture  = $this->createExecutionFixture();
+		$item_id  = 'TM-inline-' . uniqid();
+		$job_id   = $this->createJob( 'Ticketmaster inline lifecycle', 0, $fixture );
+		$engine   = $this->executionEngine( $job_id, $fixture );
+		$config   = $this->handlerConfig( '32.7765,-79.9311', 'source-step' );
+		$config['pipeline_id'] = $fixture['pipeline_id'];
+		$config['flow_id']     = $fixture['flow_id'];
+		$this->assertTrue( datamachine_set_engine_data( $job_id, $engine ) );
+		$packets = ( new TicketmasterHandlerTestDouble( array( 0 => $this->ticketmasterPage( array( $this->ticketmasterEvent( $item_id, 'Inline Resume Event' ) ) ) ) ) )
+			->get_fetch_data( $fixture['pipeline_id'], $config, (string) $job_id );
 		$packet = $packets[0]->addTo( array() )[0];
+		$claim  = $packet['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ];
+		$this->assertSame( 'inline_continuation', $this->routeSourcePackets( $job_id, $fixture, array( $packet ) )['outcome'] );
 
-		$this->assertTrue( StepLifecycleHandler::handleInlineContinuation( $job_id, array( 'step_type' => 'event_import' ), array( $packet ) ) );
-		$claim = datamachine_get_engine_data( $job_id )[ ProcessedItems::CLAIMS_METADATA_KEY ][0];
-		datamachine_merge_engine_data( $job_id, array( 'ai_resume_generation' => 2 ) );
-		$this->assertSame( $claim, datamachine_get_engine_data( $job_id )[ ProcessedItems::CLAIMS_METADATA_KEY ][0] );
-		$this->assertTrue( StepLifecycleHandler::reconcileStepOutput( $job_id, array( 'step_type' => 'ai' ), array( $packet ), true )['success'] );
-		$this->assertTrue( StepLifecycleHandler::reconcileStepOutput( $job_id, array( 'step_type' => 'upsert' ), array( $packet ), true )['success'] );
-		$this->assertTrue( ( new Jobs() )->complete_job( $job_id, JobStatus::COMPLETED ) );
+		global $wpdb;
+		$wpdb->update(
+			$wpdb->prefix . ProcessedItems::TABLE_NAME,
+			array( 'claim_expires_at' => gmdate( 'Y-m-d H:i:s', time() + 60 ) ),
+			array( 'claim_token' => $claim['ownership_token'] ),
+			array( '%s' ),
+			array( '%s' )
+		);
+		$original_settings = get_option( 'datamachine_settings', array() );
+		$limit_filter      = static fn(): int => 1;
+		add_filter( 'datamachine_pipeline_ai_concurrency_limit', $limit_filter );
+		update_option(
+			'datamachine_settings',
+			array_merge(
+				$original_settings,
+				array(
+					'mode_models' => array(
+						'pipeline' => array(
+							'provider' => 'fake_provider',
+							'model'    => 'fake-model',
+						),
+					),
+				)
+			)
+		);
+		PluginSettings::clearCache();
+		$blocker = PipelineAIConcurrencyLimiter::acquire( 'fake_provider', array( 'job_id' => 999999, 'flow_step_id' => 'blocker' ) );
+		$this->assertTrue( $blocker['acquired'] );
+
+		$scheduled_packets = array();
+		$schedule_capture  = static function ( int $scheduled_job_id, string $flow_step_id, array $routed_packets ) use ( $job_id, &$scheduled_packets ): void {
+			if ( $scheduled_job_id === $job_id && 'upsert-step' === $flow_step_id ) {
+				$scheduled_packets = $routed_packets;
+			}
+		};
+		add_action( 'datamachine_schedule_next_step', $schedule_capture, 1, 3 );
+		WpAiClientTestDouble::reset();
+		WpAiClientTestDouble::set_response_callback(
+			static fn(): array => array(
+				'success' => true,
+				'data'    => array(
+					'content'    => '',
+					'tool_calls' => array(
+						array(
+							'name'       => 'upsert_event',
+							'parameters' => array( 'description' => 'Production-shaped AI resume coverage.' ),
+						),
+					),
+					'usage'      => array( 'prompt_tokens' => 10, 'completion_tokens' => 5, 'total_tokens' => 15 ),
+				),
+			)
+		);
+
+		try {
+			$executor = new ExecuteStepAbility();
+			$first    = $executor->execute( array( 'job_id' => $job_id, 'flow_step_id' => 'ai-step' ) );
+			$this->assertSame( 'blocked', $first['outcome'] );
+			$after_first = datamachine_get_engine_data( $job_id );
+			$this->assertSame( 1, $after_first['ai_concurrency_throttle']['resume_generation'] );
+			$this->assertSame( $claim, $after_first[ ProcessedItems::CLAIMS_METADATA_KEY ][0] );
+			$this->assertGreaterThan( time() + 3000, strtotime( (string) $wpdb->get_var( $wpdb->prepare( 'SELECT claim_expires_at FROM %i WHERE claim_token = %s', $wpdb->prefix . ProcessedItems::TABLE_NAME, $claim['ownership_token'] ) ) ) );
+
+			\DataMachine\Engine\Actions\datamachine_resume_ai_step_action( $job_id, 'ai-step', 0, '', 1 );
+			$after_second = datamachine_get_engine_data( $job_id );
+			$this->assertSame( 2, $after_second['ai_concurrency_throttle']['resume_generation'] );
+			$this->assertSame( $claim, $after_second[ ProcessedItems::CLAIMS_METADATA_KEY ][0] );
+			$this->assertSame( $claim['disposition_id'], $packet['metadata'][ ProcessedItems::DISPOSITION_ID_METADATA_KEY ] );
+
+			$blocker['lease']->release();
+			\DataMachine\Engine\Actions\datamachine_resume_ai_step_action( $job_id, 'ai-step', 0, '', 2 );
+			$this->assertCount( 1, $scheduled_packets );
+			$this->assertSame( $claim, $scheduled_packets[0]['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ] );
+			$this->assertSame( $claim['disposition_id'], $scheduled_packets[0]['metadata'][ ProcessedItems::DISPOSITION_ID_METADATA_KEY ] );
+			$this->assertSame( 'completed', $executor->execute( array( 'job_id' => $job_id, 'flow_step_id' => 'upsert-step' ) )['outcome'] );
+		} finally {
+			$blocker['lease']->release();
+			remove_action( 'datamachine_schedule_next_step', $schedule_capture, 1 );
+			remove_filter( 'datamachine_pipeline_ai_concurrency_limit', $limit_filter );
+			update_option( 'datamachine_settings', $original_settings );
+			PluginSettings::clearCache();
+			WpAiClientTestDouble::reset();
+		}
 
 		$tracked = ( new TrackedItems() )->get( TicketmasterSourceIdentity::TRACK_NAMESPACE, $item_id );
 		$this->assertSame( $packet['metadata']['source_revision'], $tracked['source_revision'] );
@@ -190,7 +298,10 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 			$this->assertTrue( $replay['already_dispositioned'] );
 
 			$packet['metadata']['packet_disposition'] = $disposition;
-			$this->assertTrue( StepLifecycleHandler::reconcileStepOutput( $job_id, array( 'step_type' => 'ai' ), array( $packet ), true )['success'] );
+			$reconciled = StepLifecycleHandler::reconcileStepOutput( $job_id, array( 'step_type' => 'ai' ), array( $packet ), true );
+			$replayed   = StepLifecycleHandler::reconcileStepOutput( $job_id, array( 'step_type' => 'ai' ), array( $packet ), true );
+			$this->assertTrue( $reconciled['success'] );
+			$this->assertTrue( $replayed['success'] );
 			$tracked = ( new TrackedItems() )->get( TicketmasterSourceIdentity::TRACK_NAMESPACE, $item_id );
 			if ( 'reject_source' === $disposition ) {
 				$this->assertNotNull( $tracked );
@@ -216,30 +327,51 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 	}
 
 	public function test_two_packet_scheduled_fanout_settles_without_parent_claims(): void {
-		$parent_id = $this->createJob( 'Ticketmaster fanout parent' );
+		$fixture   = $this->createExecutionFixture();
+		$parent_id = $this->createJob( 'Ticketmaster fanout parent', 0, $fixture );
+		$engine    = $this->executionEngine( $parent_id, $fixture );
+		$this->assertTrue( ( new Jobs() )->start_job( $parent_id ) );
+		$this->assertTrue( datamachine_set_engine_data( $parent_id, $engine ) );
 		$events    = array(
 			$this->ticketmasterEvent( 'TM-fanout-a-' . uniqid(), 'Fanout A' ),
 			$this->ticketmasterEvent( 'TM-fanout-b-' . uniqid(), 'Fanout B' ),
 		);
+		$config = $this->handlerConfig( '32.7765,-79.9311', 'source-step' );
+		$config['pipeline_id'] = $fixture['pipeline_id'];
+		$config['flow_id']     = $fixture['flow_id'];
 		$packets = ( new TicketmasterHandlerTestDouble( array( 0 => $this->ticketmasterPage( $events ) ) ) )
-			->get_fetch_data( 1, $this->handlerConfig( '32.7765,-79.9311', 'fanout-fetch' ), (string) $parent_id );
+			->get_fetch_data( $fixture['pipeline_id'], $config, (string) $parent_id );
 		$this->assertCount( 2, $packets );
-		$ownership = new FanoutClaimOwnership();
-		$child_ids = array();
+		$packet_arrays = array_map( static fn( $packet ): array => $packet->addTo( array() )[0], $packets );
+		$claims        = array_column( array_column( $packet_arrays, 'metadata' ), ProcessedItems::CLAIM_METADATA_KEY );
+		$result        = $this->routeSourcePackets( $parent_id, $fixture, $packet_arrays );
+		$this->assertSame( 'batch_scheduled', $result['outcome'] );
+		$this->assertTrue( $result['batch']['adopted'] );
+		$this->assertArrayNotHasKey( 'packet_fanout_transfer', datamachine_get_engine_data( $parent_id ) );
 
-		foreach ( $packets as $index => $data_packet ) {
-			$packet      = $data_packet->addTo( array() )[0];
-			$claim       = $packet['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ];
-			$child_id    = $this->createJob( 'Ticketmaster fanout child ' . $index, $parent_id );
-			$child_ids[] = $child_id;
-			$this->assertTrue( $ownership->adopt_owned_claims( array( $claim ), $parent_id, $child_id ) );
-			$this->assertTrue( StepLifecycleHandler::handleCompleted( $child_id, array( ProcessedItems::CLAIM_METADATA_KEY => $claim ) ) );
+		global $wpdb;
+		$work_items = $wpdb->get_col( $wpdb->prepare( 'SELECT payload FROM %i WHERE batch_job_id = %d ORDER BY item_index', $wpdb->prefix . BatchItems::TABLE_NAME, $parent_id ) );
+		$this->assertCount( 2, $work_items );
+		foreach ( $work_items as $index => $payload ) {
+			$stored = json_decode( $payload, true );
+			$this->assertSame( $claims[ $index ], $stored['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ] );
+			$this->assertSame( $claims[ $index ]['disposition_id'], $stored['metadata'][ ProcessedItems::DISPOSITION_ID_METADATA_KEY ] );
 		}
 
+		( new PipelineBatchScheduler() )->processChunk( $parent_id );
+		$children = $wpdb->get_results( $wpdb->prepare( 'SELECT job_id FROM %i WHERE parent_job_id = %d ORDER BY job_id', $wpdb->prefix . 'datamachine_jobs', $parent_id ), ARRAY_A );
+		$this->assertCount( 2, $children );
+		$ownership = new FanoutClaimOwnership();
 		$this->assertCount( 0, $ownership->active_claims_for_job( $parent_id ) );
-		foreach ( $child_ids as $child_id ) {
+		foreach ( $children as $index => $child ) {
+			$child_id     = (int) $child['job_id'];
+			$child_engine = datamachine_get_engine_data( $child_id );
+			$this->assertSame( $claims[ $index ], $child_engine[ ProcessedItems::CLAIM_METADATA_KEY ] );
+			$this->assertTrue( ( new Jobs() )->complete_job( $child_id, JobStatus::COMPLETED ) );
+			PipelineBatchScheduler::onChildComplete( $child_id, JobStatus::COMPLETED );
 			$this->assertCount( 0, $ownership->active_claims_for_job( $child_id ) );
 		}
+		$this->assertSame( JobStatus::COMPLETED, ( new Jobs() )->get_job( $parent_id )['status'] );
 	}
 
 	public function test_case_variant_sql_row_uses_acquisition_descriptor_authoritatively(): void {
@@ -260,17 +392,81 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 		$this->assertNotNull( ( new TrackedItems() )->get( TicketmasterSourceIdentity::TRACK_NAMESPACE, $uppercase ) );
 	}
 
-	public function test_terminal_replay_is_idempotent_for_ticketmaster_descriptor(): void {
-		$item_id = 'TM-terminal-replay-' . uniqid();
-		$packets = ( new TicketmasterHandlerTestDouble( array( 0 => $this->ticketmasterPage( array( $this->ticketmasterEvent( $item_id, 'Replay Event' ) ) ) ) ) )
-			->get_fetch_data( 1, $this->handlerConfig( '32.7765,-79.9311', 'terminal-replay-fetch' ), '1801' );
-		$packet = $packets[0]->addTo( array() )[0];
-		$this->completePacket( $packet, 1801 );
-		StepLifecycleHandler::handleCompleted( 1801, array( ProcessedItems::CLAIM_METADATA_KEY => $packet['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ] ) );
+	public function test_unchanged_post_acquisition_revision_releases_exact_claim(): void {
+		$item_id = 'TM-unchanged-release-' . uniqid();
+		$job_id  = $this->createJob( 'Ticketmaster unchanged release' );
+		$calls   = 0;
+		$filter  = static function ( bool $skip, array $context ) use ( &$calls ): bool {
+			++$calls;
+			if ( 1 === $calls ) {
+				( new TrackedItems() )->upsert(
+					array(
+						'namespace'       => TicketmasterSourceIdentity::TRACK_NAMESPACE,
+						'item_id'         => $context['item_identifier'],
+						'item_type'       => 'event',
+						'state'           => TrackedItems::STATE_GENERATED,
+						'source_revision' => $context['source_revision'],
+					)
+				);
+				return false;
+			}
+			return $skip;
+		};
+		add_filter( 'datamachine_should_reprocess_item', $filter, 10, 2 );
+		try {
+			$packets = ( new TicketmasterHandlerTestDouble( array( 0 => $this->ticketmasterPage( array( $this->ticketmasterEvent( $item_id, 'Unchanged Release Event' ) ) ) ) ) )
+				->get_fetch_data( 1, $this->handlerConfig( '32.7765,-79.9311', 'unchanged-release-fetch' ), (string) $job_id );
+		} finally {
+			remove_filter( 'datamachine_should_reprocess_item', $filter, 10 );
+		}
 
-		$tracked = ( new TrackedItems() )->get( TicketmasterSourceIdentity::TRACK_NAMESPACE, $item_id );
-		$this->assertSame( $packet['metadata']['source_revision'], $tracked['source_revision'] );
+		$this->assertCount( 0, $packets );
+		$this->assertSame( 2, $calls );
 		$this->assertFalse( ( new ProcessedItems() )->has_active_claim( TicketmasterSourceIdentity::CLAIM_SCOPE, 'ticketmaster', $item_id ) );
+	}
+
+	public function test_unchanged_exact_release_failure_surfaces_and_terminal_cleanup_releases_job_claim(): void {
+		global $wpdb;
+		$item_id = 'TM-release-failure-' . uniqid();
+		$job_id  = $this->createJob( 'Ticketmaster release failure' );
+		$calls   = 0;
+		$filter  = static function ( bool $skip, array $context ) use ( &$calls, $job_id, $wpdb ): bool {
+			++$calls;
+			if ( 1 === $calls ) {
+				( new TrackedItems() )->upsert(
+					array(
+						'namespace'       => TicketmasterSourceIdentity::TRACK_NAMESPACE,
+						'item_id'         => $context['item_identifier'],
+						'item_type'       => 'event',
+						'state'           => TrackedItems::STATE_GENERATED,
+						'source_revision' => $context['source_revision'],
+					)
+				);
+				return false;
+			}
+			$wpdb->update(
+				$wpdb->prefix . ProcessedItems::TABLE_NAME,
+				array( 'claim_token' => 'replacement-token' ),
+				array(
+					'job_id'           => $job_id,
+					'item_identifier' => $context['item_identifier'],
+				),
+				array( '%s' ),
+				array( '%d', '%s' )
+			);
+			return $skip;
+		};
+		add_filter( 'datamachine_should_reprocess_item', $filter, 10, 2 );
+		try {
+			$this->expectException( \RuntimeException::class );
+			$this->expectExceptionMessage( 'Ticketmaster could not release the exact unchanged-revision claim.' );
+			( new TicketmasterHandlerTestDouble( array( 0 => $this->ticketmasterPage( array( $this->ticketmasterEvent( $item_id, 'Release Failure Event' ) ) ) ) ) )
+				->get_fetch_data( 1, $this->handlerConfig( '32.7765,-79.9311', 'release-failure-fetch' ), (string) $job_id );
+		} finally {
+			remove_filter( 'datamachine_should_reprocess_item', $filter, 10 );
+			$this->assertTrue( StepLifecycleHandler::handleFailed( $job_id, array() ) );
+			$this->assertFalse( ( new ProcessedItems() )->has_active_claim( TicketmasterSourceIdentity::CLAIM_SCOPE, 'ticketmaster', $item_id ) );
+		}
 	}
 
 	public function test_repeated_ticketmaster_ids_across_pages_only_schedule_once(): void {
@@ -752,17 +948,134 @@ class TicketmasterHandlerTest extends WP_UnitTestCase {
 		$this->assertTrue( StepLifecycleHandler::handleFailed( $job_id, array( ProcessedItems::CLAIM_METADATA_KEY => $packet['metadata'][ ProcessedItems::CLAIM_METADATA_KEY ] ) ) );
 	}
 
-	private function createJob( string $label, int $parent_job_id = 0 ): int {
+	private function createJob( string $label, int $parent_job_id = 0, array $fixture = array() ): int {
 		$job_id = ( new Jobs() )->create_job(
 			array(
-				'pipeline_id'   => 1,
-				'flow_id'       => 1,
+				'pipeline_id'   => $fixture['pipeline_id'] ?? 1,
+				'flow_id'       => $fixture['flow_id'] ?? 1,
 				'label'         => $label,
 				'parent_job_id' => $parent_job_id,
+				'user_id'       => $fixture['user_id'] ?? 0,
+				'agent_id'      => $fixture['agent_id'] ?? null,
 			)
 		);
 		$this->assertIsInt( $job_id );
 		return $job_id;
+	}
+
+	private function createExecutionFixture(): array {
+		datamachine_register_capabilities();
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+		$agent_id = ( new Agents() )->create_if_missing( 'ticketmaster-claims-' . uniqid(), 'Ticketmaster Claim Test Agent', $user_id );
+		$pipeline_id = ( new Pipelines() )->create_pipeline(
+			array(
+				'pipeline_name'   => 'Ticketmaster Claim Lifecycle',
+				'pipeline_config' => array(),
+				'user_id'         => $user_id,
+				'agent_id'        => $agent_id,
+			)
+		);
+		$this->assertIsInt( $pipeline_id );
+		$flow_id = ( new Flows() )->create_flow(
+			array(
+				'pipeline_id'       => $pipeline_id,
+				'flow_name'         => 'Ticketmaster Claim Lifecycle Flow',
+				'flow_config'       => array(),
+				'scheduling_config' => array( 'enabled' => true ),
+				'user_id'           => $user_id,
+				'agent_id'          => $agent_id,
+			)
+		);
+		$this->assertIsInt( $flow_id );
+
+		$flow_config = array(
+			'source-step' => FlowStepConfigFactory::build(
+				array(
+					'flow_step_id'     => 'source-step',
+					'pipeline_step_id' => 'pipeline-source',
+					'step_type'        => 'event_import',
+					'execution_order'  => 0,
+					'pipeline_id'      => $pipeline_id,
+					'flow_id'          => $flow_id,
+					'handler_slugs'    => array( 'ticketmaster' ),
+					'handler_configs'  => array( 'ticketmaster' => array() ),
+				)
+			),
+			'ai-step'     => FlowStepConfigFactory::build(
+				array(
+					'flow_step_id'     => 'ai-step',
+					'pipeline_step_id' => 'pipeline-ai',
+					'step_type'        => 'ai',
+					'execution_order'  => 1,
+					'pipeline_id'      => $pipeline_id,
+					'flow_id'          => $flow_id,
+					'queue_mode'       => 'static',
+					'prompt_queue'     => array(
+						array(
+							'prompt'   => 'Call upsert_event exactly once.',
+							'added_at' => gmdate( 'c' ),
+						),
+					),
+				)
+			),
+			'upsert-step' => FlowStepConfigFactory::build(
+				array(
+					'flow_step_id'     => 'upsert-step',
+					'pipeline_step_id' => 'pipeline-upsert',
+					'step_type'        => 'upsert',
+					'execution_order'  => 2,
+					'pipeline_id'      => $pipeline_id,
+					'flow_id'          => $flow_id,
+					'handler_slugs'    => array( 'upsert_event' ),
+					'handler_configs'  => array( 'upsert_event' => array( 'post_status' => 'draft' ) ),
+				)
+			),
+		);
+		$pipeline_config = array(
+			'pipeline-ai' => array( 'system_prompt' => 'Create the supplied event through the required upsert tool.' ),
+		);
+		$this->assertTrue( ( new Pipelines() )->update_pipeline( $pipeline_id, array( 'pipeline_config' => $pipeline_config ) ) );
+		$this->assertTrue( ( new Flows() )->update_flow( $flow_id, array( 'flow_config' => $flow_config ) ) );
+		HandlerAbilities::clearCache();
+		ToolManager::clearCache();
+
+		return compact( 'user_id', 'agent_id', 'pipeline_id', 'flow_id', 'flow_config', 'pipeline_config' );
+	}
+
+	private function executionEngine( int $job_id, array $fixture ): array {
+		return array(
+			'job'             => array(
+				'job_id'      => $job_id,
+				'flow_id'     => $fixture['flow_id'],
+				'pipeline_id' => $fixture['pipeline_id'],
+				'user_id'     => $fixture['user_id'],
+				'agent_id'    => $fixture['agent_id'],
+			),
+			'flow_config'     => $fixture['flow_config'],
+			'pipeline_config' => $fixture['pipeline_config'],
+		);
+	}
+
+	private function routeSourcePackets( int $job_id, array $fixture, array $packets ): array {
+		$engine = datamachine_get_engine_data( $job_id );
+		$route  = new \ReflectionMethod( ExecuteStepAbility::class, 'routeAfterExecution' );
+		return $route->invoke(
+			new ExecuteStepAbility(),
+			$job_id,
+			'source-step',
+			$fixture['flow_id'],
+			$fixture['flow_config']['source-step'],
+			'event_import',
+			'',
+			$packets,
+			array(
+				'job_id' => $job_id,
+				'engine' => new EngineData( $engine, $job_id ),
+			),
+			true,
+			null
+		);
 	}
 
 	private function ticketmasterEvent( string $id, string $title, string $ticket_url = '' ): array {


### PR DESCRIPTION
## Summary

- acquire Ticketmaster source ownership through `ExecutionContext::claimItemOwnership()` under the existing shared scope and three-day TTL
- attach Data Machine's canonical `_datamachine_item_claim` and `_datamachine_packet_disposition_id` metadata to every persisted Ticketmaster packet
- settle successful revisions through the registered `tracked_item` completion handler with `retain_processed=false`
- remove Ticketmaster's obsolete lifecycle hooks and surface any failed exact release during the post-acquisition unchanged-revision recheck

## Root Cause

Ticketmaster bypassed Data Machine's canonical ownership lifecycle by calling legacy `ProcessedItems::claim_item()` and retaining source identity only in Ticketmaster-specific engine data. The resulting packets had `source_item_id` but no opaque claim descriptor or disposition identity. Single-packet inline continuation therefore had nothing to persist for AI disposition or terminal settlement, while successful jobs left the legacy claim row behind.

Production evidence after Data Machine v0.175.2 fixed multi-packet scheduled fanout:

- jobs 878190 (flow 417 / pipeline 90) and 878229 (flow 559 / pipeline 154) failed inline with `packet disposition identity is required`
- both were top-level single-packet jobs with `identified_items=0`, `identifierless_items=1`, and `claim_attempts=0`
- completed top-level jobs 878148, 878153, 878166, 878169, 878208, 878212, 878218, 878219, 878243, and 878251 retained one claimed Ticketmaster row each
- job 878219 included a case-variant SQL match, demonstrating why settlement must trust the acquisition-returned descriptor rather than reconstruct identity

## Canonical Ownership

The handler now calls `ExecutionContext::claimItemOwnership()` directly with Ticketmaster's existing shared claim scope and TTL. Its opaque descriptor carries exact scope, source type, item identifier, ownership token, stable disposition ID, and the `tracked_item` completion payload.

The post-acquisition revision recheck releases only the exact token-owned descriptor. A zero/failed release is logged and thrown into Data Machine's normal job-failure path so terminal cleanup can release the job-owned row instead of silently stranding it for three days. Matching semantics and source IDs are unchanged; no Data Machine patch, source-ID inference, or SQL-collation workaround is introduced.

## Production-Path Coverage

Ticketmaster tests now exercise:

- canonical packet descriptor and stable disposition metadata
- single-packet source routing through `ExecuteStepAbility::routeAfterExecution`
- real AI concurrency saturation, parked-claim renewal, Action Scheduler continuation creation, resume generations 1 and 2, generation fencing, and the global `datamachine_resume_ai_step_action` bridge through a registered `datamachine/execute-step` ability
- deterministic handler-tool execution, resumed packet routing to the real upsert step, terminal tracked-revision commit, transient claim deletion, and processed accounting
- exact `reject_source` and `defer_item` resolution with idempotent tool and canonical reconciliation replay
- failed AI/upsert claim release without revision persistence
- two-packet fanout through `transferClaimsToFanout`, `ParallelMapFanoutAdapter`, durable transfer preparation/adoption/finalization, `PipelineBatchScheduler` work items and child seeding, child terminal settlement, and zero parent claims
- case-variant SQL rows using only the acquisition-returned descriptor
- successful unchanged-revision exact release and surfaced release failure followed by terminal cleanup

## Verification

Passed locally:

- changed-file PHPCS/PHPStan and syntax checks
- `git diff --check`
- full Homeboy audit with zero introduced findings (`14ffae3f-6834-41da-a988-e229651e9663`)
- Calendar, Event Details, and Events Map production builds during managed test preparation

Executable GitHub CI at `d73660a` ran 785 tests. Six unrelated failures were present; five match the latest `main` run exactly, while the Cactus scraper fixture is also outside this diff and reproduced across every PR run. The sole branch-owned failure was an empty resumed-routing observer because the managed test registry lacked `datamachine/execute-step`.

Commit `308ca9c` restores the canonical ability registration when the managed registry was reset and asserts the ability exists before invoking the real resume bridge. Three refreshed CI attempts did not reach repository commands: WP Codebox CLI's release artifact was unavailable and Homeboy's source-install fallback failed with `internal.io_error` in run `32273208716`. Those attempts produced no PHPUnit, lint, or audit result; they are infrastructure failures, not claimed passes.

Closes #696

Related: Extra-Chill/data-machine#3225, Extra-Chill/data-machine#3242