### PR TITLE
fix: align upcoming term count semantics

### DIFF
--- a/inc/Abilities/UpcomingCountAbilities.php
+++ b/inc/Abilities/UpcomingCountAbilities.php
@@ -7,14 +7,16 @@
  * Counts upcoming events grouped by taxonomy term. This is the raw data
  * primitive powering homepage badges, cross-site links, and market reports.
  *
- * The query joins event_dates (start_datetime >= today, post_status = 'publish')
- * to filter only future published events, then GROUP BY term for counts.
+ * The query joins event_dates using the canonical upcoming predicate and
+ * published status filter, then GROUP BY term for counts.
  * Skips the posts table entirely via denormalized post_status column.
  *
  * @package DataMachineEvents\Abilities
  */
 
 namespace DataMachineEvents\Abilities;
+
+use DataMachineEvents\Blocks\Calendar\Query\UpcomingFilter;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -107,8 +109,8 @@ class UpcomingCountAbilities {
 	 * Execute get-upcoming-counts ability.
 	 *
 	 * Single SQL query: counts upcoming events per term using GROUP BY.
-	 * Filters to published data_machine_events with start_datetime >= today
-	 * (via the datamachine_event_dates table).
+	 * Filters to published upcoming data_machine_events via the canonical
+	 * event date predicate.
 	 *
 	 * @param array $input Input parameters.
 	 * @return array|\WP_Error Term counts sorted by event count descending.
@@ -169,8 +171,10 @@ class UpcomingCountAbilities {
 
 		global $wpdb;
 
-		$today    = gmdate( 'Y-m-d 00:00:00' );
-		$ed_table = \DataMachineEvents\Core\EventDatesTable::table_name();
+		$now            = current_time( 'mysql' );
+		$upcoming_sql   = UpcomingFilter::upcoming_sql( true, 'tr.object_id' );
+		$upcoming_join  = $upcoming_sql['joins'];
+		$upcoming_where = $upcoming_sql['where'];
 
 		$parent_clause = $exclude_roots ? 'AND tt.parent != 0' : '';
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names and optional clauses are internally constructed; request values remain prepared.
@@ -186,19 +190,19 @@ class UpcomingCountAbilities {
 					FROM {$wpdb->term_relationships} tr
 					INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
 					INNER JOIN {$wpdb->terms} t ON tt.term_id = t.term_id
-					INNER JOIN {$ed_table} ed ON tr.object_id = ed.post_id
+					{$upcoming_join}
 					INNER JOIN {$wpdb->term_relationships} f_tr ON f_tr.object_id = tr.object_id
 					INNER JOIN {$wpdb->term_taxonomy} f_tt ON f_tr.term_taxonomy_id = f_tt.term_taxonomy_id
 					WHERE tt.taxonomy = %s
-					AND ed.post_status = 'publish'
-					AND ed.start_datetime >= %s
+					AND {$upcoming_where}
 					AND f_tt.taxonomy = %s
 					AND f_tt.term_id = %d
 					{$parent_clause}
 					GROUP BY t.term_id
 					ORDER BY event_count DESC",
 					$taxonomy,
-					$today,
+					$now,
+					$now,
 					$filter_taxonomy,
 					$filter_term_id
 				)
@@ -212,15 +216,15 @@ class UpcomingCountAbilities {
 					FROM {$wpdb->term_relationships} tr
 					INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
 					INNER JOIN {$wpdb->terms} t ON tt.term_id = t.term_id
-					INNER JOIN {$ed_table} ed ON tr.object_id = ed.post_id
+					{$upcoming_join}
 					WHERE tt.taxonomy = %s
-					AND ed.post_status = 'publish'
-					AND ed.start_datetime >= %s
+					AND {$upcoming_where}
 					{$parent_clause}
 					GROUP BY t.term_id
 					ORDER BY event_count DESC",
 					$taxonomy,
-					$today
+					$now,
+					$now
 				)
 			);
 		}
