### PR TITLE
Fix scraper CLI WP_Error handling

### DIFF
--- a/inc/Cli/UniversalWebScraperTestCommand.php
+++ b/inc/Cli/UniversalWebScraperTestCommand.php
@@ -38,10 +38,15 @@ class UniversalWebScraperTestCommand {
 		}
 
 		$result = $this->callAbility( $target_url );
+		if ( is_wp_error( $result ) ) {
+			\WP_CLI::error( $result->get_error_code() . ': ' . $result->get_error_message() );
+			return;
+		}
+
 		$this->outputResult( $result );
 	}
 
-	private function callAbility( string $target_url ): array {
+	private function callAbility( string $target_url ): array|\WP_Error {
 		$tester = new EventScraperTest();
 		return $tester->test( $target_url );
 	}

--- a/tests/Unit/UniversalWebScraperTestCommandTest.php
+++ b/tests/Unit/UniversalWebScraperTestCommandTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * UniversalWebScraperTestCommand regression tests.
+ *
+ * @package DataMachineEvents\Tests\Unit
+ */
+
+namespace DataMachineEvents\Tests\Unit;
+
+use DataMachineEvents\Cli\UniversalWebScraperTestCommand;
+use ReflectionClass;
+use WP_UnitTestCase;
+
+class UniversalWebScraperTestCommandTest extends WP_UnitTestCase {
+
+	public function tearDown(): void {
+		remove_all_filters( 'pre_http_request' );
+		parent::tearDown();
+	}
+
+	public function test_call_ability_preserves_wp_error(): void {
+		add_filter(
+			'pre_http_request',
+			static fn() => new \WP_Error( 'http_request_failed', 'Fixture request failed.' )
+		);
+
+		$result = $this->callAbility( 'https://example.com/events' );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'scraper_failed', $result->get_error_code() );
+		$this->assertStringContainsString( 'Fixture request failed.', $result->get_error_message() );
+	}
+
+	public function test_call_ability_preserves_normal_array_result(): void {
+		$html = <<<'HTML'
+<!doctype html>
+<html>
+<head>
+<script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "MusicEvent",
+    "name": "Adapter Boundary Show",
+    "startDate": "2099-08-21T20:00:00-04:00",
+    "location": {
+        "@type": "Place",
+        "name": "Fixture Hall",
+        "address": {
+            "@type": "PostalAddress",
+            "streetAddress": "100 Fixture Way",
+            "addressLocality": "Charleston",
+            "addressRegion": "SC"
+        }
+    }
+}
+</script>
+</head>
+<body></body>
+</html>
+HTML;
+
+		add_filter(
+			'pre_http_request',
+			static fn() => array(
+				'headers'  => array(),
+				'body'     => $html,
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'cookies'  => array(),
+				'filename' => null,
+			)
+		);
+
+		$result = $this->callAbility( 'https://example.com/events' );
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'Adapter Boundary Show', $result['event_data']['title'] );
+	}
+
+	private function callAbility( string $target_url ): array|\WP_Error {
+		$command = new UniversalWebScraperTestCommand();
+		$method  = ( new ReflectionClass( $command ) )->getMethod( 'callAbility' );
+		$method->setAccessible( true );
+
+		return $method->invoke( $command, $target_url );
+	}
+}


### PR DESCRIPTION
## Summary
- Widen the CLI adapter's scraper ability return contract from `array` to `array|WP_Error`.
- Detect ability errors before the array-only output renderer and terminate cleanly through `WP_CLI::error()` using `<error-code>: <error-message>` so the underlying code and message remain visible.
- Add regression coverage for both a scraper `WP_Error` result and the unchanged successful array result.

## Root cause
`EventScraperTest::test()` legitimately returns `array|WP_Error`, but `UniversalWebScraperTestCommand::callAbility()` declared an `array` return type. A scraper failure therefore raised a PHP `TypeError` at the CLI adapter boundary before WP-CLI could report it.

## Verification
- `php -l inc/Cli/UniversalWebScraperTestCommand.php`: passed
- `php -l tests/Unit/UniversalWebScraperTestCommandTest.php`: passed
- `homeboy review lint --placement local --changed-only --summary`: passed with zero PHPCS, ESLint, or PHPStan findings
- `homeboy review audit --changed-since origin/main --summary`: passed with zero introduced findings
- `homeboy review test --placement local -- --filter UniversalWebScraperTestCommandTest`: blocked before PHPUnit; WP Codebox returned an unparseable recipe payload and Homeboy reported 0 executed tests
- `homeboy review test --placement local --skip-lint`: same WP Codebox recipe-payload failure before PHPUnit, with 0 executed tests

No changelog or version files were edited.

Closes #630
Closes #632

#630 and #632 are duplicate reports of the same CLI adapter defect.