### PR TITLE
Fix repeated Ticketmaster import convergence

### DIFF
--- a/inc/Abilities/EventDateQueryAbilities.php
+++ b/inc/Abilities/EventDateQueryAbilities.php
@@ -549,6 +549,10 @@ class EventDateQueryAbilities {
 				$clauses['join'] .= " INNER JOIN {$table} AS ed ON {$wpdb->posts}.ID = ed.post_id";
 			}
 
+			// Taxonomy and consumer joins may match more than one relationship for
+			// a post. Calendar rows represent canonical events, never join rows.
+			$clauses['distinct'] = 'DISTINCT';
+
 			$now = current_time( 'mysql' );
 
 			// Exact date match takes priority (dedup queries). Use a half-open

--- a/inc/Abilities/EventQualityAuditAbilities.php
+++ b/inc/Abilities/EventQualityAuditAbilities.php
@@ -156,7 +156,7 @@ class EventQualityAuditAbilities {
 				$this->incrementFlowCount( $culprit_flow_counts, $flow_id, $info['flow_name'] );
 			}
 
-			$duplicate_key = $this->buildDuplicateClusterKey( $event->post_title, $venue_name, $info['startDate'] );
+			$duplicate_key = $this->buildDuplicateClusterKey( $event->post_title, $venue_name, $info['startDate'], $info['startTime'] );
 			if ( ! empty( $duplicate_key ) ) {
 				$by_duplicate_key[ $duplicate_key ][] = $info;
 			}
@@ -321,7 +321,7 @@ class EventQualityAuditAbilities {
 		return is_string( $name ) ? $name : '';
 	}
 