@@ -281,8 +285,10 @@ class UpcomingCountAbilities {
 	private function executeRollupCounts( string $taxonomy, bool $exclude_roots, bool $has_filter, ?string $filter_taxonomy, int $filter_term_id ): array|\WP_Error {
 		global $wpdb;
 
-		$today    = gmdate( 'Y-m-d 00:00:00' );
-		$ed_table = \DataMachineEvents\Core\EventDatesTable::table_name();
+		$now            = current_time( 'mysql' );
+		$upcoming_sql   = UpcomingFilter::upcoming_sql( true, 'tr.object_id' );
+		$upcoming_join  = $upcoming_sql['joins'];
+		$upcoming_where = $upcoming_sql['where'];
 
 		// Pull every (term_id, object_id) pair for upcoming published events
 		// in this taxonomy. One pass; deduped per-ancestor in PHP below.
@@ -294,16 +300,16 @@ class UpcomingCountAbilities {
 					"SELECT tt.term_id AS term_id, tr.object_id AS object_id
 					FROM {$wpdb->term_relationships} tr
 					INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
-					INNER JOIN {$ed_table} ed ON tr.object_id = ed.post_id
+					{$upcoming_join}
 					INNER JOIN {$wpdb->term_relationships} f_tr ON f_tr.object_id = tr.object_id
 					INNER JOIN {$wpdb->term_taxonomy} f_tt ON f_tr.term_taxonomy_id = f_tt.term_taxonomy_id
 					WHERE tt.taxonomy = %s
-					AND ed.post_status = 'publish'
-					AND ed.start_datetime >= %s
+					AND {$upcoming_where}
 					AND f_tt.taxonomy = %s
 					AND f_tt.term_id = %d",
 					$taxonomy,
-					$today,
+					$now,
+					$now,
 					$filter_taxonomy,
 					$filter_term_id
 				)
@@ -315,12 +321,12 @@ class UpcomingCountAbilities {
 					"SELECT tt.term_id AS term_id, tr.object_id AS object_id
 					FROM {$wpdb->term_relationships} tr
 					INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
-					INNER JOIN {$ed_table} ed ON tr.object_id = ed.post_id
+					{$upcoming_join}
 					WHERE tt.taxonomy = %s
-					AND ed.post_status = 'publish'
-					AND ed.start_datetime >= %s",
+					AND {$upcoming_where}",
 					$taxonomy,
-					$today
+					$now,
+					$now
 				)
 			);
 		}

--- a/tests/Unit/UpcomingCountAbilitiesTest.php
+++ b/tests/Unit/UpcomingCountAbilitiesTest.php
@@ -52,6 +52,19 @@ class UpcomingCountAbilitiesTest extends WP_UnitTestCase {
 		} else {
 			register_taxonomy_for_object_type( 'artist', 'data_machine_events' );
 		}
