### PR TITLE
refactor: declare event import source capabilities

### DIFF
--- a/inc/Steps/EventImport/EventImportStep.php
+++ b/inc/Steps/EventImport/EventImportStep.php
@@ -22,6 +22,8 @@ class EventImportStep extends Step {
 
 	use StepTypeRegistrationTrait;
 
+	private static bool $capabilities_registered = false;
+
 	public function __construct() {
 		parent::__construct( 'event_import' );
 
@@ -34,6 +36,30 @@ class EventImportStep extends Step {
 			usesHandler: true,
 			hasPipelineConfig: false
 		);
+
+		if ( ! self::$capabilities_registered ) {
+			add_filter( 'datamachine_step_types', array( self::class, 'registerCapabilities' ), 20 );
+			self::$capabilities_registered = true;
+		}
+	}
+
+	/**
+	 * Declare source-step behavior owned by the event import type.
+	 *
+	 * @param array $step_types Registered step types.
+	 * @return array
+	 */
+	public static function registerCapabilities( array $step_types ): array {
+		if ( ! isset( $step_types['event_import'] ) ) {
+			return $step_types;
+		}
+
+		$step_types['event_import']['source_ingestion']          = true;
+		$step_types['event_import']['allows_empty_output']       = true;
+		$step_types['event_import']['supports_item_disposition'] = true;
+		$step_types['event_import']['handler_category']          = 'source';
+
+		return $step_types;
 	}
 
 	/**

--- a/tests/Unit/EventImportStepCapabilitiesTest.php
+++ b/tests/Unit/EventImportStepCapabilitiesTest.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Event import step capability tests.
+ *
+ * @package DataMachineEvents\Tests\Unit
+ */
+
+namespace DataMachineEvents\Tests\Unit;
+
+use DataMachineEvents\Steps\EventImport\EventImportStep;
+use WP_UnitTestCase;
+
+class EventImportStepCapabilitiesTest extends WP_UnitTestCase {
+
+	public function test_event_import_declares_source_step_capabilities(): void {
+		new EventImportStep();
+
+		$step_types   = apply_filters( 'datamachine_step_types', array() );
+		$event_import = $step_types['event_import'];
+
+		$this->assertTrue( $event_import['source_ingestion'] );
+		$this->assertTrue( $event_import['allows_empty_output'] );
+		$this->assertTrue( $event_import['supports_item_disposition'] );
+		$this->assertSame( 'source', $event_import['handler_category'] );
+	}
+}


### PR DESCRIPTION
## Summary
- declare source-ingestion, empty-output, item-disposition, and source handler-category metadata from `EventImportStep`
- preserve compatibility with current Data Machine by augmenting the existing step registration filter before core removes downstream literals
- cover the Events-owned registration contract directly

## Behavior preserved
- empty source results retain `completed_no_items` semantics once the paired core metadata consumer lands
- Ticketmaster/EventImport claim lifecycle and item dispositions remain eligible through owned metadata
- source handler testing/discovery and adjacent disposition-tool visibility remain enabled

## Verification
- `php -l inc/Steps/EventImport/EventImportStep.php`
- `php -l tests/Unit/EventImportStepCapabilitiesTest.php`
- `vendor/bin/phpunit --configuration phpunit.contracts.xml` (4 tests, 58 assertions)
- Homeboy changed-scope audit and lint passed with zero findings
- Managed WP Codebox PHPUnit was attempted twice; the harness produced zero parsed tests on the first run and the hot-host supervisor terminated the expanded inventory on the coordinated core run before focused assertions executed

## Merge order
Merge this Events consumer PR first, then the paired Data Machine core PR that removes the generic literals.

Fixes #716

Core issue: https://github.com/Extra-Chill/data-machine/issues/3329