### PR TITLE
fix: preserve explicit past calendar boundaries

### DIFF
--- a/inc/Abilities/CalendarAbilities.php
+++ b/inc/Abilities/CalendarAbilities.php
@@ -633,6 +633,27 @@ class CalendarAbilities {
 		$has_tax_filter = ( $archive_taxonomy && $archive_term_id )
 			|| self::has_active_tax_filter( $tax_filters );
 
+		$temporal_where_clauses = array();
+		if ( ! empty( $params['user_date_range'] ) ) {
+			if ( ! empty( $params['date_start'] ) ) {
+				$start_dt                 = ! empty( $params['time_start'] )
+					? $params['date_start'] . ' ' . $params['time_start']
+					: $params['date_start'] . ' 00:00:00';
+				$temporal_where_clauses[] = UpcomingFilter::range_start_where( $start_dt );
+			}
+
+			if ( ! empty( $params['date_end'] ) ) {
+				$end_dt                   = ! empty( $params['time_end'] )
+					? $params['date_end'] . ' ' . $params['time_end']
+					: $params['date_end'] . ' 23:59:59';
+				$temporal_where_clauses[] = $wpdb->prepare( 'ed.start_datetime <= %s', $end_dt );
+			}
+		} elseif ( $show_past_param ) {
+			$temporal_where_clauses[] = UpcomingFilter::past_where( $current_time );
+		} else {
+			$temporal_where_clauses[] = UpcomingFilter::upcoming_where( $current_time );
+		}
+
 		// SQL fragment that buckets start_datetime by display date (with
 		// late-night cutoff applied). Identical semantics to
 		// LateNightCutoff::display_date_from_strings() at the PHP layer.
@@ -667,16 +688,8 @@ class CalendarAbilities {
 		// event_dates already carries post_status, so we can aggregate against
 		// the single table + its status_start composite index.
 		if ( ! $has_tax_filter ) {
-			$where_clauses = array( "ed.post_status = 'publish'" );
+			$where_clauses = array_merge( array( "ed.post_status = 'publish'" ), $temporal_where_clauses );
 			$query_values  = array();
-
-			if ( $show_past_param ) {
-				// Keep page buckets aligned with the canonical completed-event
-				// scope used by EventDateQueryAbilities.
-				$where_clauses[] = UpcomingFilter::past_where( $current_time );
-			} else {
-				$where_clauses[] = UpcomingFilter::upcoming_where( $current_time );
-			}
 
 			$where = implode( ' AND ', $where_clauses );
 			$sql   = "SELECT {$start_bucket_sql} AS start_date, DATE(ed.end_datetime) AS end_date, COUNT(*) AS bucket_count
@@ -696,18 +709,15 @@ class CalendarAbilities {
 
 		// Slow path: taxonomy constraints require joining posts + term tables.
 		// Still aggregates via GROUP BY to keep the result set bounded.
-		$where_clauses = array(
-			"p.post_type = 'data_machine_events'",
-			"p.post_status = 'publish'",
+		$where_clauses = array_merge(
+			array(
+				"p.post_type = 'data_machine_events'",
+				"p.post_status = 'publish'",
+			),
+			$temporal_where_clauses
 		);
 		$join_clauses  = array();
 		$query_values  = array();
-
-		if ( $show_past_param ) {
-			$where_clauses[] = UpcomingFilter::past_where( $current_time );
-		} else {
-			$where_clauses[] = UpcomingFilter::upcoming_where( $current_time );
-		}
 
 		if ( $archive_taxonomy && $archive_term_id ) {
 			$join_clauses[]  = "INNER JOIN {$wpdb->term_relationships} tr_archive ON p.ID = tr_archive.object_id";

--- a/inc/Abilities/CalendarAbilities.php
+++ b/inc/Abilities/CalendarAbilities.php
@@ -620,10 +620,11 @@ class CalendarAbilities {
 	private static function compute_unique_event_dates( array $params ): array {
 		global $wpdb;
 
-		$show_past_param = $params['show_past'] ?? false;
-		$current_date    = current_time( 'Y-m-d' );
-		$current_time    = current_time( 'mysql' );
-		$ed_table        = EventDatesTable::table_name();
+		$show_past_param    = $params['show_past'] ?? false;
+		$include_past_dates = $show_past_param || ! empty( $params['user_date_range'] );
+		$current_date       = current_time( 'Y-m-d' );
+		$current_time       = current_time( 'mysql' );
+		$ed_table           = EventDatesTable::table_name();
 
 		$archive_taxonomy = $params['archive_taxonomy'] ?? '';
 		$archive_term_id  = $params['archive_term_id'] ?? 0;
@@ -646,7 +647,7 @@ class CalendarAbilities {
 			$matching_sql = $event_query->buildMatchingPostIdsSql( self::build_event_query_input( $params ) );
 
 			if ( '' === $matching_sql ) {
-				return self::expand_date_buckets( array(), $show_past_param, $current_date );
+				return self::expand_date_buckets( array(), $show_past_param, $include_past_dates, $current_date );
 			}
 
 			$boundary_start_bucket_sql = LateNightCutoff::sql_display_date_expression( 'boundary_ed.start_datetime' );
@@ -659,7 +660,7 @@ class CalendarAbilities {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared
 			$rows = $wpdb->get_results( $sql );
 
-			return self::expand_date_buckets( $rows, $show_past_param, $current_date );
+			return self::expand_date_buckets( $rows, $show_past_param, $include_past_dates, $current_date );
 		}
 
 		// Fast path: no taxonomy constraint → skip posts/term joins entirely.
@@ -690,7 +691,7 @@ class CalendarAbilities {
 				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				: $wpdb->get_results( $wpdb->prepare( $sql, ...$query_values ) );
 
-			return self::expand_date_buckets( $rows, $show_past_param, $current_date );
+			return self::expand_date_buckets( $rows, $show_past_param, $include_past_dates, $current_date );
 		}
 
 		// Slow path: taxonomy constraints require joining posts + term tables.
@@ -756,7 +757,7 @@ class CalendarAbilities {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared
 		$rows = $wpdb->get_results( $wpdb->prepare( $sql, ...$query_values ) );
 
-		return self::expand_date_buckets( $rows, $show_past_param, $current_date );
+		return self::expand_date_buckets( $rows, $show_past_param, $include_past_dates, $current_date );
 	}
 
 	/**
@@ -866,13 +867,13 @@ class CalendarAbilities {
 	 * (start_date, end_date) pair. Multi-day events contribute to every
 	 * spanned date after their start.
 	 *
-	 * @param array  $rows            Rows with start_date, end_date, bucket_count.
-	 * @param bool   $show_past_param When true, sort result DESC; also skip the
-	 *                                "drop past dates" filter during expansion.
-	 * @param string $current_date    Today (Y-m-d) for past-date filtering.
+	 * @param array  $rows              Rows with start_date, end_date, bucket_count.
+	 * @param bool   $show_past_param   Whether to sort result descending.
+	 * @param bool   $include_past_dates Whether an explicit or past scope retains dates before today.
+	 * @param string $current_date      Today (Y-m-d) for past-date filtering.
 	 * @return array { dates, total_events, events_per_date }
 	 */
-	private static function expand_date_buckets( array $rows, bool $show_past_param, string $current_date ): array {
+	private static function expand_date_buckets( array $rows, bool $show_past_param, bool $include_past_dates, string $current_date ): array {
 		$total_events    = 0;
 		$events_per_date = array();
 
@@ -883,7 +884,7 @@ class CalendarAbilities {
 			}
 			$total_events += $count;
 
-			if ( $show_past_param || $row->start_date >= $current_date ) {
+			if ( $include_past_dates || $row->start_date >= $current_date ) {
 				$events_per_date[ $row->start_date ] = ( $events_per_date[ $row->start_date ] ?? 0 ) + $count;
 			}
 
@@ -896,7 +897,7 @@ class CalendarAbilities {
 				while ( $current <= $end_dt ) {
 					$date = $current->format( 'Y-m-d' );
 
-					if ( ! $show_past_param && $date < $current_date ) {
+					if ( ! $include_past_dates && $date < $current_date ) {
 						$current->modify( '+1 day' );
 						continue;
 					}

--- a/tests/Unit/CalendarAbilitiesTest.php
+++ b/tests/Unit/CalendarAbilitiesTest.php
@@ -279,6 +279,121 @@ class CalendarAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( array(), $result['paged_date_groups'] );
 	}
 
+	public function test_explicit_past_single_day_retains_requested_boundary_and_count(): void {
+		$date     = current_datetime()->modify( '-2 days' );
+		$event_id = $this->seed_event( 'Exact past window', $date->format( 'Y-m-d 20:00:00' ), $date->format( 'Y-m-d 22:00:00' ) );
+
+		$result = $this->abilities->executeGetCalendarPage(
+			array(
+				'date_start'   => $date->format( 'Y-m-d' ),
+				'date_end'     => $date->format( 'Y-m-d' ),
+				'include_html' => false,
+			)
+		);
+
+		$this->assertSame( 1, $result['total_event_count'] );
+		$this->assertSame( 1, $result['event_count'] );
+		$this->assertSame( array( $event_id ), $this->result_post_ids( $result ) );
+		$this->assertSame(
+			array(
+				'start_date' => $date->format( 'Y-m-d' ),
+				'end_date'   => $date->format( 'Y-m-d' ),
+			),
+			$result['date_boundaries']
+		);
+	}
+
+	public function test_explicit_multi_day_past_range_uses_past_toggle_only_for_ordering(): void {
+		$first  = current_datetime()->modify( '-5 days' );
+		$second = $first->modify( '+2 days' );
+		$this->seed_event( 'First bounded past event', $first->format( 'Y-m-d 20:00:00' ), $first->format( 'Y-m-d 22:00:00' ) );
+		$this->seed_event( 'Second bounded past event', $second->format( 'Y-m-d 20:00:00' ), $second->format( 'Y-m-d 22:00:00' ) );
+		$this->seed_event( 'Outside bounded past event', $first->modify( '-1 day' )->format( 'Y-m-d 20:00:00' ), $first->modify( '-1 day' )->format( 'Y-m-d 22:00:00' ) );
+
+		$input = array(
+			'date_start'   => $first->format( 'Y-m-d' ),
+			'date_end'     => $second->format( 'Y-m-d' ),
+			'include_html' => false,
+		);
+		$ascending  = $this->abilities->executeGetCalendarPage( $input );
+		$descending = $this->abilities->executeGetCalendarPage( array_merge( $input, array( 'past' => true ) ) );
+
+		$this->assertSame( 2, $ascending['total_event_count'] );
+		$this->assertSame( 2, $ascending['event_count'] );
+		$this->assertSame( array( $first->format( 'Y-m-d' ), $second->format( 'Y-m-d' ) ), array_column( $ascending['paged_date_groups'], 'date' ) );
+		$this->assertSame( 2, $descending['total_event_count'] );
+		$this->assertSame( 2, $descending['event_count'] );
+		$this->assertSame( array( $second->format( 'Y-m-d' ), $first->format( 'Y-m-d' ) ), array_column( $descending['paged_date_groups'], 'date' ) );
+	}
+
+	public function test_explicit_past_search_and_location_scope_keep_rows_and_boundaries_aligned(): void {
+		$location       = wp_insert_term( 'Past search location ' . uniqid(), 'calendar_test_region' );
+		$other_location = wp_insert_term( 'Other past search location ' . uniqid(), 'calendar_test_region' );
+		$this->assertNotWPError( $location );
+		$this->assertNotWPError( $other_location );
+
+		$date      = current_datetime()->modify( '-2 days' );
+		$search    = 'Past location needle ' . uniqid();
+		$target_id = $this->seed_event(
+			$search . ' target',
+			$date->format( 'Y-m-d 18:00:00' ),
+			$date->format( 'Y-m-d 21:00:00' ),
+			0,
+			array( 'calendar_test_region' => (int) $location['term_id'] )
+		);
+		$this->seed_event( $search . ' elsewhere', $date->format( 'Y-m-d 18:00:00' ), $date->format( 'Y-m-d 21:00:00' ), 0, array( 'calendar_test_region' => (int) $other_location['term_id'] ) );
+		$this->seed_event( 'Wrong title', $date->format( 'Y-m-d 18:00:00' ), $date->format( 'Y-m-d 21:00:00' ), 0, array( 'calendar_test_region' => (int) $location['term_id'] ) );
+
+		$result = $this->abilities->executeGetCalendarPage(
+			array(
+				'event_search'     => $search,
+				'archive_taxonomy' => 'calendar_test_region',
+				'archive_term_id'  => (int) $location['term_id'],
+				'date_start'       => $date->format( 'Y-m-d' ),
+				'date_end'         => $date->format( 'Y-m-d' ),
+				'include_html'     => false,
+			)
+		);
+
+		$this->assertSame( 1, $result['total_event_count'] );
+		$this->assertSame( 1, $result['event_count'] );
+		$this->assertSame( array( $target_id ), $this->result_post_ids( $result ) );
+		$this->assertSame( $date->format( 'Y-m-d' ), $result['date_boundaries']['start_date'] );
+		$this->assertSame( $date->format( 'Y-m-d' ), $result['date_boundaries']['end_date'] );
+	}
+
+	public function test_explicit_past_no_match_retains_requested_boundary_with_zero_count(): void {
+		$date = current_datetime()->modify( '-2 days' );
+
+		$result = $this->abilities->executeGetCalendarPage(
+			array(
+				'event_search' => 'Absent past event ' . uniqid(),
+				'date_start'   => $date->format( 'Y-m-d' ),
+				'date_end'     => $date->format( 'Y-m-d' ),
+				'include_html' => false,
+			)
+		);
+
+		$this->assertSame( 0, $result['total_event_count'] );
+		$this->assertSame( 0, $result['event_count'] );
+		$this->assertSame( array(), $result['paged_date_groups'] );
+		$this->assertSame( $date->format( 'Y-m-d' ), $result['date_boundaries']['start_date'] );
+		$this->assertSame( $date->format( 'Y-m-d' ), $result['date_boundaries']['end_date'] );
+	}
+
+	public function test_default_upcoming_still_excludes_completed_events(): void {
+		$past   = current_datetime()->modify( '-2 days' );
+		$future = current_datetime()->modify( '+2 days' );
+		$this->seed_event( 'Completed default event', $past->format( 'Y-m-d 20:00:00' ), $past->format( 'Y-m-d 22:00:00' ) );
+		$future_id = $this->seed_event( 'Upcoming default event', $future->format( 'Y-m-d 20:00:00' ), $future->format( 'Y-m-d 22:00:00' ) );
+
+		$result = $this->abilities->executeGetCalendarPage( array( 'include_html' => false ) );
+
+		$this->assertSame( 1, $result['total_event_count'] );
+		$this->assertSame( 1, $result['event_count'] );
+		$this->assertSame( array( $future_id ), $this->result_post_ids( $result ) );
+	}
+
 	public function test_geo_constrains_totals_boundaries_and_rows(): void {
 		$near_venue = $this->seed_venue( 'Nearby venue', '32.7765,-79.9311' );
 		$far_venue  = $this->seed_venue( 'Far venue', '40.7128,-74.0060' );


### PR DESCRIPTION
## Summary
- retain pre-today date buckets when the caller supplies an authoritative date window
- apply normalized explicit bounds in both canonical and optimized boundary-selection paths
- keep the `past` toggle responsible for ordering rather than explicit-bound visibility

## Root cause
`CalendarAbilities::build_event_query_input()` correctly changed canonical row selection to `scope=all` for an explicit `date_start` / `date_end` range, but boundary calculation had two independent mismatches:
- bucket expansion still used `past=false` to remove every date before today
- optimized non-canonical boundary SQL still applied `UpcomingFilter::upcoming_where()` before expansion whenever `past=false`

Rows could therefore match while `events_per_date` became empty and `total_event_count` was reset to zero for the requested range. Search plus location happened to use the canonical path and did not expose the second mismatch.

## Row / boundary contract
Boundary selection now builds one temporal clause set shared by the optimized taxonomy and no-taxonomy paths. An authoritative `user_date_range` uses the same existing overlap predicate and normalized time bounds as canonical row selection; otherwise the existing upcoming or completed-event predicate remains unchanged.

Bucket expansion separately distinguishes two decisions:
- `include_past_dates` retains pre-today buckets for either past mode or an authoritative caller date range
- `show_past` continues to determine descending versus ascending order

Canonical rows, optimized boundaries, requested boundaries, one-page metadata, and filtered totals now describe the same explicit window.

## Ordering and cache implications
Explicit past windows with `past=false` stay ascending; `past=true` stays descending. Default unbounded requests remain canonical upcoming queries and completed events stay excluded. No cache keys or TTLs changed: fixed date windows remain isolated by their existing date, search, taxonomy, geo, and scope inputs, while #706's transition key rotation and TTL bounding remain limited to live unbounded upcoming requests.

## Tests
Added focused coverage for:
- exact past single-day boundary, row, and count parity
- multi-date past range count and ascending order
- the same explicit range with `past=true` descending order
- title search combined with location scope
- explicit no-match zero counts with retained requested boundaries
- unchanged default-upcoming exclusion of completed events

## Gate evidence
- PHP syntax checks: pass
- `git diff --check`: pass
- local and GitHub Homeboy lint (PHPCS, PHPStan, ESLint): pass, zero findings
- local and GitHub Homeboy PR audit: pass, no introduced findings
- authoritative GitHub MySQL PHPUnit: 801 total, 790 passed, 2 skipped, 9 failed
- differential result: all five added test methods pass; the failure set contains only the same nine repository baseline failures present before this change
- local WP Codebox attempt was blocked before PHPUnit by an unparseable recipe-run payload; tracked as Extra-Chill/homeboy#12784

No deployment, release, merge, version bump, or changelog edit was performed.

Fixes #707