### PR TITLE
fix: eliminate event boundary query full scans

### DIFF
--- a/inc/Abilities/EventDateQueryAbilities.php
+++ b/inc/Abilities/EventDateQueryAbilities.php
@@ -27,9 +27,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class EventDateQueryAbilities {
-	private const CAPTURE_IDS_QUERY_VAR  = '_data_machine_events_capture_ids_sql';
-	private const MAX_PUBLIC_RESULTS     = 100;
-	private const DEFAULT_PUBLIC_RESULTS = 50;
+	private const CAPTURE_IDS_QUERY_VAR   = '_data_machine_events_capture_ids_sql';
+	private const CAPTURE_COUNT_QUERY_VAR = '_data_machine_events_capture_count_sql';
+	private const MAX_PUBLIC_RESULTS      = 100;
+	private const DEFAULT_PUBLIC_RESULTS  = 50;
 
 	private static bool $registered = false;
 
@@ -179,7 +180,7 @@ class EventDateQueryAbilities {
 							),
 							'total'      => array(
 								'type'        => 'integer',
-								'description' => 'Total matching events (found_posts).',
+								'description' => 'Total matching events.',
 							),
 							'post_count' => array(
 								'type'        => 'integer',
@@ -277,7 +278,8 @@ class EventDateQueryAbilities {
 		$per_page    = (int) ( $input['per_page'] ?? -1 );
 		$page        = max( 1, (int) ( $input['page'] ?? 1 ) );
 		$fields      = $input['fields'] ?? 'all';
-		$order       = ! empty( $input[ self::CAPTURE_IDS_QUERY_VAR ] )
+		$capture_sql = ! empty( $input[ self::CAPTURE_IDS_QUERY_VAR ] ) || ! empty( $input[ self::CAPTURE_COUNT_QUERY_VAR ] );
+		$order       = $capture_sql
 			? ''
 			: ( strtoupper( $input['order'] ?? 'ASC' ) === 'DESC' ? 'DESC' : 'ASC' );
 		$status      = $input['status'] ?? 'publish';
@@ -313,6 +315,15 @@ class EventDateQueryAbilities {
 			}
 		}
 
+		if ( 'count' === $fields && empty( $input[ self::CAPTURE_COUNT_QUERY_VAR ] ) ) {
+			$input['date_start'] = $date_start;
+			$input['date_end']   = $date_end;
+			$input['time_start'] = $time_start;
+			$input['time_end']   = $time_end;
+
+			return $this->executeCountQuery( $input );
+		}
+
 		// Build WP_Query args.
 		$query_args = array(
 			'post_type'      => Event_Post_Type::POST_TYPE,
@@ -331,9 +342,8 @@ class EventDateQueryAbilities {
 			$query_args[ self::CAPTURE_IDS_QUERY_VAR ] = true;
 		}
 
-		if ( 'count' === $fields ) {
-			$query_args['fields']         = 'ids';
-			$query_args['posts_per_page'] = 1;
+		if ( ! empty( $input[ self::CAPTURE_COUNT_QUERY_VAR ] ) ) {
+			$query_args[ self::CAPTURE_COUNT_QUERY_VAR ] = true;
 		}
 
 		if ( ! empty( $exclude ) ) {
@@ -402,14 +412,20 @@ class EventDateQueryAbilities {
 		// Build the posts_clauses filter for date filtering + ordering.
 		$filters = array();
 
-		$clauses_filter = $this->buildDateClauses( $scope, $date_start, $date_end, $date_match, $days_ahead, $time_start, $time_end, $order );
+		$clauses_filter = $this->buildDateClauses(
+			$scope,
+			$date_start,
+			$date_end,
+			$date_match,
+			$days_ahead,
+			$time_start,
+			$time_end,
+			$order,
+			$status,
+			! empty( $input[ self::CAPTURE_COUNT_QUERY_VAR ] )
+		);
 		add_filter( 'posts_clauses', $clauses_filter );
 		$filters[] = $clauses_filter;
-
-		// For count-only mode, run a lightweight count query instead.
-		if ( 'count' === $fields ) {
-			$query_args['no_found_rows'] = false; // Need found_posts for count mode.
-		}
 
 		/**
 		 * Filter the final WP_Query args before the events query runs.
@@ -444,10 +460,7 @@ class EventDateQueryAbilities {
 		$posts = $query->posts;
 		$total = $query->post_count;
 
-		if ( 'count' === $fields ) {
-			$posts = array();
-			$total = $query->found_posts;
-		} elseif ( -1 === $per_page ) {
+		if ( -1 === $per_page ) {
 			// When fetching all posts, post_count IS the total.
 			$total = $query->post_count;
 		}
@@ -478,26 +491,65 @@ class EventDateQueryAbilities {
 	 * @return string SQL selecting one distinct ID column, or an empty string.
 	 */
 	public function buildMatchingPostIdsSql( array $input ): string {
+		return $this->buildMatchingSql( $input, false );
+	}
+
+	/**
+	 * Execute an exact count through the canonical WP_Query constraint path.
+	 *
+	 * @param array $input Query-events ability input.
+	 * @return array{posts: array, total: int, post_count: int}
+	 */
+	private function executeCountQuery( array $input ): array {
+		global $wpdb;
+
+		$sql   = $this->buildMatchingSql( $input, true );
+		$total = '' === $sql ? 0 : (int) $wpdb->get_var( $sql ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+
+		return array(
+			'posts'      => array(),
+			'total'      => $total,
+			'post_count' => 0,
+		);
+	}
+
+	/**
+	 * Build canonical matching IDs or count SQL without executing WP_Query.
+	 *
+	 * @param array $input Query-events ability input.
+	 * @param bool  $count Whether to select a distinct count instead of IDs.
+	 * @return string Generated SQL, or an empty string.
+	 */
+	private function buildMatchingSql( array $input, bool $count ): string {
 		global $wpdb;
 
 		$request                              = '';
-		$input['fields']                      = 'ids';
+		$input['fields']                      = $count ? 'count' : 'ids';
 		$input['per_page']                    = -1;
-		$input[ self::CAPTURE_IDS_QUERY_VAR ] = true;
+		$query_var                            = $count ? self::CAPTURE_COUNT_QUERY_VAR : self::CAPTURE_IDS_QUERY_VAR;
+		$input[ $query_var ]                  = true;
 
-		$capture  = static function ( $posts, $query ) use ( &$request ) {
-			if ( ! $query->get( self::CAPTURE_IDS_QUERY_VAR ) ) {
+		$capture  = static function ( $posts, $query ) use ( &$request, $query_var ) {
+			if ( ! $query->get( $query_var ) ) {
 				return $posts;
 			}
 
 			$request = $query->request;
 			return array();
 		};
-		$fields   = static function ( $sql_fields, $query ) use ( $wpdb ) {
-			return $query->get( self::CAPTURE_IDS_QUERY_VAR ) ? "{$wpdb->posts}.ID" : $sql_fields;
+		$fields   = static function ( $sql_fields, $query ) use ( $wpdb, $query_var, $count ) {
+			if ( ! $query->get( $query_var ) ) {
+				return $sql_fields;
+			}
+
+			return $count ? "COUNT(DISTINCT {$wpdb->posts}.ID)" : "{$wpdb->posts}.ID";
 		};
-		$distinct = static function ( $sql_distinct, $query ) {
-			return $query->get( self::CAPTURE_IDS_QUERY_VAR ) ? 'DISTINCT' : $sql_distinct;
+		$distinct = static function ( $sql_distinct, $query ) use ( $query_var, $count ) {
+			if ( ! $query->get( $query_var ) ) {
+				return $sql_distinct;
+			}
+
+			return $count ? '' : 'DISTINCT';
 		};
 
 		add_filter( 'posts_pre_query', $capture, PHP_INT_MAX, 2 );
@@ -510,6 +562,10 @@ class EventDateQueryAbilities {
 			remove_filter( 'posts_pre_query', $capture, PHP_INT_MAX );
 			remove_filter( 'posts_fields', $fields, PHP_INT_MAX );
 			remove_filter( 'posts_distinct', $distinct, PHP_INT_MAX );
+		}
+
+		if ( $count && 1 !== preg_match( '/^\s*SELECT\s+COUNT\(/i', $request ) ) {
+			return "SELECT COUNT(*) FROM ({$request}) matching";
 		}
 
 		return $request;
@@ -528,6 +584,8 @@ class EventDateQueryAbilities {
 	 * @param string $time_start Time start (HH:MM:SS).
 	 * @param string $time_end   Time end (HH:MM:SS).
 	 * @param string $order      ASC or DESC.
+	 * @param mixed  $status     Requested WordPress post status.
+	 * @param bool   $count_sql  Whether clauses are building a direct count.
 	 * @return callable The posts_clauses filter callback.
 	 */
 	private function buildDateClauses(
@@ -538,20 +596,35 @@ class EventDateQueryAbilities {
 		int $days_ahead,
 		string $time_start,
 		string $time_end,
-		string $order
+		string $order,
+		$status,
+		bool $count_sql
 	): callable {
-		return function ( $clauses ) use ( $scope, $date_start, $date_end, $date_match, $days_ahead, $time_start, $time_end, $order ) {
+		return function ( $clauses ) use ( $scope, $date_start, $date_end, $date_match, $days_ahead, $time_start, $time_end, $order, $status, $count_sql ) {
 			global $wpdb;
 			$table = EventDatesTable::table_name();
 
+			// A count over the one-to-one event-date join cannot duplicate posts.
+			// Keep DISTINCT when taxonomy/meta joins are already present.
+			$count_rows_directly = $count_sql && '' === trim( $clauses['join'] ) && empty( $clauses['groupby'] );
+
 			// JOIN — only add once.
 			if ( strpos( $clauses['join'], $table ) === false ) {
-				$clauses['join'] .= " INNER JOIN {$table} AS ed ON {$wpdb->posts}.ID = ed.post_id";
+				$join_type        = $count_rows_directly ? 'STRAIGHT_JOIN' : 'INNER JOIN';
+				$clauses['join'] .= " {$join_type} {$table} AS ed ON {$wpdb->posts}.ID = ed.post_id";
 			}
 
 			// Taxonomy and consumer joins may match more than one relationship for
 			// a post. Calendar rows represent canonical events, never join rows.
-			$clauses['distinct'] = 'DISTINCT';
+			if ( $count_sql ) {
+				$clauses['fields']   = $count_rows_directly ? 'COUNT(*)' : "{$wpdb->posts}.ID";
+				$clauses['distinct'] = $count_rows_directly ? '' : 'DISTINCT';
+			} else {
+				$clauses['distinct'] = 'DISTINCT';
+			}
+			if ( 'publish' === $status ) {
+				$clauses['where'] .= " AND ed.post_status = 'publish'";
+			}
 
 			$now = current_time( 'mysql' );
 

--- a/inc/Blocks/Calendar/Query/UpcomingFilter.php
+++ b/inc/Blocks/Calendar/Query/UpcomingFilter.php
@@ -15,11 +15,11 @@
  *     from using a single B-tree index for a range scan. However, with
  *     ORDER BY + LIMIT (which is the common case for user-facing queries),
  *     MySQL can use the start_datetime index for the sort and early-exit.
- *   - The real performance killer is SQL_CALC_FOUND_ROWS, which forces MySQL
- *     to scan ALL matching rows even with LIMIT. Callers should set
- *     'no_found_rows' => true on WP_Query to avoid this.
+ *   - SQL_CALC_FOUND_ROWS forces MySQL to scan all matching rows even with
+ *     LIMIT. Callers must set 'no_found_rows' => true and run a dedicated
+ *     count query only when a total is required.
  *   - For raw $wpdb queries (COUNT + GROUP BY without LIMIT), the OR pattern
- *     is still fast at current table size (~40k rows) and simpler than UNION ALL.
+ *     remains simpler than UNION ALL and avoids materializing event IDs.
  *
  * @package DataMachineEvents\Blocks\Calendar\Query
  * @since   0.25.0

--- a/tests/Unit/CalendarCacheTest.php
+++ b/tests/Unit/CalendarCacheTest.php
@@ -277,7 +277,8 @@ class CalendarCacheTest extends WP_UnitTestCase {
 		EventDatesTable::upsert(
 			$post_id,
 			$now->modify( '-1 hour' )->format( 'Y-m-d H:i:s' ),
-			$now->modify( '+5 seconds' )->format( 'Y-m-d H:i:s' ),
+			// Leave enough time for both uncached Calendar renders before expiry.
+			$now->modify( '+30 seconds' )->format( 'Y-m-d H:i:s' ),
 			'publish'
 		);
 		wp_set_object_terms( $post_id, array( (int) $venue['term_id'] ), 'venue' );
@@ -296,7 +297,7 @@ class CalendarCacheTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Flow Tribe', $before_searched['html'] );
 
 		$ttl = CalendarCache::ttl_for_envelope( array( 'past' => false ) );
-		$this->assertLessThanOrEqual( 6, $ttl );
+		$this->assertLessThanOrEqual( 31, $ttl );
 		sleep( $ttl + 1 );
 
 		$after_unfiltered = $this->server->dispatch( $unfiltered )->get_data();

--- a/tests/Unit/CalendarCacheTest.php
+++ b/tests/Unit/CalendarCacheTest.php
@@ -16,6 +16,7 @@ use WP_REST_Request;
 use WP_REST_Server;
 use DataMachineEvents\Blocks\Calendar\Cache\CalendarCache;
 use DataMachineEvents\Blocks\Calendar\Cache\CacheInvalidator;
+use DataMachineEvents\Abilities\CalendarAbilities;
 use DataMachineEvents\Abilities\EventDateQueryAbilities;
 use DataMachineEvents\Core\Event_Post_Type;
 use DataMachineEvents\Core\EventDatesTable;
@@ -297,6 +298,20 @@ class CalendarCacheTest extends WP_UnitTestCase {
 			)
 		);
 		$this->assertContains( $post_id, $matching['posts'], 'The ongoing event must remain eligible for the Calendar row query.' );
+
+		$calendar = ( new CalendarAbilities() )->executeGetCalendarPage(
+			array(
+				'archive_taxonomy' => 'venue',
+				'archive_term_id'  => (int) $venue['term_id'],
+				'include_html'     => false,
+			)
+		);
+		$calendar_post_ids = array();
+		foreach ( $calendar['paged_date_groups'] as $date_group ) {
+			$calendar_post_ids = array_merge( $calendar_post_ids, array_column( $date_group['events'], 'post_id' ) );
+		}
+		$this->assertContains( $post_id, $calendar_post_ids, 'The Calendar ability must retain the ongoing event.' );
+		CalendarCache::invalidate();
 
 		$unfiltered = new WP_REST_Request( 'GET', '/datamachine/v1/events/calendar' );
 		$unfiltered->set_param( 'archive_taxonomy', 'venue' );

--- a/tests/Unit/CalendarCacheTest.php
+++ b/tests/Unit/CalendarCacheTest.php
@@ -16,6 +16,7 @@ use WP_REST_Request;
 use WP_REST_Server;
 use DataMachineEvents\Blocks\Calendar\Cache\CalendarCache;
 use DataMachineEvents\Blocks\Calendar\Cache\CacheInvalidator;
+use DataMachineEvents\Abilities\EventDateQueryAbilities;
 use DataMachineEvents\Core\Event_Post_Type;
 use DataMachineEvents\Core\EventDatesTable;
 use DataMachineEvents\Core\Venue_Taxonomy;
@@ -284,6 +285,18 @@ class CalendarCacheTest extends WP_UnitTestCase {
 		wp_set_object_terms( $post_id, array( (int) $venue['term_id'] ), 'venue' );
 		CalendarCache::invalidate();
 		wp_set_current_user( 0 );
+
+		$date     = $now->format( 'Y-m-d' );
+		$matching = ( new EventDateQueryAbilities() )->executeQueryEvents(
+			array(
+				'scope'       => 'upcoming',
+				'date_start'  => $date,
+				'date_end'    => $date,
+				'tax_filters' => array( 'venue' => array( (int) $venue['term_id'] ) ),
+				'fields'      => 'ids',
+			)
+		);
+		$this->assertContains( $post_id, $matching['posts'], 'The ongoing event must remain eligible for the Calendar row query.' );
 
 		$unfiltered = new WP_REST_Request( 'GET', '/datamachine/v1/events/calendar' );
 		$unfiltered->set_param( 'archive_taxonomy', 'venue' );

--- a/tests/Unit/CalendarCacheTest.php
+++ b/tests/Unit/CalendarCacheTest.php
@@ -16,8 +16,6 @@ use WP_REST_Request;
 use WP_REST_Server;
 use DataMachineEvents\Blocks\Calendar\Cache\CalendarCache;
 use DataMachineEvents\Blocks\Calendar\Cache\CacheInvalidator;
-use DataMachineEvents\Abilities\CalendarAbilities;
-use DataMachineEvents\Abilities\EventDateQueryAbilities;
 use DataMachineEvents\Core\Event_Post_Type;
 use DataMachineEvents\Core\EventDatesTable;
 use DataMachineEvents\Core\Venue_Taxonomy;
@@ -280,38 +278,12 @@ class CalendarCacheTest extends WP_UnitTestCase {
 			$post_id,
 			$now->modify( '-1 hour' )->format( 'Y-m-d H:i:s' ),
 			// Leave enough time for both uncached Calendar renders before expiry.
-			$now->modify( '+30 seconds' )->format( 'Y-m-d H:i:s' ),
+			$now->modify( '+1 minute' )->format( 'Y-m-d H:i:s' ),
 			'publish'
 		);
 		wp_set_object_terms( $post_id, array( (int) $venue['term_id'] ), 'venue' );
 		CalendarCache::invalidate();
 		wp_set_current_user( 0 );
-
-		$date     = $now->format( 'Y-m-d' );
-		$matching = ( new EventDateQueryAbilities() )->executeQueryEvents(
-			array(
-				'scope'       => 'upcoming',
-				'date_start'  => $date,
-				'date_end'    => $date,
-				'tax_filters' => array( 'venue' => array( (int) $venue['term_id'] ) ),
-				'fields'      => 'ids',
-			)
-		);
-		$this->assertContains( $post_id, $matching['posts'], 'The ongoing event must remain eligible for the Calendar row query.' );
-
-		$calendar = ( new CalendarAbilities() )->executeGetCalendarPage(
-			array(
-				'archive_taxonomy' => 'venue',
-				'archive_term_id'  => (int) $venue['term_id'],
-				'include_html'     => false,
-			)
-		);
-		$calendar_post_ids = array();
-		foreach ( $calendar['paged_date_groups'] as $date_group ) {
-			$calendar_post_ids = array_merge( $calendar_post_ids, array_column( $date_group['events'], 'post_id' ) );
-		}
-		$this->assertContains( $post_id, $calendar_post_ids, 'The Calendar ability must retain the ongoing event.' );
-		CalendarCache::invalidate();
 
 		$unfiltered = new WP_REST_Request( 'GET', '/datamachine/v1/events/calendar' );
 		$unfiltered->set_param( 'archive_taxonomy', 'venue' );
@@ -325,7 +297,7 @@ class CalendarCacheTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Flow Tribe', $before_searched['html'] );
 
 		$ttl = CalendarCache::ttl_for_envelope( array( 'past' => false ) );
-		$this->assertLessThanOrEqual( 31, $ttl );
+		$this->assertLessThanOrEqual( 61, $ttl );
 		sleep( $ttl + 1 );
 
 		$after_unfiltered = $this->server->dispatch( $unfiltered )->get_data();

--- a/tests/Unit/EventDateQueryAbilitiesTest.php
+++ b/tests/Unit/EventDateQueryAbilitiesTest.php
@@ -254,6 +254,54 @@ class EventDateQueryAbilitiesTest extends WP_UnitTestCase {
 		$this->assertMatchesRegularExpression( '/ORDER BY\s+ed\.start_datetime ASC,\s*[^\s]+\.ID ASC/i', $queries[0] );
 	}
 
+	public function test_count_query_skips_found_rows_and_uses_event_date_status_index(): void {
+		$now = current_datetime();
+		$this->seed_event( 'Published past event', 'publish', $now->modify( '-2 days' )->format( 'Y-m-d H:i:s' ) );
+		$this->seed_event( 'Published future event', 'publish', $now->modify( '+2 days' )->format( 'Y-m-d H:i:s' ) );
+		$this->seed_event( 'Draft past event', 'draft', $now->modify( '-3 days' )->format( 'Y-m-d H:i:s' ) );
+
+		$query_args = array();
+		$args_filter = static function ( array $args ) use ( &$query_args ): array {
+			$query_args[] = $args;
+			return $args;
+		};
+		add_filter( 'data_machine_events_calendar_query_args', $args_filter );
+
+		$queries  = array();
+		$observer = static function ( string $sql ) use ( &$queries ): string {
+			if ( false !== strpos( $sql, EventDatesTable::table_name() ) ) {
+				$queries[] = $sql;
+			}
+			return $sql;
+		};
+		add_filter( 'query', $observer );
+		try {
+			$result = ( new EventDateQueryAbilities() )->executeQueryEvents(
+				array(
+					'scope'  => 'past',
+					'fields' => 'count',
+				)
+			);
+		} finally {
+			remove_filter( 'data_machine_events_calendar_query_args', $args_filter );
+			remove_filter( 'query', $observer );
+		}
+
+		$this->assertSame( 1, $result['total'] );
+		$this->assertSame( array(), $result['posts'] );
+		$this->assertSame( 0, $result['post_count'] );
+		$this->assertNotEmpty( $query_args );
+		$this->assertTrue( $query_args[0]['no_found_rows'] );
+		$this->assertCount( 1, $queries );
+		$this->assertMatchesRegularExpression( '/SELECT\s+COUNT\(\*\)/i', $queries[0] );
+		$this->assertStringContainsString( 'STRAIGHT_JOIN', $queries[0] );
+		$this->assertStringContainsString( "ed.post_status = 'publish'", $queries[0] );
+		$this->assertStringNotContainsString( 'SQL_CALC_FOUND_ROWS', $queries[0] );
+		$this->assertStringNotContainsString( 'FOUND_ROWS()', $queries[0] );
+		$this->assertStringNotContainsString( ' LIMIT ', strtoupper( $queries[0] ) );
+		$this->assertStringNotContainsString( ' ORDER BY ', strtoupper( $queries[0] ) );
+	}
+
 	public function test_matching_ids_sql_preserves_consumer_constraints_without_querying(): void {
 		wp_load_alloptions();
 		$filter = static function ( array $query_args, array $input ): array {

--- a/tests/Unit/EventDateQueryDistinctTest.php
+++ b/tests/Unit/EventDateQueryDistinctTest.php
@@ -41,6 +41,8 @@ class EventDateQueryDistinctTest extends WP_UnitTestCase {
 			)
 		);
 		wp_set_object_terms( $post_id, array( (int) $first_term['term_id'], (int) $second_term['term_id'] ), 'event_query_distinct_style' );
+		add_post_meta( $post_id, '_event_query_distinct_marker', 'first' );
+		add_post_meta( $post_id, '_event_query_distinct_marker', 'second' );
 		EventDatesTable::upsert( $post_id, '2026-11-22 20:00:00', '2026-11-22 22:00:00', 'publish' );
 
 		$result = ( new EventDateQueryAbilities() )->executeQueryEvents(
@@ -56,5 +58,20 @@ class EventDateQueryDistinctTest extends WP_UnitTestCase {
 		$this->assertSame( 1, $result['total'] );
 		$this->assertSame( 1, $result['post_count'] );
 		$this->assertSame( array( $post_id ), $result['posts'] );
+
+		$count = ( new EventDateQueryAbilities() )->executeQueryEvents(
+			array(
+				'scope'       => 'all',
+				'date_start'  => '2026-11-22',
+				'date_end'    => '2026-11-22',
+				'tax_filters' => array( 'event_query_distinct_style' => array( (int) $first_term['term_id'], (int) $second_term['term_id'] ) ),
+				'meta_query'  => array( array( 'key' => '_event_query_distinct_marker' ) ),
+				'fields'      => 'count',
+			)
+		);
+
+		$this->assertSame( 1, $count['total'] );
+		$this->assertSame( 0, $count['post_count'] );
+		$this->assertSame( array(), $count['posts'] );
 	}
 }

--- a/tests/Unit/EventDateQueryDistinctTest.php
+++ b/tests/Unit/EventDateQueryDistinctTest.php
@@ -45,30 +45,22 @@ class EventDateQueryDistinctTest extends WP_UnitTestCase {
 		add_post_meta( $post_id, '_event_query_distinct_marker', 'second' );
 		EventDatesTable::upsert( $post_id, '2026-11-22 20:00:00', '2026-11-22 22:00:00', 'publish' );
 
-		$result = ( new EventDateQueryAbilities() )->executeQueryEvents(
-			array(
-				'scope'       => 'all',
-				'date_start'  => '2026-11-22',
-				'date_end'    => '2026-11-22',
-				'tax_filters' => array( 'event_query_distinct_style' => array( (int) $first_term['term_id'], (int) $second_term['term_id'] ) ),
-				'fields'      => 'ids',
-			)
+		$query_input = array(
+			'scope'       => 'all',
+			'date_start'  => '2026-11-22',
+			'date_end'    => '2026-11-22',
+			'tax_filters' => array( 'event_query_distinct_style' => array( (int) $first_term['term_id'], (int) $second_term['term_id'] ) ),
 		);
+		$result      = ( new EventDateQueryAbilities() )->executeQueryEvents( array_merge( $query_input, array( 'fields' => 'ids' ) ) );
 
 		$this->assertSame( 1, $result['total'] );
 		$this->assertSame( 1, $result['post_count'] );
 		$this->assertSame( array( $post_id ), $result['posts'] );
 
-		$count = ( new EventDateQueryAbilities() )->executeQueryEvents(
-			array(
-				'scope'       => 'all',
-				'date_start'  => '2026-11-22',
-				'date_end'    => '2026-11-22',
-				'tax_filters' => array( 'event_query_distinct_style' => array( (int) $first_term['term_id'], (int) $second_term['term_id'] ) ),
-				'meta_query'  => array( array( 'key' => '_event_query_distinct_marker' ) ),
-				'fields'      => 'count',
-			)
-		);
+		$count_input               = $query_input;
+		$count_input['meta_query'] = array( array( 'key' => '_event_query_distinct_marker' ) );
+		$count_input['fields']     = 'count';
+		$count                       = ( new EventDateQueryAbilities() )->executeQueryEvents( $count_input );
 
 		$this->assertSame( 1, $count['total'] );
 		$this->assertSame( 0, $count['post_count'] );


### PR DESCRIPTION
## Summary

- keep `no_found_rows` enabled for every event `WP_Query` and replace count-mode `SQL_CALC_FOUND_ROWS` with a dedicated canonical count query
- use `COUNT(*)` plus `STRAIGHT_JOIN` for one-to-one Calendar counts, while wrapping distinct matching-ID SQL when taxonomy/meta joins can duplicate posts
- add `ed.post_status = 'publish'` alongside canonical posts status checks so MariaDB can use the existing `status_start` index without trusting drifted denormalized state alone
- stabilize the real-time cache transition regression test for the additional exact-count work and remove the audit duplication finding

## Root Cause

`CalendarAbilities::compute_event_counts_via_ability()` requests past and upcoming totals through `EventDateQueryAbilities` with `fields => count`. Count mode changed `no_found_rows` to false and limited `WP_Query` to one row, causing WordPress core to emit `SQL_CALC_FOUND_ROWS` and then `SELECT FOUND_ROWS()`.

The row query also omitted the event-date status predicate, preventing MariaDB from choosing `(post_status, start_datetime)`. The canonical posts status predicate remains because production has denormalized status drift; #714 owns that repair.

## Query Path Fix

Count mode captures SQL from the existing canonical `WP_Query` path, preserving search, taxonomy, geo, meta, exclusions, and consumer constraints, then executes an explicit aggregate without pagination or ordering:

- one-to-one Calendar counts: `COUNT(*)` with posts-first `STRAIGHT_JOIN`
- taxonomy/meta joins or grouping: distinct matching-ID SQL wrapped in `SELECT COUNT(*) FROM (...) matching`

Publish-only requests add `ed.post_status = 'publish'` alongside the posts predicate. Privileged draft/other-status queries do not add the event-date publish predicate.

## Performance Evidence

Read-only production profiling:

- slow-log baseline: 1.64 seconds average for the dominant past query
- past count: about 276 ms
- upcoming count: about 358 ms
- status-neutral past row query: 2.52 seconds, confirming the indexed event-date predicate is necessary
- limited publish rows select the existing `status_start` index; no schema change is needed

## Verification

- Homeboy review audit: pass, no introduced findings
- Homeboy review lint: pass
- contract suite: 4 tests, 58 assertions, pass
- PHP syntax and `git diff --check`: pass
- production-shaped read-only runtime checks: pass for simple counts, taxonomy/meta joined counts, public publish-only rows, and privileged draft counts
- all count SQL excludes `SQL_CALC_FOUND_ROWS`, `FOUND_ROWS()`, `LIMIT`, and `ORDER BY`
- public publish queries retain both status predicates; privileged draft counts retain only canonical posts status
- branch-owned Calendar cache and REST regressions: resolved

## Full-Suite Baseline

The latest CI run reports 9 failures out of 808 with 2 skipped: https://github.com/Extra-Chill/data-machine-events/actions/runs/32621854509

Those same nine test identities are present on the `origin/main` baseline and are tracked in #694. Audit and lint are green, and #715 introduces no remaining test regression. The absolute full-suite check remains red until the repository baseline is repaired; exact current evidence was added to #694.

## Risks

- `event_dates.post_status` is not safe as the sole status source while #714 remains open, so this PR deliberately retains the posts join/status predicate.
- joined consumer constraints take the slower wrapped distinct-ID path to preserve exact deduplication.

Fixes #713