-	private function buildDuplicateClusterKey( string $title, string $venue, string $start_date ): string {
+	private function buildDuplicateClusterKey( string $title, string $venue, string $start_date, string $start_time ): string {
 		if ( '' === $start_date || '' === $venue ) {
 			return '';
 		}
@@ -330,7 +330,9 @@ class EventQualityAuditAbilities {
 			return '';
 		}
 
-		return md5( strtolower( $start_date ) . '|' . strtolower( $venue ) . '|' . strtolower( trim( wp_strip_all_tags( $title ) ) ) );
+		$start = EventIdentifierGenerator::normalizeStartDateTime( $start_date, $start_time );
+
+		return md5( strtolower( $start ) . '|' . strtolower( $venue ) . '|' . strtolower( trim( wp_strip_all_tags( $title ) ) ) );
 	}
 
 	private function incrementFlowCount( array &$counts, int $flow_id, string $flow_name ): void {

--- a/inc/Cli/Check/CleanDuplicatesCommand.php
+++ b/inc/Cli/Check/CleanDuplicatesCommand.php
@@ -29,7 +29,7 @@ class CleanDuplicatesCommand {
 	/**
 	 * Clean duplicate events by trashing the newer copy.
 	 *
-	 * Scans for duplicate events using fuzzy title + venue matching, keeps
+	 * Scans for duplicate events using fuzzy title + exact time + venue matching, keeps
 	 * the older post (more link equity), and trashes the newer one. If the
 	 * trashed post has a ticket URL that the kept post lacks, it is copied over.
 	 *
@@ -52,16 +52,19 @@ class CleanDuplicatesCommand {
 	 * ---
 	 *
 	 * [--dry-run]
-	 * : Show what would be cleaned without actually trashing.
+	 * : Show what would be cleaned without actually trashing. This is the default.
+	 *
+	 * [--apply]
+	 * : Trash the reviewed duplicates. Without this flag no changes are made.
 	 *
 	 * [--yes]
 	 * : Skip confirmation prompt.
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     wp data-machine-events check clean-duplicates --dry-run
-	 *     wp data-machine-events check clean-duplicates --scope=upcoming --yes
-	 *     wp data-machine-events check clean-duplicates --scope=all --yes
+	 *     wp data-machine-events check clean-duplicates
+	 *     wp data-machine-events check clean-duplicates --scope=upcoming --apply --yes
+	 *     wp data-machine-events check clean-duplicates --scope=all --apply --yes
 	 *
 	 * @param array $args       Positional arguments.
 	 * @param array $assoc_args Named arguments.
@@ -69,7 +72,7 @@ class CleanDuplicatesCommand {
 	public function __invoke( array $args, array $assoc_args ): void {
 		$scope        = $assoc_args['scope'] ?? 'all';
 		$days_ahead   = (int) ( $assoc_args['days-ahead'] ?? 90 );
-		$dry_run      = isset( $assoc_args['dry-run'] );
+		$dry_run      = ! isset( $assoc_args['apply'] ) || isset( $assoc_args['dry-run'] );
 		$skip_confirm = isset( $assoc_args['yes'] );
 
 		$events = $this->query_events( $scope, $days_ahead );
@@ -177,7 +180,8 @@ class CleanDuplicatesCommand {
 	 * @return array Duplicate groups.
 	 */
 	private function find_duplicates( array $events ): array {
-		$by_date = array();
+		$by_date     = array();
+		$start_cache = array();
 		foreach ( $events as $event ) {
 			$dates      = \DataMachineEvents\Core\EventDatesTable::get( $event->ID );
 			$start_meta = $dates ? $dates->start_datetime : '';
@@ -187,7 +191,8 @@ class CleanDuplicatesCommand {
 				continue;
 			}
 
-			$by_date[ $date ][] = $event;
+			$by_date[ $date ][]        = $event;
+			$start_cache[ $event->ID ] = EventIdentifierGenerator::normalizeStartDateTime( $start_meta );
 		}
 
 		$duplicate_groups = array();
@@ -214,6 +219,10 @@ class CleanDuplicatesCommand {
 					}
 
 					if ( ! EventIdentifierGenerator::titlesMatch( $event_a->post_title, $event_b->post_title ) ) {
+						continue;
+					}
+
+					if ( ( $start_cache[ $event_a->ID ] ?? '' ) !== ( $start_cache[ $event_b->ID ] ?? '' ) ) {
 						continue;
 					}
 

--- a/inc/Steps/Upsert/Events/EventUpsert.php
+++ b/inc/Steps/Upsert/Events/EventUpsert.php
@@ -114,6 +114,20 @@ class EventUpsert extends UpsertHandler {
 			$engine          = new EngineData( $engine_snapshot, $job_id );
 		}
 
+		// Workflow imports carry source context in engine data, while direct
+		// ability callers provide these canonical fields explicitly. Normalize
+		// both paths before locking and matching so stable upstream IDs own the
+		// event across revisions instead of falling back to fuzzy identity.
+		$source    = trim( (string) ( $parameters['source'] ?? $engine->get( 'source_type' ) ?? '' ) );
+		$source_id = trim( (string) ( $parameters['source_id'] ?? $engine->get( 'item_identifier' ) ?? '' ) );
+		if ( '' !== $source && '' !== $source_id ) {
+			$parameters['source']    = $source;
+			$parameters['source_id'] = $source_id;
+			if ( empty( $parameters['source_identity'] ) ) {
+				$parameters['source_identity'] = hash( 'sha256', $source . "\0" . $source_id );
+			}
+		}
+
 		// Extract event identity fields (AI title takes precedence, engine data fallback for other fields)
 		$title     = sanitize_text_field( $parameters['title'] ?? $engine->get( 'title' ) ?? '' );
 		$venue     = $engine->get( 'venue' ) ?? $parameters['venue'] ?? '';

--- a/tests/Unit/CalendarAbilitiesTest.php
+++ b/tests/Unit/CalendarAbilitiesTest.php
@@ -539,4 +539,32 @@ class CalendarAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( 1, $result['event_count'] );
 		$this->assertSame( array( $target ), $this->result_post_ids( $result ) );
 	}
+
+	public function test_multiple_matching_taxonomy_rows_render_one_canonical_event(): void {
+		$first_term  = wp_insert_term( 'Calendar multi-term A ' . uniqid(), 'calendar_test_style' );
+		$second_term = wp_insert_term( 'Calendar multi-term B ' . uniqid(), 'calendar_test_style' );
+		$this->assertNotWPError( $first_term );
+		$this->assertNotWPError( $second_term );
+		$date    = current_datetime()->modify( '+75 days' );
+		$post_id = $this->seed_event(
+			'Multi-term canonical event',
+			$date->format( 'Y-m-d 20:00:00' ),
+			$date->format( 'Y-m-d 22:00:00' ),
+			0,
+			array( 'calendar_test_style' => array( (int) $first_term['term_id'], (int) $second_term['term_id'] ) )
+		);
+
+		$result = $this->abilities->executeGetCalendarPage(
+			array(
+				'tax_filter'   => array( 'calendar_test_style' => array( (int) $first_term['term_id'], (int) $second_term['term_id'] ) ),
+				'date_start'  => $date->format( 'Y-m-d' ),
+				'date_end'    => $date->format( 'Y-m-d' ),
+				'include_html' => false,
+			)
+		);
+
+		$this->assertSame( 1, $result['total_event_count'] );
+		$this->assertSame( 1, $result['event_count'] );
+		$this->assertSame( array( $post_id ), $this->result_post_ids( $result ) );
+	}
 }

--- a/tests/Unit/CalendarAbilitiesTest.php
+++ b/tests/Unit/CalendarAbilitiesTest.php
@@ -539,32 +539,4 @@ class CalendarAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( 1, $result['event_count'] );
 		$this->assertSame( array( $target ), $this->result_post_ids( $result ) );
 	}
-
-	public function test_multiple_matching_taxonomy_rows_render_one_canonical_event(): void {
-		$first_term  = wp_insert_term( 'Calendar multi-term A ' . uniqid(), 'calendar_test_style' );
-		$second_term = wp_insert_term( 'Calendar multi-term B ' . uniqid(), 'calendar_test_style' );
-		$this->assertNotWPError( $first_term );
-		$this->assertNotWPError( $second_term );
-		$date    = current_datetime()->modify( '+75 days' );
-		$post_id = $this->seed_event(
-			'Multi-term canonical event',
-			$date->format( 'Y-m-d 20:00:00' ),
-			$date->format( 'Y-m-d 22:00:00' ),
-			0,
-			array( 'calendar_test_style' => array( (int) $first_term['term_id'], (int) $second_term['term_id'] ) )
-		);
-
-		$result = $this->abilities->executeGetCalendarPage(
-			array(
-				'tax_filter'   => array( 'calendar_test_style' => array( (int) $first_term['term_id'], (int) $second_term['term_id'] ) ),
-				'date_start'  => $date->format( 'Y-m-d' ),
-				'date_end'    => $date->format( 'Y-m-d' ),
-				'include_html' => false,
-			)
-		);
-
-		$this->assertSame( 1, $result['total_event_count'] );
-		$this->assertSame( 1, $result['event_count'] );
-		$this->assertSame( array( $post_id ), $this->result_post_ids( $result ) );
-	}
 }