+		if ( ! taxonomy_exists( 'location' ) ) {
+			register_taxonomy(
+				'location',
+				array( 'data_machine_events' ),
+				array(
+					'public'       => true,
+					'hierarchical' => true,
+					'rewrite'      => array( 'slug' => 'location' ),
+				)
+			);
+		} else {
+			register_taxonomy_for_object_type( 'location', 'data_machine_events' );
+		}
 
 		if ( ! EventDatesTable::table_exists() ) {
 			EventDatesTable::create_table();
@@ -62,18 +75,19 @@ class UpcomingCountAbilitiesTest extends WP_UnitTestCase {
 
 	/**
 	 * Insert a published event, attach it to venue + (optional) artist terms,
-	 * and seed the event_dates table with a future datetime so it counts as
-	 * "upcoming".
+	 * and seed the event_dates table.
 	 *
 	 * @param int      $venue_term_id  Venue term ID to attach.
 	 * @param int|null $artist_term_id Artist term ID to attach (optional).
 	 * @param string   $start_datetime MySQL datetime; defaults to far-future.
+	 * @param string|null $end_datetime MySQL datetime; defaults to null.
 	 * @return int Inserted post ID.
 	 */
 	private function seed_upcoming_event(
 		int $venue_term_id,
 		?int $artist_term_id = null,
-		string $start_datetime = '2099-01-01 20:00:00'
+		string $start_datetime = '2099-01-01 20:00:00',
+		?string $end_datetime = null
 	): int {
 		$post_id = wp_insert_post(
 			array(
@@ -89,7 +103,7 @@ class UpcomingCountAbilitiesTest extends WP_UnitTestCase {
 			wp_set_object_terms( $post_id, array( $artist_term_id ), 'artist' );
 		}
 
-		EventDatesTable::upsert( $post_id, $start_datetime, null, 'publish' );
+		EventDatesTable::upsert( $post_id, $start_datetime, $end_datetime, 'publish' );
 
 		return $post_id;
 	}
@@ -104,6 +118,86 @@ class UpcomingCountAbilitiesTest extends WP_UnitTestCase {
 		$term = wp_insert_term( $name . ' ' . uniqid(), 'artist' );
 		$this->assertNotWPError( $term );
 		return (int) $term['term_id'];
+	}
+
+	private function make_location( string $name, int $parent = 0 ): int {
+		$term = wp_insert_term(
+			$name . ' ' . uniqid(),
+			'location',
+			array( 'parent' => $parent )
+		);
+		$this->assertNotWPError( $term );
+		return (int) $term['term_id'];
+	}
+
+	public function test_direct_counts_include_ongoing_and_exclude_completed_events_in_site_timezone(): void {
+		$old_timezone = get_option( 'timezone_string' );
+		update_option( 'timezone_string', 'Pacific/Kiritimati' );
+
+		try {
+			$now             = current_datetime();
+			$ongoing_venue   = $this->make_venue( 'Ongoing Venue' );
+			$completed_venue = $this->make_venue( 'Completed Venue' );
+
+			$this->seed_upcoming_event(
+				$ongoing_venue,
+				null,
+				$now->modify( '-2 days' )->format( 'Y-m-d H:i:s' ),
+				$now->modify( '+1 hour' )->format( 'Y-m-d H:i:s' )
+			);
+			$this->seed_upcoming_event(
+				$completed_venue,
+				null,
+				$now->setTime( 0, 0 )->format( 'Y-m-d H:i:s' ),
+				$now->modify( '-1 minute' )->format( 'Y-m-d H:i:s' )
+			);
+
+			$result = $this->abilities->executeGetUpcomingCounts( array( 'taxonomy' => 'venue' ) );
+			$by_id  = array_column( $result['terms'], 'count', 'term_id' );
+
+			$this->assertArrayHasKey( $ongoing_venue, $by_id );
+			$this->assertSame( 1, $by_id[ $ongoing_venue ] );
+			$this->assertArrayNotHasKey( $completed_venue, $by_id );
+		} finally {
+			update_option( 'timezone_string', $old_timezone );
+		}
+	}
+
+	public function test_rollup_counts_include_ongoing_and_exclude_completed_events(): void {
+		$now              = current_datetime();
+		$venue            = $this->make_venue( 'Rollup Venue' );
+		$ongoing_parent   = $this->make_location( 'Ongoing Parent' );
+		$ongoing_child    = $this->make_location( 'Ongoing Child', $ongoing_parent );
+		$completed_parent = $this->make_location( 'Completed Parent' );
+		$completed_child  = $this->make_location( 'Completed Child', $completed_parent );
+
+		$ongoing = $this->seed_upcoming_event(
+			$venue,
+			null,
+			$now->modify( '-2 days' )->format( 'Y-m-d H:i:s' ),
+			$now->modify( '+1 hour' )->format( 'Y-m-d H:i:s' )
+		);
+		$completed = $this->seed_upcoming_event(
+			$venue,
+			null,
+			$now->modify( '-2 days' )->format( 'Y-m-d H:i:s' ),
+			$now->modify( '-1 minute' )->format( 'Y-m-d H:i:s' )
+		);
+		wp_set_object_terms( $ongoing, array( $ongoing_child ), 'location' );
+		wp_set_object_terms( $completed, array( $completed_child ), 'location' );
+
+		$result = $this->abilities->executeGetUpcomingCounts(
+			array(
+				'taxonomy'      => 'location',
+				'rollup'        => true,
+				'exclude_roots' => false,
+			)
+		);
+		$by_id  = array_column( $result['terms'], 'count', 'term_id' );
+
+		$this->assertArrayHasKey( $ongoing_parent, $by_id );
+		$this->assertSame( 1, $by_id[ $ongoing_parent ] );
+		$this->assertArrayNotHasKey( $completed_parent, $by_id );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- align direct upcoming term counts with the canonical ongoing-event predicate
- align hierarchical rollup counts with the same site-local boundary
- add regressions for ongoing, completed, rollup, and timezone-sensitive behavior

## Root Cause
`UpcomingCountAbilities` used `ed.start_datetime >= gmdate( 'Y-m-d 00:00:00' )` in both direct and rollup queries. That excluded events which started earlier but remain in progress, and the UTC-midnight boundary could include events already completed in the WordPress site timezone.

## Changes
- Direct counts now use `UpcomingFilter::upcoming_sql( true, 'tr.object_id' )` with `current_time( 'mysql' )` in both filtered and unfiltered queries.
- Rollup counts use the same canonical join, published-status clause, and `(start_datetime >= now OR end_datetime >= now)` predicate in both filtered and unfiltered queries.
- The existing `UpcomingFilter` raw-SQL primitive is reused instead of duplicating the calendar's definition, keeping archive and count semantics in one owning-layer implementation.
- Tests distinguish an event started before now but ending after now from a completed event, cover direct and hierarchical rollup results, and exercise the boundary under `Pacific/Kiritimati` to prove the comparison uses site-local time rather than UTC midnight.

## Verification
- `php -l inc/Abilities/UpcomingCountAbilities.php` - passed
- `php -l tests/Unit/UpcomingCountAbilitiesTest.php` - passed
- `git diff --check` - passed
- `homeboy review lint --path /var/lib/datamachine/workspace/data-machine-events@fix-702-upcoming-count-semantics` - passed (PHPCS, ESLint, PHPStan; existing advisory findings only)
- GitHub `Homeboy (review audit)` - passed
- GitHub `Homeboy (review lint)` - passed
- GitHub `Homeboy (review test)` - executed 789 tests; the new direct, rollup, ongoing, completed, and timezone-sensitive tests passed. The full job remains red from 11 unrelated integration failures after CI resolved newer `data-machine` main; none involve `UpcomingCountAbilitiesTest` or the changed files.
- Local focused and full Homeboy test attempts reached WP Codebox but reported zero tests because the recipe payload could not be parsed. The reporting/runtime issue is tracked upstream in Extra-Chill/homeboy#12683 and Extra-Chill/homeboy#12737.

Fixes #702