### PR TITLE
fix: bound duplicate cleanup to reviewed exact matches

### DIFF
--- a/inc/Cli/Check/CleanDuplicatesCommand.php
+++ b/inc/Cli/Check/CleanDuplicatesCommand.php
@@ -26,11 +26,13 @@ class CleanDuplicatesCommand {
 
 	use EventQueryTrait;
 
+	private const MAX_REVIEWED_CANDIDATES = 100;
+
 	/**
 	 * Clean duplicate events by trashing the newer copy.
 	 *
-	 * Scans for duplicate events using fuzzy title + exact time + venue matching, keeps
-	 * the older post (more link equity), and trashes the newer one. If the
+	 * Scans for duplicate events using exact normalized title, start time, and venue
+	 * identity, keeps the older post (more link equity), and trashes the newer one. If the
 	 * trashed post has a ticket URL that the kept post lacks, it is copied over.
 	 *
 	 * ## OPTIONS
@@ -51,6 +53,12 @@ class CleanDuplicatesCommand {
 	 * default: 90
 	 * ---
 	 *
+	 * [--location=<term-id>]
+	 * : Limit candidates to a location term (including its descendants).
+	 *
+	 * [--reviewed=<candidate-ids>]
+	 * : Comma-separated candidate IDs copied from a reviewed dry run. Required with --apply.
+	 *
 	 * [--dry-run]
 	 * : Show what would be cleaned without actually trashing. This is the default.
 	 *
@@ -63,8 +71,8 @@ class CleanDuplicatesCommand {
 	 * ## EXAMPLES
 	 *
 	 *     wp data-machine-events check clean-duplicates
-	 *     wp data-machine-events check clean-duplicates --scope=upcoming --apply --yes
-	 *     wp data-machine-events check clean-duplicates --scope=all --apply --yes
+	 *     wp data-machine-events check clean-duplicates --scope=upcoming --location=123
+	 *     wp data-machine-events check clean-duplicates --scope=upcoming --location=123 --reviewed=abc123,def456 --apply --yes
 	 *
 	 * @param array $args       Positional arguments.
 	 * @param array $assoc_args Named arguments.
@@ -72,12 +80,33 @@ class CleanDuplicatesCommand {
 	public function __invoke( array $args, array $assoc_args ): void {
 		$scope        = $assoc_args['scope'] ?? 'all';
 		$days_ahead   = (int) ( $assoc_args['days-ahead'] ?? 90 );
+		$location     = (int) ( $assoc_args['location'] ?? 0 );
 		$dry_run      = ! isset( $assoc_args['apply'] ) || isset( $assoc_args['dry-run'] );
 		$skip_confirm = isset( $assoc_args['yes'] );
+		$reviewed     = $this->parse_reviewed_candidate_ids( (string) ( $assoc_args['reviewed'] ?? '' ) );
 
-		$events = $this->query_events( $scope, $days_ahead );
+		if ( isset( $assoc_args['location'] ) && $location <= 0 ) {
+			\WP_CLI::error( '--location must be a positive location term ID.' );
+			return;
+		}
+
+		if ( ! $dry_run && empty( $reviewed ) ) {
+			\WP_CLI::error( 'Apply requires --reviewed with candidate IDs from the exact dry run being approved.' );
+			return;
+		}
+
+		if ( ! $dry_run && count( $reviewed ) > self::MAX_REVIEWED_CANDIDATES ) {
+			\WP_CLI::error( sprintf( 'Apply is limited to %d reviewed candidates at a time.', self::MAX_REVIEWED_CANDIDATES ) );
+			return;
+		}
+
+		$events = $this->query_events( $scope, $days_ahead, $location );
 
 		if ( empty( $events ) ) {
+			if ( ! $dry_run ) {
+				\WP_CLI::error( 'Reviewed candidate IDs are stale or outside the requested scope; no changes made.' );
+				return;
+			}
 			\WP_CLI::success( "No events found ({$scope} scope)." );
 			return;
 		}
@@ -87,6 +116,10 @@ class CleanDuplicatesCommand {
 		$duplicate_groups = $this->find_duplicates( $events );
 
 		if ( empty( $duplicate_groups ) ) {
+			if ( ! $dry_run ) {
+				\WP_CLI::error( 'Reviewed candidate IDs are stale or outside the requested scope; no changes made.' );
+				return;
+			}
 			\WP_CLI::success( sprintf( 'No duplicates found across %d events.', count( $events ) ) );
 			return;
 		}
@@ -94,66 +127,155 @@ class CleanDuplicatesCommand {
 		\WP_CLI::log( sprintf( 'Found %d duplicate pair(s).', count( $duplicate_groups ) ) );
 		\WP_CLI::log( '' );
 
-		// For each pair: keep older, trash newer.
-		$to_trash      = array();
-		$ticket_merges = 0;
-
-		foreach ( $duplicate_groups as $group ) {
-			$a_id   = $group['event_a']['id'];
-			$b_id   = $group['event_b']['id'];
-			$a_date = get_post( $a_id )->post_date;
-			$b_date = get_post( $b_id )->post_date;
-
-			// Keep the older one.
-			if ( strtotime( $a_date ) <= strtotime( $b_date ) ) {
-				$keep_id  = $a_id;
-				$trash_id = $b_id;
-			} else {
-				$keep_id  = $b_id;
-				$trash_id = $a_id;
+		$to_trash = $this->build_actions( $duplicate_groups );
+		if ( ! $dry_run ) {
+			$selection = $this->select_reviewed_actions( $to_trash, $reviewed );
+			if ( is_wp_error( $selection ) ) {
+				\WP_CLI::error( $selection->get_error_message() );
+				return;
 			}
-
-			// Check if we should merge ticket URL.
-			$keep_ticket         = get_post_meta( $keep_id, EVENT_TICKET_URL_META_KEY, true );
-			$trash_ticket        = get_post_meta( $trash_id, EVENT_TICKET_URL_META_KEY, true );
-			$should_merge_ticket = ! empty( $trash_ticket ) && empty( $keep_ticket );
-
-			if ( $should_merge_ticket ) {
-				++$ticket_merges;
-			}
-
-			$keep_title  = get_the_title( $keep_id );
-			$trash_title = get_the_title( $trash_id );
-
-			$to_trash[] = array(
-				'keep_id'      => $keep_id,
-				'keep_title'   => mb_substr( $keep_title, 0, 40 ),
-				'trash_id'     => $trash_id,
-				'trash_title'  => mb_substr( $trash_title, 0, 40 ),
-				'venue'        => $group['event_a']['venue'] ?: $group['event_b']['venue'],
-				'date'         => $group['date'],
-				'merge_ticket' => $should_merge_ticket ? 'yes' : 'no',
-			);
+			$to_trash = $selection;
 		}
+		$ticket_merges = count( array_filter( $to_trash, static fn( $action ) => 'yes' === $action['merge_ticket'] ) );
 
-		\WP_CLI\Utils\format_items( 'table', $to_trash, array( 'keep_id', 'keep_title', 'trash_id', 'trash_title', 'venue', 'date', 'merge_ticket' ) );
+		\WP_CLI\Utils\format_items( 'table', $to_trash, array( 'candidate_id', 'keep_id', 'keep_title', 'trash_id', 'trash_title', 'venue', 'start', 'merge_ticket' ) );
 
 		\WP_CLI::log( '' );
 		\WP_CLI::log( sprintf( 'Will trash %d posts, merge %d ticket URLs.', count( $to_trash ), $ticket_merges ) );
 
 		if ( $dry_run ) {
 			\WP_CLI::log( 'DRY RUN — no changes made.' );
+			\WP_CLI::log( 'Apply only reviewed rows with --reviewed=<candidate_id,...> plus the same scope, days-ahead, and location options.' );
 			return;
 		}
 
 		if ( ! $skip_confirm ) {
-			\WP_CLI::confirm( sprintf( 'Trash %d duplicate events?', count( $to_trash ) ) );
+			\WP_CLI::confirm( sprintf( 'Trash %d explicitly reviewed duplicate events?', count( $to_trash ) ) );
 		}
 
+		$result = $this->apply_actions( $to_trash );
+
+		\WP_CLI::success( sprintf( 'Trashed %d reviewed duplicate events, merged %d ticket URLs.', $result['trashed'], $result['merged'] ) );
+	}
+
+	/**
+	 * Find duplicate event pairs using exact normalized title, start, and venue identity.
+	 *
+	 * @param array $events Array of WP_Post objects.
+	 * @return array Duplicate groups.
+	 */
+	private function find_duplicates( array $events ): array {
+		$by_identity = array();
+		foreach ( $events as $event ) {
+			$dates      = \DataMachineEvents\Core\EventDatesTable::get( $event->ID );
+			$start_meta = $dates ? $dates->start_datetime : '';
+			$start      = EventIdentifierGenerator::normalizeStartDateTime( $start_meta );
+			$venue      = $this->get_venue_name( $event->ID );
+			$identity   = $this->build_exact_identity( $event->post_title, $start, $venue );
+
+			if ( '' === $identity ) {
+				continue;
+			}
+
+			$by_identity[ $identity ][] = array(
+				'post'  => $event,
+				'start' => $start,
+				'venue' => $venue,
+			);
+		}
+
+		$duplicate_groups = array();
+
+		foreach ( $by_identity as $identity => $identity_events ) {
+			if ( count( $identity_events ) < 2 ) {
+				continue;
+			}
+
+			usort(
+				$identity_events,
+				static fn( $a, $b ) => strcmp( $a['post']->post_date, $b['post']->post_date ) ?: ( $a['post']->ID <=> $b['post']->ID )
+			);
+			$winner = array_shift( $identity_events );
+
+			foreach ( $identity_events as $duplicate ) {
+				$duplicate_groups[] = array(
+					'identity' => $identity,
+					'start'    => $winner['start'],
+					'event_a'  => array(
+						'id'    => $winner['post']->ID,
+						'title' => $winner['post']->post_title,
+						'venue' => $winner['venue'],
+					),
+					'event_b'  => array(
+						'id'    => $duplicate['post']->ID,
+						'title' => $duplicate['post']->post_title,
+						'venue' => $duplicate['venue'],
+					),
+				);
+			}
+		}
+
+		return $duplicate_groups;
+	}
+
+	private function build_exact_identity( string $title, string $start, string $venue ): string {
+		if ( '' === trim( $title ) || '' === trim( $venue ) || ! preg_match( '/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/', $start ) ) {
+			return '';
+		}
+
+		return EventIdentifierGenerator::normalizeBasic( $title ) . "\0" . $start . "\0" . EventIdentifierGenerator::normalizeBasic( $venue );
+	}
+
+	private function build_actions( array $duplicate_groups ): array {
+		$actions = array();
+		foreach ( $duplicate_groups as $group ) {
+			$keep_id      = (int) $group['event_a']['id'];
+			$trash_id     = (int) $group['event_b']['id'];
+			$keep_ticket  = (string) get_post_meta( $keep_id, EVENT_TICKET_URL_META_KEY, true );
+			$trash_ticket = (string) get_post_meta( $trash_id, EVENT_TICKET_URL_META_KEY, true );
+			$merge_ticket = '' !== $trash_ticket && '' === $keep_ticket;
+			$fingerprint  = implode( "\0", array( 'v1', $keep_id, $trash_id, $group['identity'], $keep_ticket, $trash_ticket, $merge_ticket ? '1' : '0' ) );
+
+			$actions[] = array(
+				'candidate_id' => hash( 'sha256', $fingerprint ),
+				'keep_id'      => $keep_id,
+				'keep_title'   => mb_substr( (string) $group['event_a']['title'], 0, 40 ),
+				'trash_id'     => $trash_id,
+				'trash_title'  => mb_substr( (string) $group['event_b']['title'], 0, 40 ),
+				'venue'        => (string) $group['event_a']['venue'],
+				'start'        => (string) $group['start'],
+				'merge_ticket' => $merge_ticket ? 'yes' : 'no',
+			);
+		}
+
+		return $actions;
+	}
+
+	private function parse_reviewed_candidate_ids( string $value ): array {
+		$ids = array_filter( array_map( 'trim', explode( ',', $value ) ) );
+
+		return array_values( array_unique( $ids ) );
+	}
+
+	private function select_reviewed_actions( array $actions, array $reviewed ): array|\WP_Error {
+		$by_id   = array_column( $actions, null, 'candidate_id' );
+		$missing = array_diff( $reviewed, array_keys( $by_id ) );
+
+		if ( ! empty( $missing ) ) {
+			return new \WP_Error(
+				'stale_duplicate_review',
+				'Reviewed candidate IDs are stale or outside the requested scope; no changes made: ' . implode( ', ', $missing )
+			);
+		}
+
+		return array_values( array_intersect_key( $by_id, array_flip( $reviewed ) ) );
+	}
+
+	private function apply_actions( array $actions ): array {
 		$trashed = 0;
 		$merged  = 0;
 
-		foreach ( $to_trash as $action ) {
+		foreach ( $actions as $action ) {
 			$merge_result = EventMergeHelper::merge(
 				$action['keep_id'],
 				$action['trash_id'],
@@ -170,88 +292,6 @@ class CleanDuplicatesCommand {
 			}
 		}
 
-		\WP_CLI::success( sprintf( 'Trashed %d duplicate events, merged %d ticket URLs.', $trashed, $merged ) );
-	}
-
-	/**
-	 * Find duplicate event pairs using fuzzy title + venue matching.
-	 *
-	 * @param array $events Array of WP_Post objects.
-	 * @return array Duplicate groups.
-	 */
-	private function find_duplicates( array $events ): array {
-		$by_date     = array();
-		$start_cache = array();
-		foreach ( $events as $event ) {
-			$dates      = \DataMachineEvents\Core\EventDatesTable::get( $event->ID );
-			$start_meta = $dates ? $dates->start_datetime : '';
-			$date       = $start_meta ? substr( $start_meta, 0, 10 ) : '';
-
-			if ( empty( $date ) ) {
-				continue;
-			}
-
-			$by_date[ $date ][]        = $event;
-			$start_cache[ $event->ID ] = EventIdentifierGenerator::normalizeStartDateTime( $start_meta );
-		}
-
-		$duplicate_groups = array();
-
-		foreach ( $by_date as $date => $date_events ) {
-			if ( count( $date_events ) < 2 ) {
-				continue;
-			}
-
-			$venue_cache = array();
-			foreach ( $date_events as $event ) {
-				$venue_cache[ $event->ID ] = $this->get_venue_name( $event->ID );
-			}
-
-			$matched_ids = array();
-
-			for ( $i = 0, $count = count( $date_events ); $i < $count; $i++ ) {
-				for ( $j = $i + 1; $j < $count; $j++ ) {
-					$event_a = $date_events[ $i ];
-					$event_b = $date_events[ $j ];
-
-					if ( isset( $matched_ids[ $event_b->ID ] ) ) {
-						continue;
-					}
-
-					if ( ! EventIdentifierGenerator::titlesMatch( $event_a->post_title, $event_b->post_title ) ) {
-						continue;
-					}
-
-					if ( ( $start_cache[ $event_a->ID ] ?? '' ) !== ( $start_cache[ $event_b->ID ] ?? '' ) ) {
-						continue;
-					}
-
-					$venue_a = $venue_cache[ $event_a->ID ];
-					$venue_b = $venue_cache[ $event_b->ID ];
-
-					if ( ! EventIdentifierGenerator::venuesMatch( $venue_a, $venue_b ) ) {
-						continue;
-					}
-
-					$duplicate_groups[] = array(
-						'date'    => $date,
-						'event_a' => array(
-							'id'    => $event_a->ID,
-							'title' => $event_a->post_title,
-							'venue' => $venue_a,
-						),
-						'event_b' => array(
-							'id'    => $event_b->ID,
-							'title' => $event_b->post_title,
-							'venue' => $venue_b,
-						),
-					);
-
-					$matched_ids[ $event_b->ID ] = true;
-				}
-			}
-		}
-
-		return $duplicate_groups;
+		return compact( 'trashed', 'merged' );
 	}
 }

--- a/inc/Cli/Check/EventQueryTrait.php
+++ b/inc/Cli/Check/EventQueryTrait.php
@@ -17,10 +17,11 @@ trait EventQueryTrait {
 	 * Query events by scope.
 	 *
 	 * @param string $scope      'upcoming', 'past', or 'all'.
-	 * @param int    $days_ahead Days to look ahead for upcoming scope.
+	 * @param int    $days_ahead      Days to look ahead for upcoming scope.
+	 * @param int    $location_term_id Optional location term ID.
 	 * @return \WP_Post[] Array of post objects.
 	 */
-	private function query_events( string $scope, int $days_ahead = 90 ): array {
+	private function query_events( string $scope, int $days_ahead = 90, int $location_term_id = 0 ): array {
 		$input = array(
 			'scope' => $scope,
 			'order' => 'past' === $scope ? 'DESC' : 'ASC',
@@ -28,6 +29,10 @@ trait EventQueryTrait {
 
 		if ( 'upcoming' === $scope && $days_ahead > 0 ) {
 			$input['days_ahead'] = $days_ahead;
+		}
+
+		if ( $location_term_id > 0 ) {
+			$input['tax_filters'] = array( 'location' => array( $location_term_id ) );
 		}
 
 		$ability = new \DataMachineEvents\Abilities\EventDateQueryAbilities();

--- a/tests/Unit/CleanDuplicatesCommandTest.php
+++ b/tests/Unit/CleanDuplicatesCommandTest.php
@@ -12,6 +12,7 @@ use DataMachineEvents\Core\EventDatesTable;
 use DataMachineEvents\Core\Event_Post_Type;
 use DataMachineEvents\Core\Venue_Taxonomy;
 use WP_UnitTestCase;
+use const DataMachineEvents\Core\EVENT_TICKET_URL_META_KEY;
 
 class CleanDuplicatesCommandTest extends WP_UnitTestCase {
 
@@ -23,6 +24,9 @@ class CleanDuplicatesCommandTest extends WP_UnitTestCase {
 		}
 		if ( ! taxonomy_exists( 'venue' ) ) {
 			Venue_Taxonomy::register();
+		}
+		if ( ! taxonomy_exists( 'location' ) ) {
+			register_taxonomy( 'location', Event_Post_Type::POST_TYPE, array( 'hierarchical' => true ) );
 		}
 		if ( ! EventDatesTable::table_exists() ) {
 			EventDatesTable::create_table();
@@ -46,7 +50,125 @@ class CleanDuplicatesCommandTest extends WP_UnitTestCase {
 		$this->assertNotContains( $late, array( $groups[0]['event_a']['id'], $groups[0]['event_b']['id'] ) );
 	}
 
-	private function seedEvent( string $title, string $start, int $venue_id ): int {
+	public function test_repair_preserves_expanded_and_distinct_bills(): void {
+		$venue = wp_insert_term( 'Expanded bill venue ' . uniqid(), 'venue' );
+		$this->assertNotWPError( $venue );
+		$venue_id = (int) $venue['term_id'];
+		$events   = array(
+			$this->seedEvent( 'Meltt', '2026-11-22 20:00:00', $venue_id ),
+			$this->seedEvent( 'Meltt, Los Eclipses', '2026-11-22 20:00:00', $venue_id ),
+			$this->seedEvent( 'The Charities with Mae Powell', '2026-11-23 20:00:00', $venue_id ),
+			$this->seedEvent( 'The Charities', '2026-11-23 20:00:00', $venue_id ),
+			$this->seedEvent( 'Foxtide', '2026-11-24 20:00:00', $venue_id ),
+			$this->seedEvent( 'Foxtide with The Braymores, Geskle', '2026-11-24 20:00:00', $venue_id ),
+		);
+
+		$groups = $this->invokePrivate( 'find_duplicates', array_map( 'get_post', $events ) );
+
+		$this->assertSame( array(), $groups );
+	}
+
+	public function test_repair_accepts_exact_normalized_replays(): void {
+		$venue = wp_insert_term( 'Replay & Hall ' . uniqid(), 'venue' );
+		$this->assertNotWPError( $venue );
+		$first = $this->seedEvent( 'The Exact Replay', '2026-11-25 20:00:00', (int) $venue['term_id'] );
+		$dupe  = $this->seedEvent( ' exact   replay ', '2026-11-25 20:00:00', (int) $venue['term_id'] );
+
+		$groups = $this->invokePrivate( 'find_duplicates', array_map( 'get_post', array( $first, $dupe ) ) );
+
+		$this->assertCount( 1, $groups );
+		$this->assertEqualsCanonicalizing( array( $first, $dupe ), array( $groups[0]['event_a']['id'], $groups[0]['event_b']['id'] ) );
+	}
+
+	public function test_location_scope_uses_existing_taxonomy_query_filter(): void {
+		$venue    = wp_insert_term( 'Scoped cleaner venue ' . uniqid(), 'venue' );
+		$chicago  = wp_insert_term( 'Chicago cleaner ' . uniqid(), 'location' );
+		$nashville = wp_insert_term( 'Nashville cleaner ' . uniqid(), 'location' );
+		$this->assertNotWPError( $venue );
+		$this->assertNotWPError( $chicago );
+		$this->assertNotWPError( $nashville );
+		$inside  = $this->seedEvent( 'Chicago scoped event', '2026-11-26 20:00:00', (int) $venue['term_id'], (int) $chicago['term_id'] );
+		$outside = $this->seedEvent( 'Nashville scoped event', '2026-11-26 21:00:00', (int) $venue['term_id'], (int) $nashville['term_id'] );
+
+		$posts = $this->invokePrivate( 'query_events', 'all', 90, (int) $chicago['term_id'] );
+		$ids   = wp_list_pluck( $posts, 'ID' );
+
+		$this->assertContains( $inside, $ids );
+		$this->assertNotContains( $outside, $ids );
+	}
+
+	public function test_apply_selection_requires_exact_reviewed_candidate_parity(): void {
+		$venue = wp_insert_term( 'Reviewed cleaner venue ' . uniqid(), 'venue' );
+		$this->assertNotWPError( $venue );
+		$title  = 'Reviewed candidate ' . uniqid();
+		$first  = $this->seedEvent( $title, '2026-11-27 20:00:00', (int) $venue['term_id'] );
+		$dupe   = $this->seedEvent( $title, '2026-11-27 20:00:00', (int) $venue['term_id'] );
+		$groups = $this->invokePrivate( 'find_duplicates', array_map( 'get_post', array( $first, $dupe ) ) );
+		$actions = $this->invokePrivate( 'build_actions', $groups );
+		$reviewed_id = $actions[0]['candidate_id'];
+
+		$selected = $this->invokePrivate( 'select_reviewed_actions', $actions, array( $reviewed_id ) );
+		$this->assertCount( 1, $selected );
+		$this->assertSame( $reviewed_id, $selected[0]['candidate_id'] );
+
+		wp_update_post(
+			array(
+				'ID'         => $dupe,
+				'post_title' => $title . ' with a newly expanded bill',
+			)
+		);
+		$changed_groups  = $this->invokePrivate( 'find_duplicates', array_map( 'get_post', array( $first, $dupe ) ) );
+		$changed_actions = $this->invokePrivate( 'build_actions', $changed_groups );
+		$stale_selection = $this->invokePrivate( 'select_reviewed_actions', $changed_actions, array( $reviewed_id ) );
+
+		$this->assertWPError( $stale_selection );
+		$this->assertSame( 'stale_duplicate_review', $stale_selection->get_error_code() );
+	}
+
+	public function test_apply_selection_excludes_unreviewed_candidates(): void {
+		$venue = wp_insert_term( 'Bounded cleaner venue ' . uniqid(), 'venue' );
+		$this->assertNotWPError( $venue );
+		$venue_id    = (int) $venue['term_id'];
+		$first_keep  = $this->seedEvent( 'First bounded replay', '2026-11-28 19:00:00', $venue_id );
+		$first_trash = $this->seedEvent( 'First bounded replay', '2026-11-28 19:00:00', $venue_id );
+		$other_keep  = $this->seedEvent( 'Other bounded replay', '2026-11-28 21:00:00', $venue_id );
+		$other_dupe  = $this->seedEvent( 'Other bounded replay', '2026-11-28 21:00:00', $venue_id );
+		$posts       = array_map( 'get_post', array( $first_keep, $first_trash, $other_keep, $other_dupe ) );
+		$groups      = $this->invokePrivate( 'find_duplicates', $posts );
+		$actions     = $this->invokePrivate( 'build_actions', $groups );
+		$reviewed    = array_values( array_filter( $actions, static fn( $action ) => $first_trash === $action['trash_id'] ) );
+
+		$this->assertCount( 2, $actions );
+		$this->assertCount( 1, $reviewed );
+		$selected = $this->invokePrivate( 'select_reviewed_actions', $actions, array( $reviewed[0]['candidate_id'] ) );
+		$result   = $this->invokePrivate( 'apply_actions', $selected );
+
+		$this->assertSame( array( 'trashed' => 1, 'merged' => 0 ), $result );
+		$this->assertSame( 'trash', get_post_status( $first_trash ) );
+		$this->assertSame( 'publish', get_post_status( $other_keep ) );
+		$this->assertSame( 'publish', get_post_status( $other_dupe ) );
+	}
+
+	public function test_reviewed_apply_merges_ticket_url_from_duplicate(): void {
+		$venue = wp_insert_term( 'Ticket cleaner venue ' . uniqid(), 'venue' );
+		$this->assertNotWPError( $venue );
+		$title  = 'Ticket merge replay ' . uniqid();
+		$first  = $this->seedEvent( $title, '2026-11-29 20:00:00', (int) $venue['term_id'] );
+		$dupe   = $this->seedEvent( $title, '2026-11-29 20:00:00', (int) $venue['term_id'] );
+		$ticket = 'https://tickets.example.com/' . uniqid();
+		update_post_meta( $dupe, EVENT_TICKET_URL_META_KEY, $ticket );
+		$groups  = $this->invokePrivate( 'find_duplicates', array_map( 'get_post', array( $first, $dupe ) ) );
+		$actions = $this->invokePrivate( 'build_actions', $groups );
+
+		$this->assertSame( 'yes', $actions[0]['merge_ticket'] );
+		$result = $this->invokePrivate( 'apply_actions', $actions );
+
+		$this->assertSame( array( 'trashed' => 1, 'merged' => 1 ), $result );
+		$this->assertSame( $ticket, get_post_meta( $first, EVENT_TICKET_URL_META_KEY, true ) );
+		$this->assertSame( 'trash', get_post_status( $dupe ) );
+	}
+
+	private function seedEvent( string $title, string $start, int $venue_id, int $location_id = 0 ): int {
 		$post_id = self::factory()->post->create(
 			array(
 				'post_title'  => $title,
@@ -55,8 +177,18 @@ class CleanDuplicatesCommandTest extends WP_UnitTestCase {
 			)
 		);
 		wp_set_object_terms( $post_id, array( $venue_id ), 'venue' );
+		if ( $location_id > 0 ) {
+			wp_set_object_terms( $post_id, array( $location_id ), 'location' );
+		}
 		EventDatesTable::upsert( $post_id, $start, null, 'publish' );
 
 		return $post_id;
+	}
+
+	private function invokePrivate( string $method_name, ...$arguments ) {
+		$method = new \ReflectionMethod( CleanDuplicatesCommand::class, $method_name );
+		$method->setAccessible( true );
+
+		return $method->invoke( new CleanDuplicatesCommand(), ...$arguments );
 	}
 }


### PR DESCRIPTION
## Summary

- replace fuzzy-title cleanup candidates with exact normalized title, minute-precise start datetime, and venue identity
- add location-term scoping and deterministic reviewed candidate fingerprints, with apply limited to 100 explicit IDs
- preserve expanded bills, distinct showtimes, and unreviewed candidates while retaining ticket URL transfer for approved duplicates

## Root Cause

`CleanDuplicatesCommand` reused fuzzy `EventIdentifierGenerator::titlesMatch()` and fuzzy venue comparison. At the same venue and time, a partial headliner title could therefore match an expanded or distinct bill, and `--apply` recomputed the full discovered universe without an exact reviewed selection.

## Dangerous Dry-Run Evidence

The authoritative 90-day upcoming dry run scanned 27,190 posts and proposed trashing 493, including unsafe pairs such as `Meltt` / `Meltt, Los Eclipses`, `The Charities with Mae Powell` / `The Charities`, and `Foxtide` / `Foxtide with The Braymores, Geskle`. No production changes were applied.

## Safety Contract

A cleanup candidate now requires all of:

- non-empty title and venue
- exact `EventIdentifierGenerator::normalizeBasic()` title identity
- exact normalized venue identity
- exact minute-precise local start datetime, including showtime

Date-only or missing-time events are excluded. Expanded bills and different showtimes remain separate. Dry run remains the default.

## Targeting And Review Plan

`--location=<term-id>` reuses the existing `EventDateQueryAbilities` taxonomy filter, including descendants, so Chicago can be reviewed independently.

Dry runs emit a SHA-256 `candidate_id` bound to the keep/trash post IDs, exact event identity, both ticket URL values, and whether ticket transfer would occur. Apply requires `--reviewed=<candidate_id,...>`, accepts at most 100 IDs, filters before displaying or mutating, and aborts before any change when a reviewed ID is stale or outside the repeated scope. Unreviewed discoveries are never applied.

Existing Action Scheduler reviewed windows cannot identify event pairs, and merged-bill pending actions represent a separate agent-decision workflow. Reusing either would add unrelated persistence rather than provide exact candidate/apply parity, so this uses bounded deterministic IDs on the existing command.

## Tests

Added regressions for:

- expanded and distinct bills from the production evidence
- exact normalized replays
- distinct showtimes
- location-term scoping
- stale reviewed candidate rejection
- exclusion of unreviewed candidates during apply
- approved ticket URL transfer

## Commands And Results

- `php -l` on all changed PHP files: passed
- `git diff --check`: passed
- `homeboy review lint --changed-only --summary`: passed, zero PHPCS/PHPStan/ESLint findings
- `homeboy review audit --changed-since origin/main --profile pr --summary`: passed, zero introduced findings
- `homeboy review test --placement local --changed-since origin/main --summary`: infrastructure-blocked before PHPUnit because WP Codebox could not provision MySQL (`docker` executable absent); 0 tests executed
- targeted Homeboy retry with `--filter=CleanDuplicatesCommandTest`: same pre-PHPUnit infrastructure failure

The runner reporting defect and concrete provisioning cause are tracked at https://github.com/Extra-Chill/homeboy/issues/12795. GitHub's Docker-backed Homeboy checks remain authoritative for the PR.

Fixes #711