--- a/tests/Unit/CleanDuplicatesCommandTest.php
+++ b/tests/Unit/CleanDuplicatesCommandTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Clean duplicate events command tests.
+ *
+ * @package DataMachineEvents\Tests\Unit
+ */
+
+namespace DataMachineEvents\Tests\Unit;
+
+use DataMachineEvents\Cli\Check\CleanDuplicatesCommand;
+use DataMachineEvents\Core\EventDatesTable;
+use DataMachineEvents\Core\Event_Post_Type;
+use DataMachineEvents\Core\Venue_Taxonomy;
+use WP_UnitTestCase;
+
+class CleanDuplicatesCommandTest extends WP_UnitTestCase {
+
+	public function setUp(): void {
+		parent::setUp();
+
+		if ( ! post_type_exists( Event_Post_Type::POST_TYPE ) ) {
+			Event_Post_Type::register();
+		}
+		if ( ! taxonomy_exists( 'venue' ) ) {
+			Venue_Taxonomy::register();
+		}
+		if ( ! EventDatesTable::table_exists() ) {
+			EventDatesTable::create_table();
+		}
+	}
+
+	public function test_repair_selects_exact_replays_without_collapsing_later_showtime(): void {
+		$venue = wp_insert_term( 'Cleaner venue ' . uniqid(), 'venue' );
+		$this->assertNotWPError( $venue );
+		$title = 'Cleaner multiple showtime ' . uniqid();
+		$first = $this->seedEvent( $title, '2026-11-21 19:00:00', (int) $venue['term_id'] );
+		$dupe  = $this->seedEvent( $title, '2026-11-21 19:00:00', (int) $venue['term_id'] );
+		$late  = $this->seedEvent( $title, '2026-11-21 21:30:00', (int) $venue['term_id'] );
+
+		$method = new \ReflectionMethod( CleanDuplicatesCommand::class, 'find_duplicates' );
+		$method->setAccessible( true );
+		$groups = $method->invoke( new CleanDuplicatesCommand(), array_map( 'get_post', array( $first, $dupe, $late ) ) );
+
+		$this->assertCount( 1, $groups );
+		$this->assertEqualsCanonicalizing( array( $first, $dupe ), array( $groups[0]['event_a']['id'], $groups[0]['event_b']['id'] ) );
+		$this->assertNotContains( $late, array( $groups[0]['event_a']['id'], $groups[0]['event_b']['id'] ) );
+	}
+
+	private function seedEvent( string $title, string $start, int $venue_id ): int {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'  => $title,
+				'post_type'   => Event_Post_Type::POST_TYPE,
+				'post_status' => 'publish',
+			)
+		);
+		wp_set_object_terms( $post_id, array( $venue_id ), 'venue' );
+		EventDatesTable::upsert( $post_id, $start, null, 'publish' );
+
+		return $post_id;
+	}
+}

--- a/tests/Unit/EventDateQueryDistinctTest.php
+++ b/tests/Unit/EventDateQueryDistinctTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Event date query distinct-row tests.
+ *
+ * @package DataMachineEvents\Tests\Unit
+ */
+
+namespace DataMachineEvents\Tests\Unit;
+
+use DataMachineEvents\Abilities\EventDateQueryAbilities;
+use DataMachineEvents\Core\EventDatesTable;
+use DataMachineEvents\Core\Event_Post_Type;
+use WP_UnitTestCase;
+
+class EventDateQueryDistinctTest extends WP_UnitTestCase {
+
+	public function setUp(): void {
+		parent::setUp();
+
+		if ( ! post_type_exists( Event_Post_Type::POST_TYPE ) ) {
+			Event_Post_Type::register();
+		}
+		if ( ! taxonomy_exists( 'event_query_distinct_style' ) ) {
+			register_taxonomy( 'event_query_distinct_style', Event_Post_Type::POST_TYPE );
+		}
+		if ( ! EventDatesTable::table_exists() ) {
+			EventDatesTable::create_table();
+		}
+	}
+
+	public function test_multiple_matching_taxonomy_rows_return_one_canonical_event(): void {
+		$first_term  = wp_insert_term( 'Query multi-term A ' . uniqid(), 'event_query_distinct_style' );
+		$second_term = wp_insert_term( 'Query multi-term B ' . uniqid(), 'event_query_distinct_style' );
+		$this->assertNotWPError( $first_term );
+		$this->assertNotWPError( $second_term );
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'  => 'Multi-term canonical event',
+				'post_type'   => Event_Post_Type::POST_TYPE,
+				'post_status' => 'publish',
+			)
+		);
+		wp_set_object_terms( $post_id, array( (int) $first_term['term_id'], (int) $second_term['term_id'] ), 'event_query_distinct_style' );
+		EventDatesTable::upsert( $post_id, '2026-11-22 20:00:00', '2026-11-22 22:00:00', 'publish' );
+
+		$result = ( new EventDateQueryAbilities() )->executeQueryEvents(
+			array(
+				'scope'       => 'all',
+				'date_start'  => '2026-11-22',
+				'date_end'    => '2026-11-22',
+				'tax_filters' => array( 'event_query_distinct_style' => array( (int) $first_term['term_id'], (int) $second_term['term_id'] ) ),
+				'fields'      => 'ids',
+			)
+		);
+
+		$this->assertSame( 1, $result['total'] );
+		$this->assertSame( 1, $result['post_count'] );
+		$this->assertSame( array( $post_id ), $result['posts'] );
+	}
+}

--- a/tests/Unit/EventQualityAuditAbilitiesTest.php
+++ b/tests/Unit/EventQualityAuditAbilitiesTest.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Event quality audit tests.
+ *
+ * @package DataMachineEvents\Tests\Unit
+ */
+
+namespace DataMachineEvents\Tests\Unit;
+
+use DataMachineEvents\Abilities\EventQualityAuditAbilities;
+use WP_UnitTestCase;
+
+class EventQualityAuditAbilitiesTest extends WP_UnitTestCase {
+
+	public function test_duplicate_clusters_include_showtime(): void {
+		$method = new \ReflectionMethod( EventQualityAuditAbilities::class, 'buildDuplicateClusterKey' );
+		$method->setAccessible( true );
+		$audit = new EventQualityAuditAbilities();
+
+		$early  = $method->invoke( $audit, 'Desi Banks', 'Vic Theater', '2026-08-22', '19:00' );
+		$replay = $method->invoke( $audit, 'Desi Banks', 'Vic Theater', '2026-08-22', '19:00:00' );
+		$late   = $method->invoke( $audit, 'Desi Banks', 'Vic Theater', '2026-08-22', '21:30' );
+
+		$this->assertSame( $early, $replay );
+		$this->assertNotSame( $early, $late );
+	}
+}

--- a/tests/Unit/EventUpsertTest.php
+++ b/tests/Unit/EventUpsertTest.php
@@ -743,6 +743,72 @@ class EventUpsertTest extends WP_UnitTestCase {
 		$this->assertNotSame( $early['data']['post_id'] ?? 0, $late['data']['post_id'] ?? 0 );
 	}
 
+	public function test_workflow_source_id_replays_update_one_canonical_event(): void {
+		$source_id = 'ticketmaster-' . uniqid();
+		$first     = $this->invoke_upsert(
+			array(
+				'title'           => 'Stable Source Original ' . uniqid(),
+				'venue'           => 'Stable Source Venue ' . uniqid(),
+				'startDate'       => '2026-11-18',
+				'startTime'       => '19:00',
+				'source_type'     => 'ticketmaster',
+				'item_identifier' => $source_id,
+			)
+		);
+		$second    = $this->invoke_upsert(
+			array(
+				'title'           => 'Stable Source Revised ' . uniqid(),
+				'venue'           => 'Stable Source Revised Venue ' . uniqid(),
+				'startDate'       => '2026-11-19',
+				'startTime'       => '20:30',
+				'source_type'     => 'ticketmaster',
+				'item_identifier' => $source_id,
+			)
+		);
+
+		$this->assertTrue( $first['success'] ?? false, wp_json_encode( $first ) );
+		$this->assertTrue( $second['success'] ?? false, wp_json_encode( $second ) );
+		$this->assertSame( $first['data']['post_id'], $second['data']['post_id'] );
+		$this->assertSame( 'updated', $second['data']['action'] );
+		$this->assertSame(
+			hash( 'sha256', 'ticketmaster' . "\0" . $source_id ),
+			get_post_meta( $first['data']['post_id'], EventUpsert::SOURCE_IDENTITY_META_KEY, true )
+		);
+		$this->assertSame( 'ticketmaster', get_post_meta( $first['data']['post_id'], EventUpsert::SOURCE_NAME_META_KEY, true ) );
+		$this->assertSame( $source_id, get_post_meta( $first['data']['post_id'], EventUpsert::SOURCE_ID_META_KEY, true ) );
+	}
+
+	public function test_different_source_ids_preserve_same_title_multiple_showtimes(): void {
+		$title = 'Multiple Showtime ' . uniqid();
+		$venue = 'Multiple Showtime Venue ' . uniqid();
+		$early = $this->invoke_upsert(
+			array(
+				'title'           => $title,
+				'venue'           => $venue,
+				'startDate'       => '2026-11-20',
+				'startTime'       => '19:00',
+				'source_type'     => 'ticketmaster',
+				'item_identifier' => 'early-' . uniqid(),
+			)
+		);
+		$late  = $this->invoke_upsert(
+			array(
+				'title'           => $title,
+				'venue'           => $venue,
+				'startDate'       => '2026-11-20',
+				'startTime'       => '21:30',
+				'source_type'     => 'ticketmaster',
+				'item_identifier' => 'late-' . uniqid(),
+			)
+		);
+
+		$this->assertTrue( $early['success'] ?? false, wp_json_encode( $early ) );
+		$this->assertTrue( $late['success'] ?? false, wp_json_encode( $late ) );
+		$this->assertSame( 'created', $early['data']['action'] );
+		$this->assertSame( 'created', $late['data']['action'] );
+		$this->assertNotSame( $early['data']['post_id'], $late['data']['post_id'] );
+	}
+
 	/**
 	 * Invoke the protected upsert entry point with normal engine context.
 	 *


### PR DESCRIPTION
## Summary
- derive canonical source identity from workflow engine context so repeated Ticketmaster revisions update the same event post
- make duplicate auditing and cleanup showtime-aware while keeping cleanup dry-run unless `--apply` is explicit
- force canonical calendar queries to return distinct posts even when taxonomy or consumer joins match multiple rows

## Root cause and evidence
The read-only Chicago audit scanned 890 upcoming events and returned seven date/title/venue clusters. Record inspection proved the repeated cards were distinct imported posts, not duplicated occurrence rows: every post had one primary-keyed `datamachine_event_dates` row, while exact groups shared datetime, venue term, and canonical ticket URL. For example, Book of Wyrms IDs `258720`, `334759`, `343732`, and `347755` all point to the same 2026-08-22 20:00 occurrence and TicketWeb event, but none had `_datamachine_event_source_identity` or `_datamachine_event_source_id` metadata.

Ticketmaster correctly put its stable upstream ID in engine data as `item_identifier`. Workflow `EventUpsert` only consumed caller-provided `source_identity`, so the stable ID never reached persistence and changed/reprocessed revisions depended on fuzzy duplicate detection. Each resulting post had its own valid occurrence row, and the calendar correctly rendered each post.

The seventh audit cluster was not a duplicate: Desi Banks has separate 19:00 and 21:30 Ticketmaster IDs. The audit key omitted time.

## Canonical identity and upsert change
Workflow upsert now normalizes `source_type` plus `item_identifier` from engine data into the same SHA-256 `source\\0source_id` identity used by the public upsert ability. That identity participates in locking, exact lookup, and persisted source metadata before fuzzy matching. Revisions of one Ticketmaster ID therefore update one canonical post even when title, date, venue, or other mapped fields change.

Different Ticketmaster IDs remain different source identities. The existing time-aware duplicate strategy also preserves known start times outside its duplicate window; regression coverage uses separate 19:00 and 21:30 performances.

## Calendar and remediation safety
`EventDateQueryAbilities` now selects `DISTINCT` canonical posts, preventing multi-match taxonomy/consumer joins from multiplying one event card.

`wp data-machine-events check clean-duplicates` is now dry-run by default and requires `--apply` for mutation. Its candidate pairs must have the same normalized start minute in addition to fuzzy title and venue, so later showtimes are not cleanup targets. No production records were changed.

## Verification
- `homeboy review lint --changed-only`: passed, zero PHPCS/PHPStan/ESLint findings
- `homeboy review audit --profile pr --changed-since origin/main`: passed, zero introduced findings
- PHP syntax checks and `git diff --check`: passed
- Calendar, Event Details, and Events Map production builds: passed during managed test setup
- Focused PHPUnit regressions were added for workflow source replay, separate showtimes, distinct calendar joins, audit showtime keys, and safe cleanup selection
- Local managed PHPUnit could not execute because the WP Codebox dependency bootstrap failed before tests in Data Machine agent scaffolding; tracked as Extra-Chill/data-machine#3291. The initial missing-Docker diagnosis masking is tracked as Extra-Chill/homeboy#12776. GitHub's repository MySQL gate is authoritative for the PR.

Fixes